### PR TITLE
chore(password): remove dead intermediate shuffle in PasswordBoxSource

### DIFF
--- a/src/modules/boxSources/PasswordBoxSource.ts
+++ b/src/modules/boxSources/PasswordBoxSource.ts
@@ -47,14 +47,7 @@ function generatePassword(length: number, classes: CharClasses): string {
     }
   }
 
-  // guarantee at least one character from each enabled class by replacing
-  // random positions — shuffle first so the mandatory chars are spread evenly
-  const shuffleBuf = new Uint32Array(chars.length);
-  crypto.getRandomValues(shuffleBuf);
-  chars.sort(
-    (_, __) => shuffleBuf[chars.indexOf(_)] - shuffleBuf[chars.indexOf(__)],
-  );
-
+  // guarantee at least one character from each enabled class by replacing random positions
   const mandatory: string[] = [];
   const classCharsets: string[] = [];
   if (classes.upper) classCharsets.push(CHARSET_UPPER);


### PR DESCRIPTION
The \`Array.sort\` comparator using \`chars.indexOf()\` is non-deterministic with duplicate characters and is superseded by the crypto-backed Fisher-Yates shuffle that follows it. It is dead code — the Fisher-Yates determines the final order — so removing it has no effect on output or security.

https://claude.ai/code/session_016Q7UoTqHa1EiTAheBeyaZh