### PR TITLE
feat(settings): wire theme/density/locale/enter behavior + add timezone & server overrides

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { lazy, Suspense } from 'react';
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 
 import { LocaleProvider } from './contexts/LocaleContext';
+import { PreferencesProvider } from './contexts/PreferencesContext';
 import { SettingsProvider } from './contexts/SettingsContext';
 
 const MagicBoxPage = lazy(async () => import('@pages/MagicBox'));
@@ -14,20 +15,22 @@ const renderLoader = () => <div className="loader" />;
 
 const App = (): React.JSX.Element => (
   <LocaleProvider>
-    <SettingsProvider>
-      <Router>
-        <BaseLayout>
-          <Suspense fallback={renderLoader()}>
-            <Routes>
-              <Route element={<MagicBoxPage />} path="/" />
-              <Route element={<ToolsListPage />} path="/list" />
-              <Route element={<SettingsPage />} path="/settings" />
-            </Routes>
-          </Suspense>
-          <PwaUpdatePrompt />
-        </BaseLayout>
-      </Router>
-    </SettingsProvider>
+    <PreferencesProvider>
+      <SettingsProvider>
+        <Router>
+          <BaseLayout>
+            <Suspense fallback={renderLoader()}>
+              <Routes>
+                <Route element={<MagicBoxPage />} path="/" />
+                <Route element={<ToolsListPage />} path="/list" />
+                <Route element={<SettingsPage />} path="/settings" />
+              </Routes>
+            </Suspense>
+            <PwaUpdatePrompt />
+          </BaseLayout>
+        </Router>
+      </SettingsProvider>
+    </PreferencesProvider>
   </LocaleProvider>
 );
 

--- a/src/components/BoxTemplate/ShortenURLBoxTemplate.tsx
+++ b/src/components/BoxTemplate/ShortenURLBoxTemplate.tsx
@@ -1,5 +1,5 @@
 import { isString } from '@functions/helper';
-import env from '@global/env';
+import { getToolboxUrl } from '@functions/runtimePrefs';
 import type { BoxProps } from '@modules/Box';
 import { memo, useCallback, useEffect, useState } from 'react';
 
@@ -9,7 +9,8 @@ const ShortenURLBoxTemplate = memo(
 
     const getShortenURL = useCallback(
       async (inputURL: string): Promise<void> => {
-        const resp = await fetch(`${env.TOOLBOX_URL}/api/v1/surl`, {
+        const toolboxUrl = getToolboxUrl();
+        const resp = await fetch(`${toolboxUrl}/api/v1/surl`, {
           method: 'POST',
           body: JSON.stringify({ url: inputURL }),
         });
@@ -26,7 +27,7 @@ const ShortenURLBoxTemplate = memo(
           throw Error('The "Shorten URL" not response as expected');
         }
 
-        setShortURL(`${env.TOOLBOX_URL}/${result.shorten}`);
+        setShortURL(`${toolboxUrl}/${result.shorten}`);
       },
       [],
     );

--- a/src/components/MagicBox/index.tsx
+++ b/src/components/MagicBox/index.tsx
@@ -12,6 +12,7 @@ import React, {
   useState,
 } from 'react';
 import { useLocale } from '../../contexts/LocaleContext';
+import { usePreferences } from '../../contexts/PreferencesContext';
 import { useSettings } from '../../contexts/SettingsContext';
 import BoxCard from './BoxCard';
 import BoxModal from './BoxModal';
@@ -57,6 +58,9 @@ const MagicBox = ({
 
   const itemRefs = useRef<Map<number, HTMLDivElement | null>>(new Map());
   const { filteredBoxSources } = useSettings();
+  const {
+    prefs: { copyMode },
+  } = usePreferences();
 
   useEffect(() => {
     if (resetTrigger !== undefined) {
@@ -215,6 +219,8 @@ const MagicBox = ({
       }
 
       if (e.key === 'Enter' && !isCtrl) {
+        // honor the configured enter behavior: copy, copy & paste, or off.
+        if (copyMode === 'off') return;
         if (boxes.length === 0) return;
         const selected = boxes[selectedIndex];
         if (!selected) return;
@@ -228,13 +234,16 @@ const MagicBox = ({
         if (stdout) {
           copyText(stdout);
           selected.props.onClick(stdout);
+          if (copyMode === 'paste') {
+            pasteAsInput(stdout);
+          }
         }
       }
     };
 
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [boxes, selectedIndex, copyText, onPasteInput]);
+  }, [boxes, selectedIndex, copyText, onPasteInput, copyMode]);
 
   const setItemRef = useCallback(
     (idx: number) => (el: HTMLDivElement | null) => {

--- a/src/contexts/LocaleContext.tsx
+++ b/src/contexts/LocaleContext.tsx
@@ -1,3 +1,4 @@
+import { setRuntimePrefs } from '@functions/runtimePrefs';
 import {
   createContext,
   useCallback,
@@ -14,6 +15,10 @@ import {
   type Translations,
   translations,
 } from '../i18n';
+
+// translate the app locale code into the identifier cronstrue/i18n expects.
+const toRuntimeLocale = (locale: Locale): string =>
+  locale === 'tw' ? 'zh_TW' : 'en';
 
 interface LocaleContextType {
   locale: Locale;
@@ -43,6 +48,9 @@ export const LocaleProvider: React.FC<LocaleProviderProps> = ({ children }) => {
 
   useEffect(() => {
     document.documentElement.lang = locale === 'tw' ? 'zh-TW' : 'en';
+    // mirror the active locale into the runtime singleton so non-react box
+    // sources (e.g. cron) can emit localized output without an inline option.
+    setRuntimePrefs({ locale: toRuntimeLocale(locale) });
   }, [locale]);
 
   const setLocale = useCallback((next: Locale) => {

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -1,0 +1,165 @@
+import { patchLocalPrefs, readLocalPrefs } from '@functions/localPrefs';
+import { setRuntimePrefs } from '@functions/runtimePrefs';
+import {
+  DEFAULT_TIMEZONE_OFFSET,
+  isValidTimezoneOffset,
+} from '@functions/timezone';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+export type ThemePref = 'light' | 'dark' | 'system';
+export type DensityPref = 'comfortable' | 'compact';
+export type CopyModePref = 'enter' | 'paste' | 'off';
+
+export interface Prefs {
+  theme: ThemePref;
+  density: DensityPref;
+  // enter behavior: copy, copy & paste back, or do nothing.
+  copyMode: CopyModePref;
+  // anonymous telemetry opt-in.
+  analytics: boolean;
+  // default UTC offset (hours) for time-related boxes.
+  timezoneOffset: number;
+  // backend host overrides; blank means fall back to the env default.
+  toolboxUrl: string;
+  shortenUrl: string;
+}
+
+export const DEFAULT_PREFS: Prefs = {
+  theme: 'system',
+  density: 'comfortable',
+  copyMode: 'enter',
+  analytics: false,
+  timezoneOffset: DEFAULT_TIMEZONE_OFFSET,
+  toolboxUrl: '',
+  shortenUrl: '',
+};
+
+const isTheme = (value: unknown): value is ThemePref =>
+  value === 'light' || value === 'dark' || value === 'system';
+
+const isDensity = (value: unknown): value is DensityPref =>
+  value === 'comfortable' || value === 'compact';
+
+const isCopyMode = (value: unknown): value is CopyModePref =>
+  value === 'enter' || value === 'paste' || value === 'off';
+
+// validate that a runtime override is a usable http(s) url, or blank.
+export const isValidServerUrl = (value: string): boolean => {
+  if (value.trim() === '') return true;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export const loadPrefs = (): Prefs => {
+  const prefs = readLocalPrefs();
+  return {
+    theme: isTheme(prefs.theme) ? prefs.theme : DEFAULT_PREFS.theme,
+    density: isDensity(prefs.density) ? prefs.density : DEFAULT_PREFS.density,
+    copyMode: isCopyMode(prefs.copyMode)
+      ? prefs.copyMode
+      : DEFAULT_PREFS.copyMode,
+    analytics:
+      typeof prefs.analytics === 'boolean'
+        ? prefs.analytics
+        : DEFAULT_PREFS.analytics,
+    timezoneOffset:
+      typeof prefs.timezoneOffset === 'number' &&
+      isValidTimezoneOffset(prefs.timezoneOffset)
+        ? prefs.timezoneOffset
+        : DEFAULT_PREFS.timezoneOffset,
+    toolboxUrl:
+      typeof prefs.toolboxUrl === 'string' && isValidServerUrl(prefs.toolboxUrl)
+        ? prefs.toolboxUrl
+        : DEFAULT_PREFS.toolboxUrl,
+    shortenUrl:
+      typeof prefs.shortenUrl === 'string' && isValidServerUrl(prefs.shortenUrl)
+        ? prefs.shortenUrl
+        : DEFAULT_PREFS.shortenUrl,
+  };
+};
+
+// push the subset of prefs that plain (non-react) modules need to read.
+const syncRuntimePrefs = (prefs: Prefs): void => {
+  setRuntimePrefs({
+    timezoneOffset: prefs.timezoneOffset,
+    toolboxUrl: prefs.toolboxUrl,
+    shortenUrl: prefs.shortenUrl,
+    analytics: prefs.analytics,
+  });
+};
+
+// apply theme + density to the document root so css variables can react.
+const applyDocumentPrefs = (prefs: Prefs): void => {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.dataset.theme = prefs.theme;
+  root.dataset.density = prefs.density;
+};
+
+interface PreferencesContextType {
+  prefs: Prefs;
+  setPref: <K extends keyof Prefs>(key: K, value: Prefs[K]) => void;
+  resetPrefs: () => void;
+}
+
+const PreferencesContext = createContext<PreferencesContextType | undefined>(
+  undefined,
+);
+
+export const usePreferences = (): PreferencesContextType => {
+  const context = useContext(PreferencesContext);
+  if (!context) {
+    throw new Error('usePreferences must be used within a PreferencesProvider');
+  }
+  return context;
+};
+
+interface PreferencesProviderProps {
+  children: React.ReactNode;
+}
+
+export const PreferencesProvider: React.FC<PreferencesProviderProps> = ({
+  children,
+}) => {
+  const [prefs, setPrefs] = useState<Prefs>(loadPrefs);
+
+  // keep storage, document and the runtime singleton in sync with state.
+  useEffect(() => {
+    patchLocalPrefs(prefs);
+    applyDocumentPrefs(prefs);
+    syncRuntimePrefs(prefs);
+  }, [prefs]);
+
+  const setPref = useCallback(
+    <K extends keyof Prefs>(key: K, value: Prefs[K]) => {
+      setPrefs((p) => ({ ...p, [key]: value }));
+    },
+    [],
+  );
+
+  const resetPrefs = useCallback(() => {
+    setPrefs(DEFAULT_PREFS);
+  }, []);
+
+  const value = useMemo<PreferencesContextType>(
+    () => ({ prefs, setPref, resetPrefs }),
+    [prefs, setPref, resetPrefs],
+  );
+
+  return (
+    <PreferencesContext.Provider value={value}>
+      {children}
+    </PreferencesContext.Provider>
+  );
+};

--- a/src/contexts/__test__/PreferencesContext.test.tsx
+++ b/src/contexts/__test__/PreferencesContext.test.tsx
@@ -1,0 +1,97 @@
+import { LOCAL_PREFS_KEY } from '@functions/localPrefs';
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_PREFS,
+  isValidServerUrl,
+  loadPrefs,
+  PreferencesProvider,
+  usePreferences,
+} from '../PreferencesContext';
+
+const Probe = (): React.JSX.Element => {
+  const { prefs, setPref } = usePreferences();
+  return (
+    <div>
+      <span data-testid="tz">{prefs.timezoneOffset}</span>
+      <span data-testid="theme">{prefs.theme}</span>
+      <button onClick={() => setPref('timezoneOffset', -5)} type="button">
+        set-tz
+      </button>
+    </div>
+  );
+};
+
+describe('PreferencesContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('loadPrefs defaults', () => {
+    it('defaults timezoneOffset to +8 and servers to blank', () => {
+      const prefs = loadPrefs();
+      expect(prefs.timezoneOffset).toBe(8);
+      expect(prefs.toolboxUrl).toBe('');
+      expect(prefs.shortenUrl).toBe('');
+      expect(prefs).toEqual(DEFAULT_PREFS);
+    });
+
+    it('rejects out-of-range timezone and invalid server urls from storage', () => {
+      localStorage.setItem(
+        LOCAL_PREFS_KEY,
+        JSON.stringify({
+          timezoneOffset: 99,
+          toolboxUrl: 'not-a-url',
+          shortenUrl: 'ftp://nope.example',
+        }),
+      );
+      const prefs = loadPrefs();
+      expect(prefs.timezoneOffset).toBe(8);
+      expect(prefs.toolboxUrl).toBe('');
+      expect(prefs.shortenUrl).toBe('');
+    });
+
+    it('keeps valid stored values', () => {
+      localStorage.setItem(
+        LOCAL_PREFS_KEY,
+        JSON.stringify({
+          timezoneOffset: -3,
+          toolboxUrl: 'https://tool.example.com',
+        }),
+      );
+      const prefs = loadPrefs();
+      expect(prefs.timezoneOffset).toBe(-3);
+      expect(prefs.toolboxUrl).toBe('https://tool.example.com');
+    });
+  });
+
+  describe('isValidServerUrl', () => {
+    it('accepts blank and http(s) urls, rejects others', () => {
+      expect(isValidServerUrl('')).toBe(true);
+      expect(isValidServerUrl('   ')).toBe(true);
+      expect(isValidServerUrl('https://a.example')).toBe(true);
+      expect(isValidServerUrl('http://a.example')).toBe(true);
+      expect(isValidServerUrl('ftp://a.example')).toBe(false);
+      expect(isValidServerUrl('garbage')).toBe(false);
+    });
+  });
+
+  it('persists updates to mb_prefs storage', () => {
+    render(
+      <PreferencesProvider>
+        <Probe />
+      </PreferencesProvider>,
+    );
+
+    expect(screen.getByTestId('tz').textContent).toBe('8');
+
+    act(() => {
+      screen.getByText('set-tz').click();
+    });
+
+    expect(screen.getByTestId('tz').textContent).toBe('-5');
+    const stored = JSON.parse(localStorage.getItem(LOCAL_PREFS_KEY) ?? '{}');
+    expect(stored.timezoneOffset).toBe(-5);
+  });
+});

--- a/src/functions/__test__/runtimePrefs.test.ts
+++ b/src/functions/__test__/runtimePrefs.test.ts
@@ -1,0 +1,55 @@
+import env from '@global/env';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getLocale,
+  getShortenUrl,
+  getTimezoneOffset,
+  getToolboxUrl,
+  isAnalyticsEnabled,
+  setRuntimePrefs,
+} from '../runtimePrefs';
+import { DEFAULT_TIMEZONE_OFFSET } from '../timezone';
+
+describe('runtimePrefs', () => {
+  beforeEach(() => {
+    // reset to defaults so cases stay independent.
+    setRuntimePrefs({
+      timezoneOffset: DEFAULT_TIMEZONE_OFFSET,
+      toolboxUrl: '',
+      shortenUrl: '',
+      analytics: false,
+      locale: 'en',
+    });
+  });
+
+  it('defaults the timezone offset to +8', () => {
+    expect(getTimezoneOffset()).toBe(8);
+  });
+
+  it('falls back to env hosts when overrides are blank', () => {
+    expect(getToolboxUrl()).toBe(env.TOOLBOX_URL);
+    expect(getShortenUrl()).toBe(env.SHORTEN_URL);
+  });
+
+  it('falls back to env hosts when overrides are whitespace only', () => {
+    setRuntimePrefs({ toolboxUrl: '   ', shortenUrl: '  ' });
+    expect(getToolboxUrl()).toBe(env.TOOLBOX_URL);
+    expect(getShortenUrl()).toBe(env.SHORTEN_URL);
+  });
+
+  it('uses configured hosts when provided', () => {
+    setRuntimePrefs({
+      toolboxUrl: 'https://tool.example.com',
+      shortenUrl: 'https://s.example.com',
+    });
+    expect(getToolboxUrl()).toBe('https://tool.example.com');
+    expect(getShortenUrl()).toBe('https://s.example.com');
+  });
+
+  it('exposes the analytics gate and locale', () => {
+    expect(isAnalyticsEnabled()).toBe(false);
+    setRuntimePrefs({ analytics: true, locale: 'zh_TW' });
+    expect(isAnalyticsEnabled()).toBe(true);
+    expect(getLocale()).toBe('zh_TW');
+  });
+});

--- a/src/functions/runtimePrefs.ts
+++ b/src/functions/runtimePrefs.ts
@@ -1,0 +1,44 @@
+import env from '@global/env';
+
+import { DEFAULT_TIMEZONE_OFFSET } from './timezone';
+
+// runtime preferences are the single source of truth read by non-react code
+// (box sources, telemetry). the PreferencesContext owns the react state and
+// pushes every change here so plain modules stay in sync without prop drilling.
+
+export interface RuntimePrefs {
+  // default UTC offset in hours used by time-related boxes.
+  timezoneOffset: number;
+  // backend host overrides; empty string means "fall back to env default".
+  toolboxUrl: string;
+  shortenUrl: string;
+  // whether anonymous telemetry (sentry) is allowed to report.
+  analytics: boolean;
+  // active app locale, consumed by box sources that emit localized text.
+  locale: string;
+}
+
+const current: RuntimePrefs = {
+  timezoneOffset: DEFAULT_TIMEZONE_OFFSET,
+  toolboxUrl: '',
+  shortenUrl: '',
+  analytics: false,
+  locale: 'en',
+};
+
+export const setRuntimePrefs = (next: Partial<RuntimePrefs>): void => {
+  Object.assign(current, next);
+};
+
+export const getTimezoneOffset = (): number => current.timezoneOffset;
+
+// resolve a configured host, falling back to the env default when blank.
+export const getToolboxUrl = (): string =>
+  current.toolboxUrl.trim() || env.TOOLBOX_URL;
+
+export const getShortenUrl = (): string =>
+  current.shortenUrl.trim() || env.SHORTEN_URL;
+
+export const isAnalyticsEnabled = (): boolean => current.analytics;
+
+export const getLocale = (): string => current.locale;

--- a/src/functions/timezone.ts
+++ b/src/functions/timezone.ts
@@ -1,0 +1,38 @@
+// helpers for rendering dates against a fixed UTC offset (in hours).
+// the app historically hardcoded UTC+8; these utilities let the value come
+// from a user preference while keeping the same output shape.
+
+// clamp to the real-world range of named offsets (UTC-12 .. UTC+14).
+export const MIN_TIMEZONE_OFFSET = -12;
+export const MAX_TIMEZONE_OFFSET = 14;
+
+export const DEFAULT_TIMEZONE_OFFSET = 8;
+
+export const isValidTimezoneOffset = (value: number): boolean =>
+  Number.isInteger(value) &&
+  value >= MIN_TIMEZONE_OFFSET &&
+  value <= MAX_TIMEZONE_OFFSET;
+
+// format a `+HH:MM` / `-HH:MM` suffix for an offset given in hours.
+export const formatOffsetSuffix = (offsetHours: number): string => {
+  const sign = offsetHours < 0 ? '-' : '+';
+  const abs = Math.abs(offsetHours);
+  const hh = String(Math.trunc(abs)).padStart(2, '0');
+  const mm = String(Math.round((abs - Math.trunc(abs)) * 60)).padStart(2, '0');
+  return `${sign}${hh}:${mm}`;
+};
+
+// short human label, e.g. `UTC+8` or `UTC-3`.
+export const formatOffsetLabel = (offsetHours: number): string =>
+  `UTC${offsetHours >= 0 ? '+' : '-'}${Math.abs(offsetHours)}`;
+
+// shift a UTC date by the offset so the wall-clock reads as the target zone.
+export const shiftDateToOffset = (date: Date, offsetHours: number): Date =>
+  new Date(date.getTime() + offsetHours * 60 * 60 * 1000);
+
+// render an offset date as RFC 3339 with the proper `+HH:MM` suffix instead
+// of the trailing `Z`.
+export const toOffsetISOString = (date: Date, offsetHours: number): string =>
+  shiftDateToOffset(date, offsetHours)
+    .toISOString()
+    .replace('Z', formatOffsetSuffix(offsetHours));

--- a/src/global/styles.css
+++ b/src/global/styles.css
@@ -27,6 +27,70 @@
   --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
   --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --topbar-h: 56px;
+  /* density-driven row gap; compact tightens it (see [data-density]). */
+  --density-gap: 12px;
+  --density-pad: 16px;
+}
+
+/* dark palette tokens. applied for an explicit dark choice (.dark-theme /
+   [data-theme="dark"]) and, via the media query below, for system mode. */
+.dark-theme,
+:root[data-theme="dark"] {
+  --bg: #0b1120;
+  --bg-elev: #131b2e;
+  --ink: #e8edf5;
+  --ink-2: #c2ccda;
+  --ink-3: #8b97a8;
+  --ink-4: #64718a;
+  --line: #233047;
+  --line-2: #2f3e59;
+  --muted: #1a2436;
+  --muted-2: #233047;
+  --accent: #5b8bf5;
+  --accent-soft: #1b2c4d;
+  --accent-ink: #93b4fb;
+  --danger: #f0616d;
+  --success: #34c97f;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 16px -4px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-lg:
+    0 16px 40px -12px rgba(0, 0, 0, 0.6), 0 2px 4px rgba(0, 0, 0, 0.4);
+  color-scheme: dark;
+}
+
+/* system theme follows the OS only when no explicit light/dark is chosen. */
+@media (prefers-color-scheme: dark) {
+  :root[data-theme="system"] {
+    --bg: #0b1120;
+    --bg-elev: #131b2e;
+    --ink: #e8edf5;
+    --ink-2: #c2ccda;
+    --ink-3: #8b97a8;
+    --ink-4: #64718a;
+    --line: #233047;
+    --line-2: #2f3e59;
+    --muted: #1a2436;
+    --muted-2: #233047;
+    --accent: #5b8bf5;
+    --accent-soft: #1b2c4d;
+    --accent-ink: #93b4fb;
+    --danger: #f0616d;
+    --success: #34c97f;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md:
+      0 4px 16px -4px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-lg:
+      0 16px 40px -12px rgba(0, 0, 0, 0.6), 0 2px 4px rgba(0, 0, 0, 0.4);
+    color-scheme: dark;
+  }
+}
+
+/* compact density tightens shared spacing tokens used by lists and cards. */
+:root[data-density="compact"] {
+  --density-gap: 6px;
+  --density-pad: 10px;
+  --radius: 8px;
+  --radius-lg: 10px;
 }
 
 *,
@@ -606,7 +670,7 @@ pre,
 .boxes {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--density-gap);
 }
 
 .empty {
@@ -1702,6 +1766,33 @@ pre,
   font-weight: 500;
 }
 
+.text-input {
+  font-family: inherit;
+  font-size: 12px;
+  padding: 5px 10px;
+  min-width: 220px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--bg-elev);
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.text-input::placeholder {
+  color: var(--ink-4);
+  font-weight: 400;
+}
+
+.text-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.text-input.is-invalid {
+  border-color: var(--danger);
+}
+
 .shortcut-list {
   display: flex;
   flex-direction: column;
@@ -1929,4 +2020,12 @@ pre,
   .dnd-row {
     grid-template-columns: 20px 28px 24px minmax(0, 1fr) 32px;
   }
+}
+
+/* compact density tightens box card padding to fit more per screen. placed
+   last so it overrides the base .box-head/.box-body rules above. */
+:root[data-density="compact"] .box-head,
+:root[data-density="compact"] .box-body {
+  padding-top: 7px;
+  padding-bottom: 7px;
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -28,6 +28,18 @@ const en = {
   'settings.enterCopy': 'Copy',
   'settings.enterPaste': 'Copy & paste back',
   'settings.enterOff': 'Off',
+  'settings.timezone': 'Default timezone',
+  'settings.timezoneHint':
+    'UTC offset in hours (e.g. 8) applied to time boxes by default.',
+  'settings.section.server': 'Server',
+  'settings.section.serverHint':
+    'Override backend hosts. Leave blank to use the defaults.',
+  'settings.toolboxUrl': 'Toolbox URL',
+  'settings.toolboxUrlHint':
+    'Host for the shorten-URL API. Must be a valid http(s) URL or blank.',
+  'settings.shortenUrl': 'Shortener URL',
+  'settings.shortenUrlHint':
+    'Host that serves generated short links. Must be a valid http(s) URL or blank.',
   'settings.section.shortcuts': 'Shortcuts',
   'settings.shortcutNext': 'Next box',
   'settings.shortcutPrev': 'Previous box',

--- a/src/i18n/zhTW.ts
+++ b/src/i18n/zhTW.ts
@@ -30,6 +30,17 @@ const zhTW: Translations = {
   'settings.enterCopy': '複製',
   'settings.enterPaste': '複製並貼回',
   'settings.enterOff': '關閉',
+  'settings.timezone': '預設時區',
+  'settings.timezoneHint':
+    '以小時為單位的 UTC 偏移（例如 8），預設套用至時間 Box。',
+  'settings.section.server': '伺服器',
+  'settings.section.serverHint': '覆寫後端主機位址。留空則使用預設值。',
+  'settings.toolboxUrl': 'Toolbox 網址',
+  'settings.toolboxUrlHint':
+    '縮網址 API 的主機位址。必須是有效的 http(s) 網址或留空。',
+  'settings.shortenUrl': '縮網址服務網址',
+  'settings.shortenUrlHint':
+    '提供短連結的主機位址。必須是有效的 http(s) 網址或留空。',
   'settings.section.shortcuts': '快捷鍵',
   'settings.shortcutNext': '下一個 Box',
   'settings.shortcutPrev': '上一個 Box',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,21 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App';
+import { loadPrefs } from './contexts/PreferencesContext';
+import { isAnalyticsEnabled, setRuntimePrefs } from './functions/runtimePrefs';
 import './index.css';
+
+// seed runtime prefs and theme/density before first paint so plain modules
+// (box sources, telemetry gate) read user values and there is no theme flash.
+const initialPrefs = loadPrefs();
+setRuntimePrefs({
+  timezoneOffset: initialPrefs.timezoneOffset,
+  toolboxUrl: initialPrefs.toolboxUrl,
+  shortenUrl: initialPrefs.shortenUrl,
+  analytics: initialPrefs.analytics,
+});
+document.documentElement.dataset.theme = initialPrefs.theme;
+document.documentElement.dataset.density = initialPrefs.density;
 
 // defer firebase init until the browser is idle so the analytics SDK
 // (~150KB gzipped) does not block first paint.
@@ -41,6 +55,12 @@ init({
   sendDefaultPii: true,
   // Enable logs to be sent to Sentry
   _experiments: { enableLogs: true },
+
+  // honor the "anonymous usage" toggle at runtime: drop every event/transaction
+  // unless the user has opted in. reads the live runtime flag so toggling the
+  // setting takes effect without a reload.
+  beforeSend: (event) => (isAnalyticsEnabled() ? event : null),
+  beforeSendTransaction: (event) => (isAnalyticsEnabled() ? event : null),
 });
 
 const root = ReactDOM.createRoot(

--- a/src/modules/boxSources/CronExpressionBoxSource.ts
+++ b/src/modules/boxSources/CronExpressionBoxSource.ts
@@ -1,5 +1,6 @@
 import { DefaultBoxTemplate } from '@components/BoxTemplate';
 import { isString, trim } from '@functions/helper';
+import { getLocale } from '@functions/runtimePrefs';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, extractOptionKeys } from '@modules/Box';
 
@@ -46,7 +47,8 @@ export const CronExpressionBoxSource = {
     }
 
     try {
-      let locale = 'en';
+      // default to the active app locale; an inline `::locale=` option wins.
+      let locale = getLocale();
       if (options !== null) {
         const lang = extractOptionKeys(options, 'l', 'lang', 'locale');
         if (lang !== null && typeof lang === 'string') {

--- a/src/modules/boxSources/NowBoxSource.ts
+++ b/src/modules/boxSources/NowBoxSource.ts
@@ -1,5 +1,11 @@
 import { DefaultBoxTemplate } from '@components/BoxTemplate';
 import { isString, trim } from '@functions/helper';
+import { getTimezoneOffset } from '@functions/runtimePrefs';
+import {
+  formatOffsetLabel,
+  shiftDateToOffset,
+  toOffsetISOString,
+} from '@functions/timezone';
 import type { Box } from '@modules/Box';
 import { BoxBuilder } from '@modules/Box';
 
@@ -28,9 +34,10 @@ export const NowBoxSource = {
 
     if (regularInput === 'now') {
       const timestamp = Date.now();
-      const tzOffset = 8 * 60 * 60 * 1000;
       const date = new Date(timestamp);
-      const twDate = new Date(timestamp + tzOffset);
+      // `twDate` keeps its name for back-compat but now follows the configured
+      // default timezone offset rather than a hardcoded +8.
+      const twDate = shiftDateToOffset(date, getTimezoneOffset());
 
       return { timestamp, date, twDate };
     }
@@ -44,7 +51,8 @@ export const NowBoxSource = {
       return [];
     }
 
-    const { timestamp, date, twDate } = match;
+    const { timestamp, date } = match;
+    const offset = getTimezoneOffset();
     return [
       new BoxBuilder('RFC 3339', date.toISOString())
         .setTemplate(DefaultBoxTemplate)
@@ -52,8 +60,8 @@ export const NowBoxSource = {
         .setPriority(this.priority)
         .build(),
       new BoxBuilder(
-        'RFC 3339 (UTC+8)',
-        twDate.toISOString().replace('Z', '+08:00'),
+        `RFC 3339 (${formatOffsetLabel(offset)})`,
+        toOffsetISOString(date, offset),
       )
         .setTemplate(DefaultBoxTemplate)
         .setShowExpandButton(false)

--- a/src/modules/boxSources/ShortenURLBoxSource.ts
+++ b/src/modules/boxSources/ShortenURLBoxSource.ts
@@ -1,6 +1,6 @@
 import { DefaultBoxTemplate } from '@components/BoxTemplate';
 import { isString, trim } from '@functions/helper';
-import env from '@global/env';
+import { getShortenUrl, getToolboxUrl } from '@functions/runtimePrefs';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, extractOptionKeys } from '@modules/Box';
 
@@ -24,8 +24,8 @@ export const ShortenURLBoxSource = {
     inputURL: string,
     shorten: string | null,
   ): Promise<string> {
-    const toolBoxHost = env.TOOLBOX_URL;
-    const shortenURLHost = env.SHORTEN_URL;
+    const toolBoxHost = getToolboxUrl();
+    const shortenURLHost = getShortenUrl();
 
     const resp = await fetch(`${toolBoxHost}/api/v1/surl`, {
       method: 'POST',

--- a/src/modules/boxSources/TimestampBoxSource.ts
+++ b/src/modules/boxSources/TimestampBoxSource.ts
@@ -1,5 +1,11 @@
 import { DefaultBoxTemplate } from '@components/BoxTemplate';
 import { isNumeric } from '@functions/helper';
+import { getTimezoneOffset } from '@functions/runtimePrefs';
+import {
+  formatOffsetLabel,
+  shiftDateToOffset,
+  toOffsetISOString,
+} from '@functions/timezone';
 import type { Box } from '@modules/Box';
 import { BoxBuilder } from '@modules/Box';
 
@@ -23,7 +29,7 @@ export const TimestampBoxSource = {
       return undefined;
     }
 
-    const twTimezoneOffset = 8 * 60 * 60 * 1000;
+    const offset = getTimezoneOffset();
     const minTimestamp = new Date('1600-01-01T00:00:00');
     const maxTimestamp = new Date('2099-12-31T23:59:59');
 
@@ -43,12 +49,12 @@ export const TimestampBoxSource = {
         // guess the big number is a timestamp in ms, convert ms to sec
         date = new Date(inputNumber);
         if (maxTimestamp >= date && date >= minTimestamp) {
-          return { date, twDate: new Date(date.getTime() + twTimezoneOffset) };
+          return { date, twDate: shiftDateToOffset(date, offset) };
         }
         return undefined;
       }
 
-      return { date, twDate: new Date(date.getTime() + twTimezoneOffset) };
+      return { date, twDate: shiftDateToOffset(date, offset) };
     } catch {
       /* */
     }
@@ -63,6 +69,7 @@ export const TimestampBoxSource = {
     }
 
     const { date, twDate } = match;
+    const offset = getTimezoneOffset();
 
     const resp = [];
     if (date.getTime() > 0) {
@@ -77,8 +84,8 @@ export const TimestampBoxSource = {
     if (twDate.getTime() > 0) {
       resp.push(
         new BoxBuilder(
-          'RFC 3339 (UTC+8)',
-          twDate.toISOString().replace('Z', '+08:00'),
+          `RFC 3339 (${formatOffsetLabel(offset)})`,
+          toOffsetISOString(date, offset),
         )
           .setTemplate(DefaultBoxTemplate)
           .setShowExpandButton(false)

--- a/src/modules/boxSources/__test__/cronLocaleWiring.test.ts
+++ b/src/modules/boxSources/__test__/cronLocaleWiring.test.ts
@@ -1,0 +1,35 @@
+import { setRuntimePrefs } from '@functions/runtimePrefs';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { CronExpressionBoxSource } from '../CronExpressionBoxSource';
+
+// verifies the active locale flows into cron output without an inline option.
+describe('cron locale preference wiring', () => {
+  afterEach(() => {
+    setRuntimePrefs({ locale: 'en' });
+  });
+
+  it('renders english by default', async () => {
+    setRuntimePrefs({ locale: 'en' });
+    const boxes = await CronExpressionBoxSource.generateBoxes('*/5 * * * *');
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toMatch(/minute/i);
+  });
+
+  it('renders zh_TW when the app locale is traditional chinese', async () => {
+    setRuntimePrefs({ locale: 'zh_TW' });
+    const boxes = await CronExpressionBoxSource.generateBoxes('*/5 * * * *');
+    expect(boxes).toHaveLength(1);
+    // zh_TW output contains chinese characters, never the english "minute".
+    expect(boxes[0].props.plaintextOutput).not.toMatch(/minute/i);
+    expect(boxes[0].props.plaintextOutput).toMatch(/[一-鿿]/);
+  });
+
+  it('lets an inline ::locale option override the app locale', async () => {
+    setRuntimePrefs({ locale: 'zh_TW' });
+    const boxes = await CronExpressionBoxSource.generateBoxes('*/5 * * * *', {
+      locale: 'en',
+    });
+    expect(boxes[0].props.plaintextOutput).toMatch(/minute/i);
+  });
+});

--- a/src/modules/boxSources/__test__/timezoneWiring.test.ts
+++ b/src/modules/boxSources/__test__/timezoneWiring.test.ts
@@ -1,0 +1,47 @@
+import { setRuntimePrefs } from '@functions/runtimePrefs';
+import { DEFAULT_TIMEZONE_OFFSET } from '@functions/timezone';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NowBoxSource } from '../NowBoxSource';
+import { TimestampBoxSource } from '../TimestampBoxSource';
+
+// verifies that the default-timezone preference actually flows through the
+// runtime singleton into the time-related box outputs (label + offset suffix).
+describe('timezone preference wiring', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setRuntimePrefs({ timezoneOffset: DEFAULT_TIMEZONE_OFFSET });
+  });
+
+  it('NowBoxSource defaults to UTC+8 output', async () => {
+    setRuntimePrefs({ timezoneOffset: 8 });
+    const boxes = await NowBoxSource.generateBoxes('now');
+    expect(boxes[1].props.name).toBe('RFC 3339 (UTC+8)');
+    expect(boxes[1].props.plaintextOutput).toBe(
+      '2024-01-01T08:00:00.000+08:00',
+    );
+  });
+
+  it('NowBoxSource follows a changed timezone offset', async () => {
+    setRuntimePrefs({ timezoneOffset: -5 });
+    const boxes = await NowBoxSource.generateBoxes('now');
+    expect(boxes[1].props.name).toBe('RFC 3339 (UTC-5)');
+    expect(boxes[1].props.plaintextOutput).toBe(
+      '2023-12-31T19:00:00.000-05:00',
+    );
+  });
+
+  it('TimestampBoxSource follows a changed timezone offset', async () => {
+    setRuntimePrefs({ timezoneOffset: 9 });
+    const boxes = await TimestampBoxSource.generateBoxes('1704067200');
+    expect(boxes[1].props.name).toBe('RFC 3339 (UTC+9)');
+    expect(boxes[1].props.plaintextOutput).toBe(
+      '2024-01-01T09:00:00.000+09:00',
+    );
+  });
+});

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -14,52 +14,23 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { patchLocalPrefs, readLocalPrefs } from '@functions/localPrefs';
 import { buildVersion } from '@global/buildInfo';
+import env from '@global/env';
 import { useEffect, useMemo, useState } from 'react';
 import { useLocale } from '../contexts/LocaleContext';
+import {
+  isValidServerUrl,
+  usePreferences,
+} from '../contexts/PreferencesContext';
 import type { BoxSetting, Settings } from '../contexts/SettingsContext';
 import { useSettings } from '../contexts/SettingsContext';
+import {
+  isValidTimezoneOffset,
+  MAX_TIMEZONE_OFFSET,
+  MIN_TIMEZONE_OFFSET,
+} from '../functions/timezone';
 import { DEFAULT_LOCALE, type Locale } from '../i18n';
 import { boxSources } from '../modules/boxSources';
-
-interface Prefs {
-  theme: 'light' | 'dark' | 'system';
-  density: 'comfortable' | 'compact';
-  copyMode: 'enter' | 'paste' | 'off';
-  analytics: boolean;
-}
-
-const DEFAULT_PREFS: Prefs = {
-  theme: 'system',
-  density: 'comfortable',
-  copyMode: 'enter',
-  analytics: false,
-};
-
-const isTheme = (value: unknown): value is Prefs['theme'] =>
-  value === 'light' || value === 'dark' || value === 'system';
-
-const isDensity = (value: unknown): value is Prefs['density'] =>
-  value === 'comfortable' || value === 'compact';
-
-const isCopyMode = (value: unknown): value is Prefs['copyMode'] =>
-  value === 'enter' || value === 'paste' || value === 'off';
-
-const loadPrefs = (): Prefs => {
-  const prefs = readLocalPrefs();
-  return {
-    theme: isTheme(prefs.theme) ? prefs.theme : DEFAULT_PREFS.theme,
-    density: isDensity(prefs.density) ? prefs.density : DEFAULT_PREFS.density,
-    copyMode: isCopyMode(prefs.copyMode)
-      ? prefs.copyMode
-      : DEFAULT_PREFS.copyMode,
-    analytics:
-      typeof prefs.analytics === 'boolean'
-        ? prefs.analytics
-        : DEFAULT_PREFS.analytics,
-  };
-};
 
 const GripIcon = () => (
   <svg
@@ -255,6 +226,35 @@ const Select = <T extends string>({
   </select>
 );
 
+interface TextInputProps {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  invalid?: boolean;
+  ariaLabel: string;
+  inputMode?: 'text' | 'numeric' | 'url';
+}
+
+const TextInput = ({
+  value,
+  onChange,
+  placeholder,
+  invalid,
+  ariaLabel,
+  inputMode = 'text',
+}: TextInputProps) => (
+  <input
+    aria-invalid={invalid ?? false}
+    aria-label={ariaLabel}
+    className={`text-input${invalid ? ' is-invalid' : ''}`}
+    inputMode={inputMode}
+    onChange={(e) => onChange(e.target.value)}
+    placeholder={placeholder}
+    type="text"
+    value={value}
+  />
+);
+
 const Shortcut = ({ keys, label }: { keys: string[]; label: string }) => (
   <div className="shortcut-row">
     <span className="shortcut-label">{label}</span>
@@ -271,8 +271,40 @@ const Shortcut = ({ keys, label }: { keys: string[]; label: string }) => (
 const SettingsPage = (): React.JSX.Element => {
   const { t, locale, setLocale } = useLocale();
   const { settings, updateSettings } = useSettings();
+  const { prefs, setPref, resetPrefs } = usePreferences();
   const [orderedBoxes, setOrderedBoxes] = useState<BoxSetting[]>([]);
-  const [prefs, setPrefs] = useState<Prefs>(loadPrefs);
+  // draft strings let the user type intermediate/invalid values; we only
+  // commit to prefs once the value parses/validates.
+  const [tzDraft, setTzDraft] = useState(String(prefs.timezoneOffset));
+  const [toolboxDraft, setToolboxDraft] = useState(prefs.toolboxUrl);
+  const [shortenDraft, setShortenDraft] = useState(prefs.shortenUrl);
+
+  // resync drafts when prefs change out of band (e.g. clear local data).
+  useEffect(() => {
+    setTzDraft(String(prefs.timezoneOffset));
+    setToolboxDraft(prefs.toolboxUrl);
+    setShortenDraft(prefs.shortenUrl);
+  }, [prefs.timezoneOffset, prefs.toolboxUrl, prefs.shortenUrl]);
+
+  const tzInvalid = (() => {
+    const parsed = Number(tzDraft);
+    return tzDraft.trim() === '' || !isValidTimezoneOffset(parsed);
+  })();
+  const toolboxInvalid = !isValidServerUrl(toolboxDraft);
+  const shortenInvalid = !isValidServerUrl(shortenDraft);
+
+  const commitTimezone = (raw: string) => {
+    const parsed = Number(raw);
+    if (raw.trim() !== '' && isValidTimezoneOffset(parsed)) {
+      setPref('timezoneOffset', parsed);
+    }
+  };
+
+  const commitServerUrl = (key: 'toolboxUrl' | 'shortenUrl', raw: string) => {
+    if (isValidServerUrl(raw)) {
+      setPref(key, raw.trim());
+    }
+  };
 
   const sourceLookup = useMemo(
     () => new Map(boxSources.map((s) => [s.name, s])),
@@ -286,15 +318,6 @@ const SettingsPage = (): React.JSX.Element => {
     );
     setOrderedBoxes(arr);
   }, [settings]);
-
-  // Persist preferences locally. UI only — behavior wiring is deferred.
-  useEffect(() => {
-    patchLocalPrefs(prefs);
-  }, [prefs]);
-
-  const setPref = <K extends keyof Prefs>(key: K, value: Prefs[K]) => {
-    setPrefs((p) => ({ ...p, [key]: value }));
-  };
 
   const persistOrder = (next: BoxSetting[]) => {
     const newSettings: Settings = { ...settings, boxes: { ...settings.boxes } };
@@ -353,7 +376,7 @@ const SettingsPage = (): React.JSX.Element => {
     }
     window.localStorage.clear();
     setLocale(DEFAULT_LOCALE);
-    setPrefs(DEFAULT_PREFS);
+    resetPrefs();
     handleResetOrder();
   };
 
@@ -455,6 +478,60 @@ const SettingsPage = (): React.JSX.Element => {
                 { value: 'off', label: t('settings.enterOff') },
               ]}
               value={prefs.copyMode}
+            />
+          </Field>
+          <Field
+            hint={t('settings.timezoneHint')}
+            label={t('settings.timezone')}
+          >
+            <TextInput
+              ariaLabel={t('settings.timezone')}
+              inputMode="numeric"
+              invalid={tzInvalid}
+              onChange={(v) => {
+                setTzDraft(v);
+                commitTimezone(v);
+              }}
+              placeholder={`${MIN_TIMEZONE_OFFSET}…${MAX_TIMEZONE_OFFSET}`}
+              value={tzDraft}
+            />
+          </Field>
+        </Section>
+
+        <Section
+          subtitle={t('settings.section.serverHint')}
+          title={t('settings.section.server')}
+        >
+          <Field
+            hint={t('settings.toolboxUrlHint')}
+            label={t('settings.toolboxUrl')}
+          >
+            <TextInput
+              ariaLabel={t('settings.toolboxUrl')}
+              inputMode="url"
+              invalid={toolboxInvalid}
+              onChange={(v) => {
+                setToolboxDraft(v);
+                commitServerUrl('toolboxUrl', v);
+              }}
+              placeholder={env.TOOLBOX_URL}
+              value={toolboxDraft}
+            />
+          </Field>
+          <Field
+            hint={t('settings.shortenUrlHint')}
+            label={t('settings.shortenUrl')}
+          >
+            <TextInput
+              ariaLabel={t('settings.shortenUrl')}
+              inputMode="url"
+              invalid={shortenInvalid}
+              onChange={(v) => {
+                setShortenDraft(v);
+                commitServerUrl('shortenUrl', v);
+              }}
+              placeholder={env.SHORTEN_URL}
+              value={shortenDraft}
             />
           </Field>
         </Section>


### PR DESCRIPTION
Settings on the Settings page were previously stored in `mb_prefs` but nothing read them. This PR lifts preferences into a central `PreferencesContext` and wires every setting to real behavior, then adds two new settings.

## What each setting now controls

- **Theme** (Light/Dark/System): drives a dark palette via `[data-theme]` CSS variables on `documentElement`; `System` follows `prefers-color-scheme`. Seeded before first paint to avoid a flash. (This app has no MUI `ThemeProvider`/`createTheme` — only `CssBaseline` — so CSS variables are the idiomatic theming surface here.)
- **Density** (Comfortable/Compact): compact tightens the box-list gap (`--density-gap`) and box card padding.
- **Language** (en/zh-TW): the active locale now flows into box sources that emit localized text. `CronExpression` renders zh-TW output app-wide without needing an inline `::locale=` option (inline option still overrides).
- **Enter behavior** (Copy / Copy & paste back / Off): `MagicBox` keyboard handling honors the choice on plain Enter. The dedicated Cmd/Ctrl+Enter shortcut is unchanged.
- **Anonymous usage**: Sentry is now gated. `beforeSend`/`beforeSendTransaction` drop every event/transaction unless the toggle is on, reading a single live runtime flag — so it is no longer placebo and takes effect without reload. (Sentry was already wired in `index.tsx`; this is the single source of truth telemetry checks.)

## New settings

- **Default timezone** (UTC offset in hours, default **+8**): `NowBoxSource` and `TimestampBoxSource` read the offset from the runtime singleton instead of a hardcoded `8 * 60 * 60 * 1000`. The "RFC 3339 (UTC+8)" box label and `+08:00` suffix are now derived from the pref (e.g. `UTC-5` / `-05:00`). `DateCalculate`/`TimeFormat` operate in UTC/local and have no offset-labeled variant, so they are intentionally left unchanged.
- **Server overrides**: text fields override `TOOLBOX_URL` / `SHORTEN_URL` at runtime. `ShortenURLBoxSource` and `ShortenURLBoxTemplate` use the configured hosts, falling back to the `env` defaults when blank. UI shows the env default as placeholder with http(s)-or-empty validation.

## Architecture

- `PreferencesContext` owns all prefs state, persists to `mb_prefs` (via existing `localPrefs.ts` helpers), applies theme/density to `documentElement`, and pushes the subset non-React code needs into a `runtimePrefs` singleton (single source of truth read by box sources + the telemetry gate).
- `LocaleContext` mirrors the active locale into the same singleton.

## Tests

- `PreferencesContext` load/save/defaults (timezone defaults to +8, blank/invalid server falls back, out-of-range timezone rejected, persistence to `mb_prefs`).
- `runtimePrefs` defaults + env fallback.
- Wiring tests: timezone pref changes `Now`/`Timestamp` box output; locale pref changes `CronExpression` rendered string.
- All 219 tests pass; lint + `tsc --noEmit` + production build clean.

Adds en + zhTW strings for the two new settings.

Closes #230

https://claude.ai/code/session_016Q7UoTqHa1EiTAheBeyaZh