### PR TITLE
feat(analytics): enable anonymous usage telemetry by default

### DIFF
--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -35,7 +35,7 @@ export const DEFAULT_PREFS: Prefs = {
   theme: 'system',
   density: 'comfortable',
   copyMode: 'enter',
-  analytics: false,
+  analytics: true,
   timezoneOffset: DEFAULT_TIMEZONE_OFFSET,
   toolboxUrl: '',
   shortenUrl: '',

--- a/src/functions/__test__/runtimePrefs.test.ts
+++ b/src/functions/__test__/runtimePrefs.test.ts
@@ -17,7 +17,7 @@ describe('runtimePrefs', () => {
       timezoneOffset: DEFAULT_TIMEZONE_OFFSET,
       toolboxUrl: '',
       shortenUrl: '',
-      analytics: false,
+      analytics: true,
       locale: 'en',
     });
   });
@@ -47,9 +47,9 @@ describe('runtimePrefs', () => {
   });
 
   it('exposes the analytics gate and locale', () => {
-    expect(isAnalyticsEnabled()).toBe(false);
-    setRuntimePrefs({ analytics: true, locale: 'zh_TW' });
     expect(isAnalyticsEnabled()).toBe(true);
+    setRuntimePrefs({ analytics: false, locale: 'zh_TW' });
+    expect(isAnalyticsEnabled()).toBe(false);
     expect(getLocale()).toBe('zh_TW');
   });
 });

--- a/src/functions/runtimePrefs.ts
+++ b/src/functions/runtimePrefs.ts
@@ -22,7 +22,7 @@ const current: RuntimePrefs = {
   timezoneOffset: DEFAULT_TIMEZONE_OFFSET,
   toolboxUrl: '',
   shortenUrl: '',
-  analytics: false,
+  analytics: true,
   locale: 'en',
 };
 


### PR DESCRIPTION
## Summary

- Flips the `analytics` preference default from `false` to `true` so Sentry error and transaction telemetry is collected by default (opt-out model instead of opt-in).
- Users can still disable telemetry at any time via the **Privacy → Anonymous Usage** toggle in Settings — the opt-out path is unchanged.
- Three files changed; no behavior changes beyond the default value.

## Files changed

| File | Change |
|------|--------|
| `src/functions/runtimePrefs.ts` | `current.analytics` initialiser: `false` → `true` |
| `src/contexts/PreferencesContext.tsx` | `DEFAULT_PREFS.analytics`: `false` → `true` |
| `src/functions/__test__/runtimePrefs.test.ts` | `beforeEach` reset and the gate/locale test updated to reflect the new default (`true`; toggling to `false` still verified) |

`src/index.tsx` (`beforeSend` / `beforeSendTransaction` gating via `isAnalyticsEnabled()`) and `src/pages/SettingsPage.tsx` (toggle reads live pref) required no changes.

## Test plan

- [x] `CI=true bun run test` — 36 test files, 329 tests, all pass
- [x] `bun run lint` — 115 files checked, no issues
- [ ] Manually open Settings and confirm the Anonymous Usage toggle is ON by default for a fresh profile (clear localStorage first)
- [ ] Toggle it OFF and confirm Sentry events stop (check network tab / Sentry dashboard)

## ⚠️ Privacy note

This change switches data collection from explicit opt-in to opt-out. Before merging, confirm this is acceptable under applicable privacy regulations (e.g. GDPR, ePrivacy Directive, CCPA) for your user base and deployment regions. You may need to update the privacy policy or add a consent notice if users in covered jurisdictions are served without prior informed consent.

https://claude.ai/code/session_016Q7UoTqHa1EiTAheBeyaZh