### PR TITLE
feat(boxSources): add 8 more tools (numformat, pw-strength, ipv6, http-headers, email, ws-clean, uuidv7, md-table)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>NumberFormatBox</b> </summary>
+
+| match rule     | description                                    | example                |
+| -------------- | ---------------------------------------------- | ---------------------- |
+| `::numformat`  | grouped, compact, and scientific number formats | `1234567.89 ::numformat` |
+
+</details>
+
+<details>
+<summary> <b>PasswordStrengthBox</b> </summary>
+
+| match rule    | description                              | example               |
+| ------------- | ---------------------------------------- | --------------------- |
+| `::strength`  | estimate password entropy bits + rating  | `Tr0ub4dour ::strength` |
+
+</details>
+
+<details>
+<summary> <b>IPv6Box</b> </summary>
+
+| match rule | description                       | example            |
+| ---------- | --------------------------------- | ------------------ |
+| `::ipv6`   | expand and compress an IPv6 address (RFC 5952) | `2001:db8::1 ::ipv6` |
+
+</details>
+
+<details>
+<summary> <b>HttpHeadersBox</b> </summary>
+
+| match rule   | description                          | example                                  |
+| ------------ | ------------------------------------ | ---------------------------------------- |
+| `::headers`  | parse a raw HTTP header block        | `Content-Type: application/json ::headers` |
+
+</details>
+
+<details>
+<summary> <b>EmailParseBox</b> </summary>
+
+| match rule | description                                 | example                       |
+| ---------- | ------------------------------------------- | ----------------------------- |
+| `::email`  | validate + split local/domain/TLD/tag       | `john+news@mail.example.com ::email` |
+
+</details>
+
+<details>
+<summary> <b>WhitespaceCleanBox</b> </summary>
+
+| match rule | description                                       | example              |
+| ---------- | ------------------------------------------------- | -------------------- |
+| `::clean`  | trim lines, collapse whitespace, drop blank lines | `  a   b  ::clean`   |
+
+</details>
+
+<details>
+<summary> <b>UuidV7Box</b> </summary>
+
+| match rule  | description                              | example       |
+| ----------- | ---------------------------------------- | ------------- |
+| `::uuidv7`  | generate a time-ordered UUID v7 (RFC 9562) | `::uuidv7`   |
+
+</details>
+
+<details>
+<summary> <b>MarkdownTableBox</b> </summary>
+
+| match rule   | description                                  | example                       |
+| ------------ | -------------------------------------------- | ----------------------------- |
+| `::mdtable`  | convert CSV or a JSON array to a Markdown table | `name,age\nAlice,30 ::mdtable` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/EmailParseBoxSource.ts
+++ b/src/modules/boxSources/EmailParseBoxSource.ts
@@ -43,7 +43,11 @@ export const EmailParseBoxSource = {
 
     // extract +tag sub-address from local part (everything after the first '+')
     const plusIndex = local.indexOf('+');
-    const tag = plusIndex !== -1 ? local.slice(plusIndex + 1) : null;
+    // only treat it as a tag when there's something after the '+'
+    const tag =
+      plusIndex !== -1 && plusIndex < local.length - 1
+        ? local.slice(plusIndex + 1)
+        : null;
 
     // TLD is the last dot-segment of the domain
     const tld = domain.slice(domain.lastIndexOf('.') + 1);

--- a/src/modules/boxSources/EmailParseBoxSource.ts
+++ b/src/modules/boxSources/EmailParseBoxSource.ts
@@ -1,0 +1,75 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// RFC 5321 caps email addresses at 320 characters
+const MAX_EMAIL_LENGTH = 320;
+
+// simple linear regex: no whitespace, exactly one @, at least one dot in the domain
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const EmailParseBoxSource = {
+  name: 'Email Parse',
+  description:
+    'Validate an email address and split it into local part, domain, and tags.',
+  defaultInput: 'john.doe+news@mail.example.co.uk ::email',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'email')) return [];
+
+    const s = trim(input);
+
+    if (s.length > MAX_EMAIL_LENGTH || !emailPattern.test(s)) {
+      return [
+        new BoxBuilder('Email Parse', `"${s}" is not a valid email address.`)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // split on the last '@' to handle edge cases where local part could theoretically include it
+    const atIndex = s.lastIndexOf('@');
+    const local = s.slice(0, atIndex);
+    const domain = s.slice(atIndex + 1);
+
+    // extract +tag sub-address from local part (everything after the first '+')
+    const plusIndex = local.indexOf('+');
+    const tag = plusIndex !== -1 ? local.slice(plusIndex + 1) : null;
+
+    // TLD is the last dot-segment of the domain
+    const tld = domain.slice(domain.lastIndexOf('.') + 1);
+
+    const output: Record<string, string> = {
+      Local: local,
+      Domain: domain,
+      TLD: tld,
+    };
+
+    if (tag !== null) {
+      output.Tag = tag;
+    }
+
+    const plaintextOutput = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Email Parse', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default EmailParseBoxSource;

--- a/src/modules/boxSources/HttpHeadersBoxSource.ts
+++ b/src/modules/boxSources/HttpHeadersBoxSource.ts
@@ -23,8 +23,10 @@ export const HttpHeadersBoxSource = {
     if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
       return [];
 
-    // accumulate header values, merging repeated names with ', '
-    const headers: Record<string, string> = {};
+    // accumulate header values, merging repeated names with ', '. HTTP field
+    // names are case-insensitive (RFC 9110), so dedupe by lowercased name while
+    // preserving the first-seen display casing
+    const headers = new Map<string, { name: string; value: string }>();
 
     for (const rawLine of input.split(/\r?\n/)) {
       const line = rawLine.trim();
@@ -39,18 +41,25 @@ export const HttpHeadersBoxSource = {
 
       if (name.length === 0) continue;
 
-      if (Object.hasOwn(headers, name)) {
-        headers[name] = `${headers[name]}, ${value}`;
+      const key = name.toLowerCase();
+      const existing = headers.get(key);
+      if (existing) {
+        existing.value = `${existing.value}, ${value}`;
       } else {
-        headers[name] = value;
+        headers.set(key, { name, value });
       }
     }
 
-    if (Object.keys(headers).length === 0) return [];
+    if (headers.size === 0) return [];
+
+    const output: Record<string, string> = {};
+    for (const { name, value } of headers.values()) {
+      output[name] = value;
+    }
 
     return [
       new BoxBuilder('HTTP Headers', '')
-        .setOptions(headers)
+        .setOptions(output)
         .setTemplate(KeyValueBoxTemplate)
         .setPriority(this.priority)
         .build(),

--- a/src/modules/boxSources/HttpHeadersBoxSource.ts
+++ b/src/modules/boxSources/HttpHeadersBoxSource.ts
@@ -1,0 +1,61 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 50_000;
+
+export const HttpHeadersBoxSource = {
+  name: 'HTTP Headers',
+  description: 'Parse a raw HTTP header block into key/value pairs.',
+  defaultInput:
+    'Content-Type: application/json\nCache-Control: no-cache ::headers',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'headers', 'httpheaders')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    // accumulate header values, merging repeated names with ', '
+    const headers: Record<string, string> = {};
+
+    for (const rawLine of input.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (line.length === 0) continue;
+
+      const colonIdx = line.indexOf(':');
+      // skip lines without a colon (e.g. request/status lines like 'GET /path HTTP/1.1')
+      if (colonIdx === -1) continue;
+
+      const name = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim();
+
+      if (name.length === 0) continue;
+
+      if (Object.hasOwn(headers, name)) {
+        headers[name] = `${headers[name]}, ${value}`;
+      } else {
+        headers[name] = value;
+      }
+    }
+
+    if (Object.keys(headers).length === 0) return [];
+
+    return [
+      new BoxBuilder('HTTP Headers', '')
+        .setOptions(headers)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HttpHeadersBoxSource;

--- a/src/modules/boxSources/IPv6BoxSource.ts
+++ b/src/modules/boxSources/IPv6BoxSource.ts
@@ -1,0 +1,131 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 20;
+
+// expand :: shorthand into 8 groups of 4 hex digits each
+function expandIPv6(address: string): string | null {
+  // reject zone IDs and embedded IPv4
+  if (address.includes('%') || address.includes('.')) return null;
+
+  const halves = address.split('::');
+  if (halves.length > 2) return null;
+
+  let left: string[] = [];
+  let right: string[] = [];
+
+  if (halves.length === 2) {
+    left = halves[0] ? halves[0].split(':') : [];
+    right = halves[1] ? halves[1].split(':') : [];
+
+    const missing = 8 - left.length - right.length;
+    if (missing < 0) return null;
+
+    const middle = Array(missing).fill('0000');
+    const groups = [...left, ...middle, ...right];
+
+    return validateAndPad(groups);
+  }
+
+  // no :: — must be exactly 8 groups
+  const groups = address.split(':');
+  if (groups.length !== 8) return null;
+
+  return validateAndPad(groups);
+}
+
+// validate each group is 1-4 hex digits and pad to 4
+function validateAndPad(groups: string[]): string | null {
+  if (groups.length !== 8) return null;
+
+  const padded: string[] = [];
+  for (const g of groups) {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+    padded.push(g.toLowerCase().padStart(4, '0'));
+  }
+
+  return padded.join(':');
+}
+
+// compress per RFC 5952: lowercase, strip leading zeros, replace longest run of ≥2 zero groups with ::
+function compressIPv6(expanded: string): string {
+  const groups = expanded
+    .split(':')
+    .map((g) => Number.parseInt(g, 16).toString(16));
+
+  // find the leftmost longest run of consecutive zero groups (length ≥ 2)
+  let bestStart = -1;
+  let bestLen = 0;
+  let runStart = -1;
+  let runLen = 0;
+
+  for (let i = 0; i < groups.length; i++) {
+    if (groups[i] === '0') {
+      if (runStart === -1) {
+        runStart = i;
+        runLen = 1;
+      } else {
+        runLen++;
+      }
+      if (runLen > bestLen) {
+        bestLen = runLen;
+        bestStart = runStart;
+      }
+    } else {
+      runStart = -1;
+      runLen = 0;
+    }
+  }
+
+  // only collapse if the run is at least 2 consecutive zero groups
+  if (bestLen >= 2) {
+    const before = groups.slice(0, bestStart);
+    const after = groups.slice(bestStart + bestLen);
+    return `${before.join(':')}::${after.join(':')}`;
+  }
+
+  return groups.join(':');
+}
+
+export const IPv6BoxSource = {
+  name: 'IPv6',
+  description: 'Expand and compress an IPv6 address.',
+  defaultInput: '2001:db8::1 ::ipv6',
+  tag: '#',
+  kind: 'Network',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ipv6')) return [];
+
+    const raw = trim(input);
+    const expanded = expandIPv6(raw);
+    if (expanded === null) return [];
+
+    const compressed = compressIPv6(expanded);
+
+    const output: Record<string, string> = {
+      Expanded: expanded,
+      Compressed: compressed,
+    };
+
+    const plaintextOutput = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('IPv6', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default IPv6BoxSource;

--- a/src/modules/boxSources/IPv6BoxSource.ts
+++ b/src/modules/boxSources/IPv6BoxSource.ts
@@ -20,8 +20,10 @@ function expandIPv6(address: string): string | null {
     left = halves[0] ? halves[0].split(':') : [];
     right = halves[1] ? halves[1].split(':') : [];
 
+    // a "::" must stand for at least one zero group (RFC 4291 §2.2), so the two
+    // halves cannot already total 8 groups
     const missing = 8 - left.length - right.length;
-    if (missing < 0) return null;
+    if (missing < 1) return null;
 
     const middle = Array(missing).fill('0000');
     const groups = [...left, ...middle, ...right];

--- a/src/modules/boxSources/IPv6BoxSource.ts
+++ b/src/modules/boxSources/IPv6BoxSource.ts
@@ -106,6 +106,8 @@ export const IPv6BoxSource = {
     if (!hasOptionKeys(options, 'ipv6')) return [];
 
     const raw = trim(input);
+    // a valid IPv6 literal is <= 45 chars; bound the split() allocation
+    if (raw.length > 64) return [];
     const expanded = expandIPv6(raw);
     if (expanded === null) return [];
 

--- a/src/modules/boxSources/MarkdownTableBoxSource.ts
+++ b/src/modules/boxSources/MarkdownTableBoxSource.ts
@@ -63,10 +63,9 @@ function buildMarkdownTable(headers: string[], rows: string[][]): string {
   return [headerRow, separatorRow, ...dataRows].join('\n');
 }
 
-function buildErrorBox(options: BoxOptions): Box {
+function buildErrorBox(): Box {
   return new BoxBuilder('Markdown Table', 'Error: could not parse input.')
     .setTemplate(CodeBoxTemplate)
-    .setOptions(options)
     .setPriority(Priority)
     .build();
 }
@@ -97,7 +96,7 @@ export const MarkdownTableBoxSource = {
       try {
         parsed = JSON.parse(trimmed);
       } catch {
-        return [buildErrorBox(options)];
+        return [buildErrorBox()];
       }
 
       if (
@@ -106,7 +105,7 @@ export const MarkdownTableBoxSource = {
         typeof parsed[0] !== 'object' ||
         parsed[0] === null
       ) {
-        return [buildErrorBox(options)];
+        return [buildErrorBox()];
       }
 
       // collect headers in first-seen order across all objects
@@ -127,10 +126,10 @@ export const MarkdownTableBoxSource = {
     } else {
       // parse as CSV
       const lines = trimmed.split('\n').filter((l) => l.trim() !== '');
-      if (lines.length < 1) return [buildErrorBox(options)];
+      if (lines.length < 1) return [buildErrorBox()];
 
       const headerLine = parseCsvRow(lines[0]);
-      if (headerLine.length === 0) return [buildErrorBox(options)];
+      if (headerLine.length === 0) return [buildErrorBox()];
 
       headers = headerLine;
       rows = lines.slice(1).map((line) => {
@@ -141,16 +140,15 @@ export const MarkdownTableBoxSource = {
       });
     }
 
-    if (rows.length === 0) return [buildErrorBox(options)];
+    if (rows.length === 0) return [buildErrorBox()];
 
     const output = buildMarkdownTable(headers, rows);
 
     return [
       new BoxBuilder('Markdown Table', output)
         .setTemplate(CodeBoxTemplate)
-        .setOptions(options)
         .setShowExpandButton(true)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build(),
     ];
   },

--- a/src/modules/boxSources/MarkdownTableBoxSource.ts
+++ b/src/modules/boxSources/MarkdownTableBoxSource.ts
@@ -1,0 +1,159 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// parse a single CSV row, handling double-quoted fields with embedded commas
+function parseCsvRow(line: string): string[] {
+  const cells: string[] = [];
+  let i = 0;
+
+  while (i < line.length) {
+    if (line[i] === '"') {
+      // quoted field
+      let cell = '';
+      i++; // skip opening quote
+      while (i < line.length) {
+        if (line[i] === '"') {
+          if (line[i + 1] === '"') {
+            // escaped double-quote
+            cell += '"';
+            i += 2;
+          } else {
+            i++; // skip closing quote
+            break;
+          }
+        } else {
+          cell += line[i];
+          i++;
+        }
+      }
+      // skip trailing comma
+      if (line[i] === ',') i++;
+      cells.push(cell);
+    } else {
+      // unquoted field
+      const end = line.indexOf(',', i);
+      if (end === -1) {
+        cells.push(line.slice(i));
+        break;
+      }
+      cells.push(line.slice(i, end));
+      i = end + 1;
+    }
+  }
+
+  return cells;
+}
+
+// sanitize a cell value for use inside a Markdown table cell
+function sanitizeCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function buildMarkdownTable(headers: string[], rows: string[][]): string {
+  const headerRow = `| ${headers.map(sanitizeCell).join(' | ')} |`;
+  const separatorRow = `| ${headers.map(() => '---').join(' | ')} |`;
+  const dataRows = rows.map(
+    (row) => `| ${row.map(sanitizeCell).join(' | ')} |`,
+  );
+  return [headerRow, separatorRow, ...dataRows].join('\n');
+}
+
+function buildErrorBox(options: BoxOptions): Box {
+  return new BoxBuilder('Markdown Table', 'Error: could not parse input.')
+    .setTemplate(CodeBoxTemplate)
+    .setOptions(options)
+    .setPriority(Priority)
+    .build();
+}
+
+export const MarkdownTableBoxSource = {
+  name: 'Markdown Table',
+  description: 'Convert CSV or a JSON array of objects into a Markdown table.',
+  defaultInput: 'name,age\nAlice,30\nBob,25 ::mdtable',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'mdtable', 'markdowntable')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    let headers: string[];
+    let rows: string[][];
+
+    if (trimmed.startsWith('[')) {
+      // attempt JSON array of objects
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        return [buildErrorBox(options)];
+      }
+
+      if (
+        !Array.isArray(parsed) ||
+        parsed.length === 0 ||
+        typeof parsed[0] !== 'object' ||
+        parsed[0] === null
+      ) {
+        return [buildErrorBox(options)];
+      }
+
+      // collect headers in first-seen order across all objects
+      const headerSet = new Map<string, true>();
+      for (const obj of parsed as Record<string, unknown>[]) {
+        for (const key of Object.keys(obj)) {
+          headerSet.set(key, true);
+        }
+      }
+      headers = [...headerSet.keys()];
+
+      rows = (parsed as Record<string, unknown>[]).map((obj) =>
+        headers.map((h) => {
+          const val = (obj as Record<string, unknown>)[h];
+          return val === undefined || val === null ? '' : String(val);
+        }),
+      );
+    } else {
+      // parse as CSV
+      const lines = trimmed.split('\n').filter((l) => l.trim() !== '');
+      if (lines.length < 1) return [buildErrorBox(options)];
+
+      const headerLine = parseCsvRow(lines[0]);
+      if (headerLine.length === 0) return [buildErrorBox(options)];
+
+      headers = headerLine;
+      rows = lines.slice(1).map((line) => {
+        const cells = parseCsvRow(line);
+        // pad or trim row to match header count
+        while (cells.length < headers.length) cells.push('');
+        return cells.slice(0, headers.length);
+      });
+    }
+
+    if (rows.length === 0) return [buildErrorBox(options)];
+
+    const output = buildMarkdownTable(headers, rows);
+
+    return [
+      new BoxBuilder('Markdown Table', output)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions(options)
+        .setShowExpandButton(true)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default MarkdownTableBoxSource;

--- a/src/modules/boxSources/MarkdownTableBoxSource.ts
+++ b/src/modules/boxSources/MarkdownTableBoxSource.ts
@@ -5,6 +5,10 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 const MAX_INPUT = 100_000;
+// the byte cap doesn't bound the table shape; rows x cols is what drives work,
+// so cap dimensions to keep the build linear and avoid an O(rows x cols) freeze
+const MAX_COLS = 256;
+const MAX_ROWS = 5_000;
 
 // parse a single CSV row, handling double-quoted fields with embedded commas
 function parseCsvRow(line: string): string[] {
@@ -99,23 +103,27 @@ export const MarkdownTableBoxSource = {
         return [buildErrorBox()];
       }
 
+      // every element must be a plain object, not just the first
       if (
         !Array.isArray(parsed) ||
         parsed.length === 0 ||
-        typeof parsed[0] !== 'object' ||
-        parsed[0] === null
+        parsed.length > MAX_ROWS ||
+        !parsed.every(
+          (o) => typeof o === 'object' && o !== null && !Array.isArray(o),
+        )
       ) {
         return [buildErrorBox()];
       }
 
       // collect headers in first-seen order across all objects
-      const headerSet = new Map<string, true>();
+      const headerSet = new Set<string>();
       for (const obj of parsed as Record<string, unknown>[]) {
         for (const key of Object.keys(obj)) {
-          headerSet.set(key, true);
+          headerSet.add(key);
         }
       }
-      headers = [...headerSet.keys()];
+      headers = [...headerSet];
+      if (headers.length > MAX_COLS) return [buildErrorBox()];
 
       rows = (parsed as Record<string, unknown>[]).map((obj) =>
         headers.map((h) => {
@@ -126,10 +134,14 @@ export const MarkdownTableBoxSource = {
     } else {
       // parse as CSV
       const lines = trimmed.split('\n').filter((l) => l.trim() !== '');
-      if (lines.length < 1) return [buildErrorBox()];
+      if (lines.length < 1 || lines.length > MAX_ROWS + 1) {
+        return [buildErrorBox()];
+      }
 
       const headerLine = parseCsvRow(lines[0]);
-      if (headerLine.length === 0) return [buildErrorBox()];
+      if (headerLine.length === 0 || headerLine.length > MAX_COLS) {
+        return [buildErrorBox()];
+      }
 
       headers = headerLine;
       rows = lines.slice(1).map((line) => {

--- a/src/modules/boxSources/NumberFormatBoxSource.ts
+++ b/src/modules/boxSources/NumberFormatBoxSource.ts
@@ -1,0 +1,58 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// matches an optional minus sign followed by digits and an optional decimal part
+const numberPattern = /^-?\d+(\.\d+)?$/;
+
+export const NumberFormatBoxSource = {
+  name: 'Number Format',
+  description:
+    'Format a number with thousands separators, scientific, and compact notation.',
+  defaultInput: '1234567.89 ::numformat',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'numformat', 'numfmt')) return [];
+
+    const raw = trim(input);
+    if (!numberPattern.test(raw)) return [];
+
+    const n = Number.parseFloat(raw);
+
+    const grouped = n.toLocaleString('en-US');
+    const compact = new Intl.NumberFormat('en-US', {
+      notation: 'compact',
+    }).format(n);
+    const scientific = n.toExponential();
+
+    const output: Record<string, string> = {
+      Grouped: grouped,
+      Compact: compact,
+      Scientific: scientific,
+      Plain: raw,
+    };
+
+    const plaintextOutput = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Number Format', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberFormatBoxSource;

--- a/src/modules/boxSources/NumberFormatBoxSource.ts
+++ b/src/modules/boxSources/NumberFormatBoxSource.ts
@@ -24,6 +24,8 @@ export const NumberFormatBoxSource = {
     if (!hasOptionKeys(options, 'numformat', 'numfmt')) return [];
 
     const raw = trim(input);
+    // no legitimate number literal is this long; bound regex + Intl work
+    if (raw.length > 100) return [];
     if (!numberPattern.test(raw)) return [];
 
     const n = Number.parseFloat(raw);

--- a/src/modules/boxSources/NumberFormatBoxSource.ts
+++ b/src/modules/boxSources/NumberFormatBoxSource.ts
@@ -30,7 +30,11 @@ export const NumberFormatBoxSource = {
 
     const n = Number.parseFloat(raw);
 
-    const grouped = n.toLocaleString('en-US');
+    // group via BigInt for integers (exact for any size) and keep all decimals
+    // for fractions (toLocaleString defaults to rounding at 3 places)
+    const grouped = raw.includes('.')
+      ? n.toLocaleString('en-US', { maximumFractionDigits: 20 })
+      : BigInt(raw).toLocaleString('en-US');
     const compact = new Intl.NumberFormat('en-US', {
       notation: 'compact',
     }).format(n);

--- a/src/modules/boxSources/PasswordStrengthBoxSource.ts
+++ b/src/modules/boxSources/PasswordStrengthBoxSource.ts
@@ -10,8 +10,8 @@ const MAX_INPUT = 10_000;
 const POOL_LOWERCASE = 26;
 const POOL_UPPERCASE = 26;
 const POOL_DIGITS = 10;
-// printable ASCII symbols: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~ (33 chars)
-const POOL_SYMBOLS = 33;
+// printable ASCII symbols: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~ (32 chars)
+const POOL_SYMBOLS = 32;
 // conservative estimate for non-ASCII characters (e.g. unicode, emoji)
 const POOL_NON_ASCII = 100;
 

--- a/src/modules/boxSources/PasswordStrengthBoxSource.ts
+++ b/src/modules/boxSources/PasswordStrengthBoxSource.ts
@@ -1,0 +1,80 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 10_000;
+
+// character pool sizes for each class
+const POOL_LOWERCASE = 26;
+const POOL_UPPERCASE = 26;
+const POOL_DIGITS = 10;
+// printable ASCII symbols: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~ (33 chars)
+const POOL_SYMBOLS = 33;
+// conservative estimate for non-ASCII characters (e.g. unicode, emoji)
+const POOL_NON_ASCII = 100;
+
+function computePool(input: string): number {
+  let pool = 0;
+  if (/[a-z]/.test(input)) pool += POOL_LOWERCASE;
+  if (/[A-Z]/.test(input)) pool += POOL_UPPERCASE;
+  if (/[0-9]/.test(input)) pool += POOL_DIGITS;
+  if (/[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/.test(input)) pool += POOL_SYMBOLS;
+  // any character outside printable ASCII range
+  if (/[^\x20-\x7e]/.test(input)) pool += POOL_NON_ASCII;
+  return pool;
+}
+
+// naive shannon entropy by charset — does NOT account for dictionary words or patterns
+function computeEntropy(length: number, pool: number): number {
+  if (pool <= 0) return 0;
+  return Math.round(length * Math.log2(pool) * 10) / 10;
+}
+
+function rateEntropy(entropy: number): string {
+  if (entropy < 28) return 'Very Weak';
+  if (entropy < 36) return 'Weak';
+  if (entropy < 60) return 'Reasonable';
+  if (entropy < 128) return 'Strong';
+  return 'Very Strong';
+}
+
+export const PasswordStrengthBoxSource = {
+  name: 'Password Strength',
+  description: 'Estimate password entropy (bits) and a rough strength rating.',
+  defaultInput: 'Tr0ub4dour&3 ::strength',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'strength', 'pwstrength')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const pool = computePool(input);
+    const entropy = computeEntropy(input.length, pool);
+    const rating = rateEntropy(entropy);
+
+    const kvOptions: Record<string, string> = {
+      Length: String(input.length),
+      'Charset Size': String(pool),
+      'Entropy (bits)': String(entropy),
+      Rating: rating,
+    };
+
+    return [
+      new BoxBuilder('Password Strength', '')
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PasswordStrengthBoxSource;

--- a/src/modules/boxSources/UuidV7BoxSource.ts
+++ b/src/modules/boxSources/UuidV7BoxSource.ts
@@ -9,13 +9,15 @@ const Priority = 10;
 function generateUuidV7(): string {
   const bytes = new Uint8Array(16);
 
-  // embed the current time in the high 48 bits (bytes 0-5)
+  // embed the current time in the high 48 bits (bytes 0-5), most significant
+  // first; Math.floor keeps the byte extraction explicit (values exceed int32,
+  // so a bare `& 0xff` would rely on ToInt32 wrapping)
   const now = Date.now();
-  bytes[0] = (now / 0x10000000000) & 0xff;
-  bytes[1] = (now / 0x100000000) & 0xff;
-  bytes[2] = (now / 0x1000000) & 0xff;
-  bytes[3] = (now / 0x10000) & 0xff;
-  bytes[4] = (now / 0x100) & 0xff;
+  bytes[0] = Math.floor(now / 0x10000000000) & 0xff;
+  bytes[1] = Math.floor(now / 0x100000000) & 0xff;
+  bytes[2] = Math.floor(now / 0x1000000) & 0xff;
+  bytes[3] = Math.floor(now / 0x10000) & 0xff;
+  bytes[4] = Math.floor(now / 0x100) & 0xff;
   bytes[5] = now & 0xff;
 
   // fill bytes 6-15 with random data

--- a/src/modules/boxSources/UuidV7BoxSource.ts
+++ b/src/modules/boxSources/UuidV7BoxSource.ts
@@ -1,0 +1,75 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// builds a UUID v7 per RFC 9562: 48-bit ms timestamp + version nibble +
+// 74 random bits + variant bits, formatted as canonical lowercase hex.
+function generateUuidV7(): string {
+  const bytes = new Uint8Array(16);
+
+  // embed the current time in the high 48 bits (bytes 0-5)
+  const now = Date.now();
+  bytes[0] = (now / 0x10000000000) & 0xff;
+  bytes[1] = (now / 0x100000000) & 0xff;
+  bytes[2] = (now / 0x1000000) & 0xff;
+  bytes[3] = (now / 0x10000) & 0xff;
+  bytes[4] = (now / 0x100) & 0xff;
+  bytes[5] = now & 0xff;
+
+  // fill bytes 6-15 with random data
+  crypto.getRandomValues(new Uint8Array(bytes.buffer, 6, 10));
+
+  // set version 7 in the high nibble of byte 6
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  // set RFC 4122 variant (10xx) in the high bits of byte 8
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(
+    '',
+  );
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export const UuidV7BoxSource = {
+  name: 'UUID v7',
+  description: 'Generate a time-ordered UUID version 7 (RFC 9562).',
+  defaultInput: 'uuidv7 ::uuidv7',
+  tag: '#',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    _input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'uuidv7', 'uuid7')) return [];
+
+    if (
+      typeof crypto === 'undefined' ||
+      typeof crypto.getRandomValues !== 'function'
+    ) {
+      return [
+        new BoxBuilder(
+          'UUID v7',
+          'Error: crypto.getRandomValues is unavailable. A secure context (HTTPS or localhost) is required.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    return [
+      new BoxBuilder('UUID v7', generateUuidV7())
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UuidV7BoxSource;

--- a/src/modules/boxSources/WhitespaceCleanBoxSource.ts
+++ b/src/modules/boxSources/WhitespaceCleanBoxSource.ts
@@ -9,16 +9,15 @@ const MAX_INPUT = 100_000;
 // collapse runs of spaces/tabs to a single space on each line,
 // trim surrounding whitespace, then drop lines that become empty.
 function cleanWhitespace(input: string): string {
-  return input
-    .split('\n')
-    .map((line) =>
-      line
-        .replace(/\r$/, '')
-        .replace(/[ \t]+/g, ' ')
-        .trim(),
-    )
-    .filter((line) => line.length > 0)
-    .join('\n');
+  return (
+    input
+      // normalize CRLF and bare-CR (old Mac) line endings to \n first
+      .replace(/\r\n?/g, '\n')
+      .split('\n')
+      .map((line) => line.replace(/[ \t]+/g, ' ').trim())
+      .filter((line) => line.length > 0)
+      .join('\n')
+  );
 }
 
 export const WhitespaceCleanBoxSource = {

--- a/src/modules/boxSources/WhitespaceCleanBoxSource.ts
+++ b/src/modules/boxSources/WhitespaceCleanBoxSource.ts
@@ -1,0 +1,53 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// collapse runs of spaces/tabs to a single space on each line,
+// trim surrounding whitespace, then drop lines that become empty.
+function cleanWhitespace(input: string): string {
+  return input
+    .split('\n')
+    .map((line) =>
+      line
+        .replace(/\r$/, '')
+        .replace(/[ \t]+/g, ' ')
+        .trim(),
+    )
+    .filter((line) => line.length > 0)
+    .join('\n');
+}
+
+export const WhitespaceCleanBoxSource = {
+  name: 'Whitespace Clean',
+  description:
+    'Trim each line, collapse internal whitespace runs, and remove blank lines.',
+  defaultInput: '  hello   world  \n\n\n  foo  bar ::clean',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'clean', 'cleanws')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const cleaned = cleanWhitespace(input);
+    if (cleaned.length === 0) return [];
+
+    return [
+      new BoxBuilder('Whitespace Clean', cleaned)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default WhitespaceCleanBoxSource;

--- a/src/modules/boxSources/__test__/EmailParseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/EmailParseBoxSource.test.ts
@@ -1,0 +1,75 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { EmailParseBoxSource } from '../EmailParseBoxSource';
+
+describe('EmailParseBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no trigger option is provided', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes(
+        'john.doe+news@mail.example.co.uk',
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('parses john.doe+news@mail.example.co.uk into all parts including tag', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes(
+        'john.doe+news@mail.example.co.uk',
+        { email: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Email Parse');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Local).toBe('john.doe+news');
+      expect(opts.Domain).toBe('mail.example.co.uk');
+      expect(opts.TLD).toBe('uk');
+      expect(opts.Tag).toBe('news');
+    });
+
+    it('parses a@b.com without a Tag key', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('a@b.com', {
+        email: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Local).toBe('a');
+      expect(opts.Domain).toBe('b.com');
+      expect(opts.TLD).toBe('com');
+      expect(opts).not.toHaveProperty('Tag');
+    });
+
+    it('sets the correct priority', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('a@b.com', {
+        email: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('returns an error box for "not-an-email"', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('not-an-email', {
+        email: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/valid/i);
+    });
+
+    it('returns an error box for "a@@b.com"', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('a@@b.com', {
+        email: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/valid/i);
+    });
+
+    it('returns an error box for "a b@c.com" (space in local part)', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('a b@c.com', {
+        email: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/valid/i);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HttpHeadersBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HttpHeadersBoxSource.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { HttpHeadersBoxSource } from '../HttpHeadersBoxSource';
+
+describe('HttpHeadersBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no option is provided', async () => {
+      const boxes = await HttpHeadersBoxSource.generateBoxes(
+        'Content-Type: application/json',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] for empty input', async () => {
+      const boxes = await HttpHeadersBoxSource.generateBoxes('', {
+        headers: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should parse basic headers with ::headers option', async () => {
+      const input = 'Content-Type: application/json\nCache-Control: no-cache';
+      const boxes = await HttpHeadersBoxSource.generateBoxes(input, {
+        headers: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Content-Type']).toBe('application/json');
+      expect(boxes[0].props.options?.['Cache-Control']).toBe('no-cache');
+    });
+
+    it('should parse basic headers with ::httpheaders option', async () => {
+      const input = 'Content-Type: application/json';
+      const boxes = await HttpHeadersBoxSource.generateBoxes(input, {
+        httpheaders: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Content-Type']).toBe('application/json');
+    });
+
+    it('should preserve colons in the value (split on first colon only)', async () => {
+      const input = 'Date: Mon, 01 Jan 2024 00:00:00 GMT';
+      const boxes = await HttpHeadersBoxSource.generateBoxes(input, {
+        headers: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Date).toBe(
+        'Mon, 01 Jan 2024 00:00:00 GMT',
+      );
+    });
+
+    it('should skip request/status lines that have no colon', async () => {
+      const input = 'GET / HTTP/1.1\nHost: example.com';
+      const boxes = await HttpHeadersBoxSource.generateBoxes(input, {
+        headers: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Host).toBe('example.com');
+      expect(boxes[0].props.options?.['GET / HTTP/1.1']).toBeUndefined();
+    });
+
+    it('should merge repeated header names with ", "', async () => {
+      const input = 'Set-Cookie: a=1\nSet-Cookie: b=2';
+      const boxes = await HttpHeadersBoxSource.generateBoxes(input, {
+        headers: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Set-Cookie']).toBe('a=1, b=2');
+    });
+
+    it('should return [] when input has no valid header lines', async () => {
+      const boxes = await HttpHeadersBoxSource.generateBoxes(
+        'just text no colon',
+        { headers: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HttpHeadersBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HttpHeadersBoxSource.test.ts
@@ -80,5 +80,15 @@ describe('HttpHeadersBoxSource', () => {
       );
       expect(boxes).toHaveLength(0);
     });
+
+    it('merges case-insensitive duplicate header names (RFC 9110)', async () => {
+      const boxes = await HttpHeadersBoxSource.generateBoxes(
+        'Set-Cookie: a=1\nset-cookie: b=2',
+        { headers: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Set-Cookie']).toBe('a=1, b=2');
+      expect(opts['set-cookie']).toBeUndefined();
+    });
   });
 });

--- a/src/modules/boxSources/__test__/IPv6BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/IPv6BoxSource.test.ts
@@ -83,4 +83,19 @@ describe('IPv6BoxSource', () => {
     expect(boxes[0].props.name).toBe('IPv6');
     expect(boxes[0].props.priority).toBe(20);
   });
+
+  it('rejects :: that represents zero groups (RFC 4291)', async () => {
+    // both halves already total 8 groups, so :: stands for nothing — invalid
+    for (const bad of ['1:2:3:4:5:6:7:8::', '1:2:3:4:5:6::7:8']) {
+      const boxes = await IPv6BoxSource.generateBoxes(bad, { ipv6: true });
+      expect(boxes).toHaveLength(0);
+    }
+  });
+
+  it('handles :: (unspecified address)', async () => {
+    const boxes = await IPv6BoxSource.generateBoxes('::', { ipv6: true });
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Expanded).toBe('0000:0000:0000:0000:0000:0000:0000:0000');
+    expect(opts.Compressed).toBe('::');
+  });
 });

--- a/src/modules/boxSources/__test__/IPv6BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/IPv6BoxSource.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { IPv6BoxSource } from '../IPv6BoxSource';
+
+describe('IPv6BoxSource', () => {
+  it('returns [] when no ::ipv6 option is provided', async () => {
+    const boxes = await IPv6BoxSource.generateBoxes('2001:db8::1', null);
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when options object has no ipv6 key', async () => {
+    const boxes = await IPv6BoxSource.generateBoxes('2001:db8::1', {
+      other: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('expands and compresses 2001:db8::1', async () => {
+    const boxes = await IPv6BoxSource.generateBoxes('2001:db8::1', {
+      ipv6: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Expanded).toBe('2001:0db8:0000:0000:0000:0000:0000:0001');
+    expect(opts.Compressed).toBe('2001:db8::1');
+  });
+
+  it('expands ::1 correctly', async () => {
+    const boxes = await IPv6BoxSource.generateBoxes('::1', { ipv6: true });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Expanded).toBe('0000:0000:0000:0000:0000:0000:0000:0001');
+    expect(opts.Compressed).toBe('::1');
+  });
+
+  it('compresses fe80:0:0:0:0:0:0:1 to fe80::1', async () => {
+    const boxes = await IPv6BoxSource.generateBoxes('fe80:0:0:0:0:0:0:1', {
+      ipv6: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Compressed).toBe('fe80::1');
+  });
+
+  it('does not add :: when no run of ≥2 zero groups exists', async () => {
+    // address has at most one consecutive zero group anywhere
+    const addr = '2001:db8:0:1:2:3:4:5';
+    const boxes = await IPv6BoxSource.generateBoxes(addr, { ipv6: true });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    // no :: should appear in compressed form
+    expect(opts.Compressed).not.toContain('::');
+    expect(opts.Compressed).toBe('2001:db8:0:1:2:3:4:5');
+  });
+
+  it('returns [] for invalid address xyz', async () => {
+    const boxes = await IPv6BoxSource.generateBoxes('xyz', { ipv6: true });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for group too long (12345::1)', async () => {
+    const boxes = await IPv6BoxSource.generateBoxes('12345::1', { ipv6: true });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for too few groups with no :: (1:2:3)', async () => {
+    const boxes = await IPv6BoxSource.generateBoxes('1:2:3', { ipv6: true });
+    expect(boxes).toEqual([]);
+  });
+
+  it('RFC 5952 longest-run: picks second run (length 3) over first (length 2)', async () => {
+    // 2001:0:0:1:0:0:0:1 — first run of zeros is length 2 (groups 1-2),
+    // second run of zeros is length 3 (groups 4-6). longest wins → compress second run.
+    const boxes = await IPv6BoxSource.generateBoxes('2001:0:0:1:0:0:0:1', {
+      ipv6: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Compressed).toBe('2001:0:0:1::1');
+  });
+
+  it('box has correct name and priority', async () => {
+    const boxes = await IPv6BoxSource.generateBoxes('::1', { ipv6: true });
+    expect(boxes[0].props.name).toBe('IPv6');
+    expect(boxes[0].props.priority).toBe(20);
+  });
+});

--- a/src/modules/boxSources/__test__/MarkdownTableBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MarkdownTableBoxSource.test.ts
@@ -75,5 +75,31 @@ describe('MarkdownTableBoxSource', () => {
         '| name | note |\n| --- | --- |\n| Alice | hello, world |',
       );
     });
+
+    it('unions keys across heterogeneous JSON objects', async () => {
+      const boxes = await MarkdownTableBoxSource.generateBoxes(
+        '[{"a":1,"b":2},{"a":3,"c":4}]',
+        { mdtable: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| a | b | c |\n| --- | --- | --- |\n| 1 | 2 |  |\n| 3 |  | 4 |',
+      );
+    });
+
+    it('returns an error box when a JSON element is not an object', async () => {
+      const boxes = await MarkdownTableBoxSource.generateBoxes(
+        '[{"a":1},null,"str"]',
+        { mdtable: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toMatch(/error/i);
+    });
+
+    it('rejects a table with too many columns (DoS guard)', async () => {
+      const header = Array.from({ length: 300 }, (_, i) => `c${i}`).join(',');
+      const boxes = await MarkdownTableBoxSource.generateBoxes(`${header}\nx`, {
+        mdtable: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toMatch(/error/i);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/MarkdownTableBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MarkdownTableBoxSource.test.ts
@@ -1,0 +1,79 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { expect } from 'vitest';
+
+import { MarkdownTableBoxSource } from '../MarkdownTableBoxSource';
+
+describe('MarkdownTableBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no trigger option is present', async () => {
+      const boxes = await MarkdownTableBoxSource.generateBoxes(
+        'name,age\nAlice,30',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts CSV to a Markdown table with ::mdtable option', async () => {
+      const boxes = await MarkdownTableBoxSource.generateBoxes(
+        'name,age\nAlice,30\nBob,25',
+        { mdtable: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Markdown Table');
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| name | age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |',
+      );
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+
+    it('converts JSON array of objects to a Markdown table', async () => {
+      const boxes = await MarkdownTableBoxSource.generateBoxes(
+        '[{"a":1,"b":2}]',
+        { mdtable: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| a | b |\n| --- | --- |\n| 1 | 2 |',
+      );
+    });
+
+    it('escapes pipe characters inside CSV cells', async () => {
+      const boxes = await MarkdownTableBoxSource.generateBoxes('col\na|b', {
+        mdtable: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| col |\n| --- |\n| a\\|b |',
+      );
+    });
+
+    it('returns an error box for invalid JSON-looking input', async () => {
+      const boxes = await MarkdownTableBoxSource.generateBoxes('[bad]', {
+        mdtable: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Markdown Table');
+      expect(boxes[0].props.plaintextOutput).toContain('Error');
+    });
+
+    it('accepts ::markdowntable as an alias for the trigger option', async () => {
+      const boxes = await MarkdownTableBoxSource.generateBoxes('x\n1', {
+        markdowntable: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('| x |\n| --- |\n| 1 |');
+    });
+
+    it('handles quoted CSV fields with embedded commas', async () => {
+      const boxes = await MarkdownTableBoxSource.generateBoxes(
+        'name,note\nAlice,"hello, world"',
+        { mdtable: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| name | note |\n| --- | --- |\n| Alice | hello, world |',
+      );
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NumberFormatBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberFormatBoxSource.test.ts
@@ -65,5 +65,22 @@ describe('NumberFormatBoxSource', () => {
       expect(opts.Scientific).toBe('1.234567e+6');
       expect(opts.Plain).toBe('1234567');
     });
+
+    it('does not round fractional digits in Grouped', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1234.56789', {
+        numformat: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Grouped).toBe('1,234.56789');
+    });
+
+    it('preserves precision of very large integers via BigInt', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes(
+        '123456789012345678901234567890',
+        { numformat: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Grouped).toBe('123,456,789,012,345,678,901,234,567,890');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/NumberFormatBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberFormatBoxSource.test.ts
@@ -1,0 +1,69 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { NumberFormatBoxSource } from '../NumberFormatBoxSource';
+
+describe('NumberFormatBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no trigger option is provided', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1234567.89');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('abc', {
+        numformat: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('formats 1234567.89 with ::numformat', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1234567.89', {
+        numformat: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Number Format');
+      expect(boxes[0].props.options).toMatchObject({
+        Grouped: '1,234,567.89',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('formats 1000000 into compact 1M and grouped 1,000,000', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1000000', {
+        numfmt: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Grouped: '1,000,000',
+        Compact: '1M',
+      });
+    });
+
+    it('formats negative number -5000', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('-5000', {
+        numformat: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Grouped: '-5,000',
+      });
+    });
+
+    it('sets correct priority', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1234567', {
+        numformat: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('includes Scientific and Plain keys', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1234567', {
+        numformat: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Scientific).toBe('1.234567e+6');
+      expect(opts.Plain).toBe('1234567');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PasswordStrengthBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PasswordStrengthBoxSource.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { PasswordStrengthBoxSource } from '../PasswordStrengthBoxSource';
+
+describe('PasswordStrengthBoxSource', () => {
+  it('returns [] when no option is provided', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('abc', null);
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when option does not match', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('abc', {
+      other: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for empty input', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('', {
+      strength: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('handles ::strength option with lowercase-only input', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('abc', {
+      strength: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Charset Size']).toBe('26');
+    expect(opts.Length).toBe('3');
+  });
+
+  it('handles ::pwstrength option alias', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('abc', {
+      pwstrength: true,
+    });
+    expect(boxes).toHaveLength(1);
+  });
+
+  it('computes correct charset size for mixed aA1! input', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('aA1!', {
+      strength: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    // lowercase(26) + uppercase(26) + digits(10) + symbols(33) = 95
+    expect(opts['Charset Size']).toBe('95');
+    expect(opts.Length).toBe('4');
+  });
+
+  it('rates a 20-char mixed password as Strong or Very Strong', async () => {
+    // 20 chars, mixed: should yield high entropy
+    const boxes = await PasswordStrengthBoxSource.generateBoxes(
+      'Tr0ub4dour&3xYzQ!mN9',
+      { strength: true },
+    );
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(['Strong', 'Very Strong']).toContain(opts.Rating);
+  });
+
+  it('rates lowercase-only short password as Very Weak or Weak', async () => {
+    // 'aaaa' with pool=26: entropy = 4 * log2(26) ≈ 18.8 → Very Weak
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('aaaa', {
+      strength: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Charset Size']).toBe('26');
+    expect(['Very Weak', 'Weak']).toContain(opts.Rating);
+  });
+
+  it('includes all required keys in output', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('aA1!', {
+      strength: true,
+    });
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts).toHaveProperty('Length');
+    expect(opts).toHaveProperty('Charset Size');
+    expect(opts).toHaveProperty('Entropy (bits)');
+    expect(opts).toHaveProperty('Rating');
+  });
+
+  it('returns [] for input exceeding MAX_INPUT', async () => {
+    const long = 'a'.repeat(10_001);
+    const boxes = await PasswordStrengthBoxSource.generateBoxes(long, {
+      strength: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+});

--- a/src/modules/boxSources/__test__/PasswordStrengthBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PasswordStrengthBoxSource.test.ts
@@ -44,8 +44,8 @@ describe('PasswordStrengthBoxSource', () => {
     });
     expect(boxes).toHaveLength(1);
     const opts = boxes[0].props.options as Record<string, string>;
-    // lowercase(26) + uppercase(26) + digits(10) + symbols(33) = 95
-    expect(opts['Charset Size']).toBe('95');
+    // lowercase(26) + uppercase(26) + digits(10) + symbols(32) = 94
+    expect(opts['Charset Size']).toBe('94');
     expect(opts.Length).toBe('4');
   });
 

--- a/src/modules/boxSources/__test__/UuidV7BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UuidV7BoxSource.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { UuidV7BoxSource } from '../UuidV7BoxSource';
+
+const validUuidV7Regex =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('UuidV7BoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no trigger option is present', async () => {
+      const boxes = await UuidV7BoxSource.generateBoxes('uuidv7');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated options', async () => {
+      const boxes = await UuidV7BoxSource.generateBoxes('', { uuid: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('generates one box with a valid v7 UUID on ::uuidv7', async () => {
+      const boxes = await UuidV7BoxSource.generateBoxes('', { uuidv7: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('UUID v7');
+      expect(boxes[0].props.plaintextOutput).toMatch(validUuidV7Regex);
+    });
+
+    it('generates one box with a valid v7 UUID on ::uuid7 alias', async () => {
+      const boxes = await UuidV7BoxSource.generateBoxes('', { uuid7: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(validUuidV7Regex);
+    });
+
+    it('two consecutive generations both match the v7 format', async () => {
+      const [boxes1, boxes2] = await Promise.all([
+        UuidV7BoxSource.generateBoxes('', { uuidv7: true }),
+        UuidV7BoxSource.generateBoxes('', { uuidv7: true }),
+      ]);
+      expect(boxes1[0].props.plaintextOutput).toMatch(validUuidV7Regex);
+      expect(boxes2[0].props.plaintextOutput).toMatch(validUuidV7Regex);
+    });
+
+    it('two consecutive generations produce different values', async () => {
+      const boxes1 = await UuidV7BoxSource.generateBoxes('', { uuidv7: true });
+      const boxes2 = await UuidV7BoxSource.generateBoxes('', { uuidv7: true });
+      // astronomically unlikely to collide; guards against a frozen clock + zero-random bug
+      expect(boxes1[0].props.plaintextOutput).not.toBe(
+        boxes2[0].props.plaintextOutput,
+      );
+    });
+
+    it('input text is ignored — only the option triggers generation', async () => {
+      const boxes = await UuidV7BoxSource.generateBoxes('anything here', {
+        uuidv7: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(validUuidV7Regex);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/WhitespaceCleanBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/WhitespaceCleanBoxSource.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import { WhitespaceCleanBoxSource } from '../WhitespaceCleanBoxSource';
+
+describe('WhitespaceCleanBoxSource', () => {
+  describe('generateBoxes — gate conditions', () => {
+    it('returns [] when no option is supplied', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes(
+        '  hello   world  ',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is supplied', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes(
+        '  hello   world  ',
+        { json: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty string with ::clean', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes('', {
+        clean: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::clean', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes(
+        '   \n\n   \n',
+        { clean: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for a string of only spaces and newlines with ::cleanws', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes('  \n  \n  ', {
+        cleanws: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — cleaning behavior', () => {
+    it('collapses internal spaces and trims lines, drops blank lines (::clean)', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes(
+        '  hello   world  \n\n\n  foo  bar',
+        { clean: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello world\nfoo bar');
+    });
+
+    it('also triggers on ::cleanws', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes(
+        '  hello   world  ',
+        { cleanws: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello world');
+    });
+
+    it('collapses tabs to a single space', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes('a\t\tb', {
+        clean: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a b');
+    });
+
+    it('trims leading and trailing spaces from each line', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes(
+        '  hello   world  ',
+        { clean: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('hello world');
+    });
+
+    it('produces correct output for the spec example', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes('  a   b  ', {
+        clean: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a b');
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('sets name to "Whitespace Clean"', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes('  a  b  ', {
+        clean: true,
+      });
+      expect(boxes[0].props.name).toBe('Whitespace Clean');
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes('  a  b  ', {
+        clean: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('assigns CodeBoxTemplate as boxTemplate', async () => {
+      const boxes = await WhitespaceCleanBoxSource.generateBoxes('  a  b  ', {
+        clean: true,
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -6,15 +6,21 @@ import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import EmailParseBoxSource from './EmailParseBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HttpHeadersBoxSource from './HttpHeadersBoxSource';
+import IPv6BoxSource from './IPv6BoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import MarkdownTableBoxSource from './MarkdownTableBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberFormatBoxSource from './NumberFormatBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PasswordStrengthBoxSource from './PasswordStrengthBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
@@ -22,6 +28,8 @@ import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
+import UuidV7BoxSource from './UuidV7BoxSource';
+import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -34,21 +42,29 @@ export const boxSources = [
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  EmailParseBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HttpHeadersBoxSource,
+  IPv6BoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  MarkdownTableBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
+  NumberFormatBoxSource,
   PasswordBoxSource,
+  PasswordStrengthBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
+  UuidV7BoxSource,
   TimestampBoxSource,
+  WhitespaceCleanBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
## Summary

Sixth exploration batch — **8 more BoxSource tools** (formatting, networking, analysis), following all hardened conventions.

| Tool | Trigger | What it does |
|------|---------|--------------|
| Number Format | `::numformat` | grouped / compact (1.2M) / scientific |
| Password Strength | `::strength` | charset entropy bits + rating |
| IPv6 | `::ipv6` | expand + compress (RFC 5952 longest-run, leftmost tie) |
| HTTP Headers | `::headers` | parse a raw header block → key/value |
| Email Parse | `::email` | validate + split local/domain/TLD/+tag |
| Whitespace Clean | `::clean` | trim lines, collapse runs, drop blank lines |
| UUID v7 | `::uuidv7` | time-ordered UUID (RFC 9562) |
| Markdown Table | `::mdtable` | CSV or JSON array → GFM table |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step.
- **Verified**: IPv6 RFC 5952 longest-zero-run with leftmost-tie traced (`2001:0:0:1:0:0:0:1` → `2001:0:0:1::1`); UUID v7 version/variant bits per RFC 9562; Email + Whitespace use linear regexes only (no ReDoS); all free-text processors capped.

## Verification

- ✅ `bun run test run` — **399 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#264 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6