### PR TITLE
feat(boxSources): add 8 more tools (http-status, mime, crc32, hexdump, ratio, bytelen, uuid-inspect, json-minify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>HttpStatusBox</b> </summary>
+
+| match rule       | description                                  | example            |
+| ---------------- | -------------------------------------------- | ------------------ |
+| `::httpstatus`   | look up an HTTP status code's name & category | `404 ::httpstatus` |
+
+</details>
+
+<details>
+<summary> <b>MimeTypeBox</b> </summary>
+
+| match rule | description                                | example         |
+| ---------- | ------------------------------------------ | --------------- |
+| `::mime`   | extension ⇄ MIME type lookup               | `png ::mime`, `application/json ::mime` |
+
+</details>
+
+<details>
+<summary> <b>Crc32Box</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::crc32`   | CRC-32 (IEEE) checksum (hex + decimal) | `hello ::crc32` |
+
+</details>
+
+<details>
+<summary> <b>HexDumpBox</b> </summary>
+
+| match rule    | description                                  | example                    |
+| ------------- | -------------------------------------------- | -------------------------- |
+| `::hexdump`   | canonical hexdump (offset, hex bytes, ASCII) | `Hello, World! ::hexdump`  |
+
+</details>
+
+<details>
+<summary> <b>AspectRatioBox</b> </summary>
+
+| match rule | description                              | example              |
+| ---------- | ---------------------------------------- | -------------------- |
+| `::ratio`  | simplify width×height to an aspect ratio | `1920x1080 ::ratio`  |
+
+</details>
+
+<details>
+<summary> <b>ByteLengthBox</b> </summary>
+
+| match rule    | description                                       | example            |
+| ------------- | ------------------------------------------------- | ------------------ |
+| `::bytelen`   | count UTF-16 units, code points, UTF-8 bytes, graphemes | `héllo 😀 ::bytelen` |
+
+</details>
+
+<details>
+<summary> <b>UuidInspectBox</b> </summary>
+
+| match rule     | description                          | example                                       |
+| -------------- | ------------------------------------ | --------------------------------------------- |
+| `::uuidinfo`   | report a UUID's version and variant  | `550e8400-e29b-41d4-a716-446655440000 ::uuidinfo` |
+
+</details>
+
+<details>
+<summary> <b>JsonMinifyBox</b> </summary>
+
+| match rule    | description                                | example                       |
+| ------------- | ------------------------------------------ | ----------------------------- |
+| `::jsonmin`   | minify JSON (strip insignificant whitespace) | `{ "a": 1 } ::jsonmin`      |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/AspectRatioBoxSource.ts
+++ b/src/modules/boxSources/AspectRatioBoxSource.ts
@@ -1,0 +1,81 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// common aspect ratio names keyed by simplified ratio string
+const CommonRatios: Record<string, string> = {
+  '16:9': '16:9 Widescreen',
+  '4:3': '4:3 Standard',
+  '21:9': '21:9 Ultrawide',
+  '1:1': '1:1 Square',
+  '3:2': '3:2 Classic',
+  '16:10': '16:10 Widescreen',
+};
+
+function gcd(a: number, b: number): number {
+  while (b !== 0) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+export const AspectRatioBoxSource = {
+  name: 'Aspect Ratio',
+  description:
+    'Simplify width x height into an aspect ratio (e.g. 1920x1080 → 16:9).',
+  defaultInput: '1920x1080 ::ratio',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ratio', 'aspect')) return [];
+
+    const match = trim(input).match(/^(\d+)\s*[x:×]\s*(\d+)$/i);
+    if (!match) return [];
+
+    const w = Number.parseInt(match[1], 10);
+    const h = Number.parseInt(match[2], 10);
+    if (w <= 0 || h <= 0) return [];
+
+    const divisor = gcd(w, h);
+    const rw = w / divisor;
+    const rh = h / divisor;
+    const ratioStr = `${rw}:${rh}`;
+
+    // round to 4 significant digits and strip trailing zeros
+    const decimal = Number((w / h).toPrecision(4)).toString();
+
+    const kvOptions: Record<string, string> = {
+      Ratio: ratioStr,
+      Decimal: decimal,
+    };
+
+    const commonName = CommonRatios[ratioStr];
+    if (commonName) {
+      kvOptions.Common = commonName;
+    }
+
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Aspect Ratio', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default AspectRatioBoxSource;

--- a/src/modules/boxSources/ByteLengthBoxSource.ts
+++ b/src/modules/boxSources/ByteLengthBoxSource.ts
@@ -1,0 +1,67 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// count grapheme clusters using Intl.Segmenter when available, fall back to code points
+function countGraphemes(input: string): { count: number; fallback: boolean } {
+  if (
+    typeof Intl !== 'undefined' &&
+    typeof (Intl as { Segmenter?: unknown }).Segmenter === 'function'
+  ) {
+    const segmenter = new Intl.Segmenter(undefined, {
+      granularity: 'grapheme',
+    });
+    const count = [...segmenter.segment(input)].length;
+    return { count, fallback: false };
+  }
+  return { count: [...input].length, fallback: true };
+}
+
+export const ByteLengthBoxSource = {
+  name: 'Byte Length',
+  description:
+    'Count UTF-16 units, Unicode code points, UTF-8 bytes (and graphemes) of the input.',
+  defaultInput: 'héllo 😀 ::bytelen',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'bytelen', 'bytelength', 'len')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const utf16Units = input.length;
+    const codePoints = [...input].length;
+    const utf8Bytes = new TextEncoder().encode(input).length;
+    const { count: graphemes, fallback } = countGraphemes(input);
+
+    const graphemeLabel = fallback
+      ? 'Graphemes (approx, no Intl.Segmenter)'
+      : 'Graphemes';
+
+    const kvOptions: Record<string, string> = {
+      'UTF-16 Units': String(utf16Units),
+      'Code Points': String(codePoints),
+      'UTF-8 Bytes': String(utf8Bytes),
+      [graphemeLabel]: String(graphemes),
+    };
+
+    const box = new BoxBuilder('Byte Length', JSON.stringify(kvOptions))
+      .setTemplate(KeyValueBoxTemplate)
+      .setOptions(kvOptions)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default ByteLengthBoxSource;

--- a/src/modules/boxSources/ByteLengthBoxSource.ts
+++ b/src/modules/boxSources/ByteLengthBoxSource.ts
@@ -34,7 +34,7 @@ export const ByteLengthBoxSource = {
     input: string,
     options: BoxOptions = null,
   ): Promise<Box[]> {
-    if (!hasOptionKeys(options, 'bytelen', 'bytelength', 'len')) return [];
+    if (!hasOptionKeys(options, 'bytelen', 'bytelength')) return [];
     if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
       return [];
 

--- a/src/modules/boxSources/Crc32BoxSource.ts
+++ b/src/modules/boxSources/Crc32BoxSource.ts
@@ -1,0 +1,69 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 20;
+const MAX_INPUT = 100_000;
+
+// IEEE 802.3 polynomial in reflected (LSB-first) form
+const POLY = 0xedb88320;
+
+// build the 256-entry lookup table once at module load
+const CRC32_TABLE: Uint32Array = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? (c >>> 1) ^ POLY : c >>> 1;
+    }
+    table[i] = c;
+  }
+  return table;
+})();
+
+// compute IEEE CRC-32 over the UTF-8 encoding of `str`
+function crc32(str: string): number {
+  const bytes = new TextEncoder().encode(str);
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ byte) & 0xff];
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+export const Crc32BoxSource = {
+  name: 'CRC32',
+  description: 'Compute the CRC-32 (IEEE 802.3) checksum of the input text.',
+  defaultInput: 'hello ::crc32',
+  tag: '#',
+  kind: 'Hash',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'crc32', 'crc')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const checksum = crc32(input);
+    const hex = checksum.toString(16).padStart(8, '0');
+    const decimal = checksum.toString(10);
+
+    const output: Record<string, string> = {
+      Hex: hex,
+      Decimal: decimal,
+    };
+
+    return [
+      new BoxBuilder('CRC32', JSON.stringify(output))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Crc32BoxSource;

--- a/src/modules/boxSources/Crc32BoxSource.ts
+++ b/src/modules/boxSources/Crc32BoxSource.ts
@@ -44,7 +44,7 @@ export const Crc32BoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'crc32', 'crc')) return [];
-    if (input.length > MAX_INPUT) return [];
+    if (input.length === 0 || input.length > MAX_INPUT) return [];
 
     const checksum = crc32(input);
     const hex = checksum.toString(16).padStart(8, '0');

--- a/src/modules/boxSources/HexDumpBoxSource.ts
+++ b/src/modules/boxSources/HexDumpBoxSource.ts
@@ -1,0 +1,78 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 50_000;
+const BYTES_PER_LINE = 16;
+
+// format a single hexdump line: offset + hex columns + ascii sidebar
+function formatLine(offset: number, chunk: Uint8Array): string {
+  const offsetStr = offset.toString(16).padStart(8, '0');
+
+  // split 16 bytes into two groups of 8 for the classic mid-gap
+  const leftHex = Array.from(chunk.slice(0, 8))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join(' ');
+  const rightHex = Array.from(chunk.slice(8))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join(' ');
+
+  // pad incomplete lines so the ascii column always aligns
+  const leftPadded = leftHex.padEnd(23, ' ');
+  const rightPadded = rightHex.padEnd(23, ' ');
+
+  const ascii = Array.from(chunk)
+    .map((b) => (b >= 0x20 && b <= 0x7e ? String.fromCharCode(b) : '.'))
+    .join('');
+
+  return `${offsetStr}  ${leftPadded}  ${rightPadded}  |${ascii}|`;
+}
+
+// encode input as UTF-8 bytes and produce hexdump -C style output
+function hexdump(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  const lines: string[] = [];
+
+  for (let offset = 0; offset < bytes.length; offset += BYTES_PER_LINE) {
+    const chunk = bytes.slice(offset, offset + BYTES_PER_LINE);
+    lines.push(formatLine(offset, chunk));
+  }
+
+  // final offset line (same as hexdump -C)
+  const endOffset = bytes.length.toString(16).padStart(8, '0');
+  lines.push(endOffset);
+
+  return lines.join('\n');
+}
+
+export const HexDumpBoxSource = {
+  name: 'Hex Dump',
+  description:
+    'Produce a canonical hexdump (offset, hex bytes, ASCII) of the input.',
+  defaultInput: 'Hello, World! ::hexdump',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hexdump', 'xxd')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const output = hexdump(input);
+
+    return [
+      new BoxBuilder('Hex Dump', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HexDumpBoxSource;

--- a/src/modules/boxSources/HttpStatusBoxSource.ts
+++ b/src/modules/boxSources/HttpStatusBoxSource.ts
@@ -1,0 +1,133 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// map of IANA-registered HTTP status codes to their reason phrases
+const STATUS_TABLE: Record<number, string> = {
+  100: 'Continue',
+  101: 'Switching Protocols',
+  102: 'Processing',
+  103: 'Early Hints',
+  200: 'OK',
+  201: 'Created',
+  202: 'Accepted',
+  203: 'Non-Authoritative Information',
+  204: 'No Content',
+  205: 'Reset Content',
+  206: 'Partial Content',
+  207: 'Multi-Status',
+  208: 'Already Reported',
+  226: 'IM Used',
+  300: 'Multiple Choices',
+  301: 'Moved Permanently',
+  302: 'Found',
+  303: 'See Other',
+  304: 'Not Modified',
+  305: 'Use Proxy',
+  307: 'Temporary Redirect',
+  308: 'Permanent Redirect',
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  402: 'Payment Required',
+  403: 'Forbidden',
+  404: 'Not Found',
+  405: 'Method Not Allowed',
+  406: 'Not Acceptable',
+  407: 'Proxy Authentication Required',
+  408: 'Request Timeout',
+  409: 'Conflict',
+  410: 'Gone',
+  411: 'Length Required',
+  412: 'Precondition Failed',
+  413: 'Content Too Large',
+  414: 'URI Too Long',
+  415: 'Unsupported Media Type',
+  416: 'Range Not Satisfiable',
+  417: 'Expectation Failed',
+  418: "I'm a Teapot",
+  421: 'Misdirected Request',
+  422: 'Unprocessable Content',
+  423: 'Locked',
+  424: 'Failed Dependency',
+  425: 'Too Early',
+  426: 'Upgrade Required',
+  428: 'Precondition Required',
+  429: 'Too Many Requests',
+  431: 'Request Header Fields Too Large',
+  451: 'Unavailable For Legal Reasons',
+  500: 'Internal Server Error',
+  501: 'Not Implemented',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+  505: 'HTTP Version Not Supported',
+  506: 'Variant Also Negotiates',
+  507: 'Insufficient Storage',
+  508: 'Loop Detected',
+  510: 'Not Extended',
+  511: 'Network Authentication Required',
+};
+
+// derive the category label from the leading digit of a status code
+function getCategory(code: number): string {
+  const hundreds = Math.floor(code / 100);
+  switch (hundreds) {
+    case 1:
+      return 'Informational';
+    case 2:
+      return 'Success';
+    case 3:
+      return 'Redirection';
+    case 4:
+      return 'Client Error';
+    case 5:
+      return 'Server Error';
+    default:
+      return 'Unknown';
+  }
+}
+
+export const HttpStatusBoxSource = {
+  name: 'HTTP Status',
+  description: 'Look up the name and meaning of an HTTP status code.',
+  defaultInput: '404 ::httpstatus',
+  tag: '#',
+  kind: 'Reference',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'httpstatus', 'http')) return [];
+
+    const trimmed = trim(input);
+    // only accept a 3-digit code in the 1xx–5xx range
+    if (!/^[1-5]\d{2}$/.test(trimmed)) return [];
+
+    const code = Number.parseInt(trimmed, 10);
+    const name = STATUS_TABLE[code] ?? 'Unknown';
+    const category = getCategory(code);
+
+    const kvOptions: Record<string, string> = {
+      Code: trimmed,
+      Name: name,
+      Category: category,
+    };
+
+    const plaintextOutput = `Code: ${trimmed}\nName: ${name}\nCategory: ${category}`;
+
+    return [
+      new BoxBuilder('HTTP Status', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HttpStatusBoxSource;

--- a/src/modules/boxSources/HttpStatusBoxSource.ts
+++ b/src/modules/boxSources/HttpStatusBoxSource.ts
@@ -102,7 +102,7 @@ export const HttpStatusBoxSource = {
     input: string,
     options: BoxOptions = null,
   ): Promise<Box[]> {
-    if (!hasOptionKeys(options, 'httpstatus', 'http')) return [];
+    if (!hasOptionKeys(options, 'httpstatus')) return [];
 
     const trimmed = trim(input);
     // only accept a 3-digit code in the 1xx–5xx range

--- a/src/modules/boxSources/JsonMinifyBoxSource.ts
+++ b/src/modules/boxSources/JsonMinifyBoxSource.ts
@@ -1,0 +1,54 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+export const JsonMinifyBoxSource = {
+  name: 'JSON Minify',
+  description:
+    'Minify a JSON document by removing all insignificant whitespace.',
+  defaultInput: '{ "a": 1, "b": [1, 2, 3] } ::jsonmin',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonmin', 'minifyjson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    if (trimmed === '') return [];
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      const minified = JSON.stringify(parsed);
+      return [
+        new BoxBuilder('JSON Minify', minified)
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(true)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    } catch {
+      // input is not valid JSON — surface a descriptive error box
+      return [
+        new BoxBuilder(
+          'JSON Minify',
+          'Invalid JSON: unable to parse the input.',
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+  },
+};
+
+export default JsonMinifyBoxSource;

--- a/src/modules/boxSources/MimeTypeBoxSource.ts
+++ b/src/modules/boxSources/MimeTypeBoxSource.ts
@@ -1,0 +1,126 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// maps file extension to MIME type
+const EXT_TO_MIME: Record<string, string> = {
+  txt: 'text/plain',
+  html: 'text/html',
+  htm: 'text/html',
+  css: 'text/css',
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  json: 'application/json',
+  xml: 'application/xml',
+  csv: 'text/csv',
+  md: 'text/markdown',
+  pdf: 'application/pdf',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  ico: 'image/x-icon',
+  bmp: 'image/bmp',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  avi: 'video/x-msvideo',
+  mov: 'video/quicktime',
+  zip: 'application/zip',
+  gz: 'application/gzip',
+  tar: 'application/x-tar',
+  rar: 'application/vnd.rar',
+  '7z': 'application/x-7z-compressed',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  ttf: 'font/ttf',
+  otf: 'font/otf',
+  wasm: 'application/wasm',
+};
+
+// inverted index: mime type -> list of extensions
+const MIME_TO_EXTS: Record<string, string[]> = {};
+for (const [ext, mime] of Object.entries(EXT_TO_MIME)) {
+  if (!MIME_TO_EXTS[mime]) {
+    MIME_TO_EXTS[mime] = [];
+  }
+  MIME_TO_EXTS[mime].push(ext);
+}
+
+export const MimeTypeBoxSource = {
+  name: 'MIME Type',
+  description:
+    'Look up the MIME type for a file extension, or extensions for a MIME type.',
+  defaultInput: 'png ::mime',
+  tag: '#',
+  kind: 'Reference',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'mime', 'mimetype')) return [];
+
+    const s = trim(input).toLowerCase().replace(/^\./, '');
+    if (!s) return [];
+
+    // if input contains '/', treat it as a MIME type lookup
+    if (s.includes('/')) {
+      const exts = MIME_TO_EXTS[s];
+      if (!exts || exts.length === 0) {
+        return [
+          new BoxBuilder('MIME Type', '')
+            .setOptions({
+              'MIME Type': s,
+              Extensions: 'No matching extensions found',
+            })
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(Priority)
+            .build(),
+        ];
+      }
+      return [
+        new BoxBuilder('MIME Type', '')
+          .setOptions({ 'MIME Type': s, Extensions: exts.join(', ') })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    // treat input as a file extension
+    const mime = EXT_TO_MIME[s];
+    if (!mime) {
+      return [
+        new BoxBuilder('MIME Type', '')
+          .setOptions({ Extension: s, 'MIME Type': 'Unknown extension' })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+    return [
+      new BoxBuilder('MIME Type', '')
+        .setOptions({ Extension: s, 'MIME Type': mime })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default MimeTypeBoxSource;

--- a/src/modules/boxSources/MimeTypeBoxSource.ts
+++ b/src/modules/boxSources/MimeTypeBoxSource.ts
@@ -89,7 +89,7 @@ export const MimeTypeBoxSource = {
               Extensions: 'No matching extensions found',
             })
             .setTemplate(KeyValueBoxTemplate)
-            .setPriority(Priority)
+            .setPriority(this.priority)
             .build(),
         ];
       }
@@ -97,7 +97,7 @@ export const MimeTypeBoxSource = {
         new BoxBuilder('MIME Type', '')
           .setOptions({ 'MIME Type': s, Extensions: exts.join(', ') })
           .setTemplate(KeyValueBoxTemplate)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       ];
     }
@@ -109,7 +109,7 @@ export const MimeTypeBoxSource = {
         new BoxBuilder('MIME Type', '')
           .setOptions({ Extension: s, 'MIME Type': 'Unknown extension' })
           .setTemplate(KeyValueBoxTemplate)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       ];
     }
@@ -117,7 +117,7 @@ export const MimeTypeBoxSource = {
       new BoxBuilder('MIME Type', '')
         .setOptions({ Extension: s, 'MIME Type': mime })
         .setTemplate(KeyValueBoxTemplate)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build(),
     ];
   },

--- a/src/modules/boxSources/UuidInspectBoxSource.ts
+++ b/src/modules/boxSources/UuidInspectBoxSource.ts
@@ -15,6 +15,9 @@ const VERSION_LABELS: Record<number, string> = {
   3: 'name-based MD5',
   4: 'random',
   5: 'name-based SHA-1',
+  6: 'reordered time (RFC 9562)',
+  7: 'Unix epoch ms (RFC 9562)',
+  8: 'custom (RFC 9562)',
 };
 
 // determine RFC 4122 variant from the high bits of the variant octet

--- a/src/modules/boxSources/UuidInspectBoxSource.ts
+++ b/src/modules/boxSources/UuidInspectBoxSource.ts
@@ -1,0 +1,93 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 20;
+
+// canonical UUID regex per RFC 4122
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const VERSION_LABELS: Record<number, string> = {
+  1: 'time-based',
+  2: 'DCE security',
+  3: 'name-based MD5',
+  4: 'random',
+  5: 'name-based SHA-1',
+};
+
+// determine RFC 4122 variant from the high bits of the variant octet
+function getVariant(variantHex: string): string {
+  const nibble = Number.parseInt(variantHex, 16);
+  if (nibble >= 0xe) return 'Reserved';
+  if (nibble >= 0xc) return 'Microsoft (reserved)';
+  if (nibble >= 0x8) return 'RFC 4122';
+  return 'NCS (reserved)';
+}
+
+export const UuidInspectBoxSource = {
+  name: 'UUID Inspect',
+  description: 'Parse a UUID and report its version and variant.',
+  defaultInput: '550e8400-e29b-41d4-a716-446655440000 ::uuidinfo',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'uuidinfo', 'uuidinspect')) return [];
+
+    const uuid = trim(input).toLowerCase();
+    if (!UUID_REGEX.test(uuid)) return [];
+
+    // nil UUID special case
+    if (uuid === '00000000-0000-0000-0000-000000000000') {
+      const kvOptions = {
+        UUID: uuid,
+        Version: 'nil',
+        Variant: 'nil',
+      };
+      const plaintextOutput = `UUID: ${uuid}\nVersion: nil\nVariant: nil`;
+
+      return [
+        new BoxBuilder('UUID Inspect', plaintextOutput)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kvOptions)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // groups: [full, g1, g2, g3, g4, g5]
+    const groups = uuid.split('-');
+    // version is the first hex digit of the 3rd group (index 2), i.e. the 13th hex char
+    const versionDigit = Number.parseInt(groups[2][0], 16);
+    const label = VERSION_LABELS[versionDigit];
+    const versionStr = label
+      ? `${versionDigit} (${label})`
+      : `${versionDigit} (unknown)`;
+
+    // variant is determined by the high bits of the first hex digit of the 4th group (index 3)
+    const variantStr = getVariant(groups[3][0]);
+
+    const kvOptions = {
+      UUID: uuid,
+      Version: versionStr,
+      Variant: variantStr,
+    };
+    const plaintextOutput = `UUID: ${uuid}\nVersion: ${versionStr}\nVariant: ${variantStr}`;
+
+    return [
+      new BoxBuilder('UUID Inspect', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UuidInspectBoxSource;

--- a/src/modules/boxSources/__test__/AspectRatioBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AspectRatioBoxSource.test.ts
@@ -1,0 +1,144 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { AspectRatioBoxSource } from '../AspectRatioBoxSource';
+
+describe('AspectRatioBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are provided', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('happy path — ::ratio trigger', () => {
+    it('simplifies 1920x1080 to 16:9', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '16:9' });
+    });
+
+    it('accepts colon separator (1280:720) and gives 16:9', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1280:720', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '16:9' });
+    });
+
+    it('simplifies 1024x768 to 4:3', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1024x768', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '4:3' });
+    });
+
+    it('simplifies 500x500 to 1:1', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('500x500', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '1:1' });
+    });
+  });
+
+  describe('happy path — ::aspect trigger', () => {
+    it('also triggers on ::aspect option', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        aspect: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '16:9' });
+    });
+  });
+
+  describe('common name', () => {
+    it('includes Common name for 16:9', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        ratio: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Common: '16:9 Widescreen',
+      });
+    });
+
+    it('omits Common key for non-standard ratios', async () => {
+      // 700x300 simplifies to 7:3, which is not in the common-ratio table
+      const boxes = await AspectRatioBoxSource.generateBoxes('700x300', {
+        ratio: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '7:3' });
+      expect(boxes[0].props.options).not.toHaveProperty('Common');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('abc', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when height is zero (1920x0)', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x0', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when width is zero (0x1080)', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('0x1080', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('box structure', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        ratio: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority from source constant', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        ratio: true,
+      });
+      expect(boxes[0].props.priority).toBe(AspectRatioBoxSource.priority);
+    });
+
+    it('sets box name to Aspect Ratio', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        ratio: true,
+      });
+      expect(boxes[0].props.name).toBe('Aspect Ratio');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(AspectRatioBoxSource.name).toBe('Aspect Ratio');
+      expect(AspectRatioBoxSource.tag).toBe('#');
+      expect(AspectRatioBoxSource.kind).toBe('Convert');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ByteLengthBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ByteLengthBoxSource.test.ts
@@ -1,0 +1,96 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { ByteLengthBoxSource } from '../ByteLengthBoxSource';
+
+describe('ByteLengthBoxSource', () => {
+  it('returns [] when no option is provided', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('hello', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] when an unrelated option is provided', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('hello', {
+      qrcode: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] for empty input', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('', {
+      bytelen: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('handles ascii string with ::bytelen', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('abc', {
+      bytelen: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({
+      'UTF-16 Units': '3',
+      'Code Points': '3',
+      'UTF-8 Bytes': '3',
+    });
+    expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+  });
+
+  it('handles ascii string with ::bytelength alias', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('abc', {
+      bytelength: true,
+    });
+    expect(boxes).toHaveLength(1);
+  });
+
+  it('handles ascii string with ::len alias', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('abc', { len: true });
+    expect(boxes).toHaveLength(1);
+  });
+
+  it('correctly counts héllo (é is 1 code point, 2 UTF-8 bytes)', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('héllo', {
+      bytelen: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({
+      'Code Points': '5',
+      'UTF-8 Bytes': '6',
+    });
+  });
+
+  it('correctly counts astral 😀 (surrogate pair in UTF-16)', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('😀', {
+      bytelen: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({
+      'UTF-16 Units': '2',
+      'Code Points': '1',
+      'UTF-8 Bytes': '4',
+    });
+  });
+
+  it('correctly counts € (3 UTF-8 bytes)', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('€', {
+      bytelen: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({
+      'UTF-8 Bytes': '3',
+    });
+  });
+
+  it('sets priority from source constant', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('abc', {
+      bytelen: true,
+    });
+    expect(boxes[0].props.priority).toBe(ByteLengthBoxSource.priority);
+  });
+
+  it('sets box name to Byte Length', async () => {
+    const boxes = await ByteLengthBoxSource.generateBoxes('abc', {
+      bytelen: true,
+    });
+    expect(boxes[0].props.name).toBe('Byte Length');
+  });
+});

--- a/src/modules/boxSources/__test__/ByteLengthBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ByteLengthBoxSource.test.ts
@@ -42,9 +42,9 @@ describe('ByteLengthBoxSource', () => {
     expect(boxes).toHaveLength(1);
   });
 
-  it('handles ascii string with ::len alias', async () => {
+  it('does not trigger on the generic ::len key (reserved for clarity)', async () => {
     const boxes = await ByteLengthBoxSource.generateBoxes('abc', { len: true });
-    expect(boxes).toHaveLength(1);
+    expect(boxes).toHaveLength(0);
   });
 
   it('correctly counts héllo (é is 1 code point, 2 UTF-8 bytes)', async () => {

--- a/src/modules/boxSources/__test__/Crc32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Crc32BoxSource.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { Crc32BoxSource } from '../Crc32BoxSource';
+
+describe('Crc32BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no crc option is provided', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is provided', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        sha256: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - known CRC-32 vectors', () => {
+    it('"hello" → Hex 3610a686', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        crc32: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options).not.toBeNull();
+      expect((options as Record<string, string>).Hex).toBe('3610a686');
+    });
+
+    it('"hello" Decimal equals parseInt(hex, 16)', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        crc32: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe(String(parseInt(opts.Hex, 16)));
+    });
+
+    it('"The quick brown fox jumps over the lazy dog" → Hex 414fa339', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes(
+        'The quick brown fox jumps over the lazy dog',
+        { crc32: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Hex).toBe('414fa339');
+      expect(opts.Decimal).toBe(String(0x414fa339));
+    });
+
+    // canonical CRC-32 check value per ISO 3309 / ITU-T V.42
+    it('"123456789" → Hex cbf43926 (canonical check value)', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('123456789', {
+        crc32: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Hex).toBe('cbf43926');
+      expect(opts.Decimal).toBe(String(0xcbf43926));
+    });
+
+    it('::crc alias also triggers the box', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', { crc: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Hex).toBe('3610a686');
+    });
+  });
+
+  describe('generateBoxes - input cap', () => {
+    it('returns empty array when input exceeds MAX_INPUT (100 000 chars)', async () => {
+      const huge = 'a'.repeat(100_001);
+      const boxes = await Crc32BoxSource.generateBoxes(huge, { crc32: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('accepts input at the boundary (100 000 chars)', async () => {
+      const boundary = 'a'.repeat(100_000);
+      const boxes = await Crc32BoxSource.generateBoxes(boundary, {
+        crc32: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('box structure', () => {
+    it('box name is "CRC32"', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        crc32: true,
+      });
+      expect(boxes[0].props.name).toBe('CRC32');
+    });
+
+    it('box priority matches source priority', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        crc32: true,
+      });
+      expect(boxes[0].props.priority).toBe(Crc32BoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Crc32BoxSource.name).toBe('CRC32');
+      expect(Crc32BoxSource.tag).toBe('#');
+      expect(Crc32BoxSource.kind).toBe('Hash');
+      expect(typeof Crc32BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HexDumpBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HexDumpBoxSource.test.ts
@@ -1,0 +1,133 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { HexDumpBoxSource } from '../HexDumpBoxSource';
+
+describe('HexDumpBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when options is null', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when no hexdump/xxd option is provided', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for an unrelated option', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns empty array for empty string with hexdump option', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('', {
+        hexdump: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::hexdump trigger', () => {
+    it('produces one box named "Hex Dump" using CodeBoxTemplate', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        hexdump: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Hex Dump');
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+
+    it('first line starts with "00000000" and contains the correct hex for "Hello"', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        hexdump: true,
+      });
+      const firstLine = boxes[0].props.plaintextOutput.split('\n')[0];
+      expect(firstLine).toMatch(/^00000000/);
+      // H=0x48 e=0x65 l=0x6c l=0x6c o=0x6f
+      expect(firstLine).toContain('48 65 6c 6c 6f');
+    });
+
+    it('first line ends with the ASCII sidebar "|Hello, World!|"', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        hexdump: true,
+      });
+      const firstLine = boxes[0].props.plaintextOutput.split('\n')[0];
+      expect(firstLine.endsWith('|Hello, World!|')).toBe(true);
+    });
+  });
+
+  describe('generateBoxes - ::xxd trigger', () => {
+    it('also activates with ::xxd option', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        xxd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Hex Dump');
+    });
+  });
+
+  describe('generateBoxes - multi-line output', () => {
+    it('a string longer than 16 bytes produces 2+ data lines', async () => {
+      // 17 bytes → 2 data lines + 1 trailing offset line = 3 lines total
+      const input = 'ABCDEFGHIJKLMNOPQ'; // 17 chars, all ASCII = 17 bytes
+      const boxes = await HexDumpBoxSource.generateBoxes(input, {
+        hexdump: true,
+      });
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      // at least 2 data lines
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('second data line has offset "00000010"', async () => {
+      const input = 'ABCDEFGHIJKLMNOPQ'; // 17 bytes
+      const boxes = await HexDumpBoxSource.generateBoxes(input, {
+        hexdump: true,
+      });
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines[1]).toMatch(/^00000010/);
+    });
+  });
+
+  describe('generateBoxes - non-printable bytes', () => {
+    it('renders a newline character as "." in the ASCII column', async () => {
+      // "A\nB" → bytes 0x41 0x0a 0x42; ASCII sidebar should be "A.B"
+      const boxes = await HexDumpBoxSource.generateBoxes('A\nB', {
+        hexdump: true,
+      });
+      const firstLine = boxes[0].props.plaintextOutput.split('\n')[0];
+      expect(firstLine).toContain('|A.B|');
+    });
+
+    it('renders a null byte as "." in the ASCII column', async () => {
+      const input = 'X\x00Y';
+      const boxes = await HexDumpBoxSource.generateBoxes(input, {
+        hexdump: true,
+      });
+      const firstLine = boxes[0].props.plaintextOutput.split('\n')[0];
+      expect(firstLine).toContain('|X.Y|');
+    });
+  });
+
+  describe('generateBoxes - priority', () => {
+    it('box priority matches HexDumpBoxSource.priority', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('test', {
+        hexdump: true,
+      });
+      expect(boxes[0].props.priority).toBe(HexDumpBoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HexDumpBoxSource.name).toBe('Hex Dump');
+      expect(HexDumpBoxSource.tag).toBe('#');
+      expect(HexDumpBoxSource.kind).toBe('Analyze');
+      expect(typeof HexDumpBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HttpStatusBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HttpStatusBoxSource.test.ts
@@ -1,0 +1,163 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { HttpStatusBoxSource } from '../HttpStatusBoxSource';
+
+describe('HttpStatusBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('404', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object is empty', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('404', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('404', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('abc', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for a 2-digit number', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('99', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for a 4-digit number', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('1000', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for a 6xx code (out of range)', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('600', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::httpstatus trigger', () => {
+    it('resolves 404 to Not Found / Client Error', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('404', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('HTTP Status');
+      expect(boxes[0].props.options).toMatchObject({
+        Code: '404',
+        Name: 'Not Found',
+        Category: 'Client Error',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('resolves 200 to OK / Success', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('200', {
+        httpstatus: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Name: 'OK',
+        Category: 'Success',
+      });
+    });
+
+    it('resolves 301 to Moved Permanently / Redirection', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('301', {
+        httpstatus: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Name: 'Moved Permanently',
+        Category: 'Redirection',
+      });
+    });
+
+    it('resolves 500 to Internal Server Error / Server Error', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('500', {
+        httpstatus: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Name: 'Internal Server Error',
+        Category: 'Server Error',
+      });
+    });
+
+    it("resolves 418 to I'm a Teapot", async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('418', {
+        httpstatus: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Name: "I'm a Teapot",
+        Category: 'Client Error',
+      });
+    });
+
+    it('resolves unknown-but-valid 999 to Unknown name with correct category', async () => {
+      // 999 starts with 9, which is outside 1-5 range so regex rejects it
+      // use 599 instead — valid 5xx but not in the table
+      const boxes = await HttpStatusBoxSource.generateBoxes('599', {
+        httpstatus: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Code: '599',
+        Name: 'Unknown',
+        Category: 'Server Error',
+      });
+    });
+  });
+
+  describe('::http trigger (alias)', () => {
+    it('also works with ::http option key', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('200', {
+        http: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Code: '200',
+        Name: 'OK',
+        Category: 'Success',
+      });
+    });
+  });
+
+  describe('priority', () => {
+    it('sets priority from source constant', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('200', {
+        httpstatus: true,
+      });
+      expect(boxes[0].props.priority).toBe(HttpStatusBoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HttpStatusBoxSource.name).toBe('HTTP Status');
+      expect(HttpStatusBoxSource.tag).toBe('#');
+      expect(HttpStatusBoxSource.kind).toBe('Reference');
+      expect(typeof HttpStatusBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HttpStatusBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HttpStatusBoxSource.test.ts
@@ -129,17 +129,12 @@ describe('HttpStatusBoxSource', () => {
     });
   });
 
-  describe('::http trigger (alias)', () => {
-    it('also works with ::http option key', async () => {
+  describe('generic ::http key is not claimed', () => {
+    it('does not trigger on ::http (reserved for a future http tool)', async () => {
       const boxes = await HttpStatusBoxSource.generateBoxes('200', {
         http: true,
       });
-      expect(boxes).toHaveLength(1);
-      expect(boxes[0].props.options).toMatchObject({
-        Code: '200',
-        Name: 'OK',
-        Category: 'Success',
-      });
+      expect(boxes).toHaveLength(0);
     });
   });
 

--- a/src/modules/boxSources/__test__/JsonMinifyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonMinifyBoxSource.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonMinifyBoxSource } from '../JsonMinifyBoxSource';
+
+describe('JsonMinifyBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{ "a": 1 }', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{ "a": 1 }', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{ "a": 1 }', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty input', () => {
+    it('returns empty array for empty string with ::jsonmin', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('', {
+        jsonmin: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input with ::jsonmin', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('   ', {
+        jsonmin: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::jsonmin option', () => {
+    it('minifies a simple flat object', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes(
+        '{ "a": 1, "b": [1, 2, 3] }',
+        { jsonmin: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('{"a":1,"b":[1,2,3]}');
+    });
+
+    it('collapses pretty-printed multi-line JSON to a single compact line', async () => {
+      const pretty = `{
+  "name": "magic-box",
+  "version": "1.0.0",
+  "active": true
+}`;
+      const boxes = await JsonMinifyBoxSource.generateBoxes(pretty, {
+        jsonmin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '{"name":"magic-box","version":"1.0.0","active":true}',
+      );
+      // result must be a single line
+      expect(boxes[0].props.plaintextOutput).not.toContain('\n');
+    });
+
+    it('minifies a nested object', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes(
+        '{ "x": { "y": 2 } }',
+        { jsonmin: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('{"x":{"y":2}}');
+    });
+  });
+
+  describe('::minifyjson alias', () => {
+    it('also triggers on ::minifyjson', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{ "a": 1 }', {
+        minifyjson: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('{"a":1}');
+    });
+  });
+
+  describe('invalid JSON', () => {
+    it('returns a box mentioning invalid JSON for malformed input', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{bad}', {
+        jsonmin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON Minify');
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+
+    it('returns a box for trailing-comma JSON', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{ "a": 1, }', {
+        jsonmin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(JsonMinifyBoxSource.name).toBe('JSON Minify');
+      expect(JsonMinifyBoxSource.tag).toBe('#');
+      expect(JsonMinifyBoxSource.kind).toBe('Transform');
+      expect(typeof JsonMinifyBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/MimeTypeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MimeTypeBoxSource.test.ts
@@ -1,0 +1,99 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { MimeTypeBoxSource } from '../MimeTypeBoxSource';
+
+describe('MimeTypeBoxSource', () => {
+  it('returns [] when no mime option is present', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes('png', null);
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when unrelated option is present', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes('png', { foo: true });
+    expect(boxes).toEqual([]);
+  });
+
+  it('looks up MIME type for extension "png"', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes('png', { mime: true });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({
+      Extension: 'png',
+      'MIME Type': 'image/png',
+    });
+    expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+  });
+
+  it('strips leading dot from extension ".json"', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes('.json', {
+      mime: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({
+      Extension: 'json',
+      'MIME Type': 'application/json',
+    });
+  });
+
+  it('resolves "jpg" to image/jpeg', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes('jpg', { mime: true });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({
+      Extension: 'jpg',
+      'MIME Type': 'image/jpeg',
+    });
+  });
+
+  it('accepts ::mimetype option key', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+      mimetype: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({ 'MIME Type': 'image/png' });
+  });
+
+  it('resolves MIME type "application/json" to extensions containing "json"', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes('application/json', {
+      mime: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const extensions = (boxes[0].props.options as Record<string, string>)
+      .Extensions;
+    expect(extensions).toContain('json');
+  });
+
+  it('resolves "image/jpeg" to extensions containing both "jpg" and "jpeg"', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes('image/jpeg', {
+      mime: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const extensions = (boxes[0].props.options as Record<string, string>)
+      .Extensions;
+    expect(extensions).toContain('jpg');
+    expect(extensions).toContain('jpeg');
+  });
+
+  it('returns a no-match box for unknown extension "xyz"', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes('xyz', { mime: true });
+    expect(boxes).toHaveLength(1);
+    const mimeValue = (boxes[0].props.options as Record<string, string>)[
+      'MIME Type'
+    ];
+    expect(mimeValue).toMatch(/unknown/i);
+  });
+
+  it('returns a no-match box for unknown MIME type "application/x-unknown"', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes(
+      'application/x-unknown',
+      { mime: true },
+    );
+    expect(boxes).toHaveLength(1);
+    const extsValue = (boxes[0].props.options as Record<string, string>)
+      .Extensions;
+    expect(extsValue).toMatch(/no match|not found|unknown/i);
+  });
+
+  it('sets priority correctly', async () => {
+    const boxes = await MimeTypeBoxSource.generateBoxes('png', { mime: true });
+    expect(boxes[0].props.priority).toBe(MimeTypeBoxSource.priority);
+  });
+});

--- a/src/modules/boxSources/__test__/UuidInspectBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UuidInspectBoxSource.test.ts
@@ -1,0 +1,144 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { UuidInspectBoxSource } from '../UuidInspectBoxSource';
+
+describe('UuidInspectBoxSource', () => {
+  describe('metadata', () => {
+    it('has correct static properties', () => {
+      expect(UuidInspectBoxSource.name).toBe('UUID Inspect');
+      expect(UuidInspectBoxSource.tag).toBe('#');
+      expect(UuidInspectBoxSource.kind).toBe('Analyze');
+      expect(UuidInspectBoxSource.priority).toBe(20);
+    });
+  });
+
+  describe('option gating', () => {
+    it('returns [] when no options are provided', async () => {
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        { base64: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::uuidinfo', async () => {
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        { uuidinfo: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('triggers on ::uuidinspect', async () => {
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        { uuidinspect: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns [] for a plain string', async () => {
+      const boxes = await UuidInspectBoxSource.generateBoxes('not-a-uuid', {
+        uuidinfo: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for a too-short hex string', async () => {
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716',
+        {
+          uuidinfo: true,
+        },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for a UUID missing hyphens', async () => {
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        '550e8400e29b41d4a716446655440000',
+        { uuidinfo: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('v4 UUID (::uuidinfo)', () => {
+    it('reports Version starting with "4" and Variant "RFC 4122"', async () => {
+      // the 'a' in 'a716' → high bits 1010 → RFC 4122
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        { uuidinfo: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        UUID: '550e8400-e29b-41d4-a716-446655440000',
+        Version: expect.stringMatching(/^4/),
+        Variant: 'RFC 4122',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+
+  describe('v1 UUID', () => {
+    it('reports Version starting with "1"', async () => {
+      // 3rd group starts with '1' → version 1
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        'f47ac10b-58cc-1372-8567-0e02b2c3d479',
+        { uuidinfo: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Version: expect.stringMatching(/^1/),
+      });
+    });
+  });
+
+  describe('nil UUID', () => {
+    it('reports Version "nil" and Variant "nil"', async () => {
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        '00000000-0000-0000-0000-000000000000',
+        { uuidinfo: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        UUID: '00000000-0000-0000-0000-000000000000',
+        Version: 'nil',
+        Variant: 'nil',
+      });
+    });
+  });
+
+  describe('priority', () => {
+    it('sets priority to 20', async () => {
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        { uuidinfo: true },
+      );
+      expect(boxes[0].props.priority).toBe(20);
+    });
+  });
+
+  describe('case normalization', () => {
+    it('normalizes UUID to lowercase', async () => {
+      const boxes = await UuidInspectBoxSource.generateBoxes(
+        '550E8400-E29B-41D4-A716-446655440000',
+        { uuidinfo: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        UUID: '550e8400-e29b-41d4-a716-446655440000',
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,17 +1,24 @@
+import AspectRatioBoxSource from './AspectRatioBoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import ByteLengthBoxSource from './ByteLengthBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import Crc32BoxSource from './Crc32BoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HexDumpBoxSource from './HexDumpBoxSource';
+import HttpStatusBoxSource from './HttpStatusBoxSource';
+import JsonMinifyBoxSource from './JsonMinifyBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
+import MimeTypeBoxSource from './MimeTypeBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
@@ -22,6 +29,7 @@ import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
+import UuidInspectBoxSource from './UuidInspectBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -31,14 +39,21 @@ export const boxSources = [
   ColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  AspectRatioBoxSource,
+  ByteLengthBoxSource,
+  Crc32BoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HexDumpBoxSource,
+  HttpStatusBoxSource,
+  JsonMinifyBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
+  MimeTypeBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
@@ -48,6 +63,7 @@ export const boxSources = [
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
+  UuidInspectBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,


### PR DESCRIPTION
## Summary

Fifth exploration batch — **8 more BoxSource tools** (reference lookups, checksums, analysis), following all conventions from prior reviews.

| Tool | Trigger | What it does |
|------|---------|--------------|
| HTTP Status | `::httpstatus` | status code → reason phrase + category |
| MIME Type | `::mime` | extension ⇄ MIME type (bidirectional) |
| CRC32 | `::crc32` | CRC-32 (IEEE) checksum, hex + decimal |
| Hex Dump | `::hexdump` | canonical `hexdump -C` style (offset/hex/ASCII) |
| Aspect Ratio | `::ratio` | width×height → simplified ratio (gcd) + common name |
| Byte Length | `::bytelen` | UTF-16 units / code points / UTF-8 bytes / graphemes |
| UUID Inspect | `::uuidinfo` | parse a UUID's version + variant |
| JSON Minify | `::jsonmin` | strip insignificant whitespace |

## Design notes

- 8 sources built by isolated subagents; `index.ts` wired in one step.
- **Verified**: CRC32 against the canonical `123456789` → `cbf43926` check value; Byte Length uses `Intl.Segmenter` for graphemes with a code-point fallback; UUID Inspect derives version/variant per RFC 4122 incl. the nil-UUID special case.
- Self-review before opening fixed an Aspect Ratio test that mistakenly treated `800x600` (= 4:3, a standard ratio) as non-standard, and a non-existent `.toEndWith` matcher in the Hex Dump test.

## Verification

- ✅ `bun run test run` — **437 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#263 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6