### PR TITLE
feat: add persisted search history saved in localStorage

### DIFF
--- a/src/global/styles.css
+++ b/src/global/styles.css
@@ -399,6 +399,169 @@ pre,
   opacity: 0.85;
 }
 
+/* ---------- History panel ---------- */
+.history-toggle {
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-sm);
+  color: var(--ink-4);
+  display: grid;
+  place-items: center;
+  transition: all 120ms;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  margin-left: auto;
+}
+
+.history-toggle:hover {
+  color: var(--ink);
+  background: var(--muted);
+}
+
+.history-toggle.active {
+  color: var(--accent-ink);
+  background: var(--accent-soft);
+}
+
+.input-options + .history-toggle {
+  margin-left: 0;
+}
+
+.history-panel {
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+  animation: history-slide-in 160ms ease-out;
+}
+
+@keyframes history-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.history-list {
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.history-item {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--line);
+  transition: background 100ms;
+}
+
+.history-item:last-child {
+  border-bottom: none;
+}
+
+.history-item:hover {
+  background: var(--muted);
+}
+
+.history-item-btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+}
+
+.history-item-input {
+  flex: 1;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink);
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.history-item-time {
+  font-size: 11px;
+  color: var(--ink-4);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.history-item-del {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--ink-4);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  flex-shrink: 0;
+  margin-right: 8px;
+  opacity: 0;
+  transition: all 120ms;
+}
+
+.history-item:hover .history-item-del {
+  opacity: 1;
+}
+
+.history-item-del:hover {
+  color: var(--danger);
+  background: var(--muted-2);
+}
+
+.history-clear {
+  width: 100%;
+  padding: 8px 14px;
+  border: none;
+  border-top: 1px solid var(--line);
+  background: transparent;
+  color: var(--ink-3);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 120ms;
+  text-align: center;
+  font-family: inherit;
+}
+
+.history-clear:hover {
+  color: var(--danger);
+  background: var(--muted);
+}
+
+.history-empty {
+  padding: 20px 14px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--ink-4);
+}
+
+@media (max-width: 480px) {
+  .history-item-del {
+    opacity: 1;
+  }
+}
+
 .out-count {
   font-size: 11px;
   color: var(--ink-3);

--- a/src/hooks/useSearchHistory.ts
+++ b/src/hooks/useSearchHistory.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'mb_search_history';
+const DEFAULT_MAX_ITEMS = 50;
+
+export interface HistoryItem {
+  id: string;
+  timestamp: number;
+  input: string;
+}
+
+function loadHistory(): HistoryItem[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+function persistHistory(items: HistoryItem[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // localStorage full or unavailable — silently ignore.
+  }
+}
+
+interface UseSearchHistoryOptions {
+  maxItems?: number;
+}
+
+interface UseSearchHistoryReturn {
+  history: HistoryItem[];
+  addEntry: (input: string) => void;
+  removeEntry: (id: string) => void;
+  clearHistory: () => void;
+}
+
+export function useSearchHistory(
+  opts?: UseSearchHistoryOptions,
+): UseSearchHistoryReturn {
+  const maxItems = opts?.maxItems ?? DEFAULT_MAX_ITEMS;
+  const [history, setHistory] = useState<HistoryItem[]>(loadHistory);
+
+  // Persist whenever history changes.
+  useEffect(() => {
+    persistHistory(history);
+  }, [history]);
+
+  const addEntry = useCallback(
+    (input: string) => {
+      const trimmed = input.trim();
+      if (!trimmed) return;
+
+      setHistory((prev) => {
+        // De-duplicate: if input already exists, remove the old entry so the
+        // new one goes to the top with an updated timestamp.
+        const deduplicated = prev.filter((item) => item.input !== trimmed);
+
+        const entry: HistoryItem = {
+          id: crypto.randomUUID(),
+          timestamp: Date.now(),
+          input: trimmed,
+        };
+
+        // Prepend new entry and cap at maxItems.
+        return [entry, ...deduplicated].slice(0, maxItems);
+      });
+    },
+    [maxItems],
+  );
+
+  const removeEntry = useCallback((id: string) => {
+    setHistory((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    setHistory([]);
+  }, []);
+
+  return { history, addEntry, removeEntry, clearHistory };
+}

--- a/src/pages/MagicBox/MagicBoxPage.tsx
+++ b/src/pages/MagicBox/MagicBoxPage.tsx
@@ -1,5 +1,7 @@
 import MagicBox from '@components/MagicBox';
 import React, { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchHistory } from '../../hooks/useSearchHistory';
+import type { HistoryItem } from '../../hooks/useSearchHistory';
 
 const QRCodeReader = React.lazy(async () => import('@components/QRCodeReader'));
 
@@ -16,12 +18,29 @@ const parseOptionsForChips = (input: string) => {
   return opts;
 };
 
+/** Format a timestamp as a human-readable relative time string. */
+const formatRelativeTime = (timestamp: number): string => {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+};
+
 const MagicBoxPage = (): React.JSX.Element => {
   const [userInput, setUserInput] = useState('');
   const [magicIn, setMagicIn] = useState('');
   const [resetCounter, setResetCounter] = useState(0);
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const lastRecordedRef = useRef<string>('');
+
+  const { history, addEntry, removeEntry, clearHistory } = useSearchHistory();
 
   // Hydrate input from query string on first load (?input=... or ?i=...) and
   // focus the textarea so users can start typing without an extra click.
@@ -41,6 +60,15 @@ const MagicBoxPage = (): React.JSX.Element => {
     return () => window.clearTimeout(timeoutID);
   }, [userInput]);
 
+  // Record to search history when debounced input settles.
+  useEffect(() => {
+    const trimmed = magicIn.trim();
+    if (trimmed && trimmed !== lastRecordedRef.current) {
+      lastRecordedRef.current = trimmed;
+      addEntry(trimmed);
+    }
+  }, [magicIn, addEntry]);
+
   const optionChips = useMemo(
     () => Object.entries(parseOptionsForChips(userInput)),
     [userInput],
@@ -49,6 +77,13 @@ const MagicBoxPage = (): React.JSX.Element => {
   const handleScannedInput = (value: string) => {
     setUserInput(value);
     if (inputRef.current) inputRef.current.value = value;
+  };
+
+  const handleHistorySelect = (input: string) => {
+    setUserInput(input);
+    if (inputRef.current) inputRef.current.value = input;
+    setHistoryOpen(false);
+    inputRef.current?.focus();
   };
 
   return (
@@ -73,7 +108,77 @@ const MagicBoxPage = (): React.JSX.Element => {
                 ))}
               </span>
             ) : null}
+            <button
+              aria-label={historyOpen ? 'Close history' : 'Open history'}
+              className={`history-toggle${historyOpen ? ' active' : ''}`}
+              data-testid="history-toggle"
+              onClick={() => setHistoryOpen((o) => !o)}
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                width="14"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </button>
           </div>
+
+          {historyOpen ? (
+            <div className="history-panel" data-testid="history-panel">
+              {history.length > 0 ? (
+                <>
+                  <div className="history-list">
+                    {history.map((item: HistoryItem) => (
+                      <div className="history-item" key={item.id}>
+                        <button
+                          className="history-item-btn"
+                          onClick={() => handleHistorySelect(item.input)}
+                          title={item.input}
+                          type="button"
+                        >
+                          <span className="history-item-input">
+                            {item.input.length > 50
+                              ? `${item.input.slice(0, 50)}…`
+                              : item.input}
+                          </span>
+                          <span className="history-item-time">
+                            {formatRelativeTime(item.timestamp)}
+                          </span>
+                        </button>
+                        <button
+                          aria-label={`Delete history entry: ${item.input.slice(0, 30)}`}
+                          className="history-item-del"
+                          onClick={() => removeEntry(item.id)}
+                          type="button"
+                        >
+                          ✕
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  <button
+                    className="history-clear"
+                    onClick={clearHistory}
+                    type="button"
+                  >
+                    Clear history
+                  </button>
+                </>
+              ) : (
+                <div className="history-empty">No history yet</div>
+              )}
+            </div>
+          ) : null}
+
           <div className="input-card">
             <textarea
               ref={inputRef}


### PR DESCRIPTION
## Summary

Implements #235 — adds a persisted search history feature to MagicBox.

### What changed

| File | Change |
|------|--------|
| `src/hooks/useSearchHistory.ts` | **New** — custom hook managing history in `localStorage` (`mb_search_history` key) with de-duplication, capacity limiting (50 items), and CRUD operations |
| `src/pages/MagicBox/MagicBoxPage.tsx` | **Modified** — integrated history hook, added collapsible history panel with toggle button, click-to-load, per-item delete, and clear-all |
| `src/global/styles.css` | **Modified** — added `history-*` class styles with slide-in animation, hover states, and mobile responsive adjustments |

### How it works

1. **Recording**: When the debounced input (`magicIn`) settles on a non-empty value, it's saved to history
2. **De-duplication**: Identical inputs update the existing entry's timestamp instead of creating duplicates
3. **Capacity**: Capped at 50 items; oldest entries are discarded when exceeded
4. **Persistence**: Stored in `localStorage` under `mb_search_history`, following the existing `mb_` key convention
5. **Clearing**: Automatically cleared by the existing `localStorage.clear()` in Settings → Clear local data

### Verification

- ✅ `bun run build` — no TypeScript or build errors
- ✅ `CI=true bun run test` — all 186 tests pass

Closes #235