### PR TITLE
fix(uuid): guard crypto.randomUUID for non-secure contexts, isolate box source errors

### DIFF
--- a/src/components/MagicBox/index.tsx
+++ b/src/components/MagicBox/index.tsx
@@ -118,16 +118,22 @@ const MagicBox = ({
     const [input, options] = parseInput(magicIn);
 
     const promises = boxSources.map(async (boxSource) => {
-      const generated = await boxSource.generateBoxes(input, options);
-      // enrich each box with its source's tag/kind so the chrome can render them
-      return generated.map((b) => ({
-        ...b,
-        props: {
-          ...b.props,
-          tag: b.props.tag ?? boxSource.tag,
-          kind: b.props.kind ?? boxSource.kind,
-        },
-      }));
+      // isolate each source so one failure never suppresses results from others
+      try {
+        const generated = await boxSource.generateBoxes(input, options);
+        // enrich each box with its source's tag/kind so the chrome can render them
+        return generated.map((b) => ({
+          ...b,
+          props: {
+            ...b.props,
+            tag: b.props.tag ?? boxSource.tag,
+            kind: b.props.kind ?? boxSource.kind,
+          },
+        }));
+      } catch (err) {
+        console.error(`[MagicBox] boxSource "${boxSource.name}" threw:`, err);
+        return [];
+      }
     });
 
     Promise.all(promises).then((resultBoxes) => {

--- a/src/modules/boxSources/UuidBoxSource.ts
+++ b/src/modules/boxSources/UuidBoxSource.ts
@@ -6,6 +6,39 @@ const PriorityUuidBox = 10;
 
 type Match = boolean;
 
+// fallback for non-secure contexts (plain HTTP) where crypto.randomUUID is
+// unavailable — uses getRandomValues when possible for cryptographic quality.
+function generateUuidV4(): string {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.getRandomValues === 'function'
+  ) {
+    crypto.getRandomValues(bytes);
+  } else {
+    // last-resort fallback when the Web Crypto API is entirely absent
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+
+  // set version (4) and variant bits per RFC 4122
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(
+    '',
+  );
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 export const UuidBoxSource = {
   name: 'UUID',
   description: 'Generate a fresh UUID v4, uppercase optional.',
@@ -34,7 +67,7 @@ export const UuidBoxSource = {
       return [];
     }
 
-    let uuid: string = crypto.randomUUID();
+    let uuid: string = generateUuidV4();
     if (options && (options.uppercase || options.upper)) {
       uuid = uuid.toUpperCase();
     }

--- a/src/modules/boxSources/__test__/UuidBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UuidBoxSource.test.ts
@@ -1,5 +1,5 @@
 import { DefaultBoxTemplate } from '@components/BoxTemplate';
-import { expect } from 'vitest';
+import { afterEach, expect, vi } from 'vitest';
 
 import { UuidBoxSource } from '../UuidBoxSource';
 
@@ -69,6 +69,59 @@ describe('UuidBoxSource', () => {
           uppercase: true,
         });
         expect(boxes[0].props.plaintextOutput).toMatch(/^[0-9A-F-]+$/);
+      });
+    });
+
+    describe('crypto fallback paths', () => {
+      // save originals
+      const originalRandomUUID = crypto.randomUUID;
+      const originalGetRandomValues = crypto.getRandomValues;
+
+      afterEach(() => {
+        // restore after each test
+        Object.defineProperty(crypto, 'randomUUID', {
+          value: originalRandomUUID,
+          writable: true,
+          configurable: true,
+        });
+        Object.defineProperty(crypto, 'getRandomValues', {
+          value: originalGetRandomValues,
+          writable: true,
+          configurable: true,
+        });
+      });
+
+      it('falls back to getRandomValues when randomUUID is undefined, producing a valid v4 UUID', async () => {
+        Object.defineProperty(crypto, 'randomUUID', {
+          value: undefined,
+          writable: true,
+          configurable: true,
+        });
+
+        const boxes = await UuidBoxSource.generateBoxes('uuid');
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput).toMatch(validUUIDv4Regex);
+      });
+
+      it('falls back to Math.random when both randomUUID and getRandomValues are undefined, producing a valid v4 UUID', async () => {
+        Object.defineProperty(crypto, 'randomUUID', {
+          value: undefined,
+          writable: true,
+          configurable: true,
+        });
+        Object.defineProperty(crypto, 'getRandomValues', {
+          value: undefined,
+          writable: true,
+          configurable: true,
+        });
+
+        const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+        const boxes = await UuidBoxSource.generateBoxes('uuid');
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput).toMatch(validUUIDv4Regex);
+
+        mathRandomSpy.mockRestore();
       });
     });
   });


### PR DESCRIPTION
## Summary

- **Problem A – UUID crash in non-secure contexts**: `crypto.randomUUID()` is undefined on plain-HTTP origins (e.g. `http://192.168.x.x`). Added `generateUuidV4()` helper in `UuidBoxSource.ts` that degrades gracefully: `crypto.randomUUID` → `crypto.getRandomValues` fallback → `Math.random` last-resort. Each tier is gated with an explicit `typeof` guard.

- **Problem B – one failing box source kills all results**: `Promise.all(promises)` in `MagicBox/index.tsx` rejected the entire pipeline when any single `generateBoxes` threw. Wrapped each async map callback in a `try/catch` that logs `console.error("[MagicBox] boxSource \"…\" threw: …")` and returns `[]`, so the rest of the results are always delivered.

- **Tests**: Extended `UuidBoxSource.test.ts` with two new fallback-path cases that mock `crypto.randomUUID` (and `crypto.getRandomValues`) as `undefined` and assert a valid RFC 4122 v4 UUID is still produced.

## Test plan

- [ ] `bun run lint` → no errors or warnings (Biome clean, 92 files)
- [ ] `CI=true bun run test run src/modules/boxSources/__test__/UuidBoxSource.test.ts` → 10/10 passed
- [ ] `bunx tsc --noEmit` → no errors
- [ ] Manual: type `uuid` in a non-secure HTTP context — should no longer throw TypeError

Closes #232

https://claude.ai/code/session_016Q7UoTqHa1EiTAheBeyaZh