### PR TITLE
feat: add Color converter box (hex/rgb/hsl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Based on matching methods, we can roughly classify Boxes into two types:
 - Cmd/Ctrl + Enter: copy the selected Box output and paste it into the input field (recalculates results)
 
 <details>
+<summary> <b>ColorBox</b> </summary>
+
+| match rule                          | description                                        | example                  |
+| ----------------------------------- | -------------------------------------------------- | ------------------------ |
+| hex color (`#RGB`, `#RRGGBB`, `#RRGGBBAA`) | convert to HEX, RGB, and HSL              | `#ff6347`                |
+| `rgb()` / `rgba()`                  | convert to HEX, RGB, and HSL (alpha preserved)     | `rgb(255, 99, 71)`       |
+| `hsl()` / `hsla()`                  | convert to HEX, RGB, and HSL (alpha preserved)     | `hsl(9, 100%, 64%)`      |
+
+</details>
+
+<details>
 <summary> <b>Base64Box</b> </summary>
 
 | match rule                    | description   | output                     |

--- a/src/modules/boxSources/ColorBoxSource.ts
+++ b/src/modules/boxSources/ColorBoxSource.ts
@@ -1,0 +1,240 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder } from '@modules/Box';
+
+const PriorityColorBox = 80;
+
+interface RGBA {
+  r: number;
+  g: number;
+  b: number;
+  a: number | null;
+}
+
+// parse 3/6/8-digit hex: #RGB, #RRGGBB, #RRGGBBAA
+function parseHex(input: string): RGBA | null {
+  const m = /^#([0-9a-fA-F]{3,8})$/.exec(input);
+  if (!m) return null;
+  const h = m[1];
+
+  if (h.length === 3) {
+    return {
+      r: parseInt(h[0] + h[0], 16),
+      g: parseInt(h[1] + h[1], 16),
+      b: parseInt(h[2] + h[2], 16),
+      a: null,
+    };
+  }
+  if (h.length === 6) {
+    return {
+      r: parseInt(h.slice(0, 2), 16),
+      g: parseInt(h.slice(2, 4), 16),
+      b: parseInt(h.slice(4, 6), 16),
+      a: null,
+    };
+  }
+  if (h.length === 8) {
+    return {
+      r: parseInt(h.slice(0, 2), 16),
+      g: parseInt(h.slice(2, 4), 16),
+      b: parseInt(h.slice(4, 6), 16),
+      a: Math.round((parseInt(h.slice(6, 8), 16) / 255) * 100) / 100,
+    };
+  }
+  return null;
+}
+
+// parse rgb(r, g, b) or rgba(r, g, b, a)
+function parseRgb(input: string): RGBA | null {
+  const m =
+    /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*([\d.]+))?\s*\)$/.exec(
+      input,
+    );
+  if (!m) return null;
+
+  const r = Number(m[1]);
+  const g = Number(m[2]);
+  const b = Number(m[3]);
+  if (r > 255 || g > 255 || b > 255) return null;
+
+  const a = m[4] !== undefined ? Number(m[4]) : null;
+  if (a !== null && (a < 0 || a > 1)) return null;
+
+  return { r, g, b, a };
+}
+
+// parse hsl(h, s%, l%) or hsla(h, s%, l%, a)
+function parseHsl(input: string): RGBA | null {
+  const m =
+    /^hsla?\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%(?:\s*,\s*([\d.]+))?\s*\)$/.exec(
+      input,
+    );
+  if (!m) return null;
+
+  const h = Number(m[1]);
+  const s = Number(m[2]);
+  const l = Number(m[3]);
+  if (h < 0 || h >= 360 || s < 0 || s > 100 || l < 0 || l > 100) return null;
+
+  const a = m[4] !== undefined ? Number(m[4]) : null;
+  if (a !== null && (a < 0 || a > 1)) return null;
+
+  return { ...hslToRgb(h, s, l), a };
+}
+
+// convert hsl (h deg, s/l percent) to rgb integers 0-255
+export function hslToRgb(
+  h: number,
+  s: number,
+  l: number,
+): { r: number; g: number; b: number } {
+  const sn = s / 100;
+  const ln = l / 100;
+  const c = (1 - Math.abs(2 * ln - 1)) * sn;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = ln - c / 2;
+
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  if (h < 60) {
+    [r, g, b] = [c, x, 0];
+  } else if (h < 120) {
+    [r, g, b] = [x, c, 0];
+  } else if (h < 180) {
+    [r, g, b] = [0, c, x];
+  } else if (h < 240) {
+    [r, g, b] = [0, x, c];
+  } else if (h < 300) {
+    [r, g, b] = [x, 0, c];
+  } else {
+    [r, g, b] = [c, 0, x];
+  }
+
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255),
+  };
+}
+
+// convert rgb integers 0-255 to hsl (h deg, s/l percent)
+export function rgbToHsl(
+  r: number,
+  g: number,
+  b: number,
+): { h: number; s: number; l: number } {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rn) {
+      h = 60 * (((gn - bn) / delta) % 6);
+    } else if (max === gn) {
+      h = 60 * ((bn - rn) / delta + 2);
+    } else {
+      h = 60 * ((rn - gn) / delta + 4);
+    }
+  }
+  if (h < 0) h += 360;
+
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  return {
+    h: Math.round(h),
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+}
+
+// format rgba to 6 or 8-digit lowercase hex
+export function toHex(rgba: RGBA): string {
+  const hex = (n: number) => n.toString(16).padStart(2, '0');
+  const base = `#${hex(rgba.r)}${hex(rgba.g)}${hex(rgba.b)}`;
+  if (rgba.a === null) return base;
+  const alphaInt = Math.round(rgba.a * 255);
+  return `${base}${hex(alphaInt)}`;
+}
+
+// format rgba as rgb() or rgba()
+export function toRgbString(rgba: RGBA): string {
+  if (rgba.a === null) return `rgb(${rgba.r}, ${rgba.g}, ${rgba.b})`;
+  return `rgba(${rgba.r}, ${rgba.g}, ${rgba.b}, ${rgba.a})`;
+}
+
+// format rgba as hsl() or hsla()
+export function toHslString(rgba: RGBA): string {
+  const { h, s, l } = rgbToHsl(rgba.r, rgba.g, rgba.b);
+  if (rgba.a === null) return `hsl(${h}, ${s}%, ${l}%)`;
+  return `hsla(${h}, ${s}%, ${l}%, ${rgba.a})`;
+}
+
+function parseColor(input: string): RGBA | null {
+  return parseHex(input) ?? parseRgb(input) ?? parseHsl(input);
+}
+
+interface Match {
+  rgba: RGBA;
+}
+
+export const ColorBoxSource = {
+  name: 'Color',
+  description:
+    'Convert a color (hex, rgb/rgba, hsl/hsla) between hex, RGB, and HSL formats.',
+  defaultInput: '#ff6347',
+  tag: '🎨',
+  kind: 'Convert',
+  priority: PriorityColorBox,
+
+  checkMatch(input: string): Match | undefined {
+    const normalized = trim(input);
+    if (!normalized) return undefined;
+
+    const rgba = parseColor(normalized.toLowerCase());
+    if (!rgba) return undefined;
+    return { rgba };
+  },
+
+  async generateBoxes(
+    input: string,
+    _options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const match = this.checkMatch(input);
+    if (!match) return [];
+
+    const { rgba } = match;
+
+    const hexStr = toHex(rgba);
+    const rgbStr = toRgbString(rgba);
+    const hslStr = toHslString(rgba);
+
+    return [
+      new BoxBuilder('HEX', hexStr)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+      new BoxBuilder('RGB', rgbStr)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+      new BoxBuilder('HSL', hslStr)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ColorBoxSource;

--- a/src/modules/boxSources/__test__/ColorBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ColorBoxSource.test.ts
@@ -1,0 +1,260 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import {
+  ColorBoxSource,
+  hslToRgb,
+  rgbToHsl,
+  toHex,
+  toHslString,
+  toRgbString,
+} from '../ColorBoxSource';
+
+// ─── conversion helper unit tests ─────────────────────────────────────────────
+
+describe('hslToRgb', () => {
+  it('converts red hsl(0, 100%, 50%) to rgb(255, 0, 0)', () => {
+    expect(hslToRgb(0, 100, 50)).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it('converts green hsl(120, 100%, 50%) to rgb(0, 255, 0)', () => {
+    expect(hslToRgb(120, 100, 50)).toEqual({ r: 0, g: 255, b: 0 });
+  });
+
+  it('converts blue hsl(240, 100%, 50%) to rgb(0, 0, 255)', () => {
+    expect(hslToRgb(240, 100, 50)).toEqual({ r: 0, g: 0, b: 255 });
+  });
+
+  it('converts white hsl(0, 0%, 100%) to rgb(255, 255, 255)', () => {
+    expect(hslToRgb(0, 0, 100)).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it('converts black hsl(0, 0%, 0%) to rgb(0, 0, 0)', () => {
+    expect(hslToRgb(0, 0, 0)).toEqual({ r: 0, g: 0, b: 0 });
+  });
+});
+
+describe('rgbToHsl', () => {
+  it('converts rgb(255, 0, 0) to hsl(0, 100%, 50%)', () => {
+    expect(rgbToHsl(255, 0, 0)).toEqual({ h: 0, s: 100, l: 50 });
+  });
+
+  it('converts rgb(0, 255, 0) to hsl(120, 100%, 50%)', () => {
+    expect(rgbToHsl(0, 255, 0)).toEqual({ h: 120, s: 100, l: 50 });
+  });
+
+  it('converts rgb(0, 0, 255) to hsl(240, 100%, 50%)', () => {
+    expect(rgbToHsl(0, 0, 255)).toEqual({ h: 240, s: 100, l: 50 });
+  });
+
+  it('converts white rgb(255, 255, 255) to hsl(0, 0%, 100%)', () => {
+    expect(rgbToHsl(255, 255, 255)).toEqual({ h: 0, s: 0, l: 100 });
+  });
+
+  it('converts black rgb(0, 0, 0) to hsl(0, 0%, 0%)', () => {
+    expect(rgbToHsl(0, 0, 0)).toEqual({ h: 0, s: 0, l: 0 });
+  });
+
+  it('round-trips hsl->rgb->hsl for tomato (hsl(9,100%,64%))', () => {
+    const { r, g, b } = hslToRgb(9, 100, 64);
+    const { h, s, l } = rgbToHsl(r, g, b);
+    // allow ±1 rounding error
+    expect(Math.abs(h - 9)).toBeLessThanOrEqual(1);
+    expect(Math.abs(s - 100)).toBeLessThanOrEqual(1);
+    expect(Math.abs(l - 64)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('toHex', () => {
+  it('formats rgb(255,0,0) as #ff0000', () => {
+    expect(toHex({ r: 255, g: 0, b: 0, a: null })).toBe('#ff0000');
+  });
+
+  it('includes alpha channel when present', () => {
+    expect(toHex({ r: 255, g: 0, b: 0, a: 0.5 })).toBe('#ff000080');
+  });
+
+  it('formats fully transparent as #00000000', () => {
+    expect(toHex({ r: 0, g: 0, b: 0, a: 0 })).toBe('#00000000');
+  });
+});
+
+describe('toRgbString', () => {
+  it('formats without alpha as rgb()', () => {
+    expect(toRgbString({ r: 255, g: 0, b: 0, a: null })).toBe('rgb(255, 0, 0)');
+  });
+
+  it('formats with alpha as rgba()', () => {
+    expect(toRgbString({ r: 255, g: 0, b: 0, a: 0.5 })).toBe(
+      'rgba(255, 0, 0, 0.5)',
+    );
+  });
+});
+
+describe('toHslString', () => {
+  it('formats without alpha as hsl()', () => {
+    expect(toHslString({ r: 255, g: 0, b: 0, a: null })).toBe(
+      'hsl(0, 100%, 50%)',
+    );
+  });
+
+  it('formats with alpha as hsla()', () => {
+    expect(toHslString({ r: 255, g: 0, b: 0, a: 0.5 })).toBe(
+      'hsla(0, 100%, 50%, 0.5)',
+    );
+  });
+});
+
+// ─── ColorBoxSource.checkMatch ────────────────────────────────────────────────
+
+describe('ColorBoxSource.checkMatch', () => {
+  it('returns undefined for empty input', () => {
+    expect(ColorBoxSource.checkMatch('')).toBeUndefined();
+  });
+
+  it('returns undefined for non-color text', () => {
+    expect(ColorBoxSource.checkMatch('hello world')).toBeUndefined();
+    expect(ColorBoxSource.checkMatch('12345')).toBeUndefined();
+    expect(ColorBoxSource.checkMatch('uuid')).toBeUndefined();
+  });
+
+  it('parses 6-digit hex #ff0000', () => {
+    const m = ColorBoxSource.checkMatch('#ff0000');
+    expect(m).toBeDefined();
+    expect(m?.rgba).toMatchObject({ r: 255, g: 0, b: 0, a: null });
+  });
+
+  it('parses 3-digit hex #f00 (shorthand red)', () => {
+    const m = ColorBoxSource.checkMatch('#f00');
+    expect(m).toBeDefined();
+    expect(m?.rgba).toMatchObject({ r: 255, g: 0, b: 0, a: null });
+  });
+
+  it('parses 8-digit hex with alpha #ff000080', () => {
+    const m = ColorBoxSource.checkMatch('#ff000080');
+    expect(m).toBeDefined();
+    expect(m?.rgba.r).toBe(255);
+    expect(m?.rgba.g).toBe(0);
+    expect(m?.rgba.b).toBe(0);
+    expect(m?.rgba.a).toBeCloseTo(0.5, 2);
+  });
+
+  it('parses rgb(255, 0, 0)', () => {
+    const m = ColorBoxSource.checkMatch('rgb(255, 0, 0)');
+    expect(m).toBeDefined();
+    expect(m?.rgba).toMatchObject({ r: 255, g: 0, b: 0, a: null });
+  });
+
+  it('parses rgba(255, 0, 0, 0.5)', () => {
+    const m = ColorBoxSource.checkMatch('rgba(255, 0, 0, 0.5)');
+    expect(m).toBeDefined();
+    expect(m?.rgba).toMatchObject({ r: 255, g: 0, b: 0, a: 0.5 });
+  });
+
+  it('parses hsl(0, 100%, 50%)', () => {
+    const m = ColorBoxSource.checkMatch('hsl(0, 100%, 50%)');
+    expect(m).toBeDefined();
+    expect(m?.rgba).toMatchObject({ r: 255, g: 0, b: 0, a: null });
+  });
+
+  it('parses hsla(0, 100%, 50%, 0.5)', () => {
+    const m = ColorBoxSource.checkMatch('hsla(0, 100%, 50%, 0.5)');
+    expect(m).toBeDefined();
+    expect(m?.rgba).toMatchObject({ r: 255, g: 0, b: 0, a: 0.5 });
+  });
+
+  it('rejects rgb with out-of-range channel', () => {
+    expect(ColorBoxSource.checkMatch('rgb(300, 0, 0)')).toBeUndefined();
+  });
+
+  it('rejects hsl with invalid saturation', () => {
+    expect(ColorBoxSource.checkMatch('hsl(0, 150%, 50%)')).toBeUndefined();
+  });
+
+  it('is case-insensitive for hex', () => {
+    const m = ColorBoxSource.checkMatch('#FF0000');
+    expect(m).toBeDefined();
+    expect(m?.rgba).toMatchObject({ r: 255, g: 0, b: 0, a: null });
+  });
+
+  it('handles leading/trailing whitespace', () => {
+    const m = ColorBoxSource.checkMatch('  #ff0000  ');
+    expect(m).toBeDefined();
+  });
+});
+
+// ─── ColorBoxSource.generateBoxes ────────────────────────────────────────────
+
+describe('ColorBoxSource.generateBoxes', () => {
+  it('returns empty array for non-color input', async () => {
+    const boxes = await ColorBoxSource.generateBoxes('not a color');
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('produces 3 boxes (HEX, RGB, HSL) for #ff0000', async () => {
+    const boxes = await ColorBoxSource.generateBoxes('#ff0000');
+    expect(boxes).toHaveLength(3);
+
+    const names = boxes.map((b) => b.props.name);
+    expect(names).toContain('HEX');
+    expect(names).toContain('RGB');
+    expect(names).toContain('HSL');
+  });
+
+  it('round-trip: #ff0000 outputs match expected values', async () => {
+    const boxes = await ColorBoxSource.generateBoxes('#ff0000');
+    const byName = Object.fromEntries(
+      boxes.map((b) => [b.props.name, b.props.plaintextOutput]),
+    );
+
+    expect(byName.HEX).toBe('#ff0000');
+    expect(byName.RGB).toBe('rgb(255, 0, 0)');
+    expect(byName.HSL).toBe('hsl(0, 100%, 50%)');
+  });
+
+  it('preserves alpha channel in all three formats for rgba input', async () => {
+    const boxes = await ColorBoxSource.generateBoxes('rgba(255, 0, 0, 0.5)');
+    expect(boxes).toHaveLength(3);
+    const byName = Object.fromEntries(
+      boxes.map((b) => [b.props.name, b.props.plaintextOutput]),
+    );
+
+    expect(byName.HEX).toBe('#ff000080');
+    expect(byName.RGB).toBe('rgba(255, 0, 0, 0.5)');
+    expect(byName.HSL).toBe('hsla(0, 100%, 50%, 0.5)');
+  });
+
+  it('round-trip: hsl(120, 100%, 50%) converts to green', async () => {
+    const boxes = await ColorBoxSource.generateBoxes('hsl(120, 100%, 50%)');
+    const byName = Object.fromEntries(
+      boxes.map((b) => [b.props.name, b.props.plaintextOutput]),
+    );
+
+    expect(byName.HEX).toBe('#00ff00');
+    expect(byName.RGB).toBe('rgb(0, 255, 0)');
+    expect(byName.HSL).toBe('hsl(120, 100%, 50%)');
+  });
+
+  it('each box uses DefaultBoxTemplate', async () => {
+    const boxes = await ColorBoxSource.generateBoxes('#00ff00');
+    for (const box of boxes) {
+      expect(box.boxTemplate).toBe(DefaultBoxTemplate);
+    }
+  });
+
+  it('each box carries the correct priority', async () => {
+    const boxes = await ColorBoxSource.generateBoxes('#0000ff');
+    for (const box of boxes) {
+      expect(box.props.priority).toBe(80);
+    }
+  });
+
+  it('3-digit shorthand #f00 is equivalent to #ff0000', async () => {
+    const boxes = await ColorBoxSource.generateBoxes('#f00');
+    const byName = Object.fromEntries(
+      boxes.map((b) => [b.props.name, b.props.plaintextOutput]),
+    );
+    expect(byName.HEX).toBe('#ff0000');
+    expect(byName.RGB).toBe('rgb(255, 0, 0)');
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -2,6 +2,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -26,6 +27,7 @@ import WordCountBoxSource from './WordCountBoxSource';
 // catch-all encoders (Base64 Encode, Word Count) sit at the bottom so they
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
+  ColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,


### PR DESCRIPTION
## Summary

- Adds `ColorBoxSource` that detects a color in the whole-input (hex `#RGB`/`#RRGGBB`/`#RRGGBBAA`, `rgb()`/`rgba()`, `hsl()`/`hsla()`) and outputs three boxes: **HEX**, **RGB**, **HSL**
- Alpha channel is preserved across all three output formats
- Pure synchronous conversion helpers (`hslToRgb`, `rgbToHsl`, `toHex`, `toRgbString`, `toHslString`) — zero new dependencies
- Registered near the top of `boxSources` (high-signal, specific matcher), priority 80
- 39 unit tests: round-trip conversions, known values, alpha cases, invalid/non-color input returns `[]`
- README tools-table entry added

## Test plan

- [x] `bun run lint` — 0 errors/warnings
- [x] `CI=true bun run test run src/modules/boxSources/__test__/ColorBoxSource.test.ts` — 39/39 passed
- [x] `bunx tsc --noEmit` — clean

https://claude.ai/code/session_016Q7UoTqHa1EiTAheBeyaZh