### PR TITLE
feat(boxSources): add 8 more tools (unicode-escape, unicode-normalize, atbash, vigenere, crockford-base32, markdown-strip, gcd/lcm, ordinal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,81 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>UnicodeEscapeBox</b> </summary>
+
+| match rule            | description                          | example                  |
+| --------------------- | ------------------------------------ | ------------------------ |
+| `::unicodeescape`     | escape non-ASCII to `\uXXXX`         | `café 😀 ::unicodeescape` |
+| `::unicodeunescape`   | unescape `\uXXXX` / `\u{…}` to text  | `café ::unicodeunescape` |
+
+</details>
+
+<details>
+<summary> <b>UnicodeNormalizeBox</b> </summary>
+
+| match rule     | description                              | example            |
+| -------------- | ---------------------------------------- | ------------------ |
+| `::normalize`  | show NFC / NFD / NFKC / NFKD forms       | `ﬁ café ::normalize` |
+
+</details>
+
+<details>
+<summary> <b>AtbashBox</b> </summary>
+
+| match rule | description                          | example                 |
+| ---------- | ------------------------------------ | ----------------------- |
+| `::atbash` | Atbash cipher (A↔Z), self-inverse    | `Hello, World! ::atbash` |
+
+</details>
+
+<details>
+<summary> <b>VigenèreBox</b> </summary>
+
+| match rule              | description                  | example                       |
+| ----------------------- | ---------------------------- | ----------------------------- |
+| `::vigenere=KEY`        | Vigenère encode with keyword | `Attack at dawn ::vigenere=lemon` |
+| `::vigeneredecode=KEY`  | Vigenère decode              | `LXFOPVEFRNHR ::vigeneredecode=LEMON` |
+
+</details>
+
+<details>
+<summary> <b>CrockfordBase32Box</b> </summary>
+
+| match rule           | description                              | example            |
+| -------------------- | ---------------------------------------- | ------------------ |
+| `::crockford`        | Crockford Base32 encode (no padding)     | `hello ::crockford` |
+| `::crockforddecode`  | Crockford Base32 decode (O/I/L aliases)  | `D1JPRV3F ::crockforddecode` |
+
+</details>
+
+<details>
+<summary> <b>MarkdownStripBox</b> </summary>
+
+| match rule    | description                          | example                  |
+| ------------- | ------------------------------------ | ------------------------ |
+| `::stripmd`   | strip Markdown formatting to plain text | `# Title **bold** ::stripmd` |
+
+</details>
+
+<details>
+<summary> <b>GcdLcmBox</b> </summary>
+
+| match rule | description                                  | example            |
+| ---------- | -------------------------------------------- | ------------------ |
+| `::gcd`    | greatest common divisor + least common multiple | `12 18 24 ::gcd` |
+
+</details>
+
+<details>
+<summary> <b>OrdinalBox</b> </summary>
+
+| match rule   | description                          | example          |
+| ------------ | ------------------------------------ | ---------------- |
+| `::ordinal`  | integer → ordinal form (21 → 21st)   | `21 ::ordinal`   |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/AtbashBoxSource.ts
+++ b/src/modules/boxSources/AtbashBoxSource.ts
@@ -1,0 +1,53 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// maps each letter A-Z / a-z to its mirror; all other characters pass through
+function applyAtbash(input: string): string {
+  let result = '';
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code >= 65 && code <= 90) {
+      result += String.fromCharCode(90 - (code - 65));
+    } else if (code >= 97 && code <= 122) {
+      result += String.fromCharCode(122 - (code - 97));
+    } else {
+      result += input[i];
+    }
+  }
+  return result;
+}
+
+export const AtbashBoxSource = {
+  name: 'Atbash',
+  description:
+    'Apply the Atbash cipher (A↔Z, B↔Y, …). Preserves case, self-inverse.',
+  defaultInput: 'Hello, World! ::atbash',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'atbash')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const output = applyAtbash(input);
+    return [
+      new BoxBuilder('Atbash', output)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default AtbashBoxSource;

--- a/src/modules/boxSources/CrockfordBase32BoxSource.ts
+++ b/src/modules/boxSources/CrockfordBase32BoxSource.ts
@@ -1,0 +1,113 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// Crockford's base32: excludes I, L, O, U to avoid visual confusion; no padding
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+// reverse lookup table; aliases O→0, I→1, L→1 per Crockford spec
+const DECODE_MAP: Record<string, number> = {};
+for (let i = 0; i < ALPHABET.length; i++) {
+  DECODE_MAP[ALPHABET[i]] = i;
+}
+DECODE_MAP.O = 0;
+DECODE_MAP.I = 1;
+DECODE_MAP.L = 1;
+
+function crockfordEncode(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let bits = '';
+  for (const b of bytes) {
+    bits += b.toString(2).padStart(8, '0');
+  }
+  let result = '';
+  for (let i = 0; i < bits.length; i += 5) {
+    // pad the final group with trailing zeros if needed
+    const group = bits.slice(i, i + 5).padEnd(5, '0');
+    result += ALPHABET[Number.parseInt(group, 2)];
+  }
+  return result;
+}
+
+// returns decoded utf-8 string, or null if input contains invalid characters
+function crockfordDecode(input: string): string | null {
+  // uppercase and strip hyphens (allowed as visual separators per Crockford spec)
+  const normalized = input.toUpperCase().replace(/-/g, '');
+  let bits = '';
+  for (const c of normalized) {
+    const val = DECODE_MAP[c];
+    if (val === undefined) return null;
+    bits += val.toString(2).padStart(5, '0');
+  }
+  // discard trailing bits that don't form a full byte
+  const byteCount = Math.floor(bits.length / 8);
+  const bytes = new Uint8Array(byteCount);
+  for (let i = 0; i < byteCount; i++) {
+    bytes[i] = Number.parseInt(bits.slice(i * 8, i * 8 + 8), 2);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+export const CrockfordBase32BoxSource = {
+  name: 'Crockford Base32',
+  description:
+    "Encode text to Crockford's Base32 or decode it back (case-insensitive, no padding).",
+  defaultInput: 'hello ::crockford',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'crockford', 'crockfordencode');
+    const wantDecode = hasOptionKeys(options, 'crockforddecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = crockfordEncode(input);
+      boxes.push(
+        new BoxBuilder('Crockford Base32 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = crockfordDecode(input);
+      if (decoded === null) {
+        boxes.push(
+          new BoxBuilder(
+            'Crockford Base32 (Decode)',
+            'invalid Crockford Base32 input',
+          )
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        boxes.push(
+          new BoxBuilder('Crockford Base32 (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default CrockfordBase32BoxSource;

--- a/src/modules/boxSources/CrockfordBase32BoxSource.ts
+++ b/src/modules/boxSources/CrockfordBase32BoxSource.ts
@@ -1,4 +1,5 @@
 import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
@@ -67,7 +68,7 @@ export const CrockfordBase32BoxSource = {
     const wantEncode = hasOptionKeys(options, 'crockford', 'crockfordencode');
     const wantDecode = hasOptionKeys(options, 'crockforddecode');
     if (!wantEncode && !wantDecode) return [];
-    if (input.length > MAX_INPUT) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
 
     const boxes: Box[] = [];
 

--- a/src/modules/boxSources/CrockfordBase32BoxSource.ts
+++ b/src/modules/boxSources/CrockfordBase32BoxSource.ts
@@ -68,7 +68,9 @@ export const CrockfordBase32BoxSource = {
     const wantEncode = hasOptionKeys(options, 'crockford', 'crockfordencode');
     const wantDecode = hasOptionKeys(options, 'crockforddecode');
     if (!wantEncode && !wantDecode) return [];
-    if (!isString(input) || input.length > MAX_INPUT) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT) {
+      return [];
+    }
 
     const boxes: Box[] = [];
 

--- a/src/modules/boxSources/GcdLcmBoxSource.ts
+++ b/src/modules/boxSources/GcdLcmBoxSource.ts
@@ -39,6 +39,7 @@ export const GcdLcmBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'gcd', 'lcm', 'gcdlcm')) return [];
+    if (input.length > 100_000) return [];
 
     // parse a list of integers separated by whitespace and/or commas
     const tokens = trim(input)
@@ -46,12 +47,15 @@ export const GcdLcmBoxSource = {
       .filter((t) => t.length > 0);
     if (tokens.length < 2) return [];
 
-    // validate each token is an integer; reject the whole input on any invalid token
+    // validate each token is an integer with a bounded digit count; reject the
+    // whole input on any invalid token (50 digits keeps BigInt math sub-ms)
     for (const t of tokens) {
-      if (!/^-?\d+$/.test(t)) return [];
+      if (!/^-?\d+$/.test(t) || t.replace('-', '').length > 50) return [];
     }
 
-    const values = tokens.map((t) => BigInt(Number.parseInt(t, 10)));
+    // construct directly from the validated string — BigInt(Number.parseInt(...))
+    // would route through a lossy float and throw on Infinity for huge tokens
+    const values = tokens.map((t) => BigInt(t));
     const gcdResult = values.reduce((acc, v) => gcd(acc, v));
     const lcmResult = values.reduce((acc, v) => lcm(acc, v));
 

--- a/src/modules/boxSources/GcdLcmBoxSource.ts
+++ b/src/modules/boxSources/GcdLcmBoxSource.ts
@@ -1,0 +1,72 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// euclid's algorithm on BigInt absolute values
+function gcd(a: bigint, b: bigint): bigint {
+  a = a < 0n ? -a : a;
+  b = b < 0n ? -b : b;
+  while (b !== 0n) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+// lcm via |a*b| / gcd(a,b); returns 0n if either operand is 0
+function lcm(a: bigint, b: bigint): bigint {
+  if (a === 0n || b === 0n) return 0n;
+  const g = gcd(a, b);
+  const product = a * b;
+  return product < 0n ? -(product / g) : product / g;
+}
+
+export const GcdLcmBoxSource = {
+  name: 'GCD / LCM',
+  description:
+    'Compute the greatest common divisor and least common multiple of a list of integers.',
+  defaultInput: '12 18 24 ::gcd',
+  tag: '#',
+  kind: 'Math',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'gcd', 'lcm', 'gcdlcm')) return [];
+
+    // parse a list of integers separated by whitespace and/or commas
+    const tokens = trim(input)
+      .split(/[\s,]+/)
+      .filter((t) => t.length > 0);
+    if (tokens.length < 2) return [];
+
+    // validate each token is an integer; reject the whole input on any invalid token
+    for (const t of tokens) {
+      if (!/^-?\d+$/.test(t)) return [];
+    }
+
+    const values = tokens.map((t) => BigInt(Number.parseInt(t, 10)));
+    const gcdResult = values.reduce((acc, v) => gcd(acc, v));
+    const lcmResult = values.reduce((acc, v) => lcm(acc, v));
+
+    return [
+      new BoxBuilder('GCD / LCM', '')
+        .setOptions({
+          Numbers: tokens.join(', '),
+          GCD: gcdResult.toString(),
+          LCM: lcmResult.toString(),
+        })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default GcdLcmBoxSource;

--- a/src/modules/boxSources/MarkdownStripBoxSource.ts
+++ b/src/modules/boxSources/MarkdownStripBoxSource.ts
@@ -16,11 +16,13 @@ function stripMarkdown(text: string): string {
   // remove ATX headings: leading # characters at line start
   result = result.replace(/^#{1,6}\s+/gm, '');
 
-  // remove images before links so the pattern doesn't conflict
-  result = result.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');
+  // remove images before links so the pattern doesn't conflict.
+  // the classes exclude the OPENING delimiters ([ and () not just the closing
+  // ones — otherwise an unmatched "[" flood backtracks O(n^2) (ReDoS)
+  result = result.replace(/!\[([^[\]]*)\]\(([^()]*)\)/g, '$1');
 
   // remove links: [text](url) → text
-  result = result.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+  result = result.replace(/\[([^[\]]*)\]\(([^()]*)\)/g, '$1');
 
   // remove strikethrough: ~~x~~ → x
   result = result.replace(/~~([^~]*)~~/g, '$1');

--- a/src/modules/boxSources/MarkdownStripBoxSource.ts
+++ b/src/modules/boxSources/MarkdownStripBoxSource.ts
@@ -1,0 +1,86 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// strip markdown formatting from a string, returning plain text
+function stripMarkdown(text: string): string {
+  let result = text;
+
+  // remove fenced code blocks (``` ... ```) — keep inner content, drop fence lines
+  result = result.replace(/^```.*$/gm, '');
+
+  // remove ATX headings: leading # characters at line start
+  result = result.replace(/^#{1,6}\s+/gm, '');
+
+  // remove images before links so the pattern doesn't conflict
+  result = result.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');
+
+  // remove links: [text](url) → text
+  result = result.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+
+  // remove strikethrough: ~~x~~ → x
+  result = result.replace(/~~([^~]*)~~/g, '$1');
+
+  // remove bold: **x** or __x__ → x
+  result = result.replace(/(\*\*|__)([^*_]*)(\*\*|__)/g, '$2');
+
+  // remove italic: *x* or _x_ → x (after bold so ** is already gone)
+  result = result.replace(/(\*|_)([^*_]*)(\*|_)/g, '$2');
+
+  // remove inline code: `x` → x
+  result = result.replace(/`([^`]*)`/g, '$1');
+
+  // remove blockquote markers: leading > at line start
+  result = result.replace(/^>\s?/gm, '');
+
+  // remove unordered list markers: leading - * + at line start
+  result = result.replace(/^[-*+]\s+/gm, '');
+
+  // remove ordered list markers: leading 1. 2. etc. at line start
+  result = result.replace(/^\d+\.\s+/gm, '');
+
+  // remove horizontal rules: lines consisting solely of --- or ***
+  result = result.replace(/^[-*]{3,}$/gm, '');
+
+  // collapse multiple blank lines into one and trim overall
+  result = result.replace(/\n{3,}/g, '\n\n');
+  return trim(result);
+}
+
+export const MarkdownStripBoxSource = {
+  name: 'Markdown Strip',
+  description: 'Strip common Markdown formatting, leaving plain text.',
+  defaultInput: '# Title\n\n**bold** and _italic_ and `code` ::stripmd',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'stripmd', 'markdownstrip')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const stripped = stripMarkdown(input);
+
+    return [
+      new BoxBuilder('Markdown Strip', stripped)
+        .setTemplate(CodeBoxTemplate)
+        .setShowExpandButton(true)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default MarkdownStripBoxSource;

--- a/src/modules/boxSources/OrdinalBoxSource.ts
+++ b/src/modules/boxSources/OrdinalBoxSource.ts
@@ -1,0 +1,59 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+/** returns the English ordinal suffix for a non-negative integer string */
+function ordinalSuffix(n: number): string {
+  const abs = Math.abs(n);
+  const lastTwo = abs % 100;
+  if (lastTwo >= 11 && lastTwo <= 13) return 'th';
+  switch (abs % 10) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+}
+
+export const OrdinalBoxSource = {
+  name: 'Ordinal',
+  description: 'Convert an integer to its ordinal form (e.g. 21 → 21st).',
+  defaultInput: '21 ::ordinal',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ordinal')) return [];
+
+    const raw = trim(input);
+    // accept optional leading minus, then digits only, capped at MAX_DIGITS total digits
+    if (!/^-?\d{1,16}$/.test(raw)) return [];
+
+    const n = Number.parseInt(raw, 10);
+    if (Number.isNaN(n)) return [];
+
+    const suffix = ordinalSuffix(n);
+    const ordinal = `${n}${suffix}`;
+
+    return [
+      new BoxBuilder('Ordinal', '')
+        .setOptions({ Ordinal: ordinal, Suffix: suffix })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default OrdinalBoxSource;

--- a/src/modules/boxSources/OrdinalBoxSource.ts
+++ b/src/modules/boxSources/OrdinalBoxSource.ts
@@ -37,8 +37,9 @@ export const OrdinalBoxSource = {
     if (!hasOptionKeys(options, 'ordinal')) return [];
 
     const raw = trim(input);
-    // accept optional leading minus, then digits only, capped at MAX_DIGITS total digits
-    if (!/^-?\d{1,16}$/.test(raw)) return [];
+    // optional sign + up to 15 digits (stays within Number.MAX_SAFE_INTEGER, so
+    // parseInt doesn't round and the displayed value matches the input)
+    if (!/^-?\d{1,15}$/.test(raw)) return [];
 
     const n = Number.parseInt(raw, 10);
     if (Number.isNaN(n)) return [];

--- a/src/modules/boxSources/UnicodeEscapeBoxSource.ts
+++ b/src/modules/boxSources/UnicodeEscapeBoxSource.ts
@@ -1,3 +1,4 @@
+import { isString } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
@@ -51,7 +52,7 @@ export const UnicodeEscapeBoxSource = {
     const wantEscape = hasOptionKeys(options, 'unicodeescape', 'uescape');
     const wantUnescape = hasOptionKeys(options, 'unicodeunescape', 'uunescape');
     if (!wantEscape && !wantUnescape) return [];
-    if (input.length > MAX_INPUT) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
 
     const boxes: Box[] = [];
 

--- a/src/modules/boxSources/UnicodeEscapeBoxSource.ts
+++ b/src/modules/boxSources/UnicodeEscapeBoxSource.ts
@@ -1,0 +1,80 @@
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// escapes chars outside printable ASCII (code < 0x20 or > 0x7e) to \uXXXX;
+// iterates by UTF-16 code unit so astral chars emit their surrogate pair.
+function escapeUnicode(input: string): string {
+  let result = '';
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code < 0x20 || code > 0x7e) {
+      result += `\\u${code.toString(16).padStart(4, '0')}`;
+    } else {
+      result += input[i];
+    }
+  }
+  return result;
+}
+
+// the regex handles both \u{HEX} (Unicode code point escape) and \uXXXX (UTF-16 code unit escape).
+const UNESCAPE_RE = /\\u\{([0-9a-fA-F]{1,6})\}|\\u([0-9a-fA-F]{4})/g;
+
+function unescapeUnicode(input: string): string {
+  return input.replace(UNESCAPE_RE, (match, codePoint, codeUnit) => {
+    if (codePoint !== undefined) {
+      const cp = Number.parseInt(codePoint, 16);
+      // guard against invalid code points
+      if (cp > 0x10ffff) return match;
+      return String.fromCodePoint(cp);
+    }
+    // codeUnit is always defined when codePoint is not
+    return String.fromCharCode(Number.parseInt(codeUnit, 16));
+  });
+}
+
+export const UnicodeEscapeBoxSource = {
+  name: 'Unicode Escape',
+  description:
+    'Escape text to \\uXXXX sequences, or unescape them back to text.',
+  defaultInput: 'café 😀 ::unicodeescape',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEscape = hasOptionKeys(options, 'unicodeescape', 'uescape');
+    const wantUnescape = hasOptionKeys(options, 'unicodeunescape', 'uunescape');
+    if (!wantEscape && !wantUnescape) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEscape) {
+      boxes.push(
+        new BoxBuilder('Unicode Escape (Escape)', escapeUnicode(input))
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantUnescape) {
+      boxes.push(
+        new BoxBuilder('Unicode Escape (Unescape)', unescapeUnicode(input))
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default UnicodeEscapeBoxSource;

--- a/src/modules/boxSources/UnicodeNormalizeBoxSource.ts
+++ b/src/modules/boxSources/UnicodeNormalizeBoxSource.ts
@@ -1,0 +1,47 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// the four standard Unicode normalization forms
+const FORMS = ['NFC', 'NFD', 'NFKC', 'NFKD'] as const;
+type NormalizationForm = (typeof FORMS)[number];
+
+export const UnicodeNormalizeBoxSource = {
+  name: 'Unicode Normalize',
+  description:
+    'Normalize text to all four Unicode forms (NFC, NFD, NFKC, NFKD).',
+  defaultInput: 'ﬁ café ::normalize',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'normalize', 'unicodenormalize')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const normalized: Record<NormalizationForm, string> = {
+      NFC: input.normalize('NFC'),
+      NFD: input.normalize('NFD'),
+      NFKC: input.normalize('NFKC'),
+      NFKD: input.normalize('NFKD'),
+    };
+
+    return [
+      new BoxBuilder('Unicode Normalize', '')
+        .setOptions(normalized)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UnicodeNormalizeBoxSource;

--- a/src/modules/boxSources/VigenereBoxSource.ts
+++ b/src/modules/boxSources/VigenereBoxSource.ts
@@ -8,7 +8,7 @@ const MAX_INPUT = 100_000;
 
 // extract the key string from the option value; returns null if no letters are present
 function parseKey(raw: string | boolean): string | null {
-  if (raw === true || raw === 'true') return null;
+  if (raw === true) return null;
   const letters = String(raw)
     .replace(/[^a-zA-Z]/g, '')
     .toLowerCase();

--- a/src/modules/boxSources/VigenereBoxSource.ts
+++ b/src/modules/boxSources/VigenereBoxSource.ts
@@ -1,0 +1,125 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// extract the key string from the option value; returns null if no letters are present
+function parseKey(raw: string | boolean): string | null {
+  if (raw === true || raw === 'true') return null;
+  const letters = String(raw)
+    .replace(/[^a-zA-Z]/g, '')
+    .toLowerCase();
+  return letters.length > 0 ? letters : null;
+}
+
+// apply the vigenère cipher to a single character given a key offset
+function shiftChar(
+  charCode: number,
+  base: number,
+  keyOffset: number,
+  encode: boolean,
+): number {
+  const pos = charCode - base;
+  const shifted = encode ? (pos + keyOffset) % 26 : (pos - keyOffset + 26) % 26;
+  return base + shifted;
+}
+
+// run the vigenère cipher over the full input text, advancing the key only on alpha chars
+function vigenere(text: string, key: string, encode: boolean): string {
+  let keyIndex = 0;
+  const result: string[] = [];
+
+  for (const ch of text) {
+    const code = ch.charCodeAt(0);
+    const isUpper = code >= 65 && code <= 90;
+    const isLower = code >= 97 && code <= 122;
+
+    if (isUpper || isLower) {
+      const base = isUpper ? 65 : 97;
+      const keyOffset = key.charCodeAt(keyIndex % key.length) - 97;
+      result.push(
+        String.fromCharCode(shiftChar(code, base, keyOffset, encode)),
+      );
+      keyIndex++;
+    } else {
+      result.push(ch);
+    }
+  }
+
+  return result.join('');
+}
+
+// build a box for an invalid key (no alphabetic characters found)
+function buildNoLettersBox(priority: number): Box {
+  return new BoxBuilder(
+    'Vigenère',
+    'Key must contain at least one letter. Use ::vigenere=KEY with a word as the key.',
+  )
+    .setTemplate(DefaultBoxTemplate)
+    .setShowExpandButton(false)
+    .setPriority(priority)
+    .build();
+}
+
+export const VigenereBoxSource = {
+  name: 'Vigenère',
+  description:
+    'Encode or decode text with the Vigenère cipher. Key from ::vigenere=KEY / ::vigeneredecode=KEY.',
+  defaultInput: 'Attack at dawn ::vigenere=lemon',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const encRaw = extractOptionKeys(options, 'vigenere', 'vigenereencode');
+    const decRaw = extractOptionKeys(options, 'vigeneredecode');
+
+    if (encRaw === null && decRaw === null) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (encRaw !== null) {
+      const key = parseKey(encRaw);
+      if (key === null) {
+        boxes.push(buildNoLettersBox(this.priority));
+      } else {
+        const encoded = vigenere(input, key, true);
+        boxes.push(
+          new BoxBuilder('Vigenère (Encode)', encoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    if (decRaw !== null) {
+      const key = parseKey(decRaw);
+      if (key === null) {
+        boxes.push(buildNoLettersBox(this.priority));
+      } else {
+        const decoded = vigenere(input, key, false);
+        boxes.push(
+          new BoxBuilder('Vigenère (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default VigenereBoxSource;

--- a/src/modules/boxSources/__test__/AtbashBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AtbashBoxSource.test.ts
@@ -1,0 +1,68 @@
+import { expect } from 'vitest';
+
+import { AtbashBoxSource } from '../AtbashBoxSource';
+
+describe('AtbashBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when atbash option is absent', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('Hello, World!', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options object lacks atbash key', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('Hello, World!', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array for empty input', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('', { atbash: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should cipher Hello, World! to Svool, Dliow!', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('Hello, World!', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Atbash');
+      expect(boxes[0].props.plaintextOutput).toBe('Svool, Dliow!');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('should cipher lowercase abc to zyx', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('abc', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('zyx');
+    });
+
+    it('should cipher uppercase ABC to ZYX', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('ABC', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ZYX');
+    });
+
+    it('should be self-inverse: applying atbash twice returns original', async () => {
+      const original = 'Hello, World!';
+      const first = await AtbashBoxSource.generateBoxes(original, {
+        atbash: true,
+      });
+      const ciphered = first[0].props.plaintextOutput as string;
+      const second = await AtbashBoxSource.generateBoxes(ciphered, {
+        atbash: true,
+      });
+      expect(second[0].props.plaintextOutput).toBe(original);
+    });
+
+    it('should leave digits and punctuation unchanged', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('123!', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('123!');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CrockfordBase32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CrockfordBase32BoxSource.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { CrockfordBase32BoxSource } from '../CrockfordBase32BoxSource';
+
+describe('CrockfordBase32BoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no crockford option is present', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options object lacks crockford keys', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('encodes hello to D1JPRV3F', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('hello', {
+        crockford: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Crockford Base32 (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('D1JPRV3F');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('::crockfordencode also triggers encode', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('hello', {
+        crockfordencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Crockford Base32 (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('D1JPRV3F');
+    });
+
+    it('round-trips hello: decode(encode(hello)) === hello', async () => {
+      const encBoxes = await CrockfordBase32BoxSource.generateBoxes('hello', {
+        crockford: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput as string;
+
+      const decBoxes = await CrockfordBase32BoxSource.generateBoxes(encoded, {
+        crockforddecode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('round-trips foobar: decode(encode(foobar)) === foobar', async () => {
+      const encBoxes = await CrockfordBase32BoxSource.generateBoxes('foobar', {
+        crockford: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput as string;
+
+      const decBoxes = await CrockfordBase32BoxSource.generateBoxes(encoded, {
+        crockforddecode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe('foobar');
+    });
+
+    it('decode is case-insensitive: lowercase encoded string decodes correctly', async () => {
+      // D1JPRV3F in lowercase
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('d1jprv3f', {
+        crockforddecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decode normalizes alias I→1: DIJPRV3F decodes as hello', async () => {
+      // replace '1' with 'I' (alias for 1 per Crockford spec)
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('DIJPRV3F', {
+        crockforddecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decode normalizes alias L→1: DLJPRV3F decodes as hello', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('DLJPRV3F', {
+        crockforddecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decode normalizes alias O→0: decodes O as 0', async () => {
+      // encode '0' → first character of alphabet is '0'
+      // '0' byte = 0x30 = 00110000; as 5-bit groups: 00110 00000 → 'C', '0'
+      // so '00' encodes to 'C0'; with O alias: 'CO' should decode same as 'C0'
+      const refBoxes = await CrockfordBase32BoxSource.generateBoxes('0', {
+        crockford: true,
+      });
+      const encoded = refBoxes[0].props.plaintextOutput as string;
+      const withO = encoded.replace('0', 'O');
+      const boxes = await CrockfordBase32BoxSource.generateBoxes(withO, {
+        crockforddecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('0');
+    });
+
+    it('decode ignores hyphens used as separators', async () => {
+      // D1JPRV3F with hyphens inserted
+      const boxes = await CrockfordBase32BoxSource.generateBoxes(
+        'D1-JP-RV-3F',
+        {
+          crockforddecode: true,
+        },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decode returns invalid box for character U (not in alphabet and not an alias)', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('U', {
+        crockforddecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Crockford Base32 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'invalid Crockford Base32 input',
+      );
+    });
+
+    it('both options produce 2 boxes (encode + decode)', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('D1JPRV3F', {
+        crockford: true,
+        crockforddecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Crockford Base32 (Encode)');
+      expect(boxes[1].props.name).toBe('Crockford Base32 (Decode)');
+    });
+
+    it('returns empty array when input exceeds MAX_INPUT', async () => {
+      const big = 'a'.repeat(100_001);
+      const boxes = await CrockfordBase32BoxSource.generateBoxes(big, {
+        crockford: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/GcdLcmBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/GcdLcmBoxSource.test.ts
@@ -1,0 +1,146 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { GcdLcmBoxSource } from '../GcdLcmBoxSource';
+
+describe('GcdLcmBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12 18 24', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12 18 24', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12 18 24', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::gcd option', () => {
+    it('computes GCD=6 and LCM=72 for 12 18 24', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12 18 24', {
+        gcd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('GCD / LCM');
+      expect(boxes[0].props.options).toMatchObject({
+        Numbers: '12, 18, 24',
+        GCD: '6',
+        LCM: '72',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+
+  describe('::lcm option', () => {
+    it('accepts ::lcm trigger', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12 18', {
+        lcm: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ GCD: '6', LCM: '36' });
+    });
+  });
+
+  describe('::gcdlcm option', () => {
+    it('accepts ::gcdlcm trigger', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('4 6', {
+        gcdlcm: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ GCD: '2', LCM: '12' });
+    });
+  });
+
+  describe('comma-separated input', () => {
+    it('parses "8, 12" and returns GCD=4, LCM=24', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('8, 12', {
+        gcd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Numbers: '8, 12',
+        GCD: '4',
+        LCM: '24',
+      });
+    });
+  });
+
+  describe('negative numbers', () => {
+    it('handles "-4 6" — GCD=2, LCM=12', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('-4 6', { gcd: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ GCD: '2', LCM: '12' });
+    });
+  });
+
+  describe('insufficient input', () => {
+    it('returns empty array for a single number', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('5', { gcd: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty string', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('', { gcd: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('non-numeric input', () => {
+    it('returns empty array for alphabetic tokens', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('a b', { gcd: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for mixed numeric and alphabetic tokens', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12 abc', {
+        gcd: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('large values (BigInt exactness)', () => {
+    it('computes exact GCD and LCM for 1000000000000 and 999999999999', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes(
+        '1000000000000 999999999999',
+        { gcd: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // gcd(1000000000000, 999999999999) = 1 (consecutive integers are coprime)
+      expect(opts.GCD).toBe('1');
+      // lcm = product when gcd=1
+      expect(opts.LCM).toBe('999999999999000000000000');
+    });
+  });
+
+  describe('zero in input', () => {
+    it('reports LCM as 0 when a zero appears', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('0 6', { gcd: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ LCM: '0' });
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(GcdLcmBoxSource.name).toBe('GCD / LCM');
+      expect(GcdLcmBoxSource.tag).toBe('#');
+      expect(GcdLcmBoxSource.kind).toBe('Math');
+      expect(typeof GcdLcmBoxSource.priority).toBe('number');
+    });
+
+    it('uses priority on the generated box', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('4 6', { gcd: true });
+      expect(boxes[0].props.priority).toBe(GcdLcmBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/GcdLcmBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/GcdLcmBoxSource.test.ts
@@ -142,5 +142,17 @@ describe('GcdLcmBoxSource', () => {
       const boxes = await GcdLcmBoxSource.generateBoxes('4 6', { gcd: true });
       expect(boxes[0].props.priority).toBe(GcdLcmBoxSource.priority);
     });
+
+    it('rejects an over-long digit token instead of crashing', async () => {
+      // BigInt(Number.parseInt(huge)) would throw on Infinity; the digit cap
+      // short-circuits this safely
+      const boxes = await GcdLcmBoxSource.generateBoxes(
+        `${'9'.repeat(400)} 6`,
+        {
+          gcd: true,
+        },
+      );
+      expect(boxes).toHaveLength(0);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/MarkdownStripBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MarkdownStripBoxSource.test.ts
@@ -227,5 +227,14 @@ describe('MarkdownStripBoxSource', () => {
       });
       expect(boxes[0].props.priority).toBe(10);
     });
+
+    it('handles a bracket flood in linear time (ReDoS guard)', async () => {
+      // the old /\[([^\]]*)\]\([^)]*\)/ backtracked O(n^2): ~14s at 100k '['
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '['.repeat(100_000),
+        { stripmd: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/MarkdownStripBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MarkdownStripBoxSource.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+import { MarkdownStripBoxSource } from '../MarkdownStripBoxSource';
+
+describe('MarkdownStripBoxSource', () => {
+  describe('static metadata', () => {
+    it('has correct name, tag, kind, priority', () => {
+      expect(MarkdownStripBoxSource.name).toBe('Markdown Strip');
+      expect(MarkdownStripBoxSource.tag).toBe('#');
+      expect(MarkdownStripBoxSource.kind).toBe('Transform');
+      expect(MarkdownStripBoxSource.priority).toBe(10);
+    });
+  });
+
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', null);
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] when unrelated option is provided', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', {
+        hash: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('activates on ::stripmd option', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', {
+        stripmd: true,
+      });
+      expect(boxes.length).toBe(1);
+    });
+
+    it('activates on ::markdownstrip option', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', {
+        markdownstrip: true,
+      });
+      expect(boxes.length).toBe(1);
+    });
+  });
+
+  describe('empty / invalid input', () => {
+    it('returns [] for empty string', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('', {
+        stripmd: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] for whitespace-only string', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('   ', {
+        stripmd: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] for input exceeding MAX_INPUT', async () => {
+      const huge = 'a'.repeat(100_001);
+      const boxes = await MarkdownStripBoxSource.generateBoxes(huge, {
+        stripmd: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+  });
+
+  describe('heading stripping', () => {
+    it('strips ATX h1', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Title');
+    });
+
+    it('strips ATX h2', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('## Section', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Section');
+    });
+
+    it('strips ATX h6', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('###### Deep', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Deep');
+    });
+  });
+
+  describe('bold and italic stripping', () => {
+    it('strips **bold** and _italic_', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '**bold** and _italic_',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('bold and italic');
+    });
+
+    it('strips __bold__ and *italic*', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '__bold__ and *italic*',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('bold and italic');
+    });
+  });
+
+  describe('inline code stripping', () => {
+    it('strips backtick inline code', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('`code`', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('code');
+    });
+  });
+
+  describe('link stripping', () => {
+    it('keeps link text, drops URL', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '[text](https://x.com)',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('text');
+    });
+
+    it('keeps image alt text, drops URL', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '![alt text](https://x.com/img.png)',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('alt text');
+    });
+  });
+
+  describe('list stripping', () => {
+    it('strips unordered list marker -', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('- item', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('item');
+    });
+
+    it('strips unordered list marker *', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('* item', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('item');
+    });
+
+    it('strips ordered list marker', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('1. item', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('item');
+    });
+  });
+
+  describe('blockquote stripping', () => {
+    it('strips blockquote marker', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('> quote', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('quote');
+    });
+  });
+
+  describe('strikethrough stripping', () => {
+    it('strips ~~strikethrough~~', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('~~deleted~~', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('deleted');
+    });
+  });
+
+  describe('fenced code block stripping', () => {
+    it('removes fence lines and keeps inner content', async () => {
+      const input = '```js\nconsole.log("hi");\n```';
+      const boxes = await MarkdownStripBoxSource.generateBoxes(input, {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('console.log("hi");');
+    });
+  });
+
+  describe('horizontal rule stripping', () => {
+    it('removes --- horizontal rule', async () => {
+      const input = 'above\n---\nbelow';
+      const boxes = await MarkdownStripBoxSource.generateBoxes(input, {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).not.toContain('---');
+      expect(boxes[0].props.plaintextOutput).toContain('above');
+      expect(boxes[0].props.plaintextOutput).toContain('below');
+    });
+  });
+
+  describe('combined stripping', () => {
+    it('strips multiple formats in one input', async () => {
+      const input = '# Title\n\n**bold** and _italic_ and `code`';
+      const boxes = await MarkdownStripBoxSource.generateBoxes(input, {
+        stripmd: true,
+      });
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('Title');
+      expect(out).toContain('bold');
+      expect(out).toContain('italic');
+      expect(out).toContain('code');
+      expect(out).not.toContain('#');
+      expect(out).not.toContain('**');
+      expect(out).not.toContain('_');
+      expect(out).not.toContain('`');
+    });
+  });
+
+  describe('box structure', () => {
+    it('returns a single box named Markdown Strip', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Hello', {
+        stripmd: true,
+      });
+      expect(boxes.length).toBe(1);
+      expect(boxes[0].props.name).toBe('Markdown Strip');
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Hello', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/OrdinalBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/OrdinalBoxSource.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import { OrdinalBoxSource } from '../OrdinalBoxSource';
+
+describe('OrdinalBoxSource', () => {
+  describe('gate conditions', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options object lacks ordinal key', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for non-numeric input', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('abc', {
+        ordinal: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for input exceeding 16 digits', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('12345678901234567', {
+        ordinal: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('ordinal output', () => {
+    it('converts 21 to 21st', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', {
+        ordinal: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Ordinal).toBe('21st');
+      expect(boxes[0].props.options?.Suffix).toBe('st');
+    });
+
+    it('converts 1 to 1st', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('1', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('1st');
+      expect(boxes[0].props.options?.Suffix).toBe('st');
+    });
+
+    it('converts 2 to 2nd', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('2', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('2nd');
+      expect(boxes[0].props.options?.Suffix).toBe('nd');
+    });
+
+    it('converts 3 to 3rd', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('3', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('3rd');
+      expect(boxes[0].props.options?.Suffix).toBe('rd');
+    });
+
+    it('converts 4 to 4th', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('4', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('4th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+
+    it('converts 0 to 0th', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('0', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('0th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+  });
+
+  describe('teen exceptions (11–13 always use th)', () => {
+    it('converts 11 to 11th', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('11', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('11th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+
+    it('converts 12 to 12th', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('12', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('12th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+
+    it('converts 13 to 13th', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('13', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('13th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+
+    it('converts 111 to 111th (last two digits 11)', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('111', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('111th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+
+    it('converts 101 to 101st (last two digits 01, not a teen)', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('101', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('101st');
+      expect(boxes[0].props.options?.Suffix).toBe('st');
+    });
+
+    it('converts 22 to 22nd', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('22', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('22nd');
+      expect(boxes[0].props.options?.Suffix).toBe('nd');
+    });
+  });
+
+  describe('box structure', () => {
+    it('returns exactly one box', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', {
+        ordinal: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('box name is Ordinal', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.name).toBe('Ordinal');
+    });
+
+    it('box priority matches source priority', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.priority).toBe(OrdinalBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/OrdinalBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/OrdinalBoxSource.test.ts
@@ -151,5 +151,12 @@ describe('OrdinalBoxSource', () => {
       });
       expect(boxes[0].props.priority).toBe(OrdinalBoxSource.priority);
     });
+
+    it('rejects 16-digit input beyond MAX_SAFE_INTEGER (float would round)', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('9999999999999991', {
+        ordinal: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/UnicodeEscapeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UnicodeEscapeBoxSource.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { UnicodeEscapeBoxSource } from '../UnicodeEscapeBoxSource';
+
+describe('UnicodeEscapeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('café');
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] when options is null', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('café', null);
+      expect(boxes).toEqual([]);
+    });
+
+    it('escapes non-ASCII chars; printable ASCII stays literal', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('café', {
+        unicodeescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // é = U+00E9; c, a, f are printable ASCII
+      expect(boxes[0].props.plaintextOutput).toBe('caf\\u00e9');
+    });
+
+    it('accepts ::uescape alias', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('café', {
+        uescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('caf\\u00e9');
+    });
+
+    it('escapes astral char as surrogate pair', async () => {
+      // 😀 is U+1F600, surrogate pair: 😀
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('😀', {
+        unicodeescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('\\ud83d\\ude00');
+    });
+
+    it('unescapes \\uXXXX sequences', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('caf\\u00e9', {
+        unicodeunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('café');
+    });
+
+    it('accepts ::uunescape alias', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('caf\\u00e9', {
+        uunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('café');
+    });
+
+    it('unescapes \\u{HEX} code point escapes', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u{1f600}', {
+        unicodeunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('😀');
+    });
+
+    it('leaves invalid code points (> 0x10FFFF) verbatim', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u{110000}', {
+        unicodeunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('\\u{110000}');
+    });
+
+    it('round-trips: unescape(escape(s)) === s', async () => {
+      const original = 'héllo 😀';
+      const escapeBoxes = await UnicodeEscapeBoxSource.generateBoxes(original, {
+        unicodeescape: true,
+      });
+      const escaped = escapeBoxes[0].props.plaintextOutput;
+
+      const unescapeBoxes = await UnicodeEscapeBoxSource.generateBoxes(
+        escaped,
+        { unicodeunescape: true },
+      );
+      expect(unescapeBoxes[0].props.plaintextOutput).toBe(original);
+    });
+
+    it('returns 2 boxes when both escape and unescape options are set', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('café', {
+        unicodeescape: true,
+        unicodeunescape: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Unicode Escape (Escape)');
+      expect(boxes[1].props.name).toBe('Unicode Escape (Unescape)');
+    });
+
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const longInput = 'a'.repeat(100_001);
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes(longInput, {
+        unicodeescape: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('box has showExpandButton false', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('hi', {
+        unicodeescape: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('box has correct priority', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('hi', {
+        unicodeescape: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/UnicodeNormalizeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UnicodeNormalizeBoxSource.test.ts
@@ -1,0 +1,151 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { UnicodeNormalizeBoxSource } from '../UnicodeNormalizeBoxSource';
+
+describe('UnicodeNormalizeBoxSource', () => {
+  describe('gate conditions', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('café', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('café', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input string', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('', {
+        normalize: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when input exceeds MAX_INPUT', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes(
+        'a'.repeat(100_001),
+        { normalize: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('trigger keys', () => {
+    it('activates on ::normalize key', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('abc', {
+        normalize: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('activates on ::unicodenormalize key', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('abc', {
+        unicodenormalize: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('precomposed é (U+00E9)', () => {
+    // 'é' as a single precomposed code point (U+00E9, length 1)
+    const precomposed = 'é';
+
+    it('NFC keeps length 1 (precomposed)', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes(precomposed, {
+        normalize: true,
+      });
+      expect(boxes[0].props.options?.NFC).toHaveLength(1);
+    });
+
+    it('NFD decomposes to length 2 (base e + combining accent)', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes(precomposed, {
+        normalize: true,
+      });
+      expect(boxes[0].props.options?.NFD).toHaveLength(2);
+    });
+  });
+
+  describe('ligature ﬁ (U+FB01)', () => {
+    // 'ﬁ' is a single ligature code point that NFKC/NFKD decompose to 'fi'
+    const ligature = 'ﬁ';
+
+    it('NFKC decomposes ﬁ to "fi"', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes(ligature, {
+        normalize: true,
+      });
+      expect(boxes[0].props.options?.NFKC).toBe('fi');
+    });
+
+    it('NFKD decomposes ﬁ to "fi"', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes(ligature, {
+        normalize: true,
+      });
+      expect(boxes[0].props.options?.NFKD).toBe('fi');
+    });
+
+    it('NFC keeps ﬁ unchanged', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes(ligature, {
+        normalize: true,
+      });
+      expect(boxes[0].props.options?.NFC).toBe(ligature);
+    });
+  });
+
+  describe('plain ASCII input', () => {
+    it('all four forms are equal for plain ASCII', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('abc', {
+        normalize: true,
+      });
+      const opts = boxes[0].props.options;
+      expect(opts?.NFC).toBe('abc');
+      expect(opts?.NFD).toBe('abc');
+      expect(opts?.NFKC).toBe('abc');
+      expect(opts?.NFKD).toBe('abc');
+    });
+  });
+
+  describe('box structure', () => {
+    it('returns exactly one box with KeyValueBoxTemplate', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('café', {
+        normalize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is "Unicode Normalize"', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('café', {
+        normalize: true,
+      });
+      expect(boxes[0].props.name).toBe('Unicode Normalize');
+    });
+
+    it('box priority matches source priority', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('café', {
+        normalize: true,
+      });
+      expect(boxes[0].props.priority).toBe(UnicodeNormalizeBoxSource.priority);
+    });
+
+    it('options contain all four normalization form keys', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('test', {
+        normalize: true,
+      });
+      const keys = Object.keys(boxes[0].props.options ?? {});
+      expect(keys).toContain('NFC');
+      expect(keys).toContain('NFD');
+      expect(keys).toContain('NFKC');
+      expect(keys).toContain('NFKD');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(UnicodeNormalizeBoxSource.name).toBe('Unicode Normalize');
+      expect(UnicodeNormalizeBoxSource.tag).toBe('#');
+      expect(UnicodeNormalizeBoxSource.kind).toBe('Transform');
+      expect(typeof UnicodeNormalizeBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/VigenereBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/VigenereBoxSource.test.ts
@@ -1,0 +1,133 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { VigenereBoxSource } from '../VigenereBoxSource';
+
+describe('VigenereBoxSource', () => {
+  describe('no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — canonical ATTACKATDAWN/LEMON vector', () => {
+    it('encodes ATTACKATDAWN with key LEMON to LXFOPVEFRNHR', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('ATTACKATDAWN', {
+        vigenere: 'LEMON',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('LXFOPVEFRNHR');
+      expect(boxes[0].props.name).toBe('Vigenère (Encode)');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('also accepts the vigenereencode alias', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('ATTACKATDAWN', {
+        vigenereencode: 'LEMON',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('LXFOPVEFRNHR');
+    });
+  });
+
+  describe('encode — case and spaces preserved', () => {
+    it('encodes mixed-case input, preserving spaces', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('Attack at dawn', {
+        vigenere: 'lemon',
+      });
+      expect(boxes).toHaveLength(1);
+      // spaces pass through; key advances only on letters
+      const encoded = boxes[0].props.plaintextOutput;
+      // verify round-trip: decode must restore original
+      const decoded = await VigenereBoxSource.generateBoxes(encoded, {
+        vigeneredecode: 'lemon',
+      });
+      expect(decoded[0].props.plaintextOutput).toBe('Attack at dawn');
+    });
+  });
+
+  describe('decode', () => {
+    it('decodes LXFOPVEFRNHR with key LEMON to ATTACKATDAWN', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('LXFOPVEFRNHR', {
+        vigeneredecode: 'LEMON',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ATTACKATDAWN');
+      expect(boxes[0].props.name).toBe('Vigenère (Decode)');
+    });
+  });
+
+  describe('key with no letters', () => {
+    it('returns an informational box when key is digits only', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('hello', {
+        vigenere: '1234',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/letter/i);
+    });
+
+    it('returns an informational box when key is boolean true', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('hello', {
+        vigenere: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/letter/i);
+    });
+  });
+
+  describe('both encode and decode options', () => {
+    it('returns 2 boxes when both vigenere and vigeneredecode are set', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('ATTACKATDAWN', {
+        vigenere: 'LEMON',
+        vigeneredecode: 'LEMON',
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Vigenère (Encode)');
+      expect(names).toContain('Vigenère (Decode)');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array for empty input string', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('', {
+        vigenere: 'key',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('key with mixed letters and digits strips non-letters', async () => {
+      // key '1l2e3m4o5n6' → effective key 'lemon'
+      const boxes = await VigenereBoxSource.generateBoxes('ATTACKATDAWN', {
+        vigenere: '1l2e3m4o5n6',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('LXFOPVEFRNHR');
+    });
+
+    it('non-letter characters pass through without consuming key position', async () => {
+      // 'A B' with key 'l': A→L, space→space, B→M (key wraps: l then l)
+      const boxes = await VigenereBoxSource.generateBoxes('A B', {
+        vigenere: 'lm',
+      });
+      expect(boxes).toHaveLength(1);
+      // A + l(11) = L; space passes; B + m(12) = N
+      expect(boxes[0].props.plaintextOutput).toBe('L N');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(VigenereBoxSource.name).toBe('Vigenère');
+      expect(VigenereBoxSource.tag).toBe('#');
+      expect(VigenereBoxSource.kind).toBe('Encode');
+      expect(typeof VigenereBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,27 +1,35 @@
+import AtbashBoxSource from './AtbashBoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CrockfordBase32BoxSource from './CrockfordBase32BoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import MarkdownStripBoxSource from './MarkdownStripBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import OrdinalBoxSource from './OrdinalBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import UnicodeEscapeBoxSource from './UnicodeEscapeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
+import VigenereBoxSource from './VigenereBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -31,23 +39,31 @@ export const boxSources = [
   ColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  AtbashBoxSource,
+  CrockfordBase32BoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  GcdLcmBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  MarkdownStripBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
+  OrdinalBoxSource,
   PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
+  UnicodeEscapeBoxSource,
+  UnicodeNormalizeBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
+  VigenereBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,


### PR DESCRIPTION
## Summary

Eighth exploration batch — **8 more BoxSource tools** (Unicode utilities, classic ciphers, math).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Unicode Escape | `::unicodeescape` / `::unicodeunescape` | text ⇄ `\uXXXX` / `\u{…}` |
| Unicode Normalize | `::normalize` | NFC / NFD / NFKC / NFKD forms |
| Atbash | `::atbash` | A↔Z cipher (self-inverse) |
| Vigenère | `::vigenere=KEY` / `::vigeneredecode=KEY` | keyword cipher |
| Crockford Base32 | `::crockford` / `::crockforddecode` | no-padding, O/I/L decode aliases |
| Markdown Strip | `::stripmd` | strip Markdown to plain text |
| GCD / LCM | `::gcd` | over a list of integers (BigInt-exact) |
| Ordinal | `::ordinal` | `21` → `21st` (11/12/13 teen rule) |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step.
- **Verified vectors**: Atbash `Hello, World!`→`Svool, Dliow!`; Vigenère `ATTACKATDAWN`/`LEMON`→`LXFOPVEFRNHR`; GCD/LCM `12 18 24`→`6`/`72`; Crockford round-trips (the subagent corrected a wrong spec vector to its actual `D1JPRV3F` after tracing the bit-packing).
- All option-gated; free-text processors carry `MAX_INPUT` caps; Markdown Strip uses linear regexes only; Unicode Escape guards supra-Unicode code points.

## Verification

- ✅ `bun run test run` — **456 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#266 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6