### PR TITLE
feat: add Hash box (SHA-1/256/512)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,24 @@ Based on matching methods, we can roughly classify Boxes into two types:
 </details>
 
 <details>
+<summary> <b>HashBox</b> </summary>
+
+| match rule                               | description                           | output           |
+| ---------------------------------------- | ------------------------------------- | ---------------- |
+| contains option `hash`, `sha1`, `sha256`, or `sha512` | compute cryptographic hash of the input | lowercase hex digest |
+
+| options  | description                              | example      |
+| -------- | ---------------------------------------- | ------------ |
+| `hash`   | compute SHA-1, SHA-256, and SHA-512      | `::hash`     |
+| `sha1`   | compute SHA-1 digest                     | `::sha1`     |
+| `sha256` | compute SHA-256 digest                   | `::sha256`   |
+| `sha512` | compute SHA-512 digest                   | `::sha512`   |
+
+MD5 is intentionally omitted — it is not available in Web Crypto, and adding an npm dependency for a broken algorithm is not worthwhile.
+
+</details>
+
+<details>
 <summary> <b>JWTBox</b> </summary>
 
 | match rule       | description                | output                  |

--- a/src/modules/boxSources/HashBoxSource.ts
+++ b/src/modules/boxSources/HashBoxSource.ts
@@ -1,0 +1,92 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const PriorityHashBox = 20;
+
+// algorithms supported via Web Crypto
+type SupportedAlgorithm = 'SHA-1' | 'SHA-256' | 'SHA-512';
+
+interface AlgorithmEntry {
+  name: SupportedAlgorithm;
+  // option keys that select only this algorithm
+  keys: string[];
+  // display label used as box name
+  label: string;
+}
+
+const ALGORITHMS: AlgorithmEntry[] = [
+  { name: 'SHA-1', keys: ['sha1'], label: 'SHA-1' },
+  { name: 'SHA-256', keys: ['sha256'], label: 'SHA-256' },
+  { name: 'SHA-512', keys: ['sha512'], label: 'SHA-512' },
+];
+
+// all option keys that activate this box source
+const ALL_TRIGGER_KEYS = ['hash', 'sha1', 'sha256', 'sha512'];
+
+function bufToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function computeHash(
+  algorithm: SupportedAlgorithm,
+  input: string,
+): Promise<string> {
+  const encoded = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest(algorithm, encoded);
+  return bufToHex(digest);
+}
+
+export const HashBoxSource = {
+  name: 'Hash',
+  description:
+    'Compute cryptographic hashes (SHA-1, SHA-256, SHA-512) of the input text via Web Crypto.',
+  defaultInput: 'hello world ::sha256',
+  tag: '#',
+  kind: 'Hash',
+  priority: PriorityHashBox,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, ...ALL_TRIGGER_KEYS)) {
+      return [];
+    }
+
+    // guard for non-secure contexts where crypto.subtle is unavailable
+    if (typeof crypto === 'undefined' || !crypto.subtle) {
+      return [
+        new BoxBuilder(
+          'Hash',
+          'Hashing requires a secure context (HTTPS). crypto.subtle is not available.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const selectedAlgorithms: AlgorithmEntry[] = hasOptionKeys(options, 'hash')
+      ? ALGORITHMS // ::hash alone means "all"
+      : ALGORITHMS.filter((alg) => hasOptionKeys(options, ...alg.keys));
+
+    const boxes = await Promise.all(
+      selectedAlgorithms.map(async (alg) => {
+        const hex = await computeHash(alg.name, input);
+        return new BoxBuilder(`${alg.label}`, hex)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build();
+      }),
+    );
+
+    return boxes;
+  },
+};
+
+export default HashBoxSource;

--- a/src/modules/boxSources/__test__/HashBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HashBoxSource.test.ts
@@ -1,0 +1,147 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { HashBoxSource } from '../HashBoxSource';
+
+describe('HashBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no hash option is provided', async () => {
+      const boxes = await HashBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options', async () => {
+      const boxes = await HashBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - SHA-256 known vector', () => {
+    it('produces correct SHA-256 digest for "abc"', async () => {
+      // NIST FIPS 180-4 test vector
+      const boxes = await HashBoxSource.generateBoxes('abc', { sha256: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+      );
+      expect(boxes[0].props.name).toBe('SHA-256');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('produces correct SHA-256 digest for empty string', async () => {
+      const boxes = await HashBoxSource.generateBoxes('', { sha256: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      );
+    });
+  });
+
+  describe('generateBoxes - SHA-1 known vector', () => {
+    it('produces correct SHA-1 digest for "abc"', async () => {
+      const boxes = await HashBoxSource.generateBoxes('abc', { sha1: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'a9993e364706816aba3e25717850c26c9cd0d89d',
+      );
+      expect(boxes[0].props.name).toBe('SHA-1');
+    });
+  });
+
+  describe('generateBoxes - SHA-512 known vector', () => {
+    it('produces correct SHA-512 digest for "abc"', async () => {
+      const boxes = await HashBoxSource.generateBoxes('abc', { sha512: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f',
+      );
+      // SHA-512 hex is 128 chars
+      expect(boxes[0].props.plaintextOutput).toHaveLength(128);
+      expect(boxes[0].props.name).toBe('SHA-512');
+    });
+  });
+
+  describe('generateBoxes - ::hash produces all algorithms', () => {
+    it('returns three boxes for ::hash option', async () => {
+      const boxes = await HashBoxSource.generateBoxes('abc', { hash: true });
+      expect(boxes).toHaveLength(3);
+
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('SHA-1');
+      expect(names).toContain('SHA-256');
+      expect(names).toContain('SHA-512');
+    });
+
+    it('sha256 digest inside ::hash output matches standalone result', async () => {
+      const all = await HashBoxSource.generateBoxes('hello', { hash: true });
+      const sha256box = all.find((b) => b.props.name === 'SHA-256');
+      const standalone = await HashBoxSource.generateBoxes('hello', {
+        sha256: true,
+      });
+      expect(sha256box?.props.plaintextOutput).toBe(
+        standalone[0].props.plaintextOutput,
+      );
+    });
+  });
+
+  describe('generateBoxes - option routing', () => {
+    it('only sha1 box is returned when sha1 option set', async () => {
+      const boxes = await HashBoxSource.generateBoxes('test', { sha1: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('SHA-1');
+    });
+
+    it('only sha512 box is returned when sha512 option set', async () => {
+      const boxes = await HashBoxSource.generateBoxes('test', { sha512: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('SHA-512');
+    });
+
+    it('returns sha1 and sha256 when both options are set', async () => {
+      const boxes = await HashBoxSource.generateBoxes('test', {
+        sha1: true,
+        sha256: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('SHA-1');
+      expect(names).toContain('SHA-256');
+    });
+  });
+
+  describe('generateBoxes - non-secure context fallback', () => {
+    const originalCrypto = globalThis.crypto;
+
+    beforeEach(() => {
+      // simulate environment without crypto.subtle
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { subtle: undefined },
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('returns a single informational box when crypto.subtle is unavailable', async () => {
+      const boxes = await HashBoxSource.generateBoxes('abc', { sha256: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HashBoxSource.name).toBe('Hash');
+      expect(HashBoxSource.tag).toBe('#');
+      expect(HashBoxSource.kind).toBe('Hash');
+      expect(typeof HashBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
+import HashBoxSource from './HashBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
@@ -31,6 +32,7 @@ export const boxSources = [
   DataConverterBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
+  HashBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,


### PR DESCRIPTION
## Summary

- Adds `HashBoxSource` that computes cryptographic hashes (SHA-1, SHA-256, SHA-512) of the input text using Web Crypto (`crypto.subtle`)
- Triggers only when the user supplies a hash option (`::hash`, `::sha1`, `::sha256`, `::sha512`) — does not hash on every keystroke
- Guards for non-secure contexts: returns an informational box when `crypto.subtle` is unavailable rather than throwing

## Details

- `::hash` — computes all three algorithms and returns one box each
- `::sha1` / `::sha256` / `::sha512` — computes only the selected algorithm
- MD5 is intentionally omitted: it is not in Web Crypto and adding an npm dependency for a deprecated algorithm is not worthwhile
- Output is lowercase hex

## Test plan

- [x] 13 unit tests covering NIST-vetted known vectors (`SHA-256("abc") = ba7816bf…`, `SHA-1("abc") = a9993e36…`, `SHA-512("abc")`)
- [x] Option routing tests (single vs. combined vs. `::hash` all)
- [x] Non-secure context fallback test
- [x] `bun run lint` — clean (0 errors, 0 warnings)
- [x] `CI=true bun run test run ...HashBoxSource.test.ts` — 13 passed
- [x] `bunx tsc --noEmit` — clean

https://claude.ai/code/session_016Q7UoTqHa1EiTAheBeyaZh