### PR TITLE
feat: add Password generator box

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,24 @@ full design and roadmap, and
 </details>
 
 <details>
+<summary> <b>PasswordBox</b> </summary>
+
+| match rule                                    | description                                        | output |
+| --------------------------------------------- | -------------------------------------------------- | ------ |
+| contains option `password`, `pwd`, or `pass`  | generate 3 secure random password candidates       |        |
+
+| options                    | description                                      | example           |
+| -------------------------- | ------------------------------------------------ | ----------------- |
+| `password`, `pwd`, `pass`  | trigger; optionally set length (`::password=24`) | `::password=24`   |
+| `len`                      | password length (default: 16, range: 4–256)      | `::len=32`        |
+| `nosymbols`                | exclude symbol characters                        | `::nosymbols`     |
+| `nonumbers`                | exclude numeric characters                       | `::nonumbers`     |
+| `nolower`                  | exclude lowercase letters                        | `::nolower`       |
+| `noupper`                  | exclude uppercase letters                        | `::noupper`       |
+
+</details>
+
+<details>
 <summary> <b>ShortenURLBox</b> </summary>
 
 | match rule                          | description            | output                   |

--- a/src/modules/boxSources/PasswordBoxSource.ts
+++ b/src/modules/boxSources/PasswordBoxSource.ts
@@ -1,0 +1,192 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const PriorityPasswordBox = 10;
+const DEFAULT_LENGTH = 16;
+const MIN_LENGTH = 4;
+const MAX_LENGTH = 256;
+const CANDIDATE_COUNT = 3;
+
+const CHARSET_UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const CHARSET_LOWER = 'abcdefghijklmnopqrstuvwxyz';
+const CHARSET_NUMBERS = '0123456789';
+const CHARSET_SYMBOLS = '!@#$%^&*()-_=+[]{}|;:,.<>?';
+
+interface CharClasses {
+  upper: boolean;
+  lower: boolean;
+  numbers: boolean;
+  symbols: boolean;
+}
+
+/** Picks `count` unbiased random bytes from the charset using rejection sampling. */
+function generatePassword(length: number, classes: CharClasses): string {
+  const charset =
+    (classes.upper ? CHARSET_UPPER : '') +
+    (classes.lower ? CHARSET_LOWER : '') +
+    (classes.numbers ? CHARSET_NUMBERS : '') +
+    (classes.symbols ? CHARSET_SYMBOLS : '');
+
+  if (charset.length === 0) {
+    return '';
+  }
+
+  // rejection-sampling upper bound: largest multiple of charset.length <= 256
+  const ceiling = Math.floor(256 / charset.length) * charset.length;
+  const chars: string[] = [];
+
+  while (chars.length < length) {
+    const buf = new Uint8Array(length - chars.length + 16);
+    crypto.getRandomValues(buf);
+    for (const byte of buf) {
+      if (chars.length >= length) break;
+      if (byte < ceiling) {
+        chars.push(charset[byte % charset.length]);
+      }
+    }
+  }
+
+  // guarantee at least one character from each enabled class by replacing
+  // random positions — shuffle first so the mandatory chars are spread evenly
+  const shuffleBuf = new Uint32Array(chars.length);
+  crypto.getRandomValues(shuffleBuf);
+  chars.sort(
+    (_, __) => shuffleBuf[chars.indexOf(_)] - shuffleBuf[chars.indexOf(__)],
+  );
+
+  const mandatory: string[] = [];
+  const classCharsets: string[] = [];
+  if (classes.upper) classCharsets.push(CHARSET_UPPER);
+  if (classes.lower) classCharsets.push(CHARSET_LOWER);
+  if (classes.numbers) classCharsets.push(CHARSET_NUMBERS);
+  if (classes.symbols) classCharsets.push(CHARSET_SYMBOLS);
+
+  // pick one guaranteed char per enabled class
+  const pickBuf = new Uint8Array(classCharsets.length * 8);
+  crypto.getRandomValues(pickBuf);
+  for (let i = 0; i < classCharsets.length; i++) {
+    const cs = classCharsets[i];
+    const ceiling2 = Math.floor(256 / cs.length) * cs.length;
+    let picked: string | null = null;
+    for (let j = i * 8; j < (i + 1) * 8; j++) {
+      const byte = pickBuf[j];
+      if (byte < ceiling2) {
+        picked = cs[byte % cs.length];
+        break;
+      }
+    }
+    // fallback: just take first char of class (extremely rare rejection-sampling miss)
+    mandatory.push(picked ?? cs[0]);
+  }
+
+  // replace the first N positions with guaranteed chars
+  for (let i = 0; i < mandatory.length; i++) {
+    chars[i] = mandatory[i];
+  }
+
+  // final shuffle so mandatory chars don't cluster at the start
+  const finalBuf = new Uint32Array(chars.length);
+  crypto.getRandomValues(finalBuf);
+  for (let i = chars.length - 1; i > 0; i--) {
+    const j = finalBuf[i] % (i + 1);
+    [chars[i], chars[j]] = [chars[j], chars[i]];
+  }
+
+  return chars.join('');
+}
+
+function parseLength(options: BoxOptions): number {
+  // check ::password=N / ::pwd=N / ::pass=N first, then fall back to ::len=N
+  const triggerVal = extractOptionKeys(options, 'password', 'pwd', 'pass');
+  if (typeof triggerVal === 'string' && triggerVal !== '') {
+    const parsed = Number.parseInt(triggerVal, 10);
+    if (!Number.isNaN(parsed)) {
+      return Math.min(MAX_LENGTH, Math.max(MIN_LENGTH, parsed));
+    }
+  }
+
+  const lenVal = extractOptionKeys(options, 'len');
+  if (typeof lenVal === 'string' && lenVal !== '') {
+    const parsed = Number.parseInt(lenVal, 10);
+    if (!Number.isNaN(parsed)) {
+      return Math.min(MAX_LENGTH, Math.max(MIN_LENGTH, parsed));
+    }
+  }
+
+  return DEFAULT_LENGTH;
+}
+
+export const PasswordBoxSource = {
+  name: 'Password Generator',
+  description: 'Generates a secure random password.',
+  defaultInput: '::password',
+  tag: '🔑',
+  kind: 'Generate',
+  priority: PriorityPasswordBox,
+
+  async generateBoxes(_input: string, options: BoxOptions): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'password', 'pwd', 'pass')) {
+      return [];
+    }
+
+    if (
+      typeof crypto === 'undefined' ||
+      typeof crypto.getRandomValues !== 'function'
+    ) {
+      return [
+        new BoxBuilder(
+          'Password Generator',
+          'Error: crypto.getRandomValues is unavailable. A secure context (HTTPS or localhost) is required.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const length = parseLength(options);
+
+    const classes: CharClasses = {
+      upper: !hasOptionKeys(options, 'noupper'),
+      lower: !hasOptionKeys(options, 'nolower'),
+      numbers: !hasOptionKeys(options, 'nonumbers'),
+      symbols: !hasOptionKeys(options, 'nosymbols'),
+    };
+
+    if (
+      !classes.upper &&
+      !classes.lower &&
+      !classes.numbers &&
+      !classes.symbols
+    ) {
+      return [
+        new BoxBuilder(
+          'Password Generator',
+          'Error: all character classes are excluded. Enable at least one class.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const boxes: Box[] = [];
+    for (let i = 0; i < CANDIDATE_COUNT; i++) {
+      const password = generatePassword(length, classes);
+      boxes.push(
+        new BoxBuilder('Password Generator', password)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default PasswordBoxSource;

--- a/src/modules/boxSources/__test__/PasswordBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PasswordBoxSource.test.ts
@@ -1,0 +1,231 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { PasswordBoxSource } from '../PasswordBoxSource';
+
+const UPPERCASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const LOWERCASE = 'abcdefghijklmnopqrstuvwxyz';
+const NUMBERS = '0123456789';
+const SYMBOLS = '!@#$%^&*()-_=+[]{}|;:,.<>?';
+
+describe('PasswordBoxSource', () => {
+  describe('generateBoxes — trigger conditions', () => {
+    it('should not trigger without a password option', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('anything', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should not trigger with unrelated options', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('anything', {
+        qr: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should trigger with ::password option', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: true,
+      });
+      expect(boxes).toHaveLength(3);
+    });
+
+    it('should trigger with ::pwd alias', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', { pwd: true });
+      expect(boxes).toHaveLength(3);
+    });
+
+    it('should trigger with ::pass alias', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', { pass: true });
+      expect(boxes).toHaveLength(3);
+    });
+  });
+
+  describe('generateBoxes — defaults', () => {
+    it('should produce 3 password boxes with default length 16', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: true,
+      });
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        expect(box.props.plaintextOutput).toHaveLength(16);
+        expect(box.props.name).toBe('Password Generator');
+        expect(box.boxTemplate).toBe(DefaultBoxTemplate);
+      }
+    });
+  });
+
+  describe('generateBoxes — length control', () => {
+    it('should use length from ::password=N value', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: '24',
+      });
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        expect(box.props.plaintextOutput).toHaveLength(24);
+      }
+    });
+
+    it('should use length from ::pwd=N value', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', { pwd: '20' });
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        expect(box.props.plaintextOutput).toHaveLength(20);
+      }
+    });
+
+    it('should use length from ::len=N option', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: true,
+        len: '20',
+      });
+      // ::password=true (boolean) so len fallback is used
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        expect(box.props.plaintextOutput).toHaveLength(20);
+      }
+    });
+
+    it('should clamp length to minimum 4', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: '1',
+      });
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        expect(box.props.plaintextOutput).toHaveLength(4);
+      }
+    });
+
+    it('should clamp length to maximum 256', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: '999',
+      });
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        expect(box.props.plaintextOutput).toHaveLength(256);
+      }
+    });
+  });
+
+  describe('generateBoxes — character class toggles', () => {
+    it('should exclude symbols when ::nosymbols is set', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: true,
+        nosymbols: true,
+      });
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        for (const ch of box.props.plaintextOutput) {
+          expect(SYMBOLS).not.toContain(ch);
+        }
+      }
+    });
+
+    it('should exclude numbers when ::nonumbers is set', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: true,
+        nonumbers: true,
+      });
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        for (const ch of box.props.plaintextOutput) {
+          expect(NUMBERS).not.toContain(ch);
+        }
+      }
+    });
+
+    it('should exclude lowercase when ::nolower is set', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: true,
+        nolower: true,
+      });
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        for (const ch of box.props.plaintextOutput) {
+          expect(LOWERCASE).not.toContain(ch);
+        }
+      }
+    });
+
+    it('should exclude uppercase when ::noupper is set', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: true,
+        noupper: true,
+      });
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        for (const ch of box.props.plaintextOutput) {
+          expect(UPPERCASE).not.toContain(ch);
+        }
+      }
+    });
+
+    it('should include at least one char from each enabled class', async () => {
+      // run several times to make it statistically reliable
+      for (let i = 0; i < 5; i++) {
+        const boxes = await PasswordBoxSource.generateBoxes('', {
+          password: true,
+        });
+        for (const box of boxes) {
+          const pw = box.props.plaintextOutput;
+          expect([...pw].some((c) => UPPERCASE.includes(c))).toBe(true);
+          expect([...pw].some((c) => LOWERCASE.includes(c))).toBe(true);
+          expect([...pw].some((c) => NUMBERS.includes(c))).toBe(true);
+          expect([...pw].some((c) => SYMBOLS.includes(c))).toBe(true);
+        }
+      }
+    });
+
+    it('should include at least one number when only numbers enabled', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: true,
+        nosymbols: true,
+        nolower: true,
+        noupper: true,
+      });
+      expect(boxes).toHaveLength(3);
+      for (const box of boxes) {
+        const pw = box.props.plaintextOutput;
+        expect([...pw].every((c) => NUMBERS.includes(c))).toBe(true);
+      }
+    });
+  });
+
+  describe('generateBoxes — error cases', () => {
+    it('should return error box when all classes are excluded', async () => {
+      const boxes = await PasswordBoxSource.generateBoxes('', {
+        password: true,
+        nosymbols: true,
+        nonumbers: true,
+        nolower: true,
+        noupper: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/error/i);
+    });
+
+    it('should return error box when crypto is unavailable', async () => {
+      const original = globalThis.crypto;
+      // @ts-expect-error — intentionally removing crypto to test the fallback
+      delete globalThis.crypto;
+
+      try {
+        const boxes = await PasswordBoxSource.generateBoxes('', {
+          password: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+      } finally {
+        globalThis.crypto = original;
+      }
+    });
+  });
+
+  describe('metadata', () => {
+    it('should have correct static properties', () => {
+      expect(PasswordBoxSource.name).toBe('Password Generator');
+      expect(PasswordBoxSource.tag).toBe('🔑');
+      expect(PasswordBoxSource.kind).toBe('Generate');
+      expect(PasswordBoxSource.defaultInput).toBe('::password');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -14,6 +14,7 @@ import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
@@ -40,6 +41,7 @@ export const boxSources = [
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
+  PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,


### PR DESCRIPTION
## Summary
- Adds `PasswordBoxSource` triggered by `::password` (aliases `::pwd`, `::pass`)
- Secure random generation via `crypto.getRandomValues` with rejection sampling (no modulo bias)
- Configurable length (`::password=N` or `::len=N`, default 16, range 4–256)
- Character-class toggles: `::nosymbols`, `::nonumbers`, `::nolower`, `::noupper`
- Generates 3 password candidates per invocation
- Falls back to an explanatory error box when secure context unavailable or all classes excluded
- Unit tests covering all options and edge cases
- README tools table updated

## Test plan
- [ ] `bun run lint` passes
- [ ] `CI=true bun run test run src/modules/boxSources/__test__/PasswordBoxSource.test.ts` passes
- [ ] `bunx tsc --noEmit` passes
- [ ] Manual: type `::password` — 3 passwords appear
- [ ] Manual: type `::password=32 ::nosymbols` — 3 passwords of length 32 with no symbols

https://claude.ai/code/session_016Q7UoTqHa1EiTAheBeyaZh