### PR TITLE
feat(boxSources): add 8 more tools (base32, hex, caesar, cidr, luhn, temperature, nanoid, unicode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,81 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>Base32Box</b> </summary>
+
+| match rule         | description                   | example              |
+| ------------------ | ----------------------------- | -------------------- |
+| `::base32`         | RFC 4648 Base32 encode        | `hello ::base32`     |
+| `::base32decode`   | Base32 decode back to text    | `NBSWY3DP ::base32decode` |
+
+</details>
+
+<details>
+<summary> <b>HexStringBox</b> </summary>
+
+| match rule     | description                          | example          |
+| -------------- | ------------------------------------ | ---------------- |
+| `::hex`        | encode text to UTF-8 hex bytes       | `hi ::hex`       |
+| `::hexdecode`  | decode a hex string back to text     | `6869 ::hexdecode` |
+
+</details>
+
+<details>
+<summary> <b>CaesarCipherBox</b> </summary>
+
+| match rule     | description                       | example                    |
+| -------------- | --------------------------------- | -------------------------- |
+| `::rot13`      | rotate letters by 13 (ROT13)      | `Hello, World! ::rot13`    |
+| `::caesar=N`   | rotate letters by N (wraps, signed) | `abc ::caesar=3`         |
+
+</details>
+
+<details>
+<summary> <b>CidrBox</b> </summary>
+
+| match rule        | description                                          | example            |
+| ----------------- | --------------------------------------------------- | ------------------ |
+| `a.b.c.d/p`       | IPv4 subnet: network, broadcast, mask, host range, counts | `192.168.1.0/24` |
+
+</details>
+
+<details>
+<summary> <b>LuhnBox</b> </summary>
+
+| match rule | description                                         | example                       |
+| ---------- | -------------------------------------------------- | ----------------------------- |
+| `::luhn`   | validate via Luhn (mod 10) + detect card brand      | `4111 1111 1111 1111 ::luhn`  |
+
+</details>
+
+<details>
+<summary> <b>TemperatureBox</b> </summary>
+
+| match rule | description                            | example         |
+| ---------- | -------------------------------------- | --------------- |
+| `::temp`   | convert between Celsius, Fahrenheit, Kelvin | `100C ::temp`, `98.6F ::temp` |
+
+</details>
+
+<details>
+<summary> <b>NanoIDBox</b> </summary>
+
+| match rule    | description                              | example         |
+| ------------- | ---------------------------------------- | --------------- |
+| `::nanoid`    | generate a URL-safe NanoID (default 21)  | `::nanoid=10`   |
+
+</details>
+
+<details>
+<summary> <b>UnicodeInspectorBox</b> </summary>
+
+| match rule   | description                                       | example            |
+| ------------ | ------------------------------------------------- | ------------------ |
+| `::unicode`  | per-character code point, UTF-8 and UTF-16 bytes  | `A€😀 ::unicode`   |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/Base32BoxSource.ts
+++ b/src/modules/boxSources/Base32BoxSource.ts
@@ -6,6 +6,9 @@ const Priority = 10;
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
+// bound synchronous work; input is seeded from a ?input= url param with no cap
+const MAX_INPUT = 100_000;
+
 // char → 5-bit value, built once for an O(1) decode lookup
 const DECODE_MAP = new Map([...ALPHABET].map((ch, i) => [ch, i]));
 
@@ -40,6 +43,10 @@ function encodeBytes(bytes: Uint8Array): string {
 // on an invalid character or non-zero padding bits (RFC 4648 §6)
 function decodeToBytes(input: string): Uint8Array | null {
   const normalized = input.replace(/\s/g, '').toUpperCase().replace(/=+$/, '');
+
+  // valid base32 quanta leave 0/2/4/5/7 chars; 1/3/6 cannot form whole bytes
+  const remainder = normalized.length % 8;
+  if (remainder === 1 || remainder === 3 || remainder === 6) return null;
 
   const bytes: number[] = [];
   let bits = 0;
@@ -79,6 +86,7 @@ export const Base32BoxSource = {
     const wantEncode = hasOptionKeys(options, 'base32', 'base32encode');
     const wantDecode = hasOptionKeys(options, 'base32decode');
     if (!wantEncode && !wantDecode) return [];
+    if (input.length > MAX_INPUT) return [];
 
     const boxes: Box[] = [];
 

--- a/src/modules/boxSources/Base32BoxSource.ts
+++ b/src/modules/boxSources/Base32BoxSource.ts
@@ -6,6 +6,9 @@ const Priority = 10;
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
+// char → 5-bit value, built once for an O(1) decode lookup
+const DECODE_MAP = new Map([...ALPHABET].map((ch, i) => [ch, i]));
+
 // encodes raw bytes to RFC 4648 Base32 with padding
 function encodeBytes(bytes: Uint8Array): string {
   let bits = 0;
@@ -33,27 +36,29 @@ function encodeBytes(bytes: Uint8Array): string {
   return output;
 }
 
-// decodes a RFC 4648 Base32 string to raw bytes; returns null on invalid input
+// decodes a RFC 4648 Base32 string to raw bytes in a single pass; returns null
+// on an invalid character or non-zero padding bits (RFC 4648 §6)
 function decodeToBytes(input: string): Uint8Array | null {
   const normalized = input.replace(/\s/g, '').toUpperCase().replace(/=+$/, '');
-
-  for (const ch of normalized) {
-    if (!ALPHABET.includes(ch)) {
-      return null;
-    }
-  }
 
   const bytes: number[] = [];
   let bits = 0;
   let value = 0;
 
   for (const ch of normalized) {
-    value = (value << 5) | ALPHABET.indexOf(ch);
+    const idx = DECODE_MAP.get(ch);
+    if (idx === undefined) return null;
+    value = (value << 5) | idx;
     bits += 5;
     if (bits >= 8) {
       bits -= 8;
       bytes.push((value >>> bits) & 0xff);
     }
+  }
+
+  // the leftover low bits must be zero, otherwise the input is malformed
+  if (bits > 0 && (value & ((1 << bits) - 1)) !== 0) {
+    return null;
   }
 
   return new Uint8Array(bytes);

--- a/src/modules/boxSources/Base32BoxSource.ts
+++ b/src/modules/boxSources/Base32BoxSource.ts
@@ -1,0 +1,121 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+// encodes raw bytes to RFC 4648 Base32 with padding
+function encodeBytes(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let output = '';
+
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      output += ALPHABET[(value >>> bits) & 0x1f];
+    }
+  }
+
+  if (bits > 0) {
+    output += ALPHABET[(value << (5 - bits)) & 0x1f];
+  }
+
+  // pad to a multiple of 8
+  while (output.length % 8 !== 0) {
+    output += '=';
+  }
+
+  return output;
+}
+
+// decodes a RFC 4648 Base32 string to raw bytes; returns null on invalid input
+function decodeToBytes(input: string): Uint8Array | null {
+  const normalized = input.replace(/\s/g, '').toUpperCase().replace(/=+$/, '');
+
+  for (const ch of normalized) {
+    if (!ALPHABET.includes(ch)) {
+      return null;
+    }
+  }
+
+  const bytes: number[] = [];
+  let bits = 0;
+  let value = 0;
+
+  for (const ch of normalized) {
+    value = (value << 5) | ALPHABET.indexOf(ch);
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((value >>> bits) & 0xff);
+    }
+  }
+
+  return new Uint8Array(bytes);
+}
+
+export const Base32BoxSource = {
+  name: 'Base32',
+  description: 'Encode text to RFC 4648 Base32 or decode Base32 back to text.',
+  defaultInput: 'hello ::base32',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'base32', 'base32encode');
+    const wantDecode = hasOptionKeys(options, 'base32decode');
+    if (!wantEncode && !wantDecode) return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const bytes = new TextEncoder().encode(input);
+      const encoded = encodeBytes(bytes);
+      boxes.push(
+        new BoxBuilder('Base32 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decodeToBytes(input);
+      if (decoded === null) {
+        boxes.push(
+          new BoxBuilder(
+            'Base32 (Decode)',
+            'invalid Base32 input: contains characters outside the RFC 4648 alphabet',
+          )
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        const text = new TextDecoder().decode(decoded);
+        boxes.push(
+          new BoxBuilder('Base32 (Decode)', text)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Base32BoxSource;

--- a/src/modules/boxSources/CaesarCipherBoxSource.ts
+++ b/src/modules/boxSources/CaesarCipherBoxSource.ts
@@ -1,0 +1,72 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// rotates a single ASCII letter by shift positions, preserving case; non-letters pass through unchanged
+function rotateChar(ch: string, shift: number): string {
+  const code = ch.charCodeAt(0);
+  if (code >= 65 && code <= 90) {
+    return String.fromCharCode(((code - 65 + shift) % 26) + 65);
+  }
+  if (code >= 97 && code <= 122) {
+    return String.fromCharCode(((code - 97 + shift) % 26) + 97);
+  }
+  return ch;
+}
+
+// applies a caesar shift to every character of the input string
+function caesarShift(text: string, shift: number): string {
+  return text
+    .split('')
+    .map((ch) => rotateChar(ch, shift))
+    .join('');
+}
+
+export const CaesarCipherBoxSource = {
+  name: 'Caesar Cipher',
+  description:
+    'Rotate letters by N positions (ROT13 by default). Use ::caesar=N for a custom shift.',
+  defaultInput: 'Hello, World! ::rot13',
+  tag: 'Aa',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'rot13', 'caesar')) return [];
+    if (!isString(input) || input.length === 0) return [];
+
+    // rot13 always wins; otherwise parse the caesar= value
+    let shift: number;
+    if (hasOptionKeys(options, 'rot13')) {
+      shift = 13;
+    } else {
+      const raw = extractOptionKeys(options, 'caesar');
+      const parsed =
+        raw === true || raw === null
+          ? Number.NaN
+          : Number.parseInt(String(raw), 10);
+      shift = Number.isNaN(parsed) ? 13 : parsed;
+    }
+
+    // normalize into 0..25 (handles negative and large values)
+    const n = ((shift % 26) + 26) % 26;
+
+    const output = caesarShift(input, n);
+
+    return [
+      new BoxBuilder(`Caesar Cipher (shift ${n})`, output)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CaesarCipherBoxSource;

--- a/src/modules/boxSources/CaesarCipherBoxSource.ts
+++ b/src/modules/boxSources/CaesarCipherBoxSource.ts
@@ -5,6 +5,9 @@ import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 
+// bound synchronous work; input is seeded from a ?input= url param with no cap
+const MAX_INPUT = 100_000;
+
 // rotates a single ASCII letter by shift positions, preserving case; non-letters pass through unchanged
 function rotateChar(ch: string, shift: number): string {
   const code = ch.charCodeAt(0);
@@ -42,6 +45,7 @@ export const CaesarCipherBoxSource = {
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'rot13', 'caesar')) return [];
     if (!isString(input) || input.length === 0) return [];
+    if (input.length > MAX_INPUT) return [];
 
     // rot13 always wins; otherwise parse the caesar= value
     let shift: number;

--- a/src/modules/boxSources/CaesarCipherBoxSource.ts
+++ b/src/modules/boxSources/CaesarCipherBoxSource.ts
@@ -17,12 +17,14 @@ function rotateChar(ch: string, shift: number): string {
   return ch;
 }
 
-// applies a caesar shift to every character of the input string
+// applies a caesar shift to every character of the input string;
+// accumulates char-by-char to avoid a full intermediate array allocation
 function caesarShift(text: string, shift: number): string {
-  return text
-    .split('')
-    .map((ch) => rotateChar(ch, shift))
-    .join('');
+  let out = '';
+  for (const ch of text) {
+    out += rotateChar(ch, shift);
+  }
+  return out;
 }
 
 export const CaesarCipherBoxSource = {

--- a/src/modules/boxSources/CidrBoxSource.ts
+++ b/src/modules/boxSources/CidrBoxSource.ts
@@ -1,0 +1,124 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box } from '@modules/Box';
+import { BoxBuilder } from '@modules/Box';
+
+const Priority = 20;
+
+// converts a 32-bit unsigned integer to dotted-quad notation
+function toIPv4(n: number): string {
+  return `${(n >>> 24) & 0xff}.${(n >>> 16) & 0xff}.${(n >>> 8) & 0xff}.${n & 0xff}`;
+}
+
+interface CidrMatch {
+  network: number;
+  broadcast: number;
+  netmask: number;
+  wildcard: number;
+  firstHost: number;
+  lastHost: number;
+  total: number;
+  usable: number;
+}
+
+const CIDR_REGEX = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})$/;
+
+function parseCidr(raw: string): CidrMatch | null {
+  const m = CIDR_REGEX.exec(raw);
+  if (!m) return null;
+
+  const octets = [m[1], m[2], m[3], m[4]].map((s) => Number.parseInt(s, 10));
+  const prefix = Number.parseInt(m[5], 10);
+
+  if (octets.some((o) => o > 255) || prefix > 32) return null;
+
+  const ip = (((octets[0] << 24) |
+    (octets[1] << 16) |
+    (octets[2] << 8) |
+    octets[3]) >>>
+    0) as number;
+
+  // left-shift by 0 is identity; handle prefix 0 explicitly to avoid UB on 32-bit shift
+  const netmask = (prefix === 0 ? 0 : 0xffffffff << (32 - prefix)) >>> 0;
+  const wildcard = ~netmask >>> 0;
+  const network = (ip & netmask) >>> 0;
+  const broadcast = (network | wildcard) >>> 0;
+  const total = prefix === 32 ? 1 : 2 ** (32 - prefix);
+
+  let firstHost: number;
+  let lastHost: number;
+  let usable: number;
+
+  if (prefix === 32) {
+    firstHost = network;
+    lastHost = network;
+    usable = 1;
+  } else if (prefix === 31) {
+    // point-to-point: both addresses are usable
+    firstHost = network;
+    lastHost = broadcast;
+    usable = 2;
+  } else {
+    firstHost = (network + 1) >>> 0;
+    lastHost = (broadcast - 1) >>> 0;
+    usable = total - 2;
+  }
+
+  return {
+    network,
+    broadcast,
+    netmask,
+    wildcard,
+    firstHost,
+    lastHost,
+    total,
+    usable,
+  };
+}
+
+export const CidrBoxSource = {
+  name: 'CIDR',
+  description:
+    'Calculate IPv4 subnet details from a CIDR block (e.g. 192.168.1.0/24).',
+  defaultInput: '192.168.1.0/24',
+  tag: '#',
+  kind: 'Network',
+  priority: Priority,
+
+  async generateBoxes(input: string): Promise<Box[]> {
+    const match = parseCidr(trim(input));
+    if (!match) return [];
+
+    const {
+      network,
+      broadcast,
+      netmask,
+      wildcard,
+      firstHost,
+      lastHost,
+      total,
+      usable,
+    } = match;
+
+    const options: Record<string, string> = {
+      Network: toIPv4(network),
+      Broadcast: toIPv4(broadcast),
+      Netmask: toIPv4(netmask),
+      Wildcard: toIPv4(wildcard),
+      'First Host': toIPv4(firstHost),
+      'Last Host': toIPv4(lastHost),
+      'Total Addresses': String(total),
+      'Usable Hosts': String(usable),
+    };
+
+    return [
+      new BoxBuilder('CIDR', '')
+        .setOptions(options)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default CidrBoxSource;

--- a/src/modules/boxSources/CidrBoxSource.ts
+++ b/src/modules/boxSources/CidrBoxSource.ts
@@ -115,7 +115,7 @@ export const CidrBoxSource = {
       new BoxBuilder('CIDR', '')
         .setOptions(options)
         .setTemplate(KeyValueBoxTemplate)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build(),
     ];
   },

--- a/src/modules/boxSources/HexStringBoxSource.ts
+++ b/src/modules/boxSources/HexStringBoxSource.ts
@@ -4,6 +4,9 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 
+// bound synchronous work; input is seeded from a ?input= url param with no cap
+const MAX_INPUT = 100_000;
+
 // encode a UTF-8 string to lowercase hex bytes with no separator
 function encodeToHex(input: string): string {
   const bytes = new TextEncoder().encode(input);
@@ -41,6 +44,7 @@ export const HexStringBoxSource = {
     const wantEncode = hasOptionKeys(options, 'hex', 'hexencode');
     const wantDecode = hasOptionKeys(options, 'hexdecode');
     if (!wantEncode && !wantDecode) return [];
+    if (input.length > MAX_INPUT) return [];
 
     const boxes: Box[] = [];
 

--- a/src/modules/boxSources/HexStringBoxSource.ts
+++ b/src/modules/boxSources/HexStringBoxSource.ts
@@ -1,0 +1,77 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// encode a UTF-8 string to lowercase hex bytes with no separator
+function encodeToHex(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// decode a hex string to UTF-8 text, or return null if the input is invalid
+function decodeFromHex(input: string): string | null {
+  // strip optional leading 0x and all whitespace
+  const cleaned = input.replace(/^0x/i, '').replace(/\s/g, '');
+  if (cleaned.length % 2 !== 0) return null;
+  if (!/^[0-9a-fA-F]*$/.test(cleaned)) return null;
+  const bytes = new Uint8Array(cleaned.length / 2);
+  for (let i = 0; i < cleaned.length; i += 2) {
+    bytes[i / 2] = Number.parseInt(cleaned.slice(i, i + 2), 16);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+export const HexStringBoxSource = {
+  name: 'Hex String',
+  description:
+    'Encode text to its UTF-8 hex bytes, or decode a hex string back to text.',
+  defaultInput: 'hello ::hex',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'hex', 'hexencode');
+    const wantDecode = hasOptionKeys(options, 'hexdecode');
+    if (!wantEncode && !wantDecode) return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const hex = encodeToHex(input);
+      boxes.push(
+        new BoxBuilder('Hex (Encode)', hex)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decodeFromHex(input);
+      const output =
+        decoded !== null
+          ? decoded
+          : 'Invalid hex input: must be even-length and contain only hex characters [0-9a-fA-F].';
+      boxes.push(
+        new BoxBuilder('Hex (Decode)', output)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default HexStringBoxSource;

--- a/src/modules/boxSources/LuhnBoxSource.ts
+++ b/src/modules/boxSources/LuhnBoxSource.ts
@@ -1,0 +1,112 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// card brand prefix/length rules, evaluated in order
+interface BrandRule {
+  name: string;
+  test: (digits: string) => boolean;
+}
+
+const BRAND_RULES: BrandRule[] = [
+  {
+    name: 'Amex',
+    test: (d) => (d.startsWith('34') || d.startsWith('37')) && d.length === 15,
+  },
+  {
+    name: 'Mastercard',
+    test: (d) => {
+      if (d.length !== 16) return false;
+      const prefix2 = Number.parseInt(d.slice(0, 2), 10);
+      const prefix4 = Number.parseInt(d.slice(0, 4), 10);
+      return (
+        (prefix2 >= 51 && prefix2 <= 55) || (prefix4 >= 2221 && prefix4 <= 2720)
+      );
+    },
+  },
+  {
+    name: 'Discover',
+    test: (d) => {
+      if (d.length !== 16 && d.length !== 19) return false;
+      const prefix4 = d.slice(0, 4);
+      const prefix3 = d.slice(0, 3);
+      const prefix2 = d.slice(0, 2);
+      return (
+        prefix4 === '6011' ||
+        prefix2 === '65' ||
+        (prefix3 >= '644' && prefix3 <= '649')
+      );
+    },
+  },
+  {
+    name: 'Visa',
+    test: (d) =>
+      d.startsWith('4') &&
+      (d.length === 13 || d.length === 16 || d.length === 19),
+  },
+];
+
+// implements the Luhn (mod-10) algorithm
+function luhn(digits: string): boolean {
+  let sum = 0;
+  let double = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let n = Number.parseInt(digits[i], 10);
+    if (double) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    double = !double;
+  }
+  return sum % 10 === 0;
+}
+
+function detectBrand(digits: string): string {
+  for (const rule of BRAND_RULES) {
+    if (rule.test(digits)) return rule.name;
+  }
+  return 'Unknown';
+}
+
+export const LuhnBoxSource = {
+  name: 'Luhn Check',
+  description:
+    'Validate a number with the Luhn (mod 10) algorithm and detect the card brand.',
+  defaultInput: '4111 1111 1111 1111 ::luhn',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'luhn')) return [];
+
+    const digits = trim(input).replace(/[\s-]/g, '');
+
+    // require all digits and minimum viable length
+    if (digits.length < 2 || !/^\d+$/.test(digits)) return [];
+
+    const valid = luhn(digits);
+    const brand = valid ? detectBrand(digits) : 'Unknown';
+
+    return [
+      new BoxBuilder('Luhn Check', '')
+        .setOptions({
+          Number: digits,
+          Valid: String(valid),
+          Brand: brand,
+        })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LuhnBoxSource;

--- a/src/modules/boxSources/LuhnBoxSource.ts
+++ b/src/modules/boxSources/LuhnBoxSource.ts
@@ -34,10 +34,12 @@ const BRAND_RULES: BrandRule[] = [
       const prefix4 = d.slice(0, 4);
       const prefix3 = d.slice(0, 3);
       const prefix2 = d.slice(0, 2);
+      const prefix6 = Number.parseInt(d.slice(0, 6), 10);
       return (
         prefix4 === '6011' ||
         prefix2 === '65' ||
-        (prefix3 >= '644' && prefix3 <= '649')
+        (prefix3 >= '644' && prefix3 <= '649') ||
+        (prefix6 >= 622126 && prefix6 <= 622925)
       );
     },
   },
@@ -89,8 +91,10 @@ export const LuhnBoxSource = {
 
     const digits = trim(input).replace(/[\s-]/g, '');
 
-    // require all digits and minimum viable length
-    if (digits.length < 2 || !/^\d+$/.test(digits)) return [];
+    // no real card number exceeds 19 digits; the 30-cap also bounds work
+    if (digits.length < 2 || digits.length > 30 || !/^\d+$/.test(digits)) {
+      return [];
+    }
 
     const valid = luhn(digits);
     const brand = valid ? detectBrand(digits) : 'Unknown';

--- a/src/modules/boxSources/NanoIdBoxSource.ts
+++ b/src/modules/boxSources/NanoIdBoxSource.ts
@@ -1,0 +1,68 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const DEFAULT_SIZE = 21;
+const MAX_SIZE = 256;
+
+// url-safe alphabet — 64 chars so 256 % 64 === 0, eliminating modulo bias
+const ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
+
+function resolveSize(raw: string | boolean | null): number {
+  // a bare ::nanoid flag (boolean) or missing value uses the default size
+  if (typeof raw !== 'string') return DEFAULT_SIZE;
+  const n = Number.parseInt(raw, 10);
+  if (Number.isNaN(n) || n <= 0) return DEFAULT_SIZE;
+  return Math.min(n, MAX_SIZE);
+}
+
+export const NanoIdBoxSource = {
+  name: 'NanoID',
+  description:
+    'Generate a URL-safe NanoID. Use ::nanoid=N for a custom length (default 21).',
+  defaultInput: 'nanoid ::nanoid',
+  tag: '#',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    _input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'nanoid')) return [];
+
+    const raw = extractOptionKeys(options, 'nanoid');
+    const size = resolveSize(raw);
+
+    if (
+      typeof crypto === 'undefined' ||
+      typeof crypto.getRandomValues !== 'function'
+    ) {
+      return [
+        new BoxBuilder(
+          'NanoID',
+          'crypto.getRandomValues is unavailable in this environment',
+        )
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const bytes = new Uint8Array(size);
+    crypto.getRandomValues(bytes);
+    const id = Array.from(bytes, (b) => ALPHABET[b % ALPHABET.length]).join('');
+
+    return [
+      new BoxBuilder('NanoID', id)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NanoIdBoxSource;

--- a/src/modules/boxSources/TemperatureBoxSource.ts
+++ b/src/modules/boxSources/TemperatureBoxSource.ts
@@ -25,6 +25,9 @@ function fromCelsius(c: number): {
 
 const INPUT_REGEX = /^(-?\d+(?:\.\d+)?)\s*([cCfFkK])?$/;
 
+// absolute zero in celsius; nothing colder is physically meaningful
+const ABSOLUTE_ZERO_C = -273.15;
+
 export const TemperatureBoxSource = {
   name: 'Temperature',
   description:
@@ -63,6 +66,9 @@ export const TemperatureBoxSource = {
       celsius = value;
     }
 
+    // reject temperatures below absolute zero (physically impossible)
+    if (celsius < ABSOLUTE_ZERO_C) return [];
+
     const { celsius: c, fahrenheit: f, kelvin: k } = fromCelsius(celsius);
 
     const kvOptions: Record<string, string> = {
@@ -75,7 +81,7 @@ export const TemperatureBoxSource = {
       new BoxBuilder('Temperature', '')
         .setOptions(kvOptions)
         .setTemplate(KeyValueBoxTemplate)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build(),
     ];
   },

--- a/src/modules/boxSources/TemperatureBoxSource.ts
+++ b/src/modules/boxSources/TemperatureBoxSource.ts
@@ -1,0 +1,84 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// strips trailing decimal zeros, e.g. 100.00 → '100', 37.78 → '37.78'
+function formatValue(n: number): string {
+  return Number.parseFloat(n.toFixed(2)).toString();
+}
+
+// converts celsius to all three scales and returns formatted strings
+function fromCelsius(c: number): {
+  celsius: string;
+  fahrenheit: string;
+  kelvin: string;
+} {
+  return {
+    celsius: formatValue(c),
+    fahrenheit: formatValue(c * (9 / 5) + 32),
+    kelvin: formatValue(c + 273.15),
+  };
+}
+
+const INPUT_REGEX = /^(-?\d+(?:\.\d+)?)\s*([cCfFkK])?$/;
+
+export const TemperatureBoxSource = {
+  name: 'Temperature',
+  description:
+    'Convert a temperature between Celsius, Fahrenheit and Kelvin. e.g. "100C ::temp".',
+  defaultInput: '100C ::temp',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'temp', 'temperature')) return [];
+
+    const trimmed = trim(input);
+    const match = INPUT_REGEX.exec(trimmed);
+    if (!match) return [];
+
+    const value = Number.parseFloat(match[1]);
+
+    // unit from input suffix, then option value, then default to celsius
+    let unit = match[2]?.toLowerCase() ?? null;
+    if (!unit) {
+      const optVal = extractOptionKeys(options, 'temp', 'temperature');
+      unit = typeof optVal === 'string' ? optVal.toLowerCase() : 'c';
+    }
+
+    // compute celsius as pivot
+    let celsius: number;
+    if (unit === 'f') {
+      celsius = (value - 32) * (5 / 9);
+    } else if (unit === 'k') {
+      celsius = value - 273.15;
+    } else {
+      celsius = value;
+    }
+
+    const { celsius: c, fahrenheit: f, kelvin: k } = fromCelsius(celsius);
+
+    const kvOptions: Record<string, string> = {
+      Celsius: c,
+      Fahrenheit: f,
+      Kelvin: k,
+    };
+
+    return [
+      new BoxBuilder('Temperature', '')
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default TemperatureBoxSource;

--- a/src/modules/boxSources/TemperatureBoxSource.ts
+++ b/src/modules/boxSources/TemperatureBoxSource.ts
@@ -44,6 +44,8 @@ export const TemperatureBoxSource = {
     if (!hasOptionKeys(options, 'temp', 'temperature')) return [];
 
     const trimmed = trim(input);
+    // no valid temperature string is this long; bound regex work
+    if (trimmed.length > 50) return [];
     const match = INPUT_REGEX.exec(trimmed);
     if (!match) return [];
 

--- a/src/modules/boxSources/UnicodeInspectorBoxSource.ts
+++ b/src/modules/boxSources/UnicodeInspectorBoxSource.ts
@@ -1,0 +1,79 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_CHARS = 256;
+
+// format a code point as U+XXXX (uppercase, minimum 4 hex digits)
+function formatCodePoint(cp: number): string {
+  return `U+${cp.toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
+// encode a single code point's UTF-8 bytes as space-separated lowercase 2-digit hex
+function utf8Hex(ch: string): string {
+  return Array.from(new TextEncoder().encode(ch))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join(' ');
+}
+
+// encode a single code point's UTF-16 code units as space-separated lowercase 4-digit hex
+function utf16Hex(ch: string): string {
+  const units: string[] = [];
+  for (let i = 0; i < ch.length; i++) {
+    units.push(ch.charCodeAt(i).toString(16).padStart(4, '0'));
+  }
+  return units.join(' ');
+}
+
+// build one inspector line for a single code point character
+function inspectChar(ch: string): string {
+  const cp = ch.codePointAt(0) as number;
+  return `${ch}  ${formatCodePoint(cp)}  dec=${cp}  utf8=${utf8Hex(ch)}  utf16=${utf16Hex(ch)}`;
+}
+
+export const UnicodeInspectorBoxSource = {
+  name: 'Unicode Inspector',
+  description:
+    'Show the code point, UTF-8 and UTF-16 encoding of each character.',
+  defaultInput: 'A€😀 ::unicode',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'unicode')) return [];
+    if (!isString(input) || trim(input).length === 0) return [];
+
+    const lines: string[] = [];
+    let count = 0;
+    let truncated = false;
+
+    for (const ch of input) {
+      if (count >= MAX_CHARS) {
+        truncated = true;
+        break;
+      }
+      lines.push(inspectChar(ch));
+      count++;
+    }
+
+    // note truncation at the end of the output when input exceeds the cap
+    if (truncated) {
+      lines.push(`... truncated at ${MAX_CHARS} code points`);
+    }
+
+    const box = new BoxBuilder('Unicode Inspector', lines.join('\n'))
+      .setTemplate(CodeBoxTemplate)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default UnicodeInspectorBoxSource;

--- a/src/modules/boxSources/UnicodeInspectorBoxSource.ts
+++ b/src/modules/boxSources/UnicodeInspectorBoxSource.ts
@@ -6,6 +6,9 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 const Priority = 10;
 const MAX_CHARS = 256;
 
+// reused across the per-character utf-8 lookups
+const ENCODER = new TextEncoder();
+
 // format a code point as U+XXXX (uppercase, minimum 4 hex digits)
 function formatCodePoint(cp: number): string {
   return `U+${cp.toString(16).toUpperCase().padStart(4, '0')}`;
@@ -13,7 +16,7 @@ function formatCodePoint(cp: number): string {
 
 // encode a single code point's UTF-8 bytes as space-separated lowercase 2-digit hex
 function utf8Hex(ch: string): string {
-  return Array.from(new TextEncoder().encode(ch))
+  return Array.from(ENCODER.encode(ch))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join(' ');
 }

--- a/src/modules/boxSources/__test__/Base32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base32BoxSource.test.ts
@@ -110,6 +110,15 @@ describe('Base32BoxSource', () => {
       });
       expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
     });
+
+    it('rejects non-zero padding bits per RFC 4648 §6 (AR====== )', async () => {
+      // 'AQ======' is the canonical encoding of byte 0x04; 'AR======' carries
+      // the same bytes but with dirty padding bits and must not decode
+      const boxes = await Base32BoxSource.generateBoxes('AR======', {
+        base32decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
   });
 
   describe('generateBoxes - encode and decode together', () => {

--- a/src/modules/boxSources/__test__/Base32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base32BoxSource.test.ts
@@ -119,6 +119,16 @@ describe('Base32BoxSource', () => {
       });
       expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
     });
+
+    it('rejects structurally impossible lengths (chars % 8 in {1,3,6})', async () => {
+      // 1, 3 and 6 base32 chars cannot encode a whole number of bytes
+      for (const bad of ['A', 'MAA', 'MZXW6Y']) {
+        const boxes = await Base32BoxSource.generateBoxes(bad, {
+          base32decode: true,
+        });
+        expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+      }
+    });
   });
 
   describe('generateBoxes - encode and decode together', () => {

--- a/src/modules/boxSources/__test__/Base32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base32BoxSource.test.ts
@@ -1,0 +1,136 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { Base32BoxSource } from '@modules/boxSources/Base32BoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('Base32BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - encode (::base32)', () => {
+    it('encodes "foobar" per RFC 4648 test vector', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', {
+        base32: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base32 (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('MZXW6YTBOI======');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('encodes "foo" per RFC 4648 test vector', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foo', {
+        base32: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('MZXW6===');
+    });
+
+    it('encodes "f" per RFC 4648 test vector', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('f', { base32: true });
+      expect(boxes[0].props.plaintextOutput).toBe('MY======');
+    });
+
+    it('encodes empty string to empty string', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('', { base32: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('');
+    });
+
+    it('also triggers on ::base32encode option key', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', {
+        base32encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('MZXW6YTBOI======');
+    });
+  });
+
+  describe('generateBoxes - decode (::base32decode)', () => {
+    it('decodes "MZXW6YTBOI======" back to "foobar"', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('MZXW6YTBOI======', {
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base32 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('foobar');
+    });
+
+    it('decodes lowercase input (case-insensitive)', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('mzxw6ytboi======', {
+        base32decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('foobar');
+    });
+
+    it('decodes "MZXW6===" back to "foo"', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('MZXW6===', {
+        base32decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('foo');
+    });
+
+    it('decodes without padding ("MZXW6" → "foo")', async () => {
+      // RFC 4648 §3.3: decoders should handle missing padding
+      const boxes = await Base32BoxSource.generateBoxes('MZXW6', {
+        base32decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('foo');
+    });
+
+    it('decodes lowercase without padding ("mzxw6" → "foo")', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('mzxw6', {
+        base32decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('foo');
+    });
+  });
+
+  describe('generateBoxes - invalid decode input', () => {
+    it('returns an error box for input containing non-alphabet chars', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('0189', {
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base32 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+
+    it('returns an error box for input with digits 0, 1, 8, 9', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('HELLO0', {
+        base32decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+  });
+
+  describe('generateBoxes - encode and decode together', () => {
+    it('returns two boxes when both encode and decode options are set', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', {
+        base32: true,
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Base32 (Encode)');
+      expect(names).toContain('Base32 (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Base32BoxSource.name).toBe('Base32');
+      expect(Base32BoxSource.tag).toBe('#');
+      expect(Base32BoxSource.kind).toBe('Encode');
+      expect(typeof Base32BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CaesarCipherBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CaesarCipherBoxSource.test.ts
@@ -1,0 +1,130 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { CaesarCipherBoxSource } from '../CaesarCipherBoxSource';
+
+describe('CaesarCipherBoxSource', () => {
+  describe('no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes(
+        'Hello, World!',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes(
+        'Hello, World!',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input with rot13 option', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('', {
+        rot13: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('rot13', () => {
+    it('encodes Hello, World! correctly', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
+        rot13: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Uryyb, Jbeyq!');
+    });
+
+    it('is its own inverse — applying rot13 twice returns the original', async () => {
+      const input = 'Hello, World!';
+      const first = await CaesarCipherBoxSource.generateBoxes(input, {
+        rot13: true,
+      });
+      const rotated = first[0].props.plaintextOutput;
+      const second = await CaesarCipherBoxSource.generateBoxes(rotated, {
+        rot13: true,
+      });
+      expect(second[0].props.plaintextOutput).toBe(input);
+    });
+
+    it('box name reflects shift 13', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
+        rot13: true,
+      });
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13)');
+    });
+
+    it('uses DefaultBoxTemplate', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
+        rot13: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+
+  describe('caesar shift', () => {
+    it('shifts abc by 1 to bcd', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('abc', {
+        caesar: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('bcd');
+    });
+
+    it('wraps xyz by 3 to abc', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('xyz', {
+        caesar: '3',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('abc');
+    });
+
+    it('negative shift -1 on bcd returns abc', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('bcd', {
+        caesar: '-1',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('abc');
+    });
+
+    it('box name includes the effective shift', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('abc', {
+        caesar: '1',
+      });
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 1)');
+    });
+
+    it('defaults to shift 13 when caesar value is true (no value given)', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
+        caesar: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Uryyb, Jbeyq!');
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13)');
+    });
+
+    it('defaults to shift 13 on non-numeric caesar value', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('abc', {
+        caesar: 'xyz',
+      });
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13)');
+    });
+
+    it('preserves non-letter characters', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes(
+        'Hello, World! 123',
+        { rot13: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('Uryyb, Jbeyq! 123');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(CaesarCipherBoxSource.name).toBe('Caesar Cipher');
+      expect(CaesarCipherBoxSource.tag).toBe('Aa');
+      expect(CaesarCipherBoxSource.kind).toBe('Encode');
+      expect(typeof CaesarCipherBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CidrBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CidrBoxSource.test.ts
@@ -87,4 +87,15 @@ describe('CidrBoxSource', () => {
       expect(boxes).toHaveLength(1);
     });
   });
+
+  describe('generateBoxes — /0 default route', () => {
+    it('computes the all-internet subnet (guards the 32-bit shift edge case)', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('0.0.0.0/0');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Netmask).toBe('0.0.0.0');
+      expect(opts.Wildcard).toBe('255.255.255.255');
+      expect(opts['Total Addresses']).toBe('4294967296');
+    });
+  });
 });

--- a/src/modules/boxSources/__test__/CidrBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CidrBoxSource.test.ts
@@ -1,0 +1,90 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { CidrBoxSource } from '@modules/boxSources/CidrBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('CidrBoxSource', () => {
+  describe('generateBoxes — non-matching input', () => {
+    it('returns [] for plain text', async () => {
+      expect(await CidrBoxSource.generateBoxes('hello')).toHaveLength(0);
+    });
+
+    it('returns [] for bare IP without prefix', async () => {
+      expect(await CidrBoxSource.generateBoxes('1.2.3.4')).toHaveLength(0);
+    });
+
+    it('returns [] for octet out of range', async () => {
+      expect(await CidrBoxSource.generateBoxes('999.1.1.1/24')).toHaveLength(0);
+    });
+
+    it('returns [] for prefix > 32', async () => {
+      expect(await CidrBoxSource.generateBoxes('10.0.0.0/33')).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — /24 network', () => {
+    it('returns one box with correct subnet values', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('192.168.1.0/24');
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options).toMatchObject({
+        Network: '192.168.1.0',
+        Broadcast: '192.168.1.255',
+        Netmask: '255.255.255.0',
+        Wildcard: '0.0.0.255',
+        'First Host': '192.168.1.1',
+        'Last Host': '192.168.1.254',
+        'Total Addresses': '256',
+        'Usable Hosts': '254',
+      });
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('192.168.1.0/24');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('applies configured priority', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('192.168.1.0/24');
+      expect(boxes[0].props.priority).toBe(20);
+    });
+  });
+
+  describe('generateBoxes — /8 network', () => {
+    it('computes correct netmask and total addresses', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('10.0.0.0/8');
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Netmask).toBe('255.0.0.0');
+      expect(options?.['Total Addresses']).toBe('16777216');
+    });
+  });
+
+  describe('generateBoxes — /32 host route', () => {
+    it('reports usable 1 with first == last == the address itself', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('192.168.1.5/32');
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Usable Hosts']).toBe('1');
+      expect(options?.['First Host']).toBe('192.168.1.5');
+      expect(options?.['Last Host']).toBe('192.168.1.5');
+    });
+  });
+
+  describe('generateBoxes — /31 point-to-point', () => {
+    it('reports usable 2', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('10.0.0.0/31');
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Usable Hosts']).toBe('2');
+    });
+  });
+
+  describe('generateBoxes — whitespace tolerance', () => {
+    it('trims surrounding whitespace before parsing', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('  192.168.1.0/24  ');
+      expect(boxes).toHaveLength(1);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HexStringBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HexStringBoxSource.test.ts
@@ -1,0 +1,104 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { HexStringBoxSource } from '../HexStringBoxSource';
+
+describe('HexStringBoxSource', () => {
+  describe('no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('hi', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('hi', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ::hex / ::hexencode', () => {
+    it('encodes "hi" to "6869"', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('hi', { hex: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Hex (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('6869');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('encodes "A" to "41"', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('A', { hex: true });
+      expect(boxes[0].props.plaintextOutput).toBe('41');
+    });
+
+    it('encodes "€" (U+20AC, UTF-8 e2 82 ac) to "e282ac"', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('€', { hex: true });
+      expect(boxes[0].props.plaintextOutput).toBe('e282ac');
+    });
+
+    it('also triggers on ::hexencode', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('hi', {
+        hexencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('6869');
+    });
+  });
+
+  describe('decode — ::hexdecode', () => {
+    it('decodes "6869" to "hi"', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('6869', {
+        hexdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Hex (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('hi');
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('decodes "0x4869" (leading 0x) to "Hi"', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('0x4869', {
+        hexdecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('decodes "68 69" (with spaces) to "hi"', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('68 69', {
+        hexdecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hi');
+    });
+  });
+
+  describe('decode — invalid input', () => {
+    it('returns an invalid box for odd-length "123"', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('123', {
+        hexdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+
+    it('returns an invalid box for non-hex "zz"', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('zz', {
+        hexdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+  });
+
+  describe('both ::hex and ::hexdecode together', () => {
+    it('returns 2 boxes — one encode and one decode', async () => {
+      const boxes = await HexStringBoxSource.generateBoxes('hi', {
+        hex: true,
+        hexdecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Hex (Encode)');
+      expect(names).toContain('Hex (Decode)');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LuhnBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LuhnBoxSource.test.ts
@@ -1,0 +1,79 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { LuhnBoxSource } from '../LuhnBoxSource';
+
+describe('LuhnBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::luhn option is absent', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes(
+        '4111 1111 1111 1111',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for non-digit input', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('hello', { luhn: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('validates Visa test number as valid', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('4111 1111 1111 1111', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Luhn Check');
+      expect(boxes[0].props.options).toMatchObject({
+        Number: '4111111111111111',
+        Valid: 'true',
+        Brand: 'Visa',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('flags an invalid Visa number', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('4111 1111 1111 1112', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Valid: 'false',
+      });
+    });
+
+    it('detects Mastercard brand (5500 0000 0000 0004)', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('5500 0000 0000 0004', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Valid: 'true',
+        Brand: 'Mastercard',
+      });
+    });
+
+    it('detects Amex brand (378282246310005)', async () => {
+      // 378282246310005 is the standard Amex test card number
+      const boxes = await LuhnBoxSource.generateBoxes('378282246310005', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Valid: 'true',
+        Brand: 'Amex',
+      });
+    });
+
+    it('detects Discover brand (6011000000000004)', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('6011000000000004', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Valid: 'true',
+        Brand: 'Discover',
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LuhnBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LuhnBoxSource.test.ts
@@ -85,5 +85,22 @@ describe('LuhnBoxSource', () => {
         });
       }
     });
+
+    it('detects Discover in the 622126-622925 IIN range', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('6222000000000009', {
+        luhn: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Valid: 'true',
+        Brand: 'Discover',
+      });
+    });
+
+    it('rejects digit strings longer than 30 (no real card is that long)', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('1'.repeat(40), {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/LuhnBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LuhnBoxSource.test.ts
@@ -75,5 +75,15 @@ describe('LuhnBoxSource', () => {
         Brand: 'Discover',
       });
     });
+
+    it('detects 2-series Mastercard at both range bounds (2221-2720)', async () => {
+      for (const num of ['2221000000000009', '2720000000000005']) {
+        const boxes = await LuhnBoxSource.generateBoxes(num, { luhn: true });
+        expect(boxes[0].props.options).toMatchObject({
+          Valid: 'true',
+          Brand: 'Mastercard',
+        });
+      }
+    });
   });
 });

--- a/src/modules/boxSources/__test__/NanoIdBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NanoIdBoxSource.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { NanoIdBoxSource } from '../NanoIdBoxSource';
+
+const ALPHABET_RE = /^[A-Za-z0-9_-]+$/;
+
+describe('NanoIdBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::nanoid option is absent', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('nanoid', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is empty object (no nanoid key)', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('generates a 21-char url-safe id for ::nanoid (boolean true)', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', { nanoid: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toHaveLength(21);
+      expect(boxes[0].props.plaintextOutput).toMatch(ALPHABET_RE);
+    });
+
+    it('generates a custom-length id for ::nanoid=10', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', {
+        nanoid: '10',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toHaveLength(10);
+      expect(boxes[0].props.plaintextOutput).toMatch(ALPHABET_RE);
+    });
+
+    it('falls back to default length 21 for ::nanoid=0', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', { nanoid: '0' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toHaveLength(21);
+    });
+
+    it('falls back to default length 21 for ::nanoid=NaN (non-numeric string)', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', {
+        nanoid: 'abc',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toHaveLength(21);
+    });
+
+    it('falls back to default length 21 for ::nanoid=-5 (negative)', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', {
+        nanoid: '-5',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toHaveLength(21);
+    });
+
+    it('clamps size to MAX_SIZE (256)', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', {
+        nanoid: '9999',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toHaveLength(256);
+    });
+
+    it('ignores input text — only the option drives the trigger', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('some random text', {
+        nanoid: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toHaveLength(21);
+    });
+
+    it('produces unique ids across consecutive calls (uniqueness sanity)', async () => {
+      const [b1, b2] = await Promise.all([
+        NanoIdBoxSource.generateBoxes('', { nanoid: true }),
+        NanoIdBoxSource.generateBoxes('', { nanoid: true }),
+      ]);
+      expect(b1[0].props.plaintextOutput).not.toBe(b2[0].props.plaintextOutput);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/TemperatureBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TemperatureBoxSource.test.ts
@@ -1,0 +1,133 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { TemperatureBoxSource } from '@modules/boxSources/TemperatureBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('TemperatureBoxSource', () => {
+  describe('generateBoxes — no option', () => {
+    it('returns [] when no temp option is provided', async () => {
+      expect(
+        await TemperatureBoxSource.generateBoxes('100C', null),
+      ).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      expect(await TemperatureBoxSource.generateBoxes('100C', {})).toHaveLength(
+        0,
+      );
+    });
+  });
+
+  describe('generateBoxes — Celsius input', () => {
+    it('converts 100C correctly', async () => {
+      const boxes = await TemperatureBoxSource.generateBoxes('100C', {
+        temp: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Celsius).toBe('100');
+      expect(options?.Fahrenheit).toBe('212');
+      expect(options?.Kelvin).toBe('373.15');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await TemperatureBoxSource.generateBoxes('100C', {
+        temp: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is Temperature', async () => {
+      const boxes = await TemperatureBoxSource.generateBoxes('100C', {
+        temp: true,
+      });
+      expect(boxes[0].props.name).toBe('Temperature');
+    });
+  });
+
+  describe('generateBoxes — Fahrenheit input', () => {
+    it('converts 32F correctly', async () => {
+      const boxes = await TemperatureBoxSource.generateBoxes('32F', {
+        temp: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Celsius).toBe('0');
+      expect(options?.Fahrenheit).toBe('32');
+      expect(options?.Kelvin).toBe('273.15');
+    });
+
+    it('converts 98.6F with Celsius rounding to whole number', async () => {
+      const boxes = await TemperatureBoxSource.generateBoxes('98.6F', {
+        temp: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Celsius).toBe('37');
+    });
+  });
+
+  describe('generateBoxes — Kelvin input', () => {
+    it('converts 0K correctly', async () => {
+      const boxes = await TemperatureBoxSource.generateBoxes('0K', {
+        temp: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Celsius).toBe('-273.15');
+      expect(options?.Fahrenheit).toBe('-459.67');
+      expect(options?.Kelvin).toBe('0');
+    });
+  });
+
+  describe('generateBoxes — unit from option value', () => {
+    it('treats bare number as Fahrenheit when ::temp=f', async () => {
+      const boxes = await TemperatureBoxSource.generateBoxes('100', {
+        temp: 'f',
+      });
+      expect(boxes).toHaveLength(1);
+      // 100°F → ~37.78°C
+      expect(boxes[0].props.options?.Celsius).toBe('37.78');
+    });
+
+    it('treats bare number as Celsius by default when option value is boolean true', async () => {
+      const boxes = await TemperatureBoxSource.generateBoxes('0', {
+        temp: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Celsius).toBe('0');
+      expect(boxes[0].props.options?.Fahrenheit).toBe('32');
+    });
+  });
+
+  describe('generateBoxes — ::temperature alias', () => {
+    it('triggers on ::temperature option', async () => {
+      const boxes = await TemperatureBoxSource.generateBoxes('100C', {
+        temperature: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Celsius).toBe('100');
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns [] for non-numeric input', async () => {
+      expect(
+        await TemperatureBoxSource.generateBoxes('hello', { temp: true }),
+      ).toHaveLength(0);
+    });
+
+    it('returns [] for empty string', async () => {
+      expect(
+        await TemperatureBoxSource.generateBoxes('', { temp: true }),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(TemperatureBoxSource.name).toBe('Temperature');
+      expect(TemperatureBoxSource.tag).toBe('#');
+      expect(TemperatureBoxSource.kind).toBe('Convert');
+      expect(typeof TemperatureBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/UnicodeInspectorBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UnicodeInspectorBoxSource.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { UnicodeInspectorBoxSource } from '../UnicodeInspectorBoxSource';
+
+describe('UnicodeInspectorBoxSource', () => {
+  describe('guard conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('A', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object lacks ::unicode', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('A', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::unicode', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::unicode', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('   ', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('ASCII character — A (U+0041)', () => {
+    it('produces one box with a line containing U+0041, dec=65, utf8=41, utf16=0041', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('A', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Unicode Inspector');
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('U+0041');
+      expect(output).toContain('dec=65');
+      expect(output).toContain('utf8=41');
+      expect(output).toContain('utf16=0041');
+    });
+  });
+
+  describe('BMP non-ASCII character — € (U+20AC)', () => {
+    it('produces a line containing U+20AC and utf8=e2 82 ac', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('€', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('U+20AC');
+      expect(output).toContain('utf8=e2 82 ac');
+    });
+  });
+
+  describe('astral plane character — 😀 (U+1F600)', () => {
+    it('produces exactly ONE line (surrogate pair treated as single code point)', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('😀', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toHaveLength(1);
+    });
+
+    it('line contains U+1F600, dec=128512, utf16=d83d de00, utf8=f0 9f 98 80', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('😀', {
+        unicode: true,
+      });
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('U+1F600');
+      expect(output).toContain('dec=128512');
+      expect(output).toContain('utf16=d83d de00');
+      expect(output).toContain('utf8=f0 9f 98 80');
+    });
+  });
+
+  describe('multi-character string', () => {
+    it('a 3-char string yields 3 lines in the output', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('A€!', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toHaveLength(3);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,7 +1,10 @@
+import Base32BoxSource from './Base32BoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import CaesarCipherBoxSource from './CaesarCipherBoxSource';
+import CidrBoxSource from './CidrBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -9,17 +12,22 @@ import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HexStringBoxSource from './HexStringBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LuhnBoxSource from './LuhnBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
+import NanoIdBoxSource from './NanoIdBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import TemperatureBoxSource from './TemperatureBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import UnicodeInspectorBoxSource from './UnicodeInspectorBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
@@ -31,24 +39,32 @@ export const boxSources = [
   ColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  Base32BoxSource,
+  CaesarCipherBoxSource,
+  CidrBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HexStringBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LuhnBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
+  NanoIdBoxSource,
   NowBoxSource,
   PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
+  TemperatureBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
   TimestampBoxSource,
+  UnicodeInspectorBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
## Summary

Second exploration batch — **8 more self-contained BoxSource tools**. Like batch 1 (#260), each is option-gated or strictly input-shape-matched so it never steals input from another source.

| Tool | Trigger | What it does |
|------|---------|--------------|
| Base32 | `::base32` / `::base32decode` | RFC 4648 encode/decode |
| Hex String | `::hex` / `::hexdecode` | UTF-8 bytes ⇄ hex |
| Caesar Cipher | `::rot13` / `::caesar=N` | letter rotation (signed, wrapping) |
| CIDR | `a.b.c.d/p` | IPv4 subnet: network, broadcast, mask, wildcard, host range, counts |
| Luhn Check | `::luhn` | mod-10 validation + card brand (Visa/MC/Amex/Discover) |
| Temperature | `::temp` | Celsius / Fahrenheit / Kelvin |
| NanoID | `::nanoid=N` | URL-safe random id, `crypto.getRandomValues` |
| Unicode Inspector | `::unicode` | per-char code point + UTF-8/UTF-16 bytes |

## Design notes

- 8 sources built in parallel by isolated subagents (each owned only its source + test); `index.ts` wired in one serialized step.
- **Spec-anchored correctness**: Base32 uses RFC 4648 test vectors, CIDR uses unsigned 32-bit math (`>>> 0` to avoid sign bugs at `/0`–`/8`), Luhn test numbers are all verified to pass mod-10, NanoID alphabet is 64 chars so `256 % 64 === 0` → zero modulo bias.
- **NanoID is non-deterministic** — tests assert length + charset + uniqueness, never an exact value.
- CIDR matches by input shape (the `/p` suffix is specific); everything else is `::option`-gated.

## Verification

- ✅ `bun run test run` — **423 passing** (94 new across the 8 tools)
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Note: stacks conceptually on #260 (batch 1) but branched from `main` and is independent — no file overlap, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6