### PR TITLE
feat(boxSources): add 8 more tools (csv/json, query string, duration, hmac, num-to-words, line tools, ulid, base58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,81 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>CsvJsonBox</b> </summary>
+
+| match rule | description                                  | example                          |
+| ---------- | -------------------------------------------- | -------------------------------- |
+| `::csv`    | CSV ⇄ JSON array of objects (auto-direction) | `name,age\nAlice,30 ::csv`       |
+
+</details>
+
+<details>
+<summary> <b>QueryStringBox</b> </summary>
+
+| match rule       | description                              | example            |
+| ---------------- | ---------------------------------------- | ------------------ |
+| `::qs`           | query string ⇄ JSON (repeated keys → array) | `a=1&b=2&b=3 ::qs` |
+
+</details>
+
+<details>
+<summary> <b>DurationBox</b> </summary>
+
+| match rule    | description                                   | example           |
+| ------------- | --------------------------------------------- | ----------------- |
+| `::duration`  | humanize a number of seconds (d/h/m/s)        | `3661 ::duration` |
+
+</details>
+
+<details>
+<summary> <b>HmacBox</b> </summary>
+
+| match rule    | description                                       | example                       |
+| ------------- | ------------------------------------------------- | ----------------------------- |
+| `::hmac=key`  | compute HMAC (SHA-256 default; ::sha1/::sha512)   | `message ::hmac=secret`       |
+
+</details>
+
+<details>
+<summary> <b>NumberToWordsBox</b> </summary>
+
+| match rule    | description                       | example            |
+| ------------- | --------------------------------- | ------------------ |
+| `::numwords`  | spell an integer in English words | `1234 ::numwords`  |
+
+</details>
+
+<details>
+<summary> <b>LineToolsBox</b> </summary>
+
+| match rule        | description                  | example                       |
+| ----------------- | ---------------------------- | ----------------------------- |
+| `::sortlines`     | sort lines ascending         | `banana\napple ::sortlines`   |
+| `::uniquelines`   | drop duplicate lines (keep order) | `a\nb\na ::uniquelines`  |
+| `::reverselines`  | reverse line order           | `1\n2\n3 ::reverselines`      |
+
+</details>
+
+<details>
+<summary> <b>ULIDBox</b> </summary>
+
+| match rule | description                                       | example     |
+| ---------- | ------------------------------------------------- | ----------- |
+| `::ulid`   | generate a 26-char sortable ULID (time + random)  | `::ulid`    |
+
+</details>
+
+<details>
+<summary> <b>Base58Box</b> </summary>
+
+| match rule        | description                          | example                  |
+| ----------------- | ------------------------------------ | ------------------------ |
+| `::base58`        | Base58 encode (Bitcoin alphabet)     | `Hello World! ::base58`  |
+| `::base58decode`  | Base58 decode back to text           | `2NEpo7TZRRrLZSi2U ::base58decode` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/Base58BoxSource.ts
+++ b/src/modules/boxSources/Base58BoxSource.ts
@@ -24,8 +24,10 @@ function base58EncodeBytes(bytes: Uint8Array): string {
     leadingZeros++;
   }
 
-  // mutable working copy; each element is a base-256 digit
-  const digits = Array.from(bytes);
+  // working copy excluding leading zero bytes; an all-zero input leaves this
+  // empty so the loop never runs and we return only the '1' padding (otherwise
+  // the division emits a spurious extra '1' and breaks the round-trip)
+  const digits = Array.from(bytes.subarray(leadingZeros));
   let result = '';
 
   while (digits.length > 0) {

--- a/src/modules/boxSources/Base58BoxSource.ts
+++ b/src/modules/boxSources/Base58BoxSource.ts
@@ -3,7 +3,9 @@ import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
-const MAX_INPUT = 100_000;
+// base58 long-division is O(n²); base58 is meant for small blobs (keys, hashes,
+// addresses), so a low cap keeps worst-case work sub-millisecond
+const MAX_INPUT = 1_024;
 
 // bitcoin alphabet: excludes 0, O, I, l to avoid visual ambiguity
 const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';

--- a/src/modules/boxSources/Base58BoxSource.ts
+++ b/src/modules/boxSources/Base58BoxSource.ts
@@ -1,0 +1,139 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// bitcoin alphabet: excludes 0, O, I, l to avoid visual ambiguity
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+// precompute decode map for O(1) char lookup
+const ALPHABET_MAP: Record<string, number> = {};
+for (let i = 0; i < ALPHABET.length; i++) {
+  ALPHABET_MAP[ALPHABET[i]] = i;
+}
+
+// encodes a byte array to base58 string using long division
+function base58EncodeBytes(bytes: Uint8Array): string {
+  let leadingZeros = 0;
+  for (const b of bytes) {
+    if (b !== 0) break;
+    leadingZeros++;
+  }
+
+  // mutable working copy; each element is a base-256 digit
+  const digits = Array.from(bytes);
+  let result = '';
+
+  while (digits.length > 0) {
+    let carry = 0;
+    const next: number[] = [];
+    for (const byte of digits) {
+      carry = carry * 256 + byte;
+      const quotient = Math.floor(carry / 58);
+      carry = carry % 58;
+      if (next.length > 0 || quotient > 0) {
+        next.push(quotient);
+      }
+    }
+    result = ALPHABET[carry] + result;
+    digits.length = 0;
+    for (const v of next) digits.push(v);
+  }
+
+  return '1'.repeat(leadingZeros) + result;
+}
+
+// decodes a base58 string to a byte array; returns null on invalid input
+function base58DecodeBytes(input: string): Uint8Array | null {
+  let leadingZeros = 0;
+  for (const ch of input) {
+    if (ch !== '1') break;
+    leadingZeros++;
+  }
+
+  // mutable working copy; each element is a base-58 digit value
+  const digits: number[] = [];
+  for (const ch of input.slice(leadingZeros)) {
+    const value = ALPHABET_MAP[ch];
+    if (value === undefined) return null;
+
+    let carry = value;
+    for (let i = digits.length - 1; i >= 0; i--) {
+      carry += digits[i] * 58;
+      digits[i] = carry % 256;
+      carry = Math.floor(carry / 256);
+    }
+    while (carry > 0) {
+      digits.unshift(carry % 256);
+      carry = Math.floor(carry / 256);
+    }
+  }
+
+  const result = new Uint8Array(leadingZeros + digits.length);
+  for (let i = 0; i < digits.length; i++) {
+    result[leadingZeros + i] = digits[i];
+  }
+  return result;
+}
+
+export const Base58BoxSource = {
+  name: 'Base58',
+  description:
+    'Encode text to Base58 (Bitcoin alphabet) or decode Base58 back to text.',
+  defaultInput: 'Hello World! ::base58',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'base58', 'base58encode');
+    const wantDecode = hasOptionKeys(options, 'base58decode');
+    if (!wantEncode && !wantDecode) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const bytes = new TextEncoder().encode(input);
+      const encoded = base58EncodeBytes(bytes);
+      boxes.push(
+        new BoxBuilder('Base58 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const bytes = base58DecodeBytes(input);
+      if (bytes === null) {
+        boxes.push(
+          new BoxBuilder('Base58 (Decode)', 'invalid Base58 input')
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        const decoded = new TextDecoder().decode(bytes);
+        boxes.push(
+          new BoxBuilder('Base58 (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Base58BoxSource;

--- a/src/modules/boxSources/CsvJsonBoxSource.ts
+++ b/src/modules/boxSources/CsvJsonBoxSource.ts
@@ -205,7 +205,7 @@ export const CsvJsonBoxSource = {
 
     // treat as CSV → JSON
     try {
-      const output = csvToJson(input);
+      const output = csvToJson(trimmed);
       return [
         new BoxBuilder('CSV → JSON', output)
           .setTemplate(CodeBoxTemplate)

--- a/src/modules/boxSources/CsvJsonBoxSource.ts
+++ b/src/modules/boxSources/CsvJsonBoxSource.ts
@@ -1,0 +1,227 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+// cap work to avoid DoS via uncapped ?input= URL param
+const MAX_INPUT = 100_000;
+
+// parse a single CSV row, handling quoted fields with embedded commas, newlines, and escaped quotes.
+// a field is emitted at every comma and once after the loop, so a trailing empty field appears only
+// when the row genuinely ends with a separator (no phantom column on a plain row)
+function parseCsvRow(line: string): string[] {
+  const fields: string[] = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          field += '"'; // escaped quote
+          i++;
+        } else {
+          inQuotes = false; // closing quote
+        }
+      } else {
+        field += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      fields.push(field);
+      field = '';
+    } else {
+      field += ch;
+    }
+  }
+
+  fields.push(field);
+  return fields;
+}
+
+// split CSV text into logical rows, respecting quoted fields that span multiple lines
+function splitCsvRows(text: string): string[] {
+  const rows: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  let i = 0;
+
+  while (i < text.length) {
+    const ch = text[i];
+
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+      current += ch;
+      i++;
+    } else if (
+      !inQuotes &&
+      (ch === '\n' || (ch === '\r' && text[i + 1] === '\n'))
+    ) {
+      rows.push(current);
+      current = '';
+      i += ch === '\r' ? 2 : 1;
+    } else {
+      current += ch;
+      i++;
+    }
+  }
+
+  if (current.length > 0) rows.push(current);
+
+  return rows;
+}
+
+// quote a CSV field value if it contains commas, double-quotes, or newlines
+function quoteCsvField(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function csvToJson(input: string): string {
+  const rows = splitCsvRows(trim(input)).filter((r) => r.trim() !== '');
+  if (rows.length === 0) throw new Error('empty CSV input');
+
+  const headers = parseCsvRow(rows[0]);
+  if (headers.length === 0) throw new Error('no headers found in CSV');
+
+  const result: Record<string, string>[] = [];
+
+  for (let i = 1; i < rows.length; i++) {
+    const fields = parseCsvRow(rows[i]);
+    const obj: Record<string, string> = {};
+    for (let j = 0; j < headers.length; j++) {
+      obj[headers[j]] = fields[j] ?? '';
+    }
+    result.push(obj);
+  }
+
+  return JSON.stringify(result, null, 2);
+}
+
+function jsonToCsv(input: string): string {
+  const parsed: unknown = JSON.parse(trim(input));
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('JSON input must be an array of objects');
+  }
+
+  // collect union of keys in first-seen order
+  const headerSet = new Set<string>();
+  for (const item of parsed) {
+    if (item !== null && typeof item === 'object' && !Array.isArray(item)) {
+      for (const key of Object.keys(item as Record<string, unknown>)) {
+        headerSet.add(key);
+      }
+    }
+  }
+
+  const headers = Array.from(headerSet);
+  const csvRows: string[] = [headers.map(quoteCsvField).join(',')];
+
+  for (const item of parsed) {
+    const record =
+      item !== null && typeof item === 'object' && !Array.isArray(item)
+        ? (item as Record<string, unknown>)
+        : {};
+    const row = headers.map((h) => quoteCsvField(String(record[h] ?? '')));
+    csvRows.push(row.join(','));
+  }
+
+  return csvRows.join('\n');
+}
+
+export const CsvJsonBoxSource = {
+  name: 'CSV / JSON',
+  description:
+    'Convert CSV to a JSON array of objects, or a JSON array back to CSV.',
+  defaultInput: 'name,age\nAlice,30\nBob,25 ::csv',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'csv')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    // detect direction: JSON array/object → CSV; everything else → JSON
+    const looksLikeJson = trimmed.startsWith('[') || trimmed.startsWith('{');
+
+    if (looksLikeJson) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        return [
+          new BoxBuilder(
+            'JSON → CSV',
+            `Parse error: input looks like JSON but is invalid`,
+          )
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      if (!Array.isArray(parsed)) {
+        return [
+          new BoxBuilder(
+            'JSON → CSV',
+            'Error: JSON input must be an array of objects',
+          )
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      try {
+        const output = jsonToCsv(trimmed);
+        return [
+          new BoxBuilder('JSON → CSV', output)
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return [
+          new BoxBuilder('JSON → CSV', `Error: ${msg}`)
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // treat as CSV → JSON
+    try {
+      const output = csvToJson(input);
+      return [
+        new BoxBuilder('CSV → JSON', output)
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return [
+        new BoxBuilder('CSV → JSON', `Error: ${msg}`)
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+  },
+};
+
+export default CsvJsonBoxSource;

--- a/src/modules/boxSources/DurationBoxSource.ts
+++ b/src/modules/boxSources/DurationBoxSource.ts
@@ -1,0 +1,87 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// seconds per unit
+const SECONDS_PER_DAY = 86400;
+const SECONDS_PER_HOUR = 3600;
+const SECONDS_PER_MINUTE = 60;
+
+interface DurationParts {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  totalSeconds: number;
+}
+
+// break a non-negative total-seconds value into d/h/m/s components
+function decompose(total: number): DurationParts {
+  const days = Math.floor(total / SECONDS_PER_DAY);
+  const afterDays = total - days * SECONDS_PER_DAY;
+  const hours = Math.floor(afterDays / SECONDS_PER_HOUR);
+  const afterHours = afterDays - hours * SECONDS_PER_HOUR;
+  const minutes = Math.floor(afterHours / SECONDS_PER_MINUTE);
+  const seconds = afterHours - minutes * SECONDS_PER_MINUTE;
+  return { days, hours, minutes, seconds, totalSeconds: total };
+}
+
+// join only non-zero components; for zero total return '0s'
+function humanize(parts: DurationParts): string {
+  const segments: string[] = [];
+  if (parts.days > 0) segments.push(`${parts.days}d`);
+  if (parts.hours > 0) segments.push(`${parts.hours}h`);
+  if (parts.minutes > 0) segments.push(`${parts.minutes}m`);
+  if (parts.seconds > 0 || segments.length === 0) {
+    segments.push(`${parts.seconds}s`);
+  }
+  return segments.join(' ');
+}
+
+export const DurationBoxSource = {
+  name: 'Duration',
+  description:
+    'Convert a number of seconds into a human-readable duration (days, hours, minutes, seconds).',
+  defaultInput: '3661 ::duration',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'duration')) return [];
+
+    const raw = trim(input).slice(0, 50);
+    if (!/^\d+(\.\d+)?$/.test(raw)) return [];
+
+    const total = Number.parseFloat(raw);
+    if (Number.isNaN(total) || total < 0) return [];
+
+    const parts = decompose(total);
+    const human = humanize(parts);
+
+    const data: Record<string, string> = {
+      Human: human,
+      Days: String(parts.days),
+      Hours: String(parts.hours),
+      Minutes: String(parts.minutes),
+      Seconds: String(parts.seconds),
+      'Total Seconds': String(total),
+    };
+
+    return [
+      new BoxBuilder('Duration', '')
+        .setOptions(data)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DurationBoxSource;

--- a/src/modules/boxSources/DurationBoxSource.ts
+++ b/src/modules/boxSources/DurationBoxSource.ts
@@ -25,7 +25,9 @@ function decompose(total: number): DurationParts {
   const hours = Math.floor(afterDays / SECONDS_PER_HOUR);
   const afterHours = afterDays - hours * SECONDS_PER_HOUR;
   const minutes = Math.floor(afterHours / SECONDS_PER_MINUTE);
-  const seconds = afterHours - minutes * SECONDS_PER_MINUTE;
+  // round to 3 decimals so fractional input doesn't surface float noise (1.900000000000091)
+  const seconds =
+    Math.round((afterHours - minutes * SECONDS_PER_MINUTE) * 1000) / 1000;
   return { days, hours, minutes, seconds, totalSeconds: total };
 }
 

--- a/src/modules/boxSources/HmacBoxSource.ts
+++ b/src/modules/boxSources/HmacBoxSource.ts
@@ -1,0 +1,112 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 20;
+
+// supported HMAC hash algorithms
+type HmacHash = 'SHA-1' | 'SHA-256' | 'SHA-512';
+
+interface HmacAlgorithmEntry {
+  hash: HmacHash;
+  optionKeys: string[];
+  label: string;
+}
+
+const HMAC_ALGORITHMS: HmacAlgorithmEntry[] = [
+  { hash: 'SHA-1', optionKeys: ['sha1'], label: 'SHA1' },
+  { hash: 'SHA-256', optionKeys: ['sha256'], label: 'SHA256' },
+  { hash: 'SHA-512', optionKeys: ['sha512'], label: 'SHA512' },
+];
+
+function bufToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function computeHmac(
+  hash: HmacHash,
+  keyStr: string,
+  message: string,
+): Promise<string> {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(keyStr),
+    { name: 'HMAC', hash },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign(
+    'HMAC',
+    keyMaterial,
+    enc.encode(message),
+  );
+  return bufToHex(sig);
+}
+
+function resolveAlgorithm(options: BoxOptions): HmacAlgorithmEntry {
+  const match = HMAC_ALGORITHMS.find((alg) =>
+    hasOptionKeys(options, ...alg.optionKeys),
+  );
+  // default to SHA-256 when no algorithm option is present
+  return match ?? HMAC_ALGORITHMS[1];
+}
+
+export const HmacBoxSource = {
+  name: 'HMAC',
+  description:
+    'Compute an HMAC (SHA-256 by default) of the input using a key. e.g. "msg ::hmac=secret".',
+  defaultInput: 'The quick brown fox ::hmac=key',
+  tag: '#',
+  kind: 'Hash',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hmac')) return [];
+
+    // guard: crypto.subtle requires a secure context
+    if (typeof crypto === 'undefined' || !crypto.subtle) {
+      return [
+        new BoxBuilder(
+          'HMAC',
+          'HMAC requires a secure context (HTTPS). crypto.subtle is not available.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const keyValue = extractOptionKeys(options, 'hmac');
+
+    // bare ::hmac without a value yields true (boolean) — key is required
+    if (!keyValue || typeof keyValue !== 'string') {
+      return [
+        new BoxBuilder('HMAC', 'HMAC requires a key, e.g. ::hmac=secret')
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const alg = resolveAlgorithm(options);
+    const hex = await computeHmac(alg.hash, keyValue, input);
+
+    return [
+      new BoxBuilder(`HMAC-${alg.label}`, hex)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HmacBoxSource;

--- a/src/modules/boxSources/HmacBoxSource.ts
+++ b/src/modules/boxSources/HmacBoxSource.ts
@@ -2,7 +2,9 @@ import { DefaultBoxTemplate } from '@components/BoxTemplate';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
 
+// higher than the generic converters: hmac is always opt-in via an explicit key
 const Priority = 20;
+const MAX_INPUT = 100_000;
 
 // supported HMAC hash algorithms
 type HmacHash = 'SHA-1' | 'SHA-256' | 'SHA-512';
@@ -13,10 +15,12 @@ interface HmacAlgorithmEntry {
   label: string;
 }
 
+// hmac-prefixed selectors so they don't collide with HashBoxSource's
+// ::sha1/::sha256/::sha512 trigger keys
 const HMAC_ALGORITHMS: HmacAlgorithmEntry[] = [
-  { hash: 'SHA-1', optionKeys: ['sha1'], label: 'SHA1' },
-  { hash: 'SHA-256', optionKeys: ['sha256'], label: 'SHA256' },
-  { hash: 'SHA-512', optionKeys: ['sha512'], label: 'SHA512' },
+  { hash: 'SHA-1', optionKeys: ['hmac-sha1'], label: 'SHA1' },
+  { hash: 'SHA-256', optionKeys: ['hmac-sha256'], label: 'SHA256' },
+  { hash: 'SHA-512', optionKeys: ['hmac-sha512'], label: 'SHA512' },
 ];
 
 function bufToHex(buf: ArrayBuffer): string {
@@ -57,7 +61,7 @@ function resolveAlgorithm(options: BoxOptions): HmacAlgorithmEntry {
 export const HmacBoxSource = {
   name: 'HMAC',
   description:
-    'Compute an HMAC (SHA-256 by default) of the input using a key. e.g. "msg ::hmac=secret".',
+    'Compute an HMAC (SHA-256 by default) of the input using a key. e.g. "msg ::hmac=secret". Pick the hash with ::hmac-sha1 / ::hmac-sha512.',
   defaultInput: 'The quick brown fox ::hmac=key',
   tag: '#',
   kind: 'Hash',
@@ -68,6 +72,7 @@ export const HmacBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'hmac')) return [];
+    if (input.length > MAX_INPUT) return [];
 
     // guard: crypto.subtle requires a secure context
     if (typeof crypto === 'undefined' || !crypto.subtle) {

--- a/src/modules/boxSources/LineToolsBoxSource.ts
+++ b/src/modules/boxSources/LineToolsBoxSource.ts
@@ -6,9 +6,12 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 const Priority = 10;
 const MAX_INPUT = 100_000;
 
-// strip trailing \r from each line to tolerate CRLF input
+// split into lines, stripping trailing \r (CRLF) and dropping the single empty
+// element a trailing newline would otherwise produce
 function splitLines(input: string): string[] {
-  return input.split('\n').map((line) => line.replace(/\r$/, ''));
+  const lines = input.split('\n').map((line) => line.replace(/\r$/, ''));
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return lines;
 }
 
 export const LineToolsBoxSource = {

--- a/src/modules/boxSources/LineToolsBoxSource.ts
+++ b/src/modules/boxSources/LineToolsBoxSource.ts
@@ -1,0 +1,77 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// strip trailing \r from each line to tolerate CRLF input
+function splitLines(input: string): string[] {
+  return input.split('\n').map((line) => line.replace(/\r$/, ''));
+}
+
+export const LineToolsBoxSource = {
+  name: 'Line Tools',
+  description: 'Sort, de-duplicate, or reverse the lines of a text block.',
+  defaultInput: 'banana\napple\ncherry\napple ::sortlines',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantSort = hasOptionKeys(options, 'sortlines');
+    const wantUnique = hasOptionKeys(options, 'uniquelines');
+    const wantReverse = hasOptionKeys(options, 'reverselines');
+
+    if (!wantSort && !wantUnique && !wantReverse) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const lines = splitLines(input);
+    const boxes: Box[] = [];
+
+    if (wantSort) {
+      const sorted = [...lines].sort((a, b) => a.localeCompare(b));
+      boxes.push(
+        new BoxBuilder('Sorted Lines', sorted.join('\n'))
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantUnique) {
+      // keep first occurrence order
+      const seen = new Set<string>();
+      const unique = lines.filter((line) => {
+        if (seen.has(line)) return false;
+        seen.add(line);
+        return true;
+      });
+      boxes.push(
+        new BoxBuilder('Unique Lines', unique.join('\n'))
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantReverse) {
+      const reversed = [...lines].reverse();
+      boxes.push(
+        new BoxBuilder('Reversed Lines', reversed.join('\n'))
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default LineToolsBoxSource;

--- a/src/modules/boxSources/NumberToWordsBoxSource.ts
+++ b/src/modules/boxSources/NumberToWordsBoxSource.ts
@@ -1,0 +1,148 @@
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max digit length we're willing to handle (~10^39 would overflow quintillions scale)
+const MAX_INPUT_LENGTH = 40;
+
+const ones = [
+  '',
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten',
+  'eleven',
+  'twelve',
+  'thirteen',
+  'fourteen',
+  'fifteen',
+  'sixteen',
+  'seventeen',
+  'eighteen',
+  'nineteen',
+];
+
+const tens = [
+  '',
+  '',
+  'twenty',
+  'thirty',
+  'forty',
+  'fifty',
+  'sixty',
+  'seventy',
+  'eighty',
+  'ninety',
+];
+
+// named scale groups in ascending order (each covers 3 decimal digits)
+const scales = [
+  '',
+  'thousand',
+  'million',
+  'billion',
+  'trillion',
+  'quadrillion',
+  'quintillion',
+];
+
+// convert a value in [0, 999] to english words
+function convertHundreds(n: number): string {
+  if (n === 0) return '';
+
+  const parts: string[] = [];
+
+  if (n >= 100) {
+    parts.push(`${ones[Math.floor(n / 100)]} hundred`);
+    n %= 100;
+  }
+
+  if (n >= 20) {
+    const t = tens[Math.floor(n / 10)];
+    const o = ones[n % 10];
+    parts.push(o ? `${t}-${o}` : t);
+  } else if (n > 0) {
+    parts.push(ones[n]);
+  }
+
+  return parts.join(' ');
+}
+
+// convert a non-negative BigInt to english words
+function bigIntToWords(n: bigint): string {
+  if (n === 0n) return 'zero';
+
+  const groupSize = 1000n;
+  const groups: number[] = [];
+
+  let remaining = n;
+  while (remaining > 0n) {
+    groups.push(Number(remaining % groupSize));
+    remaining /= groupSize;
+  }
+
+  if (groups.length > scales.length) {
+    // number exceeds quintillions — reject
+    return '';
+  }
+
+  const parts: string[] = [];
+  for (let i = groups.length - 1; i >= 0; i--) {
+    const g = groups[i];
+    if (g === 0) continue;
+
+    const words = convertHundreds(g);
+    const scale = scales[i];
+    parts.push(scale ? `${words} ${scale}` : words);
+  }
+
+  return parts.join(' ');
+}
+
+export const NumberToWordsBoxSource = {
+  name: 'Number to Words',
+  description: 'Spell an integer in English words.',
+  defaultInput: '1234 ::numwords',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'numwords')) return [];
+
+    const raw = trim(input);
+
+    // reject overly long strings before BigInt parsing
+    if (raw.length > MAX_INPUT_LENGTH) return [];
+
+    if (!/^-?\d+$/.test(raw)) return [];
+
+    const negative = raw.startsWith('-');
+    const digits = negative ? raw.slice(1) : raw;
+
+    const words = bigIntToWords(BigInt(digits));
+    if (!words) return [];
+
+    const output = negative ? `negative ${words}` : words;
+
+    return [
+      new BoxBuilder('Number to Words', output)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberToWordsBoxSource;

--- a/src/modules/boxSources/NumberToWordsBoxSource.ts
+++ b/src/modules/boxSources/NumberToWordsBoxSource.ts
@@ -132,7 +132,17 @@ export const NumberToWordsBoxSource = {
     const digits = negative ? raw.slice(1) : raw;
 
     const words = bigIntToWords(BigInt(digits));
-    if (!words) return [];
+    if (!words) {
+      return [
+        new BoxBuilder(
+          'Number to Words',
+          'number exceeds the maximum supported scale (999 quintillion)',
+        )
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
 
     const output = negative ? `negative ${words}` : words;
 

--- a/src/modules/boxSources/QueryStringBoxSource.ts
+++ b/src/modules/boxSources/QueryStringBoxSource.ts
@@ -28,9 +28,16 @@ function parseQueryString(raw: string): Record<string, string | string[]> {
   const params = new URLSearchParams(stripped);
   const result: Record<string, string | string[]> = {};
 
-  for (const key of params.keys()) {
-    const values = params.getAll(key);
-    result[key] = values.length === 1 ? values[0] : values;
+  // single entries() pass — calling getAll() inside a keys() loop would be O(k^2)
+  for (const [key, value] of params.entries()) {
+    const existing = result[key];
+    if (existing === undefined) {
+      result[key] = value;
+    } else if (Array.isArray(existing)) {
+      existing.push(value);
+    } else {
+      result[key] = [existing, value];
+    }
   }
   return result;
 }

--- a/src/modules/boxSources/QueryStringBoxSource.ts
+++ b/src/modules/boxSources/QueryStringBoxSource.ts
@@ -1,0 +1,106 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// serialize a plain object to a URL query string, encoding keys and values
+function serializeToQueryString(obj: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const encodedKey = encodeURIComponent(key);
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        parts.push(`${encodedKey}=${encodeURIComponent(String(item))}`);
+      }
+    } else {
+      parts.push(`${encodedKey}=${encodeURIComponent(String(value))}`);
+    }
+  }
+  return parts.join('&');
+}
+
+// parse a query string into an object; repeated keys become arrays
+function parseQueryString(raw: string): Record<string, string | string[]> {
+  const stripped = raw.startsWith('?') ? raw.slice(1) : raw;
+  const params = new URLSearchParams(stripped);
+  const result: Record<string, string | string[]> = {};
+
+  for (const key of params.keys()) {
+    const values = params.getAll(key);
+    result[key] = values.length === 1 ? values[0] : values;
+  }
+  return result;
+}
+
+export const QueryStringBoxSource = {
+  name: 'Query String',
+  description:
+    'Parse a URL query string into JSON, or serialize a JSON object into a query string.',
+  defaultInput: 'a=1&b=2&b=3 ::qs',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'qs', 'querystring')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const s = trim(input);
+
+    // JSON → Query String
+    if (s.startsWith('{')) {
+      try {
+        const obj = JSON.parse(s) as Record<string, unknown>;
+        const output = serializeToQueryString(obj);
+        return [
+          new BoxBuilder('JSON → Query String', output)
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        return [
+          new BoxBuilder(
+            'Query String Error',
+            `Failed to parse JSON: ${message}`,
+          )
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // Query String → JSON
+    try {
+      const obj = parseQueryString(s);
+      const output = JSON.stringify(obj, null, 2);
+      return [
+        new BoxBuilder('Query String → JSON', output)
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return [
+        new BoxBuilder(
+          'Query String Error',
+          `Failed to parse query string: ${message}`,
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+  },
+};
+
+export default QueryStringBoxSource;

--- a/src/modules/boxSources/UlidBoxSource.ts
+++ b/src/modules/boxSources/UlidBoxSource.ts
@@ -1,0 +1,88 @@
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// Crockford base32 alphabet: digits + uppercase letters minus I, L, O, U
+const ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+// encodes a 48-bit timestamp (ms) as 10 Crockford base32 chars, MSB first
+function encodeTime(ms: number): string {
+  const chars: string[] = [];
+  let t = ms;
+  for (let i = 0; i < 10; i++) {
+    chars.unshift(ENCODING[t % 32]);
+    t = Math.floor(t / 32);
+  }
+  return chars.join('');
+}
+
+// encodes 10 random bytes (80 bits) as 16 Crockford base32 chars via 5-bit groups
+function encodeRandom(bytes: Uint8Array): string {
+  let buf = 0;
+  let bits = 0;
+  let out = '';
+
+  for (const byte of bytes) {
+    buf = (buf << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      out += ENCODING[(buf >> bits) & 0x1f];
+    }
+  }
+
+  // flush any remaining bits (80 % 5 === 0, so this won't fire for 10 bytes)
+  if (bits > 0) {
+    out += ENCODING[(buf << (5 - bits)) & 0x1f];
+  }
+
+  return out;
+}
+
+export const UlidBoxSource = {
+  name: 'ULID',
+  description:
+    'Generate a ULID — a 26-char lexicographically sortable identifier (48-bit time + 80-bit randomness).',
+  defaultInput: 'ulid ::ulid',
+  tag: '#',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    _input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ulid')) return [];
+
+    if (
+      typeof crypto === 'undefined' ||
+      typeof crypto.getRandomValues !== 'function'
+    ) {
+      return [
+        new BoxBuilder(
+          'ULID',
+          'crypto.getRandomValues is unavailable in this context',
+        )
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const timeChars = encodeTime(Date.now());
+    const randomBytes = new Uint8Array(10);
+    crypto.getRandomValues(randomBytes);
+    const randomChars = encodeRandom(randomBytes);
+    const ulid = timeChars + randomChars;
+
+    return [
+      new BoxBuilder('ULID', ulid)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UlidBoxSource;

--- a/src/modules/boxSources/__test__/Base58BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base58BoxSource.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { Base58BoxSource } from '../Base58BoxSource';
+
+describe('Base58BoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Base58BoxSource.name).toBe('Base58');
+      expect(Base58BoxSource.tag).toBe('#');
+      expect(Base58BoxSource.kind).toBe('Encode');
+      expect(typeof Base58BoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('Hello World!', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('Hello World!', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - encode known vector', () => {
+    it('encodes "Hello World!" to canonical base58', async () => {
+      // canonical vector: base58(ASCII bytes of "Hello World!")
+      const boxes = await Base58BoxSource.generateBoxes('Hello World!', {
+        base58: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base58 (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('2NEpo7TZRRrLZSi2U');
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('accepts ::base58encode option alias', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('Hello World!', {
+        base58encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('2NEpo7TZRRrLZSi2U');
+    });
+  });
+
+  describe('generateBoxes - decode', () => {
+    it('decodes "2NEpo7TZRRrLZSi2U" back to "Hello World!"', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('2NEpo7TZRRrLZSi2U', {
+        base58decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base58 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('Hello World!');
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('returns invalid box for forbidden chars (0, O, I, l)', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('0OIl', {
+        base58decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base58 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('invalid Base58 input');
+    });
+  });
+
+  describe('generateBoxes - round-trip', () => {
+    it('decode(encode("Hello World!")) === "Hello World!"', async () => {
+      const encBoxes = await Base58BoxSource.generateBoxes('Hello World!', {
+        base58: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Base58BoxSource.generateBoxes(encoded, {
+        base58decode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe('Hello World!');
+    });
+
+    it('decode(encode("foobar")) === "foobar"', async () => {
+      const encBoxes = await Base58BoxSource.generateBoxes('foobar', {
+        base58: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Base58BoxSource.generateBoxes(encoded, {
+        base58decode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe('foobar');
+    });
+  });
+
+  describe('generateBoxes - both options', () => {
+    it('returns 2 boxes when both encode and decode options are set', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('Hello World!', {
+        base58: true,
+        base58decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Base58 (Encode)');
+      expect(names).toContain('Base58 (Decode)');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/Base58BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base58BoxSource.test.ts
@@ -92,6 +92,32 @@ describe('Base58BoxSource', () => {
     });
   });
 
+  describe('generateBoxes - leading zero bytes', () => {
+    const NUL = String.fromCharCode(0);
+
+    it('encodes a single NUL byte to exactly "1" and round-trips', async () => {
+      const enc = await Base58BoxSource.generateBoxes(NUL, { base58: true });
+      expect(enc[0].props.plaintextOutput).toBe('1');
+
+      const dec = await Base58BoxSource.generateBoxes('1', {
+        base58decode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe(NUL);
+    });
+
+    it('preserves a leading NUL before a printable byte', async () => {
+      const enc = await Base58BoxSource.generateBoxes(`${NUL}A`, {
+        base58: true,
+      });
+      const encoded = enc[0].props.plaintextOutput;
+      expect(encoded.startsWith('1')).toBe(true);
+      const dec = await Base58BoxSource.generateBoxes(encoded, {
+        base58decode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe(`${NUL}A`);
+    });
+  });
+
   describe('generateBoxes - both options', () => {
     it('returns 2 boxes when both encode and decode options are set', async () => {
       const boxes = await Base58BoxSource.generateBoxes('Hello World!', {

--- a/src/modules/boxSources/__test__/CsvJsonBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CsvJsonBoxSource.test.ts
@@ -87,5 +87,24 @@ describe('CsvJsonBoxSource', () => {
       expect(boxes[0].props.name).toBe('JSON → CSV');
       expect(boxes[0].props.plaintextOutput).toMatch(/error/i);
     });
+
+    it('keeps a newline embedded in a quoted CSV field as one row', async () => {
+      const input = 'name,note\n"a\nb",x';
+      const boxes = await CsvJsonBoxSource.generateBoxes(input, { csv: true });
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].name).toBe('a\nb');
+      expect(parsed[0].note).toBe('x');
+    });
+
+    it('unions heterogeneous keys (first-seen order, missing → empty)', async () => {
+      const boxes = await CsvJsonBoxSource.generateBoxes('[{"a":1},{"b":2}]', {
+        csv: true,
+      });
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines[0]).toBe('a,b');
+      expect(lines[1]).toBe('1,');
+      expect(lines[2]).toBe(',2');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/CsvJsonBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CsvJsonBoxSource.test.ts
@@ -1,0 +1,91 @@
+import { CsvJsonBoxSource } from '@modules/boxSources/CsvJsonBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('CsvJsonBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::csv option is absent', async () => {
+      const boxes = await CsvJsonBoxSource.generateBoxes(
+        'name,age\nAlice,30',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when ::csv option is absent (empty options)', async () => {
+      const boxes = await CsvJsonBoxSource.generateBoxes(
+        'name,age\nAlice,30',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts CSV → JSON array of objects (values stay strings)', async () => {
+      const boxes = await CsvJsonBoxSource.generateBoxes(
+        'name,age\nAlice,30\nBob,25',
+        {
+          csv: true,
+        },
+      );
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('CSV → JSON');
+
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual([
+        { name: 'Alice', age: '30' },
+        { name: 'Bob', age: '25' },
+      ]);
+    });
+
+    it('handles quoted fields with embedded commas and escaped quotes', async () => {
+      const input = 'name,note\n"Smith, Jr.","said ""hi"""';
+      const boxes = await CsvJsonBoxSource.generateBoxes(input, { csv: true });
+
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].name).toBe('Smith, Jr.');
+      expect(parsed[0].note).toBe('said "hi"');
+    });
+
+    it('converts JSON array → CSV with correct header and data rows', async () => {
+      const input = '[{"a":1,"b":2},{"a":3,"b":4}]';
+      const boxes = await CsvJsonBoxSource.generateBoxes(input, { csv: true });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → CSV');
+
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines[0]).toBe('a,b');
+      expect(lines[1]).toBe('1,2');
+      expect(lines[2]).toBe('3,4');
+    });
+
+    it('quotes CSV fields that contain commas', async () => {
+      const input = '[{"val":"x,y"}]';
+      const boxes = await CsvJsonBoxSource.generateBoxes(input, { csv: true });
+
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      // header row
+      expect(lines[0]).toBe('val');
+      // value must be quoted because it contains a comma
+      expect(lines[1]).toBe('"x,y"');
+    });
+
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const huge = `${'a,b\n1,2\n'.repeat(20_000)}`;
+      const boxes = await CsvJsonBoxSource.generateBoxes(huge, { csv: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns an error box on malformed JSON input', async () => {
+      const boxes = await CsvJsonBoxSource.generateBoxes('[{invalid}]', {
+        csv: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → CSV');
+      expect(boxes[0].props.plaintextOutput).toMatch(/error/i);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/DurationBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DurationBoxSource.test.ts
@@ -64,6 +64,15 @@ describe('DurationBoxSource', () => {
       expect(opts.Human).toBe('1d 2h 3m 4s');
     });
 
+    it('rounds fractional seconds without floating-point noise', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('3661.9', {
+        duration: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1h 1m 1.9s');
+      expect(opts.Seconds).toBe('1.9');
+    });
+
     it('uses KeyValueBoxTemplate', async () => {
       const boxes = await DurationBoxSource.generateBoxes('3661', {
         duration: true,

--- a/src/modules/boxSources/__test__/DurationBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DurationBoxSource.test.ts
@@ -1,0 +1,74 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DurationBoxSource } from '../DurationBoxSource';
+
+describe('DurationBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::duration option is absent', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('3661', null);
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('abc', {
+        duration: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] for negative input', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('-5', {
+        duration: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns 0s for total of 0 seconds', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('0', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Human: '0s' });
+    });
+
+    it('humanizes 3661 seconds as 1h 1m 1s', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('3661', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1h 1m 1s');
+      expect(opts.Days).toBe('0');
+      expect(opts.Hours).toBe('1');
+      expect(opts.Minutes).toBe('1');
+      expect(opts.Seconds).toBe('1');
+    });
+
+    it('humanizes 90 seconds as 1m 30s', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('90', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect((boxes[0].props.options as Record<string, string>).Human).toBe(
+        '1m 30s',
+      );
+    });
+
+    it('humanizes 93784 seconds as 1d 2h 3m 4s', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('93784', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1d 2h 3m 4s');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('3661', {
+        duration: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HmacBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HmacBoxSource.test.ts
@@ -48,22 +48,31 @@ describe('HmacBoxSource', () => {
   });
 
   describe('generateBoxes - algorithm selection', () => {
-    it('uses SHA-1 when ::sha1 option is set', async () => {
+    it('uses SHA-1 when ::hmac-sha1 option is set', async () => {
       const boxes = await HmacBoxSource.generateBoxes('msg', {
         hmac: 'secret',
-        sha1: true,
+        'hmac-sha1': true,
       });
       expect(boxes).toHaveLength(1);
       expect(boxes[0].props.name).toMatch(/SHA1/i);
     });
 
-    it('uses SHA-512 when ::sha512 option is set', async () => {
+    it('uses SHA-512 when ::hmac-sha512 option is set', async () => {
       const boxes = await HmacBoxSource.generateBoxes('msg', {
         hmac: 'secret',
-        sha512: true,
+        'hmac-sha512': true,
       });
       expect(boxes).toHaveLength(1);
       expect(boxes[0].props.name).toMatch(/SHA512/i);
+    });
+
+    it('does not select an algorithm from bare ::sha256 (avoids HashBox collision)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', {
+        hmac: 'secret',
+        sha256: true,
+      });
+      // bare ::sha* no longer selects; default SHA-256 still applies
+      expect(boxes[0].props.name).toMatch(/SHA256/i);
     });
   });
 

--- a/src/modules/boxSources/__test__/HmacBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HmacBoxSource.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { HmacBoxSource } from '../HmacBoxSource';
+
+describe('HmacBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when hmac option is absent', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - SHA-256 RFC vector', () => {
+    it('produces correct HMAC-SHA256 for the RFC 4231 / FIPS vector', async () => {
+      // vector: key="key", message="The quick brown fox jumps over the lazy dog"
+      // expected: f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8
+      const boxes = await HmacBoxSource.generateBoxes(
+        'The quick brown fox jumps over the lazy dog',
+        { hmac: 'key' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8',
+      );
+    });
+
+    it('box name contains SHA256 for the default algorithm', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', {
+        hmac: 'secret',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toMatch(/SHA256/i);
+    });
+  });
+
+  describe('generateBoxes - key required', () => {
+    it('returns a box mentioning key when ::hmac has no value (bare flag)', async () => {
+      // bare ::hmac parsed as { hmac: true }
+      const boxes = await HmacBoxSource.generateBoxes('msg', { hmac: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/key/i);
+    });
+  });
+
+  describe('generateBoxes - algorithm selection', () => {
+    it('uses SHA-1 when ::sha1 option is set', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', {
+        hmac: 'secret',
+        sha1: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toMatch(/SHA1/i);
+    });
+
+    it('uses SHA-512 when ::sha512 option is set', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', {
+        hmac: 'secret',
+        sha512: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toMatch(/SHA512/i);
+    });
+  });
+
+  describe('generateBoxes - non-secure context fallback', () => {
+    const originalCrypto = globalThis.crypto;
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { subtle: undefined },
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('returns an informational box when crypto.subtle is unavailable', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', { hmac: 'key' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HmacBoxSource.name).toBe('HMAC');
+      expect(HmacBoxSource.tag).toBe('#');
+      expect(HmacBoxSource.kind).toBe('Hash');
+      expect(typeof HmacBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LineToolsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LineToolsBoxSource.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { LineToolsBoxSource } from '../LineToolsBoxSource';
+
+describe('LineToolsBoxSource', () => {
+  describe('trigger guards', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes(
+        'banana\napple',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes('banana\napple', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes('', {
+        sortlines: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when input exceeds MAX_INPUT', async () => {
+      const big = 'a\n'.repeat(60_000);
+      const boxes = await LineToolsBoxSource.generateBoxes(big, {
+        sortlines: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::sortlines', () => {
+    it('sorts lines ascending by localeCompare', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        { sortlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Sorted Lines');
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nbanana\ncherry');
+    });
+  });
+
+  describe('::uniquelines', () => {
+    it('removes duplicate lines keeping first occurrence order', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes('a\nb\na\nc\nb', {
+        uniquelines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Unique Lines');
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb\nc');
+    });
+  });
+
+  describe('::reverselines', () => {
+    it('reverses the order of lines', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes('1\n2\n3', {
+        reverselines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Reversed Lines');
+      expect(boxes[0].props.plaintextOutput).toBe('3\n2\n1');
+    });
+  });
+
+  describe('combined options', () => {
+    it('returns two boxes for ::sortlines + ::uniquelines', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes('banana\napple', {
+        sortlines: true,
+        uniquelines: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Sorted Lines');
+      expect(names).toContain('Unique Lines');
+    });
+
+    it('returns three boxes when all three options are set', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        { sortlines: true, uniquelines: true, reverselines: true },
+      );
+      expect(boxes).toHaveLength(3);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Sorted Lines');
+      expect(names).toContain('Unique Lines');
+      expect(names).toContain('Reversed Lines');
+    });
+  });
+
+  describe('CRLF tolerance', () => {
+    it('strips trailing \\r from each line before processing', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes(
+        'banana\r\napple\r\ncherry\r\n',
+        { sortlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      // trailing empty string after final \n is sorted first, then words
+      const output = boxes[0].props.plaintextOutput as string;
+      expect(output).toContain('apple');
+      expect(output).toContain('banana');
+      expect(output).toContain('cherry');
+      // no \r should remain in output
+      expect(output).not.toContain('\r');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LineToolsBoxSource.name).toBe('Line Tools');
+      expect(LineToolsBoxSource.tag).toBe('#');
+      expect(LineToolsBoxSource.kind).toBe('Transform');
+      expect(typeof LineToolsBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NumberToWordsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberToWordsBoxSource.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { NumberToWordsBoxSource } from '../NumberToWordsBoxSource';
+
+describe('NumberToWordsBoxSource', () => {
+  describe('generateBoxes — option guard', () => {
+    it('returns [] when ::numwords option is absent', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('1234', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is an empty object', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('1234', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — valid integers', () => {
+    async function words(input: string): Promise<string> {
+      const boxes = await NumberToWordsBoxSource.generateBoxes(input, {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(1);
+      return boxes[0].props.plaintextOutput;
+    }
+
+    it('converts 0 to "zero"', async () => {
+      expect(await words('0')).toBe('zero');
+    });
+
+    it('converts 21 to "twenty-one"', async () => {
+      expect(await words('21')).toBe('twenty-one');
+    });
+
+    it('converts 100 to "one hundred"', async () => {
+      expect(await words('100')).toBe('one hundred');
+    });
+
+    it('converts 1234 to "one thousand two hundred thirty-four"', async () => {
+      expect(await words('1234')).toBe('one thousand two hundred thirty-four');
+    });
+
+    it('converts 1000000 to "one million"', async () => {
+      expect(await words('1000000')).toBe('one million');
+    });
+
+    it('converts -42 to "negative forty-two"', async () => {
+      expect(await words('-42')).toBe('negative forty-two');
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns [] for non-numeric input "abc"', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('abc', {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for decimal "1.5"', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('1.5', {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty string', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('', {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('sets name, showExpandButton false, and correct priority', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('5', {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { props, boxTemplate } = boxes[0];
+      expect(props.name).toBe('Number to Words');
+      expect(props.priority).toBe(10);
+      expect(props.showExpandButton).toBe(false);
+      expect(boxTemplate).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/QueryStringBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/QueryStringBoxSource.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { QueryStringBoxSource } from '../QueryStringBoxSource';
+
+describe('QueryStringBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no qs/querystring option is provided', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('a=1&b=2', null);
+      expect(boxes).toEqual([]);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('a=1&b=2', {
+        json: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('should parse query string with repeated keys into array', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('a=1&b=2&b=3', {
+        qs: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Query String → JSON');
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ a: '1', b: ['2', '3'] });
+    });
+
+    it('should strip leading ? and decode percent-encoded values', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes(
+        '?x=hello%20world',
+        { qs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ x: 'hello world' });
+    });
+
+    it('should serialize JSON object to query string', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes(
+        '{"a":"1","b":["2","3"]}',
+        { qs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → Query String');
+      expect(boxes[0].props.plaintextOutput).toBe('a=1&b=2&b=3');
+    });
+
+    it('should percent-encode special characters in JSON values', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('{"q":"a b&c"}', {
+        qs: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('q=a%20b%26c');
+    });
+
+    it('should accept ::querystring option alias', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('x=1', {
+        querystring: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Query String → JSON');
+    });
+
+    it('should return [] when input exceeds MAX_INPUT', async () => {
+      const huge = 'a=1&'.repeat(30_000); // ~120k chars
+      const boxes = await QueryStringBoxSource.generateBoxes(huge, {
+        qs: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/UlidBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UlidBoxSource.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { UlidBoxSource } from '../UlidBoxSource';
+
+// valid Crockford base32 alphabet: digits + uppercase minus I, L, O, U
+const ULID_REGEX = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+describe('UlidBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when ::ulid option is absent', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns 1 box with a 26-char Crockford base32 output when ::ulid is set', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', { ulid: true });
+      expect(boxes).toHaveLength(1);
+
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toHaveLength(26);
+      expect(output).toMatch(ULID_REGEX);
+    });
+
+    it('produces different ULIDs on consecutive calls', async () => {
+      const [a, b] = await Promise.all([
+        UlidBoxSource.generateBoxes('', { ulid: true }),
+        UlidBoxSource.generateBoxes('', { ulid: true }),
+      ]);
+      // statistically impossible to collide; guards against a frozen-clock + fixed-random bug
+      expect(a[0].props.plaintextOutput).not.toBe(b[0].props.plaintextOutput);
+    });
+
+    it('time component (first 10 chars) contains only valid Crockford alphabet chars', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', { ulid: true });
+      const timeComponent = boxes[0].props.plaintextOutput.slice(0, 10);
+      expect(timeComponent).toMatch(/^[0-9A-HJKMNP-TV-Z]{10}$/);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,25 +1,33 @@
+import Base58BoxSource from './Base58BoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
+import CsvJsonBoxSource from './CsvJsonBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HmacBoxSource from './HmacBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberToWordsBoxSource from './NumberToWordsBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import QueryStringBoxSource from './QueryStringBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import UlidBoxSource from './UlidBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
@@ -31,17 +39,24 @@ export const boxSources = [
   ColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  Base58BoxSource,
   CronExpressionBoxSource,
+  CsvJsonBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  DurationBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HmacBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LineToolsBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
+  NumberToWordsBoxSource,
   PasswordBoxSource,
+  QueryStringBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
@@ -49,6 +64,7 @@ export const boxSources = [
   URLDecodeBoxSource,
   UuidBoxSource,
   TimestampBoxSource,
+  UlidBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
## Summary

Third exploration batch — **8 more BoxSource tools**, each option-gated and input-capped, following the conventions hardened across #260/#261 reviews.

| Tool | Trigger | What it does |
|------|---------|--------------|
| CSV / JSON | `::csv` | RFC 4180-aware CSV ⇄ JSON array of objects, auto-direction |
| Query String | `::qs` / `::querystring` | query string ⇄ JSON (repeated keys → arrays) |
| Duration | `::duration` | humanize seconds → `1d 2h 3m 4s` + breakdown |
| HMAC | `::hmac=key` | Web Crypto HMAC, SHA-256 default (`::sha1`/`::sha512`) |
| Number to Words | `::numwords` | integer → English words (BigInt, up to quintillion) |
| Line Tools | `::sortlines` / `::uniquelines` / `::reverselines` | sort / dedupe / reverse lines (multi-box) |
| ULID | `::ulid` | 26-char sortable id (48-bit time + 80-bit random, Crockford base32) |
| Base58 | `::base58` / `::base58decode` | Bitcoin-alphabet encode/decode |

## Design notes

- 8 sources built by isolated subagents (each owns its source + test); `index.ts` wired in one step.
- **Verified test vectors**: HMAC-SHA256(key,"The quick brown fox…") = `f7bc83…1a3cd8`; Base58("Hello World!") = `2NEpo7TZRRrLZSi2U` (encoder confirmed against the canonical value).
- **Input caps** baked in from the start (`MAX_INPUT`) on the free-text processors (CSV, QS, Line Tools, Base58) — applying the DoS-class lesson from the earlier batches rather than waiting for review.
- ULID/HMAC use the secure-context guards / `crypto` APIs already established by Uuid/Hash.
- Self-review caught + fixed a CSV parser bug (a phantom trailing empty column) before opening this PR.

## Verification

- ✅ `bun run test run` — **399 passing** (70 new across the 8 tools)
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260/#261 — branched from `main`, no file overlap, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6