### PR TITLE
refactor: make MagicBox textarea fully controlled

### DIFF
--- a/src/pages/MagicBox/MagicBoxPage.test.tsx
+++ b/src/pages/MagicBox/MagicBoxPage.test.tsx
@@ -1,0 +1,136 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LocaleProvider } from '../../contexts/LocaleContext';
+
+// Mock the heavy children so the page can be tested in isolation without
+// pulling in SettingsContext / WASM box sources. The mocks expose the page's
+// callbacks (onPasteInput, QR setUserInput) as DOM buttons we can trigger.
+vi.mock('@components/MagicBox', () => ({
+  default: ({
+    input,
+    onPasteInput,
+  }: {
+    input: string;
+    onPasteInput?: (value: string) => void;
+  }) => (
+    <div>
+      <div data-testid="magic-input-echo">{input}</div>
+      <button
+        data-testid="paste-back"
+        onClick={() => onPasteInput?.('pasted-value')}
+        type="button"
+      >
+        paste back
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@components/QRCodeReader', () => ({
+  default: ({ setUserInput }: { setUserInput: (value: string) => void }) => (
+    <button
+      data-testid="qr-trigger"
+      onClick={() => setUserInput('scanned-value')}
+      type="button"
+    >
+      scan
+    </button>
+  ),
+}));
+
+import MagicBoxPage from './MagicBoxPage';
+
+const renderPage = () =>
+  render(
+    <LocaleProvider>
+      <MagicBoxPage />
+    </LocaleProvider>,
+  );
+
+const getInput = () => screen.getByTestId('magic-input') as HTMLTextAreaElement;
+
+describe('<MagicBoxPage />', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+    vi.clearAllMocks();
+  });
+
+  it('prefills state from the ?input query param on mount', async () => {
+    window.history.replaceState({}, '', '/?input=hello%20world');
+
+    renderPage();
+
+    expect(getInput().value).toBe('hello world');
+  });
+
+  it('prefills state from the short ?i query param on mount', () => {
+    window.history.replaceState({}, '', '/?i=short');
+
+    renderPage();
+
+    expect(getInput().value).toBe('short');
+  });
+
+  it('keeps the textarea controlled when typing', () => {
+    renderPage();
+    const input = getInput();
+
+    fireEvent.change(input, { target: { value: 'typed text' } });
+
+    expect(input.value).toBe('typed text');
+  });
+
+  it('updates state and caret when a QR scan result is applied', async () => {
+    renderPage();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('qr-trigger'));
+    });
+
+    const input = getInput();
+    expect(input.value).toBe('scanned-value');
+    // caret should land at the end of the inserted text
+    await waitFor(() => {
+      expect(input.selectionStart).toBe('scanned-value'.length);
+      expect(input.selectionEnd).toBe('scanned-value'.length);
+    });
+  });
+
+  it('updates state and caret when output is pasted back into the input', async () => {
+    renderPage();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('paste-back'));
+    });
+
+    const input = getInput();
+    expect(input.value).toBe('pasted-value');
+    await waitFor(() => {
+      expect(input.selectionStart).toBe('pasted-value'.length);
+      expect(input.selectionEnd).toBe('pasted-value'.length);
+    });
+  });
+
+  it('does not write through the DOM ref directly (value driven by state)', () => {
+    // typing flows through React state: the rendered value must reflect the
+    // controlled `userInput`, proving the DOM value is not mutated out of band.
+    renderPage();
+    const input = getInput();
+
+    fireEvent.change(input, { target: { value: 'abc' } });
+    expect(input.value).toBe('abc');
+
+    fireEvent.change(input, { target: { value: '' } });
+    expect(input.value).toBe('');
+  });
+});

--- a/src/pages/MagicBox/MagicBoxPage.tsx
+++ b/src/pages/MagicBox/MagicBoxPage.tsx
@@ -2,7 +2,14 @@ import MagicBox from '@components/MagicBox';
 import ShareLinkButton from '@components/ShareLinkButton';
 import { parseOptionsForChips } from '@functions/parseOptions';
 import { buildShareLink } from '@functions/shareLink';
-import React, { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  Suspense,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useLocale } from '../../contexts/LocaleContext';
 import type { HistoryItem } from '../../hooks/useSearchHistory';
 import { useSearchHistory } from '../../hooks/useSearchHistory';
@@ -40,6 +47,9 @@ const MagicBoxPage = (): React.JSX.Element => {
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const lastRecordedRef = useRef<string>('');
+  // caret index to restore after a programmatic (non-typing) value update;
+  // null means "leave the caret where the browser puts it" (normal typing).
+  const pendingCaretRef = useRef<number | null>(null);
 
   const { history, addEntry, removeEntry, clearHistory } = useSearchHistory();
 
@@ -69,14 +79,39 @@ const MagicBoxPage = (): React.JSX.Element => {
     [userInput],
   );
 
-  const handleScannedInput = (value: string) => {
+  // After a programmatic value replacement, the controlled textarea re-renders
+  // with the new value but the browser would otherwise leave the caret at a
+  // stale offset. Restore the intended caret position once the DOM reflects
+  // the new value, using the ref only for selection (never as the value
+  // source). Runs synchronously before paint to avoid a visible caret jump.
+  // userInput is the intended trigger: the effect reads refs but must re-run
+  // after every value commit so the caret is restored against the freshly
+  // rendered DOM value.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: userInput is a deliberate trigger, not a read dependency
+  useLayoutEffect(() => {
+    const caret = pendingCaretRef.current;
+    if (caret === null) return;
+    pendingCaretRef.current = null;
+    const el = inputRef.current;
+    if (!el) return;
+    const pos = Math.min(caret, el.value.length);
+    el.setSelectionRange(pos, pos);
+  }, [userInput]);
+
+  // Replaces the whole input programmatically (QR scan, history pick, paste
+  // back). Marks the caret to land at the end of the inserted text so the
+  // next keystroke continues naturally.
+  const replaceInput = (value: string) => {
+    pendingCaretRef.current = value.length;
     setUserInput(value);
-    if (inputRef.current) inputRef.current.value = value;
+  };
+
+  const handleScannedInput = (value: string) => {
+    replaceInput(value);
   };
 
   const handleHistorySelect = (input: string) => {
-    setUserInput(input);
-    if (inputRef.current) inputRef.current.value = input;
+    replaceInput(input);
     setHistoryOpen(false);
     inputRef.current?.focus();
   };
@@ -221,8 +256,7 @@ const MagicBoxPage = (): React.JSX.Element => {
             <MagicBox
               input={magicIn}
               onPasteInput={(val: string) => {
-                setUserInput(val);
-                if (inputRef.current) inputRef.current.value = val;
+                replaceInput(val);
               }}
               resetTrigger={resetCounter}
             />


### PR DESCRIPTION
## Problem (#233)

`src/pages/MagicBox/MagicBoxPage.tsx` renders the textarea as a controlled component (`value={userInput}` + `onChange`), but several callbacks bypassed React state and wrote `inputRef.current.value = ...` directly:

- QR-scan result (`handleScannedInput`)
- history selection (`handleHistorySelect`)
- paste-back from output (`onPasteInput`)

Writing the DOM value directly while React owns the value desynchronizes React state from the DOM and causes caret jumping.

## Fix

All programmatic value changes now flow through `setUserInput` (the single source of truth) via one `replaceInput(value)` helper. No code writes `inputRef.current.value` anymore. The ref is still used for `focus()` and `setSelectionRange()` only — never as a value source. The textarea stays a controlled component (no uncontrolled patterns introduced).

The URL query-param load was already state-driven via the `useState` initializer (`?input` / `?i`), so it needed no DOM write; it is covered by tests to lock that in.

### Caret handling

Replacing the full input via `setUserInput` triggers a controlled re-render, after which the browser would leave the caret at a stale offset (the source of the jump). To reproduce the intended UX correctly under controlled state:

1. `replaceInput` records the desired caret index in a `pendingCaretRef` (set to `value.length` so the caret lands at the end of the inserted text, the natural continuation point for a full replacement) and calls `setUserInput`.
2. A `useLayoutEffect` keyed on `userInput` runs **after the new value is committed to the DOM but before paint**, reads `pendingCaretRef`, clamps it to the current value length, and calls `el.setSelectionRange(pos, pos)`. Using a layout effect (rather than `requestAnimationFrame`) avoids a visible one-frame caret flicker.
3. `pendingCaretRef` is reset to `null` after each restore; `null` means "normal typing — leave the caret where the browser puts it", so ordinary `onChange` keystrokes are untouched.

The `useExhaustiveDependencies` biome rule flags `userInput` as unread inside the effect; it is a deliberate *trigger* dependency (the effect must re-run on every committed value), documented with a narrow `biome-ignore`.

Option-chip stripping (`parseOptionsForChips`) and all other behavior are unchanged.

## Tests

Added `src/pages/MagicBox/MagicBoxPage.test.tsx` (React Testing Library, matching repo patterns). The heavy `MagicBox` and `QRCodeReader` children are mocked so the page is tested in isolation without pulling in `SettingsContext` / WASM box sources. Coverage:

- `?input` and short `?i` query-param prefill populate state on mount
- controlled typing keeps value in sync
- QR-scan result updates state **and** places the caret at end
- paste-back updates state **and** places the caret at end
- value is driven by state (clearing to empty works), proving no out-of-band DOM mutation

## Verification

- `bun run lint` — clean
- `bunx tsc --noEmit` — clean
- `CI=true bun run test run` — 25 files, 209 tests passing (no WASM skips needed; build was present)

Closes #233

https://claude.ai/code/session_016Q7UoTqHa1EiTAheBeyaZh