### PR TITLE
perf: use syntax-highlighter Light build to cut PWA precache

### DIFF
--- a/src/components/BoxTemplate/CodeBoxTemplate.tsx
+++ b/src/components/BoxTemplate/CodeBoxTemplate.tsx
@@ -9,15 +9,24 @@ interface HighlighterProps {
   dataTestId?: string;
 }
 
-// dynamic import to reduce bundle size
+// lazy-load the Light build so the highlighter stays out of the main bundle.
+// only the languages actually used by the app are registered, avoiding the
+// 500+ per-language chunks emitted when importing the full build.
 const LazyHighlighter = lazy(async () => {
-  const [highlighterModule, styleModule] = await Promise.all([
-    import('react-syntax-highlighter'),
-    import('react-syntax-highlighter/dist/esm/styles/hljs'),
-  ]);
+  const [{ Light: SyntaxHighlighter }, atomOneLight, json, yaml, xml] =
+    await Promise.all([
+      import('react-syntax-highlighter'),
+      import('react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light'),
+      import('react-syntax-highlighter/dist/esm/languages/hljs/json'),
+      import('react-syntax-highlighter/dist/esm/languages/hljs/yaml'),
+      import('react-syntax-highlighter/dist/esm/languages/hljs/xml'),
+    ]);
 
-  const SyntaxHighlighterComponent = highlighterModule.default;
-  const atomOneLight = styleModule.atomOneLight;
+  SyntaxHighlighter.registerLanguage('json', json.default);
+  SyntaxHighlighter.registerLanguage('yaml', yaml.default);
+  // xml covers HTML as well
+  SyntaxHighlighter.registerLanguage('xml', xml.default);
+  // hljs has no toml grammar; toml output falls back to plaintext highlighting
 
   return {
     default: ({
@@ -26,14 +35,15 @@ const LazyHighlighter = lazy(async () => {
       customStyle,
       dataTestId,
     }: HighlighterProps) => (
-      <SyntaxHighlighterComponent
+      <SyntaxHighlighter
         customStyle={customStyle}
         data-testid={dataTestId}
-        language={language}
-        style={atomOneLight}
+        // map toml to 'plaintext' since hljs has no toml grammar
+        language={language === 'toml' ? 'plaintext' : language}
+        style={atomOneLight.default}
       >
         {children}
-      </SyntaxHighlighterComponent>
+      </SyntaxHighlighter>
     ),
   };
 });

--- a/src/components/BoxTemplate/__test__/CodeBoxTemplate.test.tsx
+++ b/src/components/BoxTemplate/__test__/CodeBoxTemplate.test.tsx
@@ -1,0 +1,66 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import CodeBoxTemplate from '../CodeBoxTemplate';
+
+// renders the template and waits for the lazy highlighter to resolve
+async function renderHighlighter(
+  plaintextOutput: string,
+  language: string,
+): Promise<void> {
+  act(() => {
+    render(
+      <CodeBoxTemplate
+        name="Test"
+        onClick={(): void => {}}
+        options={{ language }}
+        plaintextOutput={plaintextOutput}
+      />,
+    );
+  });
+
+  await waitFor(
+    () => {
+      expect(screen.getByTestId('magic-box-result-text')).toBeTruthy();
+    },
+    { timeout: 3000 },
+  );
+}
+
+describe('<CodeBoxTemplate />', () => {
+  it('renders json content', async () => {
+    await renderHighlighter('{"key":1}', 'json');
+  });
+
+  it('renders yaml content', async () => {
+    await renderHighlighter('key: value', 'yaml');
+  });
+
+  it('renders xml content', async () => {
+    await renderHighlighter('<root><item>1</item></root>', 'xml');
+  });
+
+  it('renders toml content (falls back to plaintext)', async () => {
+    await renderHighlighter('key = "value"', 'toml');
+  });
+
+  it('defaults to yaml when no language option is provided', async () => {
+    act(() => {
+      render(
+        <CodeBoxTemplate
+          name="Test"
+          onClick={(): void => {}}
+          options={null}
+          plaintextOutput="key: value"
+        />,
+      );
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('magic-box-result-text')).toBeTruthy();
+      },
+      { timeout: 3000 },
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`CodeBoxTemplate` dynamically imported the **full** `react-syntax-highlighter` build
and the entire hljs styles barrel (`react-syntax-highlighter/dist/esm/styles/hljs`).
Vite/Rollup emits one chunk per language (~500+ chunks) and the Workbox service
worker precaches all of them, inflating the PWA precache to ~5.8 MB.

## Fix

Switch to the **Light build** and register only the three languages the app actually
uses (confirmed by grepping all `BoxSource` files):

| Language | Used by |
|---|---|
| `json` | `DataConverterBoxSource`, `JWTBoxSource` |
| `yaml` | `DataConverterBoxSource`, `CodeBoxTemplate` default |
| `xml` | `DataConverterBoxSource` |

`toml` is produced by `DataConverterBoxSource` but **hljs has no toml grammar**; TOML
output is mapped to `'plaintext'` so syntax tokens are still displayed without errors.

The styles import is narrowed from the full barrel to the specific file already in use:
`react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light`.

The component stays lazily loaded (inside `React.lazy`) so the highlighter + language
grammars remain out of the main bundle.

## Changes

- `src/components/BoxTemplate/CodeBoxTemplate.tsx` — Light build + language registration
- `src/components/BoxTemplate/__test__/CodeBoxTemplate.test.tsx` — new unit tests for
  all supported languages (json, yaml, xml, toml→plaintext) and the default-language path

## Verification

- `bun run lint` — clean
- `CI=true bun run test run` — **208/208 tests pass** (25 test files)
- `bunx tsc --noEmit` — no errors
- Bundle/precache size comparison: WASM modules are not built in this environment so
  `bun run build` could not be run; the chunk reduction is mechanical — only 3 language
  files are imported instead of 500+.

Closes #229

https://claude.ai/code/session_016Q7UoTqHa1EiTAheBeyaZh