### PR TITLE
feat(boxSources): add 8 new tools (case, html entity, number base, lorem, slug, roman, chmod, morse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,82 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>CaseConverterBox</b> </summary>
+
+| match rule | description                                                                                          | example                       |
+| ---------- | --------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `::case`   | convert text to camelCase, PascalCase, snake_case, kebab-case, CONSTANT_CASE, dot.case, Title/Sentence | `hello world foo bar ::case` |
+
+</details>
+
+<details>
+<summary> <b>HtmlEntityBox</b> </summary>
+
+| match rule       | description                                  | example                                  |
+| ---------------- | -------------------------------------------- | ---------------------------------------- |
+| `::htmlencode`   | encode text to HTML entities                 | `<div>Tom & Jerry</div> ::htmlencode`    |
+| `::htmldecode`   | decode HTML entities (named + numeric)       | `&lt;b&gt;hi&lt;/b&gt; ::htmldecode`     |
+| `::htmlentity`   | show both encode and decode                  | `<a> ::htmlentity`                       |
+
+</details>
+
+<details>
+<summary> <b>NumberBaseBox</b> </summary>
+
+| match rule | description                                            | example          |
+| ---------- | ----------------------------------------------------- | ---------------- |
+| `::base`   | show integer in decimal, hex, octal, binary (BigInt)  | `255 ::base`, `0xff ::base` |
+
+</details>
+
+<details>
+<summary> <b>LoremIpsumBox</b> </summary>
+
+| match rule    | description                          | example         |
+| ------------- | ------------------------------------ | --------------- |
+| `::lorem`     | generate N paragraphs (default 3)    | `::lorem=2`     |
+| `::words`     | generate N words                     | `::words=5`     |
+
+</details>
+
+<details>
+<summary> <b>SlugifyBox</b> </summary>
+
+| match rule | description                                            | example                       |
+| ---------- | ----------------------------------------------------- | ----------------------------- |
+| `::slug`   | lowercase hyphenated URL slug, diacritics removed     | `Héllo World! Foo_Bar ::slug` |
+
+</details>
+
+<details>
+<summary> <b>RomanNumeralBox</b> </summary>
+
+| match rule | description                                       | example         |
+| ---------- | ------------------------------------------------- | --------------- |
+| `::roman`  | integer (1-3999) ⇄ Roman numeral, auto-direction  | `2024 ::roman`, `MMXXIV ::roman` |
+
+</details>
+
+<details>
+<summary> <b>ChmodBox</b> </summary>
+
+| match rule | description                                          | example                  |
+| ---------- | --------------------------------------------------- | ------------------------ |
+| `::chmod`  | Unix permissions octal ⇄ symbolic (incl. special bits) | `755 ::chmod`, `rwxr-xr-x ::chmod` |
+
+</details>
+
+<details>
+<summary> <b>MorseCodeBox</b> </summary>
+
+| match rule       | description                  | example                    |
+| ---------------- | ---------------------------- | -------------------------- |
+| `::morse`        | encode text to Morse code    | `SOS ::morse`              |
+| `::morsedecode`  | decode Morse code to text    | `... --- ... ::morsedecode` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/CaseConverterBoxSource.ts
+++ b/src/modules/boxSources/CaseConverterBoxSource.ts
@@ -1,0 +1,103 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// split input into lowercase tokens by whitespace, separators, and camelCase/PascalCase boundaries
+function tokenize(input: string): string[] {
+  // insert a space before every uppercase letter that follows a lowercase letter or digit (camelCase boundary)
+  const expanded = input
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    // insert a space before a run of uppercase letters followed by a lowercase letter (e.g. XMLParser → XML Parser)
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2');
+
+  return expanded
+    .split(/[\s\-_.]+/)
+    .map((t) => t.toLowerCase())
+    .filter((t) => t.length > 0);
+}
+
+function capitalize(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+function toCamelCase(tokens: string[]): string {
+  return tokens.map((t, i) => (i === 0 ? t : capitalize(t))).join('');
+}
+
+function toPascalCase(tokens: string[]): string {
+  return tokens.map(capitalize).join('');
+}
+
+function toSnakeCase(tokens: string[]): string {
+  return tokens.join('_');
+}
+
+function toKebabCase(tokens: string[]): string {
+  return tokens.join('-');
+}
+
+function toConstantCase(tokens: string[]): string {
+  return tokens.map((t) => t.toUpperCase()).join('_');
+}
+
+function toDotCase(tokens: string[]): string {
+  return tokens.join('.');
+}
+
+function toTitleCase(tokens: string[]): string {
+  return tokens.map(capitalize).join(' ');
+}
+
+function toSentenceCase(tokens: string[]): string {
+  return tokens.map((t, i) => (i === 0 ? capitalize(t) : t)).join(' ');
+}
+
+export const CaseConverterBoxSource = {
+  name: 'Case Converter',
+  description:
+    'Convert text between camelCase, snake_case, kebab-case, PascalCase, CONSTANT_CASE, dot.case, Title Case and Sentence case.',
+  defaultInput: 'hello world foo bar ::case',
+  tag: 'Aa',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    // gate on ::case option so this never intercepts unrelated inputs
+    if (!hasOptionKeys(options, 'case')) return [];
+    if (!isString(input) || trim(input).length === 0) return [];
+
+    const tokens = tokenize(trim(input));
+    if (tokens.length === 0) return [];
+
+    const output: Record<string, string> = {
+      camelCase: toCamelCase(tokens),
+      PascalCase: toPascalCase(tokens),
+      snake_case: toSnakeCase(tokens),
+      'kebab-case': toKebabCase(tokens),
+      CONSTANT_CASE: toConstantCase(tokens),
+      'dot.case': toDotCase(tokens),
+      'Title Case': toTitleCase(tokens),
+      'Sentence case': toSentenceCase(tokens),
+    };
+
+    const content = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Case Converter', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CaseConverterBoxSource;

--- a/src/modules/boxSources/CaseConverterBoxSource.ts
+++ b/src/modules/boxSources/CaseConverterBoxSource.ts
@@ -10,8 +10,10 @@ function tokenize(input: string): string[] {
   // insert a space before every uppercase letter that follows a lowercase letter or digit (camelCase boundary)
   const expanded = input
     .replace(/([a-z\d])([A-Z])/g, '$1 $2')
-    // insert a space before a run of uppercase letters followed by a lowercase letter (e.g. XMLParser → XML Parser)
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2');
+    // split an acronym from a following word (XMLParser → XML Parser); the
+    // fixed-width lookahead avoids the catastrophic backtracking that
+    // `([A-Z]+)([A-Z][a-z])` exhibits on long uppercase runs (ReDoS)
+    .replace(/([A-Z])(?=[A-Z][a-z])/g, '$1 ');
 
   return expanded
     .split(/[\s\-_.]+/)

--- a/src/modules/boxSources/ChmodBoxSource.ts
+++ b/src/modules/boxSources/ChmodBoxSource.ts
@@ -1,0 +1,129 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// octal digit (0-7) → rwx string, applying special-bit override to the execute slot
+function digitToRwx(
+  digit: number,
+  specialExecuteChar: 's' | 't' | null,
+): string {
+  const r = digit & 4 ? 'r' : '-';
+  const w = digit & 2 ? 'w' : '-';
+  const hasX = !!(digit & 1);
+
+  let x: string;
+  if (specialExecuteChar !== null) {
+    // 's'/'t' when execute bit set, 'S'/'T' when not
+    x = hasX ? specialExecuteChar : specialExecuteChar.toUpperCase();
+  } else {
+    x = hasX ? 'x' : '-';
+  }
+
+  return r + w + x;
+}
+
+// convert 3- or 4-digit octal string to 9-char symbolic permissions
+function octalToSymbolic(octal: string): string {
+  const digits = octal.length === 4 ? octal : `0${octal}`;
+  const special = Number.parseInt(digits[0], 10);
+  const user = Number.parseInt(digits[1], 10);
+  const group = Number.parseInt(digits[2], 10);
+  const other = Number.parseInt(digits[3], 10);
+
+  const setuid = !!(special & 4);
+  const setgid = !!(special & 2);
+  const sticky = !!(special & 1);
+
+  const userStr = digitToRwx(user, setuid ? 's' : null);
+  const groupStr = digitToRwx(group, setgid ? 's' : null);
+  const otherStr = digitToRwx(other, sticky ? 't' : null);
+
+  return userStr + groupStr + otherStr;
+}
+
+// convert 9-char symbolic permission string back to octal, including special bits
+function symbolicToOctal(sym: string): string {
+  // each group of 3 chars: r w x/s/S/t/T
+  function groupToDigit(chars: string): number {
+    const r = chars[0] === 'r' ? 4 : 0;
+    const w = chars[1] === 'w' ? 2 : 0;
+    // lowercase x/s/t all count as execute bit set
+    const x = 'xst'.includes(chars[2]) ? 1 : 0;
+    return r + w + x;
+  }
+
+  const userStr = sym.slice(0, 3);
+  const groupStr = sym.slice(3, 6);
+  const otherStr = sym.slice(6, 9);
+
+  const userDigit = groupToDigit(userStr);
+  const groupDigit = groupToDigit(groupStr);
+  const otherDigit = groupToDigit(otherStr);
+
+  // detect special bits from the execute slot character
+  const setuid = 'sS'.includes(userStr[2]) ? 4 : 0;
+  const setgid = 'sS'.includes(groupStr[2]) ? 2 : 0;
+  const sticky = 'tT'.includes(otherStr[2]) ? 1 : 0;
+  const specialDigit = setuid | setgid | sticky;
+
+  const base = `${userDigit}${groupDigit}${otherDigit}`;
+  return specialDigit !== 0 ? `${specialDigit}${base}` : base;
+}
+
+const OCTAL_RE = /^[0-7]{3,4}$/;
+const SYMBOLIC_RE = /^[rwxsStT-]{9}$/;
+
+export const ChmodBoxSource = {
+  name: 'Chmod',
+  description:
+    'Convert Unix file permissions between octal (e.g. 755) and symbolic (e.g. rwxr-xr-x).',
+  defaultInput: '755 ::chmod',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'chmod')) return [];
+
+    const s = trim(input);
+    if (!s) return [];
+
+    let octal: string;
+    let symbolic: string;
+
+    if (OCTAL_RE.test(s)) {
+      octal = s;
+      symbolic = octalToSymbolic(s);
+    } else if (SYMBOLIC_RE.test(s)) {
+      symbolic = s;
+      octal = symbolicToOctal(s);
+    } else {
+      return [];
+    }
+
+    const output: Record<string, string> = {
+      Octal: octal,
+      Symbolic: symbolic,
+    };
+
+    const content = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Chmod', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ChmodBoxSource;

--- a/src/modules/boxSources/ChmodBoxSource.ts
+++ b/src/modules/boxSources/ChmodBoxSource.ts
@@ -74,7 +74,8 @@ function symbolicToOctal(sym: string): string {
 }
 
 const OCTAL_RE = /^[0-7]{3,4}$/;
-const SYMBOLIC_RE = /^[rwxsStT-]{9}$/;
+// positional grammar: r/w on fixed slots, execute slots also carry special bits
+const SYMBOLIC_RE = /^[r-][w-][xsS-][r-][w-][xsS-][r-][w-][xtT-]$/;
 
 export const ChmodBoxSource = {
   name: 'Chmod',

--- a/src/modules/boxSources/HtmlEntityBoxSource.ts
+++ b/src/modules/boxSources/HtmlEntityBoxSource.ts
@@ -14,6 +14,12 @@ function encodeHtml(input: string): string {
     .replace(/'/g, '&#39;');
 }
 
+// map a numeric entity to its character; out-of-range code points (> U+10FFFF)
+// are left as the original entity text instead of throwing a RangeError
+function fromCodePointSafe(codePoint: number, original: string): string {
+  return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : original;
+}
+
 // decode named and numeric entities; &amp; goes last to prevent over-decoding
 function decodeHtml(input: string): string {
   return input
@@ -21,10 +27,12 @@ function decodeHtml(input: string): string {
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;|&apos;/g, "'")
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16)),
+    .replace(/&#x([0-9a-fA-F]+);/g, (match, hex) =>
+      fromCodePointSafe(Number.parseInt(hex, 16), match),
     )
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&#(\d+);/g, (match, dec) =>
+      fromCodePointSafe(Number.parseInt(dec, 10), match),
+    )
     .replace(/&amp;/g, '&');
 }
 

--- a/src/modules/boxSources/HtmlEntityBoxSource.ts
+++ b/src/modules/boxSources/HtmlEntityBoxSource.ts
@@ -27,7 +27,7 @@ function decodeHtml(input: string): string {
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;|&apos;/g, "'")
-    .replace(/&#x([0-9a-fA-F]+);/g, (match, hex) =>
+    .replace(/&#[xX]([0-9a-fA-F]+);/g, (match, hex) =>
       fromCodePointSafe(Number.parseInt(hex, 16), match),
     )
     .replace(/&#(\d+);/g, (match, dec) =>

--- a/src/modules/boxSources/HtmlEntityBoxSource.ts
+++ b/src/modules/boxSources/HtmlEntityBoxSource.ts
@@ -1,0 +1,81 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// encode special HTML characters; & must go first to avoid double-encoding
+function encodeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// decode named and numeric entities; &amp; goes last to prevent over-decoding
+function decodeHtml(input: string): string {
+  return input
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
+      String.fromCodePoint(parseInt(hex, 16)),
+    )
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+    .replace(/&amp;/g, '&');
+}
+
+export const HtmlEntityBoxSource = {
+  name: 'HTML Entity',
+  description:
+    'Encode text to HTML entities or decode HTML entities back to text.',
+  defaultInput: '<div class="x">Tom & Jerry</div> ::htmlencode',
+  tag: '&',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(
+      options,
+      'htmlencode',
+      'htmlentity',
+      'htmlentities',
+    );
+    const wantDecode = hasOptionKeys(
+      options,
+      'htmldecode',
+      'htmlentity',
+      'htmlentities',
+    );
+    if (!wantEncode && !wantDecode) return [];
+
+    const boxes: Box[] = [];
+    if (wantEncode) {
+      boxes.push(
+        new BoxBuilder('HTML Encode', encodeHtml(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+    if (wantDecode) {
+      boxes.push(
+        new BoxBuilder('HTML Decode', decodeHtml(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+    return boxes;
+  },
+};
+
+export default HtmlEntityBoxSource;

--- a/src/modules/boxSources/LoremIpsumBoxSource.ts
+++ b/src/modules/boxSources/LoremIpsumBoxSource.ts
@@ -1,0 +1,147 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// classic lorem ipsum word bank — fixed order for deterministic output
+const WORD_BANK = [
+  'lorem',
+  'ipsum',
+  'dolor',
+  'sit',
+  'amet',
+  'consectetur',
+  'adipiscing',
+  'elit',
+  'sed',
+  'do',
+  'eiusmod',
+  'tempor',
+  'incididunt',
+  'ut',
+  'labore',
+  'et',
+  'dolore',
+  'magna',
+  'aliqua',
+  'enim',
+  'ad',
+  'minim',
+  'veniam',
+  'quis',
+  'nostrud',
+  'exercitation',
+  'ullamco',
+  'laboris',
+  'nisi',
+  'aliquip',
+  'ex',
+  'ea',
+  'commodo',
+  'consequat',
+];
+
+const MAX_PARAGRAPHS = 200;
+const MAX_WORDS = 5000;
+const DEFAULT_PARAGRAPHS = 3;
+const DEFAULT_WORDS = 50;
+
+// words per sentence for each sentence in a paragraph (fixed layout)
+const SENTENCE_LENGTHS = [8, 10, 7, 9];
+
+// cycle through the word bank starting at the given index, returns [words, nextIndex]
+function takeWords(count: number, startIndex: number): [string[], number] {
+  const words: string[] = [];
+  let idx = startIndex;
+  for (let i = 0; i < count; i++) {
+    words.push(WORD_BANK[idx % WORD_BANK.length]);
+    idx++;
+  }
+  return [words, idx];
+}
+
+function capitalize(word: string): string {
+  if (!word) return word;
+  return word[0].toUpperCase() + word.slice(1);
+}
+
+function buildWords(n: number): string {
+  const [words] = takeWords(n, 0);
+  words[0] = capitalize(words[0]);
+  return `${words.join(' ')}.`;
+}
+
+function buildParagraphs(n: number): string {
+  const paragraphs: string[] = [];
+  let bankIndex = 0;
+
+  for (let p = 0; p < n; p++) {
+    const sentences: string[] = [];
+
+    for (const sentenceLen of SENTENCE_LENGTHS) {
+      const [words, nextIndex] = takeWords(sentenceLen, bankIndex);
+      bankIndex = nextIndex;
+      words[0] = capitalize(words[0]);
+      sentences.push(`${words.join(' ')}.`);
+    }
+
+    paragraphs.push(sentences.join(' '));
+  }
+
+  return paragraphs.join('\n\n');
+}
+
+function parseCount(
+  value: string | boolean,
+  defaultValue: number,
+  max: number,
+): number {
+  if (value === true) return defaultValue;
+  const n = parseInt(value as string, 10);
+  if (Number.isNaN(n) || n <= 0) return defaultValue;
+  return Math.min(n, max);
+}
+
+export const LoremIpsumBoxSource = {
+  name: 'Lorem Ipsum',
+  description:
+    'Generate placeholder lorem ipsum text. Use ::lorem=N for N paragraphs or ::words=N for N words.',
+  defaultInput: 'lorem ::lorem=2',
+  tag: '¶',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    _input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'lorem', 'words')) return [];
+
+    let output: string;
+
+    const wordsValue = extractOptionKeys(options, 'words');
+    if (wordsValue !== null) {
+      const count = parseCount(wordsValue, DEFAULT_WORDS, MAX_WORDS);
+      output = buildWords(count);
+    } else {
+      const loremValue = extractOptionKeys(options, 'lorem');
+      const count =
+        loremValue !== null
+          ? parseCount(loremValue, DEFAULT_PARAGRAPHS, MAX_PARAGRAPHS)
+          : DEFAULT_PARAGRAPHS;
+      output = buildParagraphs(count);
+    }
+
+    return [
+      new BoxBuilder('Lorem Ipsum', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(Priority)
+        .setTag('¶')
+        .setKind('Generate')
+        .build(),
+    ];
+  },
+};
+
+export default LoremIpsumBoxSource;

--- a/src/modules/boxSources/LoremIpsumBoxSource.ts
+++ b/src/modules/boxSources/LoremIpsumBoxSource.ts
@@ -136,7 +136,7 @@ export const LoremIpsumBoxSource = {
     return [
       new BoxBuilder('Lorem Ipsum', output)
         .setTemplate(CodeBoxTemplate)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build(),
     ];
   },

--- a/src/modules/boxSources/LoremIpsumBoxSource.ts
+++ b/src/modules/boxSources/LoremIpsumBoxSource.ts
@@ -98,7 +98,7 @@ function parseCount(
   max: number,
 ): number {
   if (value === true) return defaultValue;
-  const n = parseInt(value as string, 10);
+  const n = Number.parseInt(value as string, 10);
   if (Number.isNaN(n) || n <= 0) return defaultValue;
   return Math.min(n, max);
 }
@@ -137,8 +137,6 @@ export const LoremIpsumBoxSource = {
       new BoxBuilder('Lorem Ipsum', output)
         .setTemplate(CodeBoxTemplate)
         .setPriority(Priority)
-        .setTag('¶')
-        .setKind('Generate')
         .build(),
     ];
   },

--- a/src/modules/boxSources/MorseCodeBoxSource.ts
+++ b/src/modules/boxSources/MorseCodeBoxSource.ts
@@ -119,7 +119,7 @@ export const MorseCodeBoxSource = {
         new BoxBuilder('Morse Code (Encode)', encode(input))
           .setTemplate(DefaultBoxTemplate)
           .setShowExpandButton(false)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       );
     }
@@ -129,7 +129,7 @@ export const MorseCodeBoxSource = {
         new BoxBuilder('Morse Code (Decode)', decode(input))
           .setTemplate(DefaultBoxTemplate)
           .setShowExpandButton(false)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       );
     }

--- a/src/modules/boxSources/MorseCodeBoxSource.ts
+++ b/src/modules/boxSources/MorseCodeBoxSource.ts
@@ -4,7 +4,7 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 
-// ITU-R M.1677-1 standard Morse code table
+// ITU-R M.1677-1 morse code table plus common non-standard extensions ($)
 const MORSE_ENCODE: Record<string, string> = {
   A: '.-',
   B: '-...',

--- a/src/modules/boxSources/MorseCodeBoxSource.ts
+++ b/src/modules/boxSources/MorseCodeBoxSource.ts
@@ -1,0 +1,141 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// ITU-R M.1677-1 standard Morse code table
+const MORSE_ENCODE: Record<string, string> = {
+  A: '.-',
+  B: '-...',
+  C: '-.-.',
+  D: '-..',
+  E: '.',
+  F: '..-.',
+  G: '--.',
+  H: '....',
+  I: '..',
+  J: '.---',
+  K: '-.-',
+  L: '.-..',
+  M: '--',
+  N: '-.',
+  O: '---',
+  P: '.--.',
+  Q: '--.-',
+  R: '.-.',
+  S: '...',
+  T: '-',
+  U: '..-',
+  V: '...-',
+  W: '.--',
+  X: '-..-',
+  Y: '-.--',
+  Z: '--..',
+  '0': '-----',
+  '1': '.----',
+  '2': '..---',
+  '3': '...--',
+  '4': '....-',
+  '5': '.....',
+  '6': '-....',
+  '7': '--...',
+  '8': '---..',
+  '9': '----.',
+  '.': '.-.-.-',
+  ',': '--..--',
+  '?': '..--..',
+  "'": '.----.',
+  '!': '-.-.--',
+  '/': '-..-.',
+  '(': '-.--.',
+  ')': '-.--.-',
+  '&': '.-...',
+  ':': '---...',
+  ';': '-.-.-.',
+  '=': '-...-',
+  '+': '.-.-.',
+  '-': '-....-',
+  _: '..--.-',
+  '"': '.-..-.',
+  $: '...-..-',
+  '@': '.--.-.',
+};
+
+// reverse map for decoding
+const MORSE_DECODE: Record<string, string> = Object.fromEntries(
+  Object.entries(MORSE_ENCODE).map(([char, code]) => [code, char]),
+);
+
+/** encodes a plain-text string to Morse code. words are separated by ` / `, letters by ` `. */
+function encode(text: string): string {
+  const words = text.toUpperCase().split(/\s+/).filter(Boolean);
+  return words
+    .map((word) =>
+      word
+        .split('')
+        .map((ch) => MORSE_ENCODE[ch])
+        .filter(Boolean)
+        .join(' '),
+    )
+    .filter(Boolean)
+    .join(' / ');
+}
+
+/** decodes a Morse code string back to plain text. words split on ` / `, symbols on space. */
+function decode(morse: string): string {
+  return morse
+    .split(' / ')
+    .map((word) =>
+      word
+        .trim()
+        .split(' ')
+        .map((sym) => MORSE_DECODE[sym] ?? '')
+        .join(''),
+    )
+    .join(' ');
+}
+
+export const MorseCodeBoxSource = {
+  name: 'Morse Code',
+  description: 'Encode text to Morse code or decode Morse code back to text.',
+  defaultInput: 'SOS ::morse',
+  tag: '·',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'morse', 'morseencode');
+    const wantDecode = hasOptionKeys(options, 'morsedecode');
+    if (!wantEncode && !wantDecode) return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      boxes.push(
+        new BoxBuilder('Morse Code (Encode)', encode(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(Priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      boxes.push(
+        new BoxBuilder('Morse Code (Decode)', decode(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(Priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default MorseCodeBoxSource;

--- a/src/modules/boxSources/NumberBaseBoxSource.ts
+++ b/src/modules/boxSources/NumberBaseBoxSource.ts
@@ -1,0 +1,78 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// parse a string as a bigint, supporting 0x/0o/0b/decimal prefixes and a leading minus sign
+function parseIntegerInput(raw: string): bigint | null {
+  const s = trim(raw);
+  if (s === '' || s === '-') return null;
+
+  const negative = s.startsWith('-');
+  const abs = negative ? s.slice(1) : s;
+
+  // BigInt() natively handles 0x/0o/0b/decimal literals
+  try {
+    const value = BigInt(abs);
+    return negative ? -value : value;
+  } catch {
+    return null;
+  }
+}
+
+// format a bigint in the requested base with the standard prefix, preserving sign
+function formatBigInt(value: bigint, radix: number, prefix: string): string {
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+  const digits = abs.toString(radix);
+  return negative ? `-${prefix}${digits}` : `${prefix}${digits}`;
+}
+
+export const NumberBaseBoxSource = {
+  name: 'Number Base',
+  description:
+    'Convert an integer between decimal, hexadecimal, octal and binary. Input may be prefixed 0x / 0o / 0b.',
+  defaultInput: '255 ::base',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'base')) return [];
+
+    const value = parseIntegerInput(input);
+    if (value === null) return [];
+
+    const decimal = value.toString(10);
+    const hex = formatBigInt(value, 16, '0x');
+    const octal = formatBigInt(value, 8, '0o');
+    const binary = formatBigInt(value, 2, '0b');
+
+    const output: Record<string, string> = {
+      Decimal: decimal,
+      Hexadecimal: hex,
+      Octal: octal,
+      Binary: binary,
+    };
+
+    // plaintext output joins key=value pairs for copy/TUI display
+    const plaintextOutput = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Number Base', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberBaseBoxSource;

--- a/src/modules/boxSources/NumberBaseBoxSource.ts
+++ b/src/modules/boxSources/NumberBaseBoxSource.ts
@@ -13,6 +13,10 @@ function parseIntegerInput(raw: string): bigint | null {
   const negative = s.startsWith('-');
   const abs = negative ? s.slice(1) : s;
 
+  // bound the digit count: BigInt parse/format is O(n^2) for non-power-of-two
+  // bases, so an unbounded string would freeze the main thread (DoS)
+  if (abs.length > 1024) return null;
+
   // BigInt() treats a leading zero as decimal, so rewrite classic C-style octal
   // (e.g. 0755) to the explicit 0o form before parsing
   const normalized = /^0[0-7]+$/.test(abs) ? `0o${abs.slice(1)}` : abs;

--- a/src/modules/boxSources/NumberBaseBoxSource.ts
+++ b/src/modules/boxSources/NumberBaseBoxSource.ts
@@ -13,9 +13,13 @@ function parseIntegerInput(raw: string): bigint | null {
   const negative = s.startsWith('-');
   const abs = negative ? s.slice(1) : s;
 
+  // BigInt() treats a leading zero as decimal, so rewrite classic C-style octal
+  // (e.g. 0755) to the explicit 0o form before parsing
+  const normalized = /^0[0-7]+$/.test(abs) ? `0o${abs.slice(1)}` : abs;
+
   // BigInt() natively handles 0x/0o/0b/decimal literals
   try {
-    const value = BigInt(abs);
+    const value = BigInt(normalized);
     return negative ? -value : value;
   } catch {
     return null;

--- a/src/modules/boxSources/RomanNumeralBoxSource.ts
+++ b/src/modules/boxSources/RomanNumeralBoxSource.ts
@@ -1,0 +1,98 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// ordered pairs used for the standard subtractive algorithm
+const ROMAN_TABLE: [number, string][] = [
+  [1000, 'M'],
+  [900, 'CM'],
+  [500, 'D'],
+  [400, 'CD'],
+  [100, 'C'],
+  [90, 'XC'],
+  [50, 'L'],
+  [40, 'XL'],
+  [10, 'X'],
+  [9, 'IX'],
+  [5, 'V'],
+  [4, 'IV'],
+  [1, 'I'],
+];
+
+// strict regex that only accepts valid subtractive-form roman numerals
+const ROMAN_REGEX = /^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$/;
+
+function toRoman(n: number): string {
+  let result = '';
+  let remaining = n;
+  for (const [value, numeral] of ROMAN_TABLE) {
+    while (remaining >= value) {
+      result += numeral;
+      remaining -= value;
+    }
+  }
+  return result;
+}
+
+function fromRoman(s: string): number {
+  let result = 0;
+  let i = 0;
+  for (const [value, numeral] of ROMAN_TABLE) {
+    while (s.startsWith(numeral, i)) {
+      result += value;
+      i += numeral.length;
+    }
+  }
+  return result;
+}
+
+export const RomanNumeralBoxSource = {
+  name: 'Roman Numeral',
+  description:
+    'Convert an integer (1-3999) to a Roman numeral, or a Roman numeral back to an integer.',
+  defaultInput: '2024 ::roman',
+  tag: 'Ⅼ',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'roman')) return [];
+
+    const s = trim(input);
+
+    if (/^[0-9]+$/.test(s)) {
+      const n = Number.parseInt(s, 10);
+      if (n < 1 || n > 3999) return [];
+      const roman = toRoman(n);
+      return [
+        new BoxBuilder('Roman Numeral', roman)
+          .setTemplate(DefaultBoxTemplate)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    const upper = s.toUpperCase();
+    // ensure the string is non-empty and matches valid subtractive form
+    if (upper.length > 0 && ROMAN_REGEX.test(upper)) {
+      const n = fromRoman(upper);
+      if (n === 0) return [];
+      return [
+        new BoxBuilder('Roman Numeral', String(n))
+          .setTemplate(DefaultBoxTemplate)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    return [];
+  },
+};
+
+export default RomanNumeralBoxSource;

--- a/src/modules/boxSources/RomanNumeralBoxSource.ts
+++ b/src/modules/boxSources/RomanNumeralBoxSource.ts
@@ -73,7 +73,7 @@ export const RomanNumeralBoxSource = {
       return [
         new BoxBuilder('Roman Numeral', roman)
           .setTemplate(DefaultBoxTemplate)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       ];
     }
@@ -86,7 +86,7 @@ export const RomanNumeralBoxSource = {
       return [
         new BoxBuilder('Roman Numeral', String(n))
           .setTemplate(DefaultBoxTemplate)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       ];
     }

--- a/src/modules/boxSources/SlugifyBoxSource.ts
+++ b/src/modules/boxSources/SlugifyBoxSource.ts
@@ -5,10 +5,11 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 
-// unicode combining marks range (diacritics produced by NFKD decomposition)
-const COMBINING_MARKS = /[̀-ͯ]/g;
+// every nonspacing combining mark (diacritics produced by NFKD decomposition);
+// \p{Mn} covers Latin, Greek, Cyrillic and the extended/supplement blocks
+const COMBINING_MARKS = /\p{Mn}/gu;
 
-/** converts text to a lowercase, hyphen-separated URL slug with diacritics removed */
+// converts text to a lowercase, hyphen-separated URL slug with diacritics removed
 function slugify(input: string): string {
   return input
     .normalize('NFKD')

--- a/src/modules/boxSources/SlugifyBoxSource.ts
+++ b/src/modules/boxSources/SlugifyBoxSource.ts
@@ -1,0 +1,52 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unicode combining marks range (diacritics produced by NFKD decomposition)
+const COMBINING_MARKS = /[̀-ͯ]/g;
+
+/** converts text to a lowercase, hyphen-separated URL slug with diacritics removed */
+function slugify(input: string): string {
+  return input
+    .normalize('NFKD')
+    .replace(COMBINING_MARKS, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export const SlugifyBoxSource = {
+  name: 'Slugify',
+  description:
+    'Convert text into a lowercase, hyphen-separated URL slug (diacritics removed).',
+  defaultInput: 'Héllo World! Foo_Bar ::slug',
+  tag: '/',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'slug')) return [];
+    if (!isString(input) || trim(input).length === 0) return [];
+
+    const slug = slugify(input);
+
+    // if the entire input collapses to empty after stripping non-latin chars, skip
+    if (slug.length === 0) return [];
+
+    return [
+      new BoxBuilder('Slugify', slug)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default SlugifyBoxSource;

--- a/src/modules/boxSources/__test__/CaseConverterBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CaseConverterBoxSource.test.ts
@@ -1,0 +1,94 @@
+import { CaseConverterBoxSource } from '@modules/boxSources/CaseConverterBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('CaseConverterBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::case option is absent', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes(
+        'hello world',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with ::case option', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes('   ', {
+        case: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes('', {
+        case: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts multi-word space-separated input to all cases', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes('hello world', {
+        case: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+
+      expect(opts.camelCase).toBe('helloWorld');
+      expect(opts.PascalCase).toBe('HelloWorld');
+      expect(opts.snake_case).toBe('hello_world');
+      expect(opts['kebab-case']).toBe('hello-world');
+      expect(opts.CONSTANT_CASE).toBe('HELLO_WORLD');
+      expect(opts['dot.case']).toBe('hello.world');
+      expect(opts['Title Case']).toBe('Hello World');
+      expect(opts['Sentence case']).toBe('Hello world');
+    });
+
+    it('tokenizes camelCase input correctly', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes('fooBarBaz', {
+        case: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+
+      expect(opts.camelCase).toBe('fooBarBaz');
+      expect(opts.PascalCase).toBe('FooBarBaz');
+      expect(opts.snake_case).toBe('foo_bar_baz');
+      expect(opts['kebab-case']).toBe('foo-bar-baz');
+      expect(opts.CONSTANT_CASE).toBe('FOO_BAR_BAZ');
+      expect(opts['dot.case']).toBe('foo.bar.baz');
+      expect(opts['Title Case']).toBe('Foo Bar Baz');
+      expect(opts['Sentence case']).toBe('Foo bar baz');
+    });
+
+    it('tokenizes mixed separators (hyphens and underscores)', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes(
+        'hello-world_foo',
+        { case: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+
+      expect(opts.snake_case).toBe('hello_world_foo');
+      expect(opts['kebab-case']).toBe('hello-world-foo');
+      expect(opts.CONSTANT_CASE).toBe('HELLO_WORLD_FOO');
+    });
+
+    it('plaintextOutput lists all conversions as key: value lines', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes('hello world', {
+        case: true,
+      });
+
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('camelCase: helloWorld');
+      expect(text).toContain('PascalCase: HelloWorld');
+      expect(text).toContain('snake_case: hello_world');
+      expect(text).toContain('kebab-case: hello-world');
+      expect(text).toContain('CONSTANT_CASE: HELLO_WORLD');
+      expect(text).toContain('dot.case: hello.world');
+      expect(text).toContain('Title Case: Hello World');
+      expect(text).toContain('Sentence case: Hello world');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CaseConverterBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CaseConverterBoxSource.test.ts
@@ -75,6 +75,35 @@ describe('CaseConverterBoxSource', () => {
       expect(opts.CONSTANT_CASE).toBe('HELLO_WORLD_FOO');
     });
 
+    it('splits acronym boundaries (XMLParser, myHTTPSClient)', async () => {
+      const xml = await CaseConverterBoxSource.generateBoxes('XMLParser', {
+        case: true,
+      });
+      expect((xml[0].props.options as Record<string, string>).camelCase).toBe(
+        'xmlParser',
+      );
+
+      const https = await CaseConverterBoxSource.generateBoxes(
+        'myHTTPSClient',
+        {
+          case: true,
+        },
+      );
+      expect((https[0].props.options as Record<string, string>).camelCase).toBe(
+        'myHttpsClient',
+      );
+    });
+
+    it('tokenizes a long uppercase run in linear time (ReDoS guard)', async () => {
+      // the old /([A-Z]+)([A-Z][a-z])/g regex took ~7s on 100k uppercase chars;
+      // the lookahead form is linear, so this resolves well under the test timeout
+      const boxes = await CaseConverterBoxSource.generateBoxes(
+        `${'A'.repeat(100_000)}b`,
+        { case: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
     it('plaintextOutput lists all conversions as key: value lines', async () => {
       const boxes = await CaseConverterBoxSource.generateBoxes('hello world', {
         case: true,

--- a/src/modules/boxSources/__test__/ChmodBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ChmodBoxSource.test.ts
@@ -103,6 +103,21 @@ describe('ChmodBoxSource', () => {
     });
   });
 
+  describe('symbolic structural validation', () => {
+    it('rejects character-allowlist garbage that is not a valid permission string', async () => {
+      for (const bad of ['xxxxxxxxx', 'sssssssss', 'rr-r--r--']) {
+        const boxes = await ChmodBoxSource.generateBoxes(bad, { chmod: true });
+        expect(boxes).toHaveLength(0);
+      }
+    });
+
+    it('converts setgid-only octal input', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('2755', { chmod: true });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Symbolic).toBe('rwxr-sr-x');
+    });
+  });
+
   describe('metadata', () => {
     it('has expected static properties', () => {
       expect(ChmodBoxSource.name).toBe('Chmod');

--- a/src/modules/boxSources/__test__/ChmodBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ChmodBoxSource.test.ts
@@ -1,0 +1,114 @@
+import { ChmodBoxSource } from '@modules/boxSources/ChmodBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('ChmodBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns [] when ::chmod option is absent', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - octal input', () => {
+    it('converts 755 to rwxr-xr-x', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Octal).toBe('755');
+      expect(opts.Symbolic).toBe('rwxr-xr-x');
+    });
+
+    it('converts 644 to rw-r--r--', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('644', { chmod: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Octal).toBe('644');
+      expect(opts.Symbolic).toBe('rw-r--r--');
+    });
+
+    it('converts 4755 (setuid) to rwsr-xr-x', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('4755', { chmod: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Octal).toBe('4755');
+      expect(opts.Symbolic).toBe('rwsr-xr-x');
+    });
+
+    it('converts 1777 (sticky) to rwxrwxrwt', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('1777', { chmod: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Octal).toBe('1777');
+      expect(opts.Symbolic).toBe('rwxrwxrwt');
+    });
+  });
+
+  describe('generateBoxes - symbolic input', () => {
+    it('converts rwxr-xr-x to 755', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwxr-xr-x', {
+        chmod: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Octal).toBe('755');
+      expect(opts.Symbolic).toBe('rwxr-xr-x');
+    });
+
+    it('converts rwsr-xr-x back to 4755', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwsr-xr-x', {
+        chmod: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Octal).toBe('4755');
+      expect(opts.Symbolic).toBe('rwsr-xr-x');
+    });
+  });
+
+  describe('generateBoxes - invalid input', () => {
+    it('returns [] for 999 (invalid octal digit)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('999', { chmod: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for 888 (invalid octal digit)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('888', { chmod: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for arbitrary text', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('hello', {
+        chmod: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - output shape', () => {
+    it('plaintextOutput contains both Octal and Symbolic lines', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Octal: 755');
+      expect(text).toContain('Symbolic: rwxr-xr-x');
+    });
+
+    it('box name is Chmod', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      expect(boxes[0].props.name).toBe('Chmod');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(ChmodBoxSource.name).toBe('Chmod');
+      expect(ChmodBoxSource.kind).toBe('Convert');
+      expect(ChmodBoxSource.defaultInput).toBe('755 ::chmod');
+      expect(typeof ChmodBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HtmlEntityBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HtmlEntityBoxSource.test.ts
@@ -142,4 +142,21 @@ describe('HtmlEntityBoxSource', () => {
       expect(typeof HtmlEntityBoxSource.priority).toBe('number');
     });
   });
+
+  describe('numeric entity edge cases', () => {
+    it('decodes in-range numeric entities', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&#65;&#x42;', {
+        htmldecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+
+    it('leaves out-of-range code points untouched instead of throwing', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes(
+        '&#x110000;&#2147483647;',
+        { htmldecode: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('&#x110000;&#2147483647;');
+    });
+  });
 });

--- a/src/modules/boxSources/__test__/HtmlEntityBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HtmlEntityBoxSource.test.ts
@@ -1,0 +1,145 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { HtmlEntityBoxSource } from '../HtmlEntityBoxSource';
+
+describe('HtmlEntityBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('<b>hi</b>', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('<b>hi</b>', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::htmlencode', () => {
+    it('produces exactly one encode box', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes(
+        '<a href="x">A & B</a>',
+        { htmlencode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('HTML Encode');
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '&lt;a href=&quot;x&quot;&gt;A &amp; B&lt;/a&gt;',
+      );
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('encodes & before < to avoid double-encoding', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&<>', {
+        htmlencode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('&amp;&lt;&gt;');
+    });
+
+    it('encodes single quotes', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes("it's", {
+        htmlencode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('it&#39;s');
+    });
+  });
+
+  describe('generateBoxes - ::htmldecode', () => {
+    it('produces exactly one decode box', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes(
+        '&lt;b&gt;hi&amp;bye&lt;/b&gt;',
+        { htmldecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('HTML Decode');
+      expect(boxes[0].props.plaintextOutput).toBe('<b>hi&bye</b>');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('decodes &amp; last so &amp;lt; becomes &lt; not <', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&amp;lt;', {
+        htmldecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('&lt;');
+    });
+
+    it('decodes double-quotes', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes(
+        'say &quot;hi&quot;',
+        {
+          htmldecode: true,
+        },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('say "hi"');
+    });
+  });
+
+  describe('generateBoxes - ::htmlentity / ::htmlentities', () => {
+    it('produces two boxes for ::htmlentity', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('<x>', {
+        htmlentity: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('HTML Encode');
+      expect(boxes[1].props.name).toBe('HTML Decode');
+    });
+
+    it('produces two boxes for ::htmlentities', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('<x>', {
+        htmlentities: true,
+      });
+      expect(boxes).toHaveLength(2);
+    });
+  });
+
+  describe('generateBoxes - numeric entity decode', () => {
+    it('decodes decimal numeric entities', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&#65;&#66;', {
+        htmldecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+
+    it('decodes hex numeric entities', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&#x41;&#x42;', {
+        htmldecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+
+    it('decodes mixed decimal and hex', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&#65;&#x42;', {
+        htmldecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns encode box with empty string on empty input when triggered', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('', {
+        htmlencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('');
+    });
+
+    it('returns decode box with empty string on empty input when triggered', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('', {
+        htmldecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HtmlEntityBoxSource.name).toBe('HTML Entity');
+      expect(HtmlEntityBoxSource.tag).toBe('&');
+      expect(HtmlEntityBoxSource.kind).toBe('Encode');
+      expect(typeof HtmlEntityBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LoremIpsumBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LoremIpsumBoxSource.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { LoremIpsumBoxSource } from '../LoremIpsumBoxSource';
+
+describe('LoremIpsumBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no lorem/words option', async () => {
+      const boxes = await LoremIpsumBoxSource.generateBoxes('', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options do not include lorem or words', async () => {
+      const boxes = await LoremIpsumBoxSource.generateBoxes('', {
+        other: 'value',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('::words=5 produces exactly 5 words, capitalized first, ending with period', async () => {
+      const boxes = await LoremIpsumBoxSource.generateBoxes('', { words: '5' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'Lorem ipsum dolor sit amet.',
+      );
+    });
+
+    it('::words=5 output has exactly 5 words', async () => {
+      const boxes = await LoremIpsumBoxSource.generateBoxes('', { words: '5' });
+      const text = boxes[0].props.plaintextOutput;
+      // strip trailing period and count words
+      const words = text.replace(/\.$/, '').split(' ');
+      expect(words).toHaveLength(5);
+    });
+
+    it('::lorem=2 produces two paragraphs separated by exactly one \\n\\n', async () => {
+      const boxes = await LoremIpsumBoxSource.generateBoxes('', { lorem: '2' });
+      expect(boxes).toHaveLength(1);
+      const text = boxes[0].props.plaintextOutput;
+      const parts = text.split('\n\n');
+      expect(parts).toHaveLength(2);
+    });
+
+    it('::lorem=2 output is deterministic', async () => {
+      const a = await LoremIpsumBoxSource.generateBoxes('', { lorem: '2' });
+      const b = await LoremIpsumBoxSource.generateBoxes('', { lorem: '2' });
+      expect(a[0].props.plaintextOutput).toBe(b[0].props.plaintextOutput);
+    });
+
+    it('bare ::lorem (value true) defaults to 3 paragraphs', async () => {
+      const boxes = await LoremIpsumBoxSource.generateBoxes('', {
+        lorem: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const text = boxes[0].props.plaintextOutput;
+      const parts = text.split('\n\n');
+      expect(parts).toHaveLength(3);
+    });
+
+    it('box name is Lorem Ipsum', async () => {
+      const boxes = await LoremIpsumBoxSource.generateBoxes('', { lorem: '1' });
+      expect(boxes[0].props.name).toBe('Lorem Ipsum');
+    });
+
+    it('box has a template set (CodeBoxTemplate)', async () => {
+      const boxes = await LoremIpsumBoxSource.generateBoxes('', { lorem: '1' });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+
+    it('input text is ignored — only options matter', async () => {
+      const a = await LoremIpsumBoxSource.generateBoxes('anything here', {
+        words: '5',
+      });
+      const b = await LoremIpsumBoxSource.generateBoxes('', { words: '5' });
+      expect(a[0].props.plaintextOutput).toBe(b[0].props.plaintextOutput);
+    });
+
+    it('invalid words value falls back to default 50 words', async () => {
+      const boxes = await LoremIpsumBoxSource.generateBoxes('', {
+        words: 'abc',
+      });
+      expect(boxes).toHaveLength(1);
+      const words = boxes[0].props.plaintextOutput
+        .replace(/\.$/, '')
+        .split(' ');
+      expect(words).toHaveLength(50);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/MorseCodeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MorseCodeBoxSource.test.ts
@@ -1,0 +1,145 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { MorseCodeBoxSource } from '../MorseCodeBoxSource';
+
+describe('MorseCodeBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(MorseCodeBoxSource.name).toBe('Morse Code');
+      expect(MorseCodeBoxSource.tag).toBe('·');
+      expect(MorseCodeBoxSource.kind).toBe('Encode');
+      expect(typeof MorseCodeBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when options are null', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option keys', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', {
+        sha256: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - encode via ::morse', () => {
+    it('SOS encodes to ... --- ...', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Morse Code (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('HELLO WORLD encodes correctly with word separator', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('HELLO WORLD', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '.... . .-.. .-.. --- / .-- --- .-. .-.. -..',
+      );
+    });
+
+    it('lowercase input is treated as uppercase', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('sos', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+    });
+
+    it('unknown characters are skipped silently', async () => {
+      // digit 1 is known, tilde is not
+      const boxes = await MorseCodeBoxSource.generateBoxes('A~B', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // ~ skipped; A and B encoded and joined
+      expect(boxes[0].props.plaintextOutput).toBe('.- -...');
+    });
+  });
+
+  describe('generateBoxes - encode via ::morseencode', () => {
+    it('morseencode option also triggers encode box', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', {
+        morseencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Morse Code (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+    });
+  });
+
+  describe('generateBoxes - decode via ::morsedecode', () => {
+    it('decodes ... --- ... back to SOS', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('... --- ...', {
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Morse Code (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('SOS');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('decodes HELLO WORLD Morse string correctly', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes(
+        '.... . .-.. .-.. --- / .-- --- .-. .-.. -..',
+        { morsedecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('HELLO WORLD');
+    });
+
+    it('unknown Morse symbols produce empty characters (skipped)', async () => {
+      // '....' is H, '.....' is 5, '......' is unknown
+      const boxes = await MorseCodeBoxSource.generateBoxes('.... ......', {
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // unknown symbol maps to '' so result is just 'H'
+      expect(boxes[0].props.plaintextOutput).toBe('H');
+    });
+  });
+
+  describe('generateBoxes - both encode and decode options together', () => {
+    it('returns two boxes when both morse and morsedecode are set', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', {
+        morse: true,
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Morse Code (Encode)');
+      expect(names).toContain('Morse Code (Decode)');
+    });
+  });
+
+  describe('generateBoxes - roundtrip', () => {
+    it('encode then decode returns the original uppercased text', async () => {
+      const original = 'MAGIC BOX';
+      const [encodeBox] = await MorseCodeBoxSource.generateBoxes(original, {
+        morse: true,
+      });
+      const [decodeBox] = await MorseCodeBoxSource.generateBoxes(
+        encodeBox.props.plaintextOutput,
+        { morsedecode: true },
+      );
+      expect(decodeBox.props.plaintextOutput).toBe(original);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NumberBaseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberBaseBoxSource.test.ts
@@ -78,4 +78,21 @@ describe('NumberBaseBoxSource', () => {
     const boxes = await NumberBaseBoxSource.generateBoxes('1', { base: true });
     expect(boxes[0].props.name).toBe('Number Base');
   });
+
+  it('treats classic leading-zero input as octal (0755 -> 493)', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('0755', {
+      base: true,
+    });
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Decimal).toBe('493');
+    expect(opts.Hexadecimal).toBe('0x1ed');
+  });
+
+  it('handles zero', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('0', { base: true });
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Decimal).toBe('0');
+    expect(opts.Hexadecimal).toBe('0x0');
+    expect(opts.Binary).toBe('0b0');
+  });
 });

--- a/src/modules/boxSources/__test__/NumberBaseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberBaseBoxSource.test.ts
@@ -88,6 +88,13 @@ describe('NumberBaseBoxSource', () => {
     expect(opts.Hexadecimal).toBe('0x1ed');
   });
 
+  it('rejects oversized input to avoid quadratic BigInt work (DoS guard)', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('9'.repeat(2000), {
+      base: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
   it('handles zero', async () => {
     const boxes = await NumberBaseBoxSource.generateBoxes('0', { base: true });
     const opts = boxes[0].props.options as Record<string, string>;

--- a/src/modules/boxSources/__test__/NumberBaseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberBaseBoxSource.test.ts
@@ -1,0 +1,81 @@
+import { NumberBaseBoxSource } from '@modules/boxSources/NumberBaseBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('NumberBaseBoxSource', () => {
+  it('returns [] when ::base option is absent', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('255', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('converts decimal 255 to all bases', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('255', {
+      base: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const { options } = boxes[0].props;
+    expect(options).toEqual({
+      Decimal: '255',
+      Hexadecimal: '0xff',
+      Octal: '0o377',
+      Binary: '0b11111111',
+    });
+  });
+
+  it('converts hex literal 0xff (same result as decimal 255)', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('0xff', {
+      base: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toEqual({
+      Decimal: '255',
+      Hexadecimal: '0xff',
+      Octal: '0o377',
+      Binary: '0b11111111',
+    });
+  });
+
+  it('converts binary literal 0b1010', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('0b1010', {
+      base: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect((boxes[0].props.options as Record<string, string>).Decimal).toBe(
+      '10',
+    );
+  });
+
+  it('returns [] for non-integer input', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('hello', {
+      base: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('handles large values beyond Number.MAX_SAFE_INTEGER exactly', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes(
+      '0xffffffffffffffff',
+      { base: true },
+    );
+    expect(boxes).toHaveLength(1);
+    expect((boxes[0].props.options as Record<string, string>).Decimal).toBe(
+      '18446744073709551615',
+    );
+  });
+
+  it('converts negative decimal', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('-255', {
+      base: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Decimal).toBe('-255');
+    expect(opts.Hexadecimal).toBe('-0xff');
+    expect(opts.Octal).toBe('-0o377');
+    expect(opts.Binary).toBe('-0b11111111');
+  });
+
+  it('sets box name to "Number Base"', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('1', { base: true });
+    expect(boxes[0].props.name).toBe('Number Base');
+  });
+});

--- a/src/modules/boxSources/__test__/RomanNumeralBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/RomanNumeralBoxSource.test.ts
@@ -1,0 +1,78 @@
+import { RomanNumeralBoxSource } from '@modules/boxSources/RomanNumeralBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('RomanNumeralBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::roman option is absent', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('2024', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts 2024 to MMXXIV', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('2024', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('MMXXIV');
+    });
+
+    it('converts 4 to IV', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('4', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('IV');
+    });
+
+    it('converts 3999 to MMMCMXCIX', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('3999', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('MMMCMXCIX');
+    });
+
+    it('converts lowercase roman mmxxiv to 2024', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('mmxxiv', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('2024');
+    });
+
+    it('returns [] for 0 (out of range)', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('0', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for 4000 (out of range)', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('4000', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for IIII (invalid subtractive form)', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('IIII', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for arbitrary non-roman string', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('hello', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('box name is Roman Numeral', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('2024', {
+        roman: true,
+      });
+      expect(boxes[0].props.name).toBe('Roman Numeral');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/SlugifyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SlugifyBoxSource.test.ts
@@ -1,0 +1,66 @@
+import { SlugifyBoxSource } from '@modules/boxSources/SlugifyBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('SlugifyBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::slug option is absent', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes(
+        'Héllo World! Foo_Bar',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::slug option', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('', { slug: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('   ', { slug: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts accented text with punctuation and underscores', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes(
+        'Héllo World! Foo_Bar',
+        { slug: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello-world-foo-bar');
+    });
+
+    it('collapses special characters between words correctly', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('  C++  & Rust!! ', {
+        slug: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('c-rust');
+    });
+
+    it('drops non-latin characters and collapses remaining segments', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('日本語 test', {
+        slug: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('test');
+    });
+
+    it('returns [] when input reduces to empty after slugification', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('日本語!!!', {
+        slug: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('produces no leading, trailing, or double hyphens', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('--Hello--World--', {
+        slug: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const slug = boxes[0].props.plaintextOutput as string;
+      expect(slug).not.toMatch(/^-|-$|--/);
+      expect(slug).toBe('hello-world');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -2,6 +2,8 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import CaseConverterBoxSource from './CaseConverterBoxSource';
+import ChmodBoxSource from './ChmodBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -9,15 +11,21 @@ import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HtmlEntityBoxSource from './HtmlEntityBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LoremIpsumBoxSource from './LoremIpsumBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
+import MorseCodeBoxSource from './MorseCodeBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberBaseBoxSource from './NumberBaseBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import RomanNumeralBoxSource from './RomanNumeralBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SlugifyBoxSource from './SlugifyBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
@@ -31,20 +39,28 @@ export const boxSources = [
   ColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  CaseConverterBoxSource,
+  ChmodBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HtmlEntityBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LoremIpsumBoxSource,
   MathExpressionBoxSource,
+  MorseCodeBoxSource,
   MyIPBoxSource,
   NowBoxSource,
+  NumberBaseBoxSource,
   PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
+  RomanNumeralBoxSource,
   ShortenURLBoxSource,
+  SlugifyBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,

--- a/src/tui/runBoxes.ts
+++ b/src/tui/runBoxes.ts
@@ -16,15 +16,21 @@ export async function runBoxes(
 
   const grouped = await Promise.all(
     sources.map(async (source) => {
-      const generated = await source.generateBoxes(input, options);
-      return generated.map((box) => ({
-        ...box,
-        props: {
-          ...box.props,
-          tag: box.props.tag ?? source.tag,
-          kind: box.props.kind ?? source.kind,
-        },
-      }));
+      // isolate each source like the web pipeline: a throwing source must not
+      // wipe out every other source's output
+      try {
+        const generated = await source.generateBoxes(input, options);
+        return generated.map((box) => ({
+          ...box,
+          props: {
+            ...box.props,
+            tag: box.props.tag ?? source.tag,
+            kind: box.props.kind ?? source.kind,
+          },
+        }));
+      } catch {
+        return [];
+      }
     }),
   );
 


### PR DESCRIPTION
## Summary

Explores and adds **8 new self-contained BoxSource tools** to Magic Box. Each is **option-gated** (`hasOptionKeys`) so it never steals input from existing input-matched sources (Math, Timestamp, Color, etc.).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Case Converter | `::case` | camelCase / PascalCase / snake_case / kebab-case / CONSTANT_CASE / dot.case / Title / Sentence |
| HTML Entity | `::htmlencode` `::htmldecode` `::htmlentity` | encode/decode named + numeric (`&#65;`, `&#x42;`) entities |
| Number Base | `::base` | integer → decimal/hex/octal/binary, `BigInt`-backed (no precision loss) |
| Lorem Ipsum | `::lorem=N` `::words=N` | deterministic placeholder text (no `Math.random`) |
| Slugify | `::slug` | NFKD diacritic strip → lowercase hyphenated URL slug |
| Roman Numeral | `::roman` | integer 1–3999 ⇄ Roman, auto-direction, strict validation |
| Chmod | `::chmod` | octal ⇄ symbolic incl. setuid/setgid/sticky bits |
| Morse Code | `::morse` `::morsedecode` | full ITU table, words split on ` / ` |

## Implementation notes

- 8 sources built in parallel by isolated subagents; each owned only its own source + test file. The shared `boxSources/index.ts` registry was wired in a single serialized step to avoid write conflicts.
- New sources sit alphabetically in the default display order; none are catch-alls, so ordering is cosmetic.
- README documents each tool with match rule + example.

## Verification

- ✅ `bun run test run` — **417 passing** (88 new across the 8 tools)
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

An automated multi-agent review will be posted as a comment on this PR shortly.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6