### PR TITLE
feat(boxSources): add 8 more tools (punycode, radix, parse-duration, isbn, adler32, json-pointer, frequency, gray-code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,80 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>PunycodeBox</b> </summary>
+
+| match rule           | description                          | example                  |
+| -------------------- | ------------------------------------ | ------------------------ |
+| `::punycode`         | IDN → Punycode (xn--) ASCII form     | `münchen.de ::punycode`  |
+| `::punycodedecode`   | Punycode → Unicode domain            | `xn--mnchen-3ya.de ::punycodedecode` |
+
+</details>
+
+<details>
+<summary> <b>RadixBox</b> </summary>
+
+| match rule          | description                              | example              |
+| ------------------- | ---------------------------------------- | -------------------- |
+| `::radix=FROM:TO`   | convert an integer between bases 2–36    | `ff ::radix=16:2`    |
+
+</details>
+
+<details>
+<summary> <b>DurationParseBox</b> </summary>
+
+| match rule         | description                              | example               |
+| ------------------ | ---------------------------------------- | --------------------- |
+| `::parseduration`  | parse "1h30m" etc. into total seconds    | `1h30m20s ::parseduration` |
+
+</details>
+
+<details>
+<summary> <b>IsbnBox</b> </summary>
+
+| match rule | description                          | example                       |
+| ---------- | ------------------------------------ | ----------------------------- |
+| `::isbn`   | validate ISBN-10 / ISBN-13 + check digit | `978-0-306-40615-7 ::isbn` |
+
+</details>
+
+<details>
+<summary> <b>Adler32Box</b> </summary>
+
+| match rule    | description                       | example                |
+| ------------- | --------------------------------- | ---------------------- |
+| `::adler32`   | Adler-32 checksum (hex + decimal) | `Wikipedia ::adler32`  |
+
+</details>
+
+<details>
+<summary> <b>JsonPointerBox</b> </summary>
+
+| match rule              | description                           | example                            |
+| ----------------------- | ------------------------------------- | ---------------------------------- |
+| `::jsonpointer=POINTER` | resolve an RFC 6901 JSON Pointer      | `{"a":{"b":[10,20]}} ::jsonpointer=/a/b/1` |
+
+</details>
+
+<details>
+<summary> <b>FrequencyBox</b> </summary>
+
+| match rule  | description                              | example              |
+| ----------- | ---------------------------------------- | -------------------- |
+| `::freq`    | character frequency analysis, sorted     | `hello world ::freq` |
+
+</details>
+
+<details>
+<summary> <b>GrayCodeBox</b> </summary>
+
+| match rule       | description                          | example            |
+| ---------------- | ------------------------------------ | ------------------ |
+| `::gray`         | integer → Gray code                  | `4 ::gray`         |
+| `::graydecode`   | Gray code (binary) → integer         | `110 ::graydecode` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/Adler32BoxSource.ts
+++ b/src/modules/boxSources/Adler32BoxSource.ts
@@ -1,0 +1,56 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 20;
+const MAX_INPUT = 100_000;
+// adler-32 modulus (largest prime < 2^16)
+const MOD_ADLER = 65521;
+
+// compute adler-32 checksum over the utf-8 encoding of `str`
+function computeAdler32(str: string): number {
+  const bytes = new TextEncoder().encode(str);
+  let a = 1;
+  let b = 0;
+  for (const byte of bytes) {
+    a = (a + byte) % MOD_ADLER;
+    b = (b + a) % MOD_ADLER;
+  }
+  return ((b << 16) | a) >>> 0;
+}
+
+export const Adler32BoxSource = {
+  name: 'Adler-32',
+  description: 'Compute the Adler-32 checksum of the input text.',
+  defaultInput: 'Wikipedia ::adler32',
+  tag: '#',
+  kind: 'Hash',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'adler32', 'adler')) return [];
+    if (input.length === 0 || input.length > MAX_INPUT) return [];
+
+    const checksum = computeAdler32(input);
+    const hex = checksum.toString(16).padStart(8, '0');
+    const decimal = checksum.toString(10);
+
+    const output: Record<string, string> = {
+      Hex: hex,
+      Decimal: decimal,
+    };
+
+    return [
+      new BoxBuilder('Adler-32', `Hex: ${hex}\nDecimal: ${decimal}`)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Adler32BoxSource;

--- a/src/modules/boxSources/DurationParseBoxSource.ts
+++ b/src/modules/boxSources/DurationParseBoxSource.ts
@@ -1,0 +1,126 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// maps unit letter(s) to their value in seconds
+const UNIT_SECONDS: Record<string, number> = {
+  w: 604800,
+  d: 86400,
+  h: 3600,
+  m: 60,
+  s: 1,
+  ms: 0.001,
+};
+
+// tokenizes a duration string into (value, unit) pairs; returns null on any invalid segment
+const SEGMENT_RE = /(\d+(?:\.\d+)?)\s*(ms|[wdhms])/gi;
+
+function parseTotalSeconds(input: string): number | null {
+  const cleaned = input.trim();
+  if (!cleaned) return null;
+
+  const matches = [...cleaned.matchAll(SEGMENT_RE)];
+  if (matches.length === 0) return null;
+
+  // verify the full string is covered — no leftover garbage characters
+  const reconstructed = matches.map((m) => m[0].replace(/\s+/g, '')).join('');
+  const withoutSpaces = cleaned.replace(/\s+/g, '');
+  if (reconstructed !== withoutSpaces) return null;
+
+  let total = 0;
+  for (const match of matches) {
+    const value = Number.parseFloat(match[1]);
+    const unit = match[2].toLowerCase();
+    const multiplier = UNIT_SECONDS[unit];
+    if (multiplier === undefined) return null;
+    total += value * multiplier;
+  }
+
+  return total;
+}
+
+// rebuilds a human-readable string (e.g. '1h 30m 20s') from total seconds
+function toHumanDuration(totalSeconds: number): string {
+  const units: Array<[string, number]> = [
+    ['w', 604800],
+    ['d', 86400],
+    ['h', 3600],
+    ['m', 60],
+    ['s', 1],
+  ];
+
+  const parts: string[] = [];
+  let remaining = totalSeconds;
+
+  for (const [label, secs] of units) {
+    if (remaining >= secs) {
+      const count = Math.floor(remaining / secs);
+      parts.push(`${count}${label}`);
+      remaining -= count * secs;
+    }
+  }
+
+  // include sub-second milliseconds when no whole seconds remain
+  if (remaining > 0) {
+    const ms = Math.round(remaining * 1000);
+    parts.push(`${ms}ms`);
+  }
+
+  return parts.join(' ') || '0s';
+}
+
+export const DurationParseBoxSource = {
+  name: 'Parse Duration',
+  description:
+    'Parse a human duration like "1h30m" or "2d4h" into total seconds.',
+  defaultInput: '1h30m20s ::parseduration',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'parseduration', 'duration2s')) return [];
+
+    const cleaned = trim(input).slice(0, 100);
+    const totalSeconds = parseTotalSeconds(cleaned);
+    if (totalSeconds === null) return [];
+
+    const totalMs = totalSeconds * 1000;
+    const human = toHumanDuration(totalSeconds);
+
+    // format numbers without trailing zeros for clean display
+    const fmtSeconds = Number.isInteger(totalSeconds)
+      ? totalSeconds.toString()
+      : Number.parseFloat(totalSeconds.toFixed(6)).toString();
+
+    const fmtMs = Number.isInteger(totalMs)
+      ? totalMs.toString()
+      : Number.parseFloat(totalMs.toFixed(3)).toString();
+
+    const output: Record<string, string> = {
+      'Total Seconds': fmtSeconds,
+      'Total Milliseconds': fmtMs,
+      Human: human,
+    };
+
+    const content = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Parse Duration', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DurationParseBoxSource;

--- a/src/modules/boxSources/FrequencyBoxSource.ts
+++ b/src/modules/boxSources/FrequencyBoxSource.ts
@@ -1,0 +1,77 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+const MAX_ROWS = 200;
+
+// counts non-whitespace characters by code point, returns entries sorted by
+// count descending then by codepoint ascending for stable tie-breaking
+function computeFrequency(input: string): [string, number][] {
+  const counts = new Map<string, number>();
+  for (const char of input) {
+    // skip whitespace (space, tab, newline, carriage return, etc.)
+    if (/\s/u.test(char)) continue;
+    counts.set(char, (counts.get(char) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort(([aChar, aCount], [bChar, bCount]) => {
+    if (bCount !== aCount) return bCount - aCount;
+    return (aChar.codePointAt(0) ?? 0) - (bChar.codePointAt(0) ?? 0);
+  });
+}
+
+function buildTable(entries: [string, number][], total: number): string {
+  const truncated = entries.length > MAX_ROWS;
+  const rows = truncated ? entries.slice(0, MAX_ROWS) : entries;
+
+  const lines = rows.map(([char, count]) => {
+    const percent = ((count / total) * 100).toFixed(1);
+    return `${char}  ${count}  ${percent}%`;
+  });
+
+  if (truncated) {
+    lines.push(`... (truncated to ${MAX_ROWS} rows)`);
+  }
+
+  return lines.join('\n');
+}
+
+export const FrequencyBoxSource = {
+  name: 'Frequency',
+  description: 'Count character frequencies in the input, sorted by count.',
+  defaultInput: 'hello world ::freq',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'freq', 'frequency')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const entries = computeFrequency(input);
+    if (entries.length === 0) return [];
+
+    const total = entries.reduce((sum, [, count]) => sum + count, 0);
+    const output = buildTable(entries, total);
+
+    return [
+      new BoxBuilder('Frequency', output)
+        .setTemplate(CodeBoxTemplate)
+        .setShowExpandButton(true)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FrequencyBoxSource;

--- a/src/modules/boxSources/GrayCodeBoxSource.ts
+++ b/src/modules/boxSources/GrayCodeBoxSource.ts
@@ -1,0 +1,84 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// encode: n XOR (n >> 1) produces the gray code for integer n
+function encodeGray(n: bigint): bigint {
+  return n ^ (n >> 1n);
+}
+
+// decode: convert a gray code back to the natural binary integer
+// each output bit is the XOR of all gray bits from MSB down to that position
+function decodeGray(g: bigint): bigint {
+  let n = g;
+  // shift and XOR until the shift exceeds the bit width
+  for (let shift = 1n; 1n << shift <= g; shift <<= 1n) {
+    n ^= n >> shift;
+  }
+  return n;
+}
+
+export const GrayCodeBoxSource = {
+  name: 'Gray Code',
+  description:
+    'Convert a non-negative integer to its Gray code, or a Gray code (binary) back to an integer.',
+  defaultInput: '4 ::gray',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'gray', 'graycode');
+    const wantDecode = hasOptionKeys(options, 'graydecode');
+    if (!wantEncode && !wantDecode) return [];
+
+    const raw = trim(input);
+
+    if (wantEncode) {
+      // accept only non-negative decimal integers
+      if (!/^\d+$/.test(raw)) return [];
+
+      const n = BigInt(Number.parseInt(raw, 10));
+      const gray = encodeGray(n);
+
+      const box = new BoxBuilder('Gray Code', gray.toString(2))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions({
+          Decimal: n.toString(10),
+          Binary: n.toString(2),
+          'Gray (binary)': gray.toString(2),
+          'Gray (decimal)': gray.toString(10),
+        })
+        .setPriority(this.priority)
+        .build();
+
+      return [box];
+    }
+
+    // wantDecode: accept only binary strings
+    if (!/^[01]+$/.test(raw)) return [];
+
+    const g = BigInt(`0b${raw}`);
+    const n = decodeGray(g);
+
+    const box = new BoxBuilder('Gray Code', n.toString(10))
+      .setTemplate(KeyValueBoxTemplate)
+      .setOptions({
+        'Gray (binary)': raw,
+        Decimal: n.toString(10),
+        Binary: n.toString(2),
+      })
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default GrayCodeBoxSource;

--- a/src/modules/boxSources/GrayCodeBoxSource.ts
+++ b/src/modules/boxSources/GrayCodeBoxSource.ts
@@ -4,6 +4,8 @@ import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
+// bound BigInt cost; input is seeded from a ?input= url param with no cap
+const MAX_INPUT = 10_000;
 
 // encode: n XOR (n >> 1) produces the gray code for integer n
 function encodeGray(n: bigint): bigint {
@@ -37,6 +39,7 @@ export const GrayCodeBoxSource = {
     const wantEncode = hasOptionKeys(options, 'gray', 'graycode');
     const wantDecode = hasOptionKeys(options, 'graydecode');
     if (!wantEncode && !wantDecode) return [];
+    if (input.length > MAX_INPUT) return [];
 
     const raw = trim(input);
 
@@ -44,7 +47,9 @@ export const GrayCodeBoxSource = {
       // accept only non-negative decimal integers
       if (!/^\d+$/.test(raw)) return [];
 
-      const n = BigInt(Number.parseInt(raw, 10));
+      // BigInt straight from the validated string — Number.parseInt would round
+      // anything above 2^53 to a wrong value
+      const n = BigInt(raw);
       const gray = encodeGray(n);
 
       const box = new BoxBuilder('Gray Code', gray.toString(2))

--- a/src/modules/boxSources/IsbnBoxSource.ts
+++ b/src/modules/boxSources/IsbnBoxSource.ts
@@ -1,0 +1,104 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// strip hyphens and spaces from raw isbn input
+function cleanIsbn(raw: string): string {
+  return raw.replace(/[-\s]/g, '');
+}
+
+// compute the expected isbn-10 check digit for the first 9 digits
+function computeIsbn10Check(digits: string): string {
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += Number.parseInt(digits[i], 10) * (10 - i);
+  }
+  const remainder = (11 - (sum % 11)) % 11;
+  return remainder === 10 ? 'X' : String(remainder);
+}
+
+// compute the expected isbn-13 check digit for the first 12 digits
+function computeIsbn13Check(digits: string): string {
+  let sum = 0;
+  for (let i = 0; i < 12; i++) {
+    sum += Number.parseInt(digits[i], 10) * (i % 2 === 0 ? 1 : 3);
+  }
+  const remainder = (10 - (sum % 10)) % 10;
+  return String(remainder);
+}
+
+// validate and describe an isbn string, returning null if input is unusable
+function analyzeIsbn(cleaned: string): {
+  type: string;
+  valid: boolean;
+  checkDigit: string;
+} | null {
+  const len = cleaned.length;
+
+  if (len === 10) {
+    // last char may be 'X' (represents 10); all others must be digits
+    const body = cleaned.slice(0, 9);
+    const last = cleaned[9].toUpperCase();
+    if (!/^\d{9}$/.test(body) || !/^[\dX]$/.test(last)) return null;
+
+    const expectedCheck = computeIsbn10Check(body);
+    const actualValue = last === 'X' ? 10 : Number.parseInt(last, 10);
+    const expectedValue =
+      expectedCheck === 'X' ? 10 : Number.parseInt(expectedCheck, 10);
+    const valid = actualValue === expectedValue;
+
+    return { type: 'ISBN-10', valid, checkDigit: expectedCheck };
+  }
+
+  if (len === 13) {
+    if (!/^\d{13}$/.test(cleaned)) return null;
+
+    const expectedCheck = computeIsbn13Check(cleaned);
+    const valid = cleaned[12] === expectedCheck;
+
+    return { type: 'ISBN-13', valid, checkDigit: expectedCheck };
+  }
+
+  return null;
+}
+
+export const IsbnBoxSource = {
+  name: 'ISBN',
+  description:
+    'Validate an ISBN-10 or ISBN-13 and show its type and check digit.',
+  defaultInput: '978-0-306-40615-7 ::isbn',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'isbn')) return [];
+
+    const cleaned = cleanIsbn(trim(input));
+    const result = analyzeIsbn(cleaned);
+    if (!result) return [];
+
+    const kv: Record<string, string> = {
+      ISBN: cleaned,
+      Type: result.type,
+      Valid: String(result.valid),
+      'Check Digit': result.checkDigit,
+    };
+
+    const box = new BoxBuilder('ISBN', cleaned)
+      .setTemplate(KeyValueBoxTemplate)
+      .setOptions(kv)
+      .setPriority(Priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default IsbnBoxSource;

--- a/src/modules/boxSources/JsonPointerBoxSource.ts
+++ b/src/modules/boxSources/JsonPointerBoxSource.ts
@@ -1,0 +1,104 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+const MAX_POINTER_LEN = 1000;
+
+// resolves an RFC 6901 JSON Pointer against a parsed value; returns the found
+// value or a sentinel symbol when the path does not exist
+const NOT_FOUND = Symbol('not-found');
+
+function resolvePointer(
+  doc: unknown,
+  pointer: string,
+): unknown | typeof NOT_FOUND {
+  // empty pointer → whole document (RFC 6901 §4)
+  if (pointer === '') return doc;
+
+  if (!pointer.startsWith('/')) return NOT_FOUND;
+
+  // split on '/', drop the leading empty segment produced by the leading '/'
+  const tokens = pointer
+    .split('/')
+    .slice(1)
+    .map((t) =>
+      // unescape ~1 first, then ~0 (order matters per RFC 6901 §3)
+      t.replace(/~1/g, '/').replace(/~0/g, '~'),
+    );
+
+  let current: unknown = doc;
+  for (const token of tokens) {
+    if (Array.isArray(current)) {
+      // '-' denotes past-the-end in RFC 6901; not a readable index
+      if (token === '-') return NOT_FOUND;
+      const idx = Number(token);
+      if (!Number.isInteger(idx) || idx < 0 || String(idx) !== token)
+        return NOT_FOUND;
+      if (idx >= current.length) return NOT_FOUND;
+      current = current[idx];
+    } else if (current !== null && typeof current === 'object') {
+      if (!Object.hasOwn(current as object, token)) return NOT_FOUND;
+      current = (current as Record<string, unknown>)[token];
+    } else {
+      return NOT_FOUND;
+    }
+  }
+  return current;
+}
+
+export const JsonPointerBoxSource = {
+  name: 'JSON Pointer',
+  description:
+    'Resolve an RFC 6901 JSON Pointer (e.g. /a/b/0) against JSON input.',
+  defaultInput: '{"a":{"b":[10,20]}} ::jsonpointer=/a/b/1',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonpointer', 'jptr')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // extract the pointer value; bare flag (true) means empty string (whole doc)
+    const raw = extractOptionKeys(options, 'jsonpointer', 'jptr');
+    const pointer = raw === true || raw === null ? '' : String(raw);
+
+    if (pointer.length > MAX_POINTER_LEN) return [];
+
+    const makeBox = (output: string) =>
+      new BoxBuilder('JSON Pointer', output)
+        .setOptions({ language: 'json' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build();
+
+    let doc: unknown;
+    try {
+      doc = JSON.parse(trim(input));
+    } catch {
+      return [makeBox('Invalid JSON input.')];
+    }
+
+    // validate pointer format before walking: must be empty or start with '/'
+    if (pointer !== '' && !pointer.startsWith('/')) {
+      return [
+        makeBox(`Invalid JSON Pointer: "${pointer}" must start with "/".`),
+      ];
+    }
+
+    const result = resolvePointer(doc, pointer);
+    if (result === NOT_FOUND) {
+      return [makeBox(`Pointer "${pointer}" was not found in the document.`)];
+    }
+
+    return [makeBox(JSON.stringify(result, null, 2))];
+  },
+};
+
+export default JsonPointerBoxSource;

--- a/src/modules/boxSources/PunycodeBoxSource.ts
+++ b/src/modules/boxSources/PunycodeBoxSource.ts
@@ -1,0 +1,239 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 10_000;
+
+// RFC 3492 bootstring constants
+const BASE = 36;
+const TMIN = 1;
+const TMAX = 26;
+const SKEW = 38;
+const DAMP = 700;
+const INITIAL_BIAS = 72;
+const INITIAL_N = 128;
+const DELIMITER = '-';
+
+// adapts bias after each encoded delta per RFC 3492 §6.1
+function adaptBias(
+  delta: number,
+  numPoints: number,
+  firstTime: boolean,
+): number {
+  let d = firstTime ? Math.floor(delta / DAMP) : delta >> 1;
+  d += Math.floor(d / numPoints);
+  let k = 0;
+  while (d > ((BASE - TMIN) * TMAX) >> 1) {
+    d = Math.floor(d / (BASE - TMIN));
+    k += BASE;
+  }
+  return Math.floor(k + ((BASE - TMIN + 1) * d) / (d + SKEW));
+}
+
+// maps a digit value to its ASCII character per RFC 3492 §5
+function digitToBasic(digit: number): number {
+  return digit < 26 ? digit + 97 : digit + 22; // a-z then 0-9
+}
+
+// maps a basic code point to its digit value; -1 if not valid
+function basicToDigit(cp: number): number {
+  if (cp >= 48 && cp <= 57) return cp - 22; // 0-9 → 26-35
+  if (cp >= 65 && cp <= 90) return cp - 65; // A-Z → 0-25
+  if (cp >= 97 && cp <= 122) return cp - 97; // a-z → 0-25
+  return -1;
+}
+
+// encodes a single Punycode label (no xn-- prefix) per RFC 3492 §6.3
+function punycodeEncode(input: number[]): string {
+  const n = input.length;
+  let bias = INITIAL_BIAS;
+  let delta = 0;
+  let currentN = INITIAL_N;
+  let h = 0;
+  let b = 0;
+  const output: number[] = [];
+
+  for (const cp of input) {
+    if (cp < INITIAL_N) {
+      output.push(cp);
+      h++;
+      b++;
+    }
+  }
+
+  if (b > 0) output.push(DELIMITER.charCodeAt(0));
+
+  while (h < n) {
+    // find the next larger non-basic code point
+    let m = Number.MAX_SAFE_INTEGER;
+    for (const cp of input) {
+      if (cp >= currentN && cp < m) m = cp;
+    }
+
+    delta += (m - currentN) * (h + 1);
+    currentN = m;
+
+    for (const cp of input) {
+      if (cp < currentN) delta++;
+      if (cp === currentN) {
+        // encode delta as generalized variable-length integer
+        let q = delta;
+        for (let k = BASE; ; k += BASE) {
+          const t =
+            k <= bias + TMIN ? TMIN : k >= bias + TMAX ? TMAX : k - bias;
+          if (q < t) break;
+          output.push(digitToBasic(t + ((q - t) % (BASE - t))));
+          q = Math.floor((q - t) / (BASE - t));
+        }
+        output.push(digitToBasic(q));
+        bias = adaptBias(delta, h + 1, h === b);
+        delta = 0;
+        h++;
+      }
+    }
+
+    delta++;
+    currentN++;
+  }
+
+  return String.fromCharCode(...output);
+}
+
+// decodes a Punycode-encoded label (without xn-- prefix) per RFC 3492 §6.2
+function punycodeDecode(input: string): string {
+  const output: number[] = [];
+  let bias = INITIAL_BIAS;
+  let i = 0;
+  let currentN = INITIAL_N;
+
+  const delimIdx = input.lastIndexOf(DELIMITER);
+  const basic = delimIdx < 0 ? '' : input.slice(0, delimIdx);
+  const extended = delimIdx < 0 ? input : input.slice(delimIdx + 1);
+
+  for (let j = 0; j < basic.length; j++) {
+    output.push(basic.charCodeAt(j));
+  }
+
+  let idx = 0;
+  while (idx < extended.length) {
+    const oldi = i;
+    let w = 1;
+    for (let k = BASE; ; k += BASE) {
+      if (idx >= extended.length) throw new RangeError('invalid punycode');
+      const digit = basicToDigit(extended.charCodeAt(idx++));
+      if (digit < 0) throw new RangeError('invalid punycode');
+      i += digit * w;
+      const t = k <= bias + TMIN ? TMIN : k >= bias + TMAX ? TMAX : k - bias;
+      if (digit < t) break;
+      w *= BASE - t;
+    }
+    const len = output.length + 1;
+    bias = adaptBias(i - oldi, len, oldi === 0);
+    currentN += Math.floor(i / len);
+    i %= len;
+    output.splice(i, 0, currentN);
+    i++;
+  }
+
+  return String.fromCodePoint(...output);
+}
+
+// returns true if every character in the string is ASCII (< 128)
+function isAsciiOnly(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) >= 128) return false;
+  }
+  return true;
+}
+
+// converts a domain to ASCII Punycode form (IDNA ToASCII per label)
+function toAscii(domain: string): string {
+  return domain
+    .toLowerCase()
+    .split('.')
+    .map((label) => {
+      if (isAsciiOnly(label)) return label;
+      const codePoints = [...label].map((ch) => ch.codePointAt(0) as number);
+      return `xn--${punycodeEncode(codePoints)}`;
+    })
+    .join('.');
+}
+
+// converts an ASCII Punycode domain back to its Unicode form
+function toUnicode(domain: string): string {
+  return domain
+    .split('.')
+    .map((label) => {
+      if (label.toLowerCase().startsWith('xn--')) {
+        return punycodeDecode(label.slice(4));
+      }
+      return label;
+    })
+    .join('.');
+}
+
+export const PunycodeBoxSource = {
+  name: 'Punycode',
+  description:
+    'Convert an internationalized domain name to/from its Punycode (xn--) ASCII form.',
+  defaultInput: 'münchen.de ::punycode',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantToAscii = hasOptionKeys(
+      options,
+      'punycode',
+      'punycodeencode',
+      'idn',
+    );
+    const wantToUnicode = hasOptionKeys(options, 'punycodedecode', 'idndecode');
+    if (!wantToAscii && !wantToUnicode) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const domain = trim(input);
+    const boxes: Box[] = [];
+
+    if (wantToAscii) {
+      let result: string;
+      try {
+        result = toAscii(domain);
+      } catch {
+        result = 'Invalid domain: unable to encode to Punycode.';
+      }
+      boxes.push(
+        new BoxBuilder('Punycode (ToASCII)', result)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantToUnicode) {
+      let result: string;
+      try {
+        result = toUnicode(domain);
+      } catch {
+        result = 'Invalid domain: unable to decode from Punycode.';
+      }
+      boxes.push(
+        new BoxBuilder('Punycode (ToUnicode)', result)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default PunycodeBoxSource;

--- a/src/modules/boxSources/RadixBoxSource.ts
+++ b/src/modules/boxSources/RadixBoxSource.ts
@@ -1,0 +1,134 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// converts a non-negative BigInt value to a string in the given base (2-36).
+function bigintToBase(value: bigint, base: number): string {
+  if (value === 0n) return '0';
+  const digits = '0123456789abcdefghijklmnopqrstuvwxyz';
+  const b = BigInt(base);
+  let result = '';
+  let n = value;
+  while (n > 0n) {
+    result = digits[Number(n % b)] + result;
+    n = n / b;
+  }
+  return result;
+}
+
+// parses a string as a non-negative integer in the given base using BigInt arithmetic.
+// returns null if any character is not a valid digit for the base.
+function parseBaseString(str: string, base: number): bigint | null {
+  const b = BigInt(base);
+  let result = 0n;
+  for (const ch of str) {
+    const digit =
+      ch >= '0' && ch <= '9'
+        ? ch.charCodeAt(0) - 48
+        : ch >= 'a' && ch <= 'z'
+          ? ch.charCodeAt(0) - 87
+          : -1;
+    if (digit < 0 || digit >= base) return null;
+    result = result * b + BigInt(digit);
+  }
+  return result;
+}
+
+function makeErrorBox(message: string): Box {
+  return new BoxBuilder('Radix Convert', message)
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions({ Info: message })
+    .setPriority(Priority)
+    .build();
+}
+
+export const RadixBoxSource = {
+  name: 'Radix Convert',
+  description:
+    'Convert an integer between arbitrary bases (2-36). e.g. ::radix=16:2 for hex→binary.',
+  defaultInput: 'ff ::radix=16:2',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'radix', 'baseconvert')) return [];
+
+    const rawSpec = extractOptionKeys(options, 'radix', 'baseconvert');
+
+    // when the option is present but has no "from:to" value, show usage hint.
+    if (
+      rawSpec === true ||
+      typeof rawSpec !== 'string' ||
+      !rawSpec.includes(':')
+    ) {
+      return [
+        makeErrorBox('Usage: ::radix=FROM:TO (e.g. ::radix=16:2), bases 2-36.'),
+      ];
+    }
+
+    const [fromStr, toStr] = rawSpec.split(':');
+    const fromBase = Number.parseInt(fromStr, 10);
+    const toBase = Number.parseInt(toStr, 10);
+
+    if (
+      Number.isNaN(fromBase) ||
+      Number.isNaN(toBase) ||
+      fromBase < 2 ||
+      fromBase > 36 ||
+      toBase < 2 ||
+      toBase > 36
+    ) {
+      return [
+        makeErrorBox('Both FROM and TO bases must be integers in range 2-36.'),
+      ];
+    }
+
+    const rawInput = trim(input);
+    const negative = rawInput.startsWith('-');
+    const digits = (negative ? rawInput.slice(1) : rawInput).toLowerCase();
+
+    if (!digits) {
+      return [
+        makeErrorBox(`Input is empty; expected a base-${fromBase} integer.`),
+      ];
+    }
+
+    const magnitude = parseBaseString(digits, fromBase);
+    if (magnitude === null) {
+      return [
+        makeErrorBox(
+          `Input "${rawInput}" contains a digit not valid in base ${fromBase}.`,
+        ),
+      ];
+    }
+
+    const decimal = negative ? -magnitude : magnitude;
+    const resultStr =
+      (negative && magnitude !== 0n ? '-' : '') +
+      bigintToBase(magnitude, toBase);
+    const decimalStr = decimal.toString();
+
+    const box = new BoxBuilder('Radix Convert', resultStr)
+      .setTemplate(KeyValueBoxTemplate)
+      .setOptions({
+        Input: rawInput,
+        From: `base ${fromBase}`,
+        To: `base ${toBase}`,
+        Result: resultStr,
+        Decimal: decimalStr,
+      })
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default RadixBoxSource;

--- a/src/modules/boxSources/RadixBoxSource.ts
+++ b/src/modules/boxSources/RadixBoxSource.ts
@@ -59,6 +59,8 @@ export const RadixBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'radix', 'baseconvert')) return [];
+    // BigInt base parsing is O(digits^2); bound it (input is uncapped ?input=)
+    if (input.length > 4_000) return [];
 
     const rawSpec = extractOptionKeys(options, 'radix', 'baseconvert');
 

--- a/src/modules/boxSources/__test__/Adler32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Adler32BoxSource.test.ts
@@ -1,0 +1,96 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Adler32BoxSource } from '../Adler32BoxSource';
+
+describe('Adler32BoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Adler32BoxSource.name).toBe('Adler-32');
+      expect(Adler32BoxSource.tag).toBe('#');
+      expect(Adler32BoxSource.kind).toBe('Hash');
+      expect(typeof Adler32BoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - option gate', () => {
+    it('returns empty array when no option provided', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('', { adler32: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - canonical vector: Wikipedia', () => {
+    it('produces correct Decimal and Hex for "Wikipedia" via ::adler32', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {
+        adler32: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // canonical adler-32 of 'Wikipedia' is 0x11E60398 = 300286872
+      expect(opts.Decimal).toBe('300286872');
+      expect(opts.Hex).toBe('11e60398');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {
+        adler32: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets the box name to Adler-32', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {
+        adler32: true,
+      });
+      expect(boxes[0].props.name).toBe('Adler-32');
+    });
+  });
+
+  describe('generateBoxes - canonical vector: "a"', () => {
+    it('produces correct checksum for single character "a"', async () => {
+      // utf-8 byte 97 → a=98, b=98 → (98<<16|98) = 6422626 = 0x00620062
+      const boxes = await Adler32BoxSource.generateBoxes('a', {
+        adler32: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('6422626');
+      expect(opts.Hex).toBe('00620062');
+    });
+  });
+
+  describe('generateBoxes - ::adler alias', () => {
+    it('::adler alias triggers the same computation as ::adler32', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {
+        adler: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('300286872');
+      expect(opts.Hex).toBe('11e60398');
+    });
+  });
+
+  describe('generateBoxes - priority', () => {
+    it('sets priority on the box', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {
+        adler32: true,
+      });
+      expect(boxes[0].props.priority).toBe(Adler32BoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/DurationParseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DurationParseBoxSource.test.ts
@@ -1,0 +1,157 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DurationParseBoxSource } from '../DurationParseBoxSource';
+
+describe('DurationParseBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes(
+        '1h30m20s',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is set', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::parseduration trigger', () => {
+    it('parses 1h30m20s to 5420 total seconds', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('5420');
+    });
+
+    it('parses 2d to 172800 total seconds', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('2d', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('172800');
+    });
+
+    it('parses 90m to 5400 total seconds', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('90m', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('5400');
+    });
+
+    it('parses 1.5h to 5400 total seconds', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1.5h', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('5400');
+    });
+
+    it('parses 500ms to 0.5 total seconds and 500 total milliseconds', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('500ms', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('0.5');
+      expect(boxes[0].props.options?.['Total Milliseconds']).toBe('500');
+    });
+
+    it('parses duration with spaces between segments (1h 30m)', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h 30m', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('5400');
+    });
+  });
+
+  describe('generateBoxes - ::duration2s trigger', () => {
+    it('also triggers on ::duration2s option key', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        duration2s: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('5420');
+    });
+  });
+
+  describe('generateBoxes - garbage input', () => {
+    it('returns empty array for alphabetic garbage "abc"', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('abc', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unknown unit "1x"', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1x', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty string', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - output structure', () => {
+    it('box name is Parse Duration', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        parseduration: true,
+      });
+      expect(boxes[0].props.name).toBe('Parse Duration');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        parseduration: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('includes Total Milliseconds key for 1h30m20s', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        parseduration: true,
+      });
+      expect(boxes[0].props.options?.['Total Milliseconds']).toBe('5420000');
+    });
+
+    it('includes Human key with rebuilt duration for 1h30m20s', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        parseduration: true,
+      });
+      expect(boxes[0].props.options?.Human).toBe('1h 30m 20s');
+    });
+
+    it('has correct priority', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h', {
+        parseduration: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(DurationParseBoxSource.name).toBe('Parse Duration');
+      expect(DurationParseBoxSource.kind).toBe('Convert');
+      expect(typeof DurationParseBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/FrequencyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FrequencyBoxSource.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import { FrequencyBoxSource } from '../FrequencyBoxSource';
+
+describe('FrequencyBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('hello', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty / whitespace input', () => {
+    it('returns empty array for empty string', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('', { freq: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('   \t\n', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::freq trigger', () => {
+    it("counts 'l' twice in 'hello' and places it first", async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('hello', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const firstLine = boxes[0].props.plaintextOutput.split('\n')[0];
+      expect(firstLine).toMatch(/^l/);
+      expect(firstLine).toContain('2');
+    });
+
+    it("counts 'a' three times and 'b' once in 'aaab'", async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('aaab', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines[0]).toMatch(/^a/);
+      expect(lines[0]).toContain('3');
+      expect(lines[1]).toMatch(/^b/);
+      expect(lines[1]).toContain('1');
+    });
+  });
+
+  describe('generateBoxes - ::frequency trigger', () => {
+    it('also triggers on ::frequency option key', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('abc', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes - whitespace exclusion', () => {
+    it("counts 'a' as 2 and excludes the space in 'a a'", async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('a a', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      // only one unique non-whitespace char
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatch(/^a/);
+      expect(lines[0]).toContain('2');
+    });
+  });
+
+  describe('generateBoxes - astral / multi-codepoint characters', () => {
+    it("counts '😀' as one character per occurrence", async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('😀😀', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatch(/^😀/);
+      expect(lines[0]).toContain('2');
+    });
+  });
+
+  describe('generateBoxes - output format', () => {
+    it('includes percent in each row', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('aa', {
+        freq: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('100.0%');
+    });
+
+    it('box name is Frequency', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('x', { freq: true });
+      expect(boxes[0].props.name).toBe('Frequency');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(FrequencyBoxSource.name).toBe('Frequency');
+      expect(FrequencyBoxSource.tag).toBe('#');
+      expect(FrequencyBoxSource.kind).toBe('Analyze');
+      expect(typeof FrequencyBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/GrayCodeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/GrayCodeBoxSource.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { GrayCodeBoxSource } from '../GrayCodeBoxSource';
+
+describe('GrayCodeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no option is present', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('4', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is present', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('4', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    // encode: 4 (100) XOR 2 (010) = 6 (110)
+    it('encodes 4 to Gray (binary) 110 via ::gray', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('4', { gray: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Gray (binary)']).toBe('110');
+      expect(boxes[0].props.options?.['Gray (decimal)']).toBe('6');
+      expect(boxes[0].props.options?.Decimal).toBe('4');
+      expect(boxes[0].props.options?.Binary).toBe('100');
+    });
+
+    it('encodes 4 to Gray (binary) 110 via ::graycode', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('4', {
+        graycode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Gray (binary)']).toBe('110');
+    });
+
+    // encode: 0 XOR 0 = 0
+    it('encodes 0 to Gray (binary) 0', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('0', { gray: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Gray (binary)']).toBe('0');
+    });
+
+    // encode: 7 (111) XOR 3 (011) = 4 (100)
+    it('encodes 7 to Gray (binary) 100', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('7', { gray: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Gray (binary)']).toBe('100');
+      expect(boxes[0].props.options?.['Gray (decimal)']).toBe('4');
+    });
+
+    it('decodes Gray binary 110 back to decimal 4 via ::graydecode', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('110', {
+        graydecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Decimal).toBe('4');
+      expect(boxes[0].props.options?.['Gray (binary)']).toBe('110');
+      expect(boxes[0].props.options?.Binary).toBe('100');
+    });
+
+    // round-trip for n=4: encode then decode
+    it('round-trips n=4: decode(encode(4)) === 4', async () => {
+      const encBoxes = await GrayCodeBoxSource.generateBoxes('4', {
+        gray: true,
+      });
+      const grayBin = encBoxes[0].props.options?.['Gray (binary)'] as string;
+      const decBoxes = await GrayCodeBoxSource.generateBoxes(grayBin, {
+        graydecode: true,
+      });
+      expect(decBoxes[0].props.options?.Decimal).toBe('4');
+    });
+
+    // round-trip for n=7: encode then decode
+    it('round-trips n=7: decode(encode(7)) === 7', async () => {
+      const encBoxes = await GrayCodeBoxSource.generateBoxes('7', {
+        gray: true,
+      });
+      const grayBin = encBoxes[0].props.options?.['Gray (binary)'] as string;
+      const decBoxes = await GrayCodeBoxSource.generateBoxes(grayBin, {
+        graydecode: true,
+      });
+      expect(decBoxes[0].props.options?.Decimal).toBe('7');
+    });
+
+    it('returns empty array for invalid encode input (non-numeric)', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('abc', {
+        gray: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for invalid decode input (non-binary digits)', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('102', {
+        graydecode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('plaintextOutput for encode is the Gray binary string', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('4', { gray: true });
+      expect(boxes[0].props.plaintextOutput).toBe('110');
+    });
+
+    it('plaintextOutput for decode is the decoded decimal string', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('110', {
+        graydecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('4');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/GrayCodeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/GrayCodeBoxSource.test.ts
@@ -107,5 +107,19 @@ describe('GrayCodeBoxSource', () => {
       });
       expect(boxes[0].props.plaintextOutput).toBe('4');
     });
+
+    it('round-trips a value beyond MAX_SAFE_INTEGER (BigInt-exact)', async () => {
+      const big = '9007199254740993'; // 2^53 + 1
+      const enc = await GrayCodeBoxSource.generateBoxes(big, { gray: true });
+      const gray = (enc[0].props.options as Record<string, string>)[
+        'Gray (binary)'
+      ];
+      const dec = await GrayCodeBoxSource.generateBoxes(gray, {
+        graydecode: true,
+      });
+      expect((dec[0].props.options as Record<string, string>).Decimal).toBe(
+        big,
+      );
+    });
   });
 });

--- a/src/modules/boxSources/__test__/IsbnBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/IsbnBoxSource.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { IsbnBoxSource } from '../IsbnBoxSource';
+
+describe('IsbnBoxSource', () => {
+  it('returns [] when ::isbn option is absent', async () => {
+    const boxes = await IsbnBoxSource.generateBoxes('9780306406157', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] when option object exists but isbn key is missing', async () => {
+    const boxes = await IsbnBoxSource.generateBoxes('9780306406157', {
+      foo: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] for input with wrong length after cleaning', async () => {
+    const boxes = await IsbnBoxSource.generateBoxes('12345', { isbn: true });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('validates ISBN-13: 978-0-306-40615-7 → valid', async () => {
+    const boxes = await IsbnBoxSource.generateBoxes('978-0-306-40615-7', {
+      isbn: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Type).toBe('ISBN-13');
+    expect(kv.Valid).toBe('true');
+    expect(kv['Check Digit']).toBe('7');
+    expect(kv.ISBN).toBe('9780306406157');
+  });
+
+  it('validates ISBN-13 with no separators: 9780306406157 → valid', async () => {
+    const boxes = await IsbnBoxSource.generateBoxes('9780306406157', {
+      isbn: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Type).toBe('ISBN-13');
+    expect(kv.Valid).toBe('true');
+  });
+
+  it('validates ISBN-10 with hyphens: 0-306-40615-2 → valid', async () => {
+    const boxes = await IsbnBoxSource.generateBoxes('0-306-40615-2', {
+      isbn: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Type).toBe('ISBN-10');
+    expect(kv.Valid).toBe('true');
+    expect(kv['Check Digit']).toBe('2');
+    expect(kv.ISBN).toBe('0306406152');
+  });
+
+  it('validates ISBN-10 without separators: 0306406152 → valid', async () => {
+    const boxes = await IsbnBoxSource.generateBoxes('0306406152', {
+      isbn: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Type).toBe('ISBN-10');
+    expect(kv.Valid).toBe('true');
+  });
+
+  it('validates ISBN-10 with X check digit: 080442957X → valid', async () => {
+    const boxes = await IsbnBoxSource.generateBoxes('080442957X', {
+      isbn: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Type).toBe('ISBN-10');
+    expect(kv.Valid).toBe('true');
+    expect(kv['Check Digit']).toBe('X');
+  });
+
+  it('flags invalid check digit: 978-0-306-40615-0 → Valid false', async () => {
+    const boxes = await IsbnBoxSource.generateBoxes('978-0-306-40615-0', {
+      isbn: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Type).toBe('ISBN-13');
+    expect(kv.Valid).toBe('false');
+    // expected check digit is still 7, even though provided digit is 0
+    expect(kv['Check Digit']).toBe('7');
+  });
+});

--- a/src/modules/boxSources/__test__/JsonPointerBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonPointerBoxSource.test.ts
@@ -1,0 +1,146 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { JsonPointerBoxSource } from '../JsonPointerBoxSource';
+
+describe('JsonPointerBoxSource', () => {
+  const json = '{"a":{"b":[10,20]}}';
+
+  describe('option gating', () => {
+    it('returns [] when no option is present', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes(json, null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are present', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes(json, {
+        foo: 'bar',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('pointer resolution', () => {
+    it('resolves a nested array index', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes(json, {
+        jsonpointer: '/a/b/1',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('20');
+      expect(boxes[0].props.name).toBe('JSON Pointer');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+
+    it('resolves index 0', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes(json, {
+        jsonpointer: '/a/b/0',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('10');
+    });
+
+    it('resolves an object value directly', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes('{"x":42}', {
+        jsonpointer: '/x',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('42');
+    });
+  });
+
+  describe('RFC 6901 escape sequences', () => {
+    it('unescapes ~1 to /', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes('{"a/b":5}', {
+        jsonpointer: '/a~1b',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('5');
+    });
+
+    it('unescapes ~0 to ~', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes('{"m~n":7}', {
+        jsonpointer: '/m~0n',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('7');
+    });
+
+    it('handles ~01 per RFC 6901 §3 (~1→/ first, then ~0→~ leaves ~1)', async () => {
+      // ~01: no literal ~1 to turn into /, then ~0→~ yields the key "~1"
+      const boxes = await JsonPointerBoxSource.generateBoxes('{"~1":99}', {
+        jsonpointer: '/~01',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('99');
+    });
+  });
+
+  describe('whole-document pointer', () => {
+    it('returns the whole doc when option value is empty string', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes(json, {
+        jsonpointer: '',
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ a: { b: [10, 20] } });
+    });
+
+    it('returns the whole doc when option is a bare flag (true)', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes(json, {
+        jsonpointer: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ a: { b: [10, 20] } });
+    });
+
+    it('accepts ::jptr alias', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes(json, {
+        jptr: '/a/b/0',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('10');
+    });
+  });
+
+  describe('error cases', () => {
+    it('returns a box mentioning "not found" for a missing key', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes('{"a":1}', {
+        jsonpointer: '/x',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain(
+        'not found',
+      );
+    });
+
+    it('returns a box mentioning "not found" for out-of-range array index', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes('{"a":[1,2]}', {
+        jsonpointer: '/a/5',
+      });
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain(
+        'not found',
+      );
+    });
+
+    it('returns a box mentioning "not found" for RFC 6901 "-" past-end index', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes('[1,2,3]', {
+        jsonpointer: '/-',
+      });
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain(
+        'not found',
+      );
+    });
+
+    it('returns a box mentioning "invalid" for a pointer not starting with /', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes('{"a":1}', {
+        jsonpointer: 'a/b',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+
+    it('returns a box mentioning "invalid" for invalid JSON input', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes('not-json', {
+        jsonpointer: '/a',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PunycodeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PunycodeBoxSource.test.ts
@@ -1,0 +1,137 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { PunycodeBoxSource } from '../PunycodeBoxSource';
+
+describe('PunycodeBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(PunycodeBoxSource.name).toBe('Punycode');
+      expect(PunycodeBoxSource.tag).toBe('#');
+      expect(PunycodeBoxSource.kind).toBe('Encode');
+      expect(typeof PunycodeBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no punycode option is provided', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ToASCII (::punycode)', () => {
+    it('encodes münchen.de to xn--mnchen-3ya.de', async () => {
+      // ground truth: new URL('http://münchen.de').hostname === 'xn--mnchen-3ya.de'
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', {
+        punycode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Punycode (ToASCII)');
+      expect(boxes[0].props.plaintextOutput).toBe('xn--mnchen-3ya.de');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('encodes bücher.com to xn--bcher-kva.com', async () => {
+      // ground truth: new URL('http://bücher.com').hostname === 'xn--bcher-kva.com'
+      const boxes = await PunycodeBoxSource.generateBoxes('bücher.com', {
+        punycode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('xn--bcher-kva.com');
+    });
+
+    it('leaves pure-ASCII domain unchanged', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('example.com', {
+        punycode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('example.com');
+    });
+
+    it('accepts ::punycodeencode alias', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', {
+        punycodeencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('xn--mnchen-3ya.de');
+    });
+
+    it('accepts ::idn alias', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', {
+        idn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('xn--mnchen-3ya.de');
+    });
+  });
+
+  describe('generateBoxes - ToUnicode (::punycodedecode)', () => {
+    it('decodes xn--mnchen-3ya.de to münchen.de', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('xn--mnchen-3ya.de', {
+        punycodedecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Punycode (ToUnicode)');
+      expect(boxes[0].props.plaintextOutput).toBe('münchen.de');
+    });
+
+    it('leaves non-xn-- labels unchanged during decode', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('example.com', {
+        punycodedecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('example.com');
+    });
+
+    it('accepts ::idndecode alias', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('xn--mnchen-3ya.de', {
+        idndecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('münchen.de');
+    });
+  });
+
+  describe('generateBoxes - round-trip', () => {
+    it('toUnicode(toAscii(münchen.de)) === münchen.de', async () => {
+      const asciiBoxes = await PunycodeBoxSource.generateBoxes('münchen.de', {
+        punycode: true,
+      });
+      const ascii = asciiBoxes[0].props.plaintextOutput;
+      const unicodeBoxes = await PunycodeBoxSource.generateBoxes(ascii, {
+        punycodedecode: true,
+      });
+      expect(unicodeBoxes[0].props.plaintextOutput).toBe('münchen.de');
+    });
+  });
+
+  describe('generateBoxes - both options', () => {
+    it('returns 2 boxes when both ::punycode and ::punycodedecode are set', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', {
+        punycode: true,
+        punycodedecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Punycode (ToASCII)');
+      expect(names).toContain('Punycode (ToUnicode)');
+    });
+  });
+
+  describe('generateBoxes - input guard', () => {
+    it('returns empty array when input exceeds MAX_INPUT', async () => {
+      const huge = 'a'.repeat(10_001);
+      const boxes = await PunycodeBoxSource.generateBoxes(huge, {
+        punycode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/RadixBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/RadixBoxSource.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { RadixBoxSource } from '../RadixBoxSource';
+
+describe('RadixBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no radix option is present', async () => {
+      const boxes = await RadixBoxSource.generateBoxes('ff', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated options are present', async () => {
+      const boxes = await RadixBoxSource.generateBoxes('ff', { json: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts hex ff to binary (base 16 → base 2)', async () => {
+      const boxes = await RadixBoxSource.generateBoxes('ff', { radix: '16:2' });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.Result).toBe('11111111');
+      expect(opts?.Decimal).toBe('255');
+      expect(opts?.From).toBe('base 16');
+      expect(opts?.To).toBe('base 2');
+      expect(opts?.Input).toBe('ff');
+    });
+
+    it('converts decimal 255 to hex (base 10 → base 16)', async () => {
+      const boxes = await RadixBoxSource.generateBoxes('255', {
+        radix: '10:16',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Result).toBe('ff');
+    });
+
+    it('converts negative decimal -10 to binary', async () => {
+      const boxes = await RadixBoxSource.generateBoxes('-10', {
+        radix: '10:2',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Result).toBe('-1010');
+    });
+
+    it('converts z in base 36 to decimal', async () => {
+      const boxes = await RadixBoxSource.generateBoxes('z', { radix: '36:10' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Result).toBe('35');
+      expect(boxes[0].props.options?.Decimal).toBe('35');
+    });
+
+    it('returns error box for digit not valid in the given base (9 in base 2)', async () => {
+      const boxes = await RadixBoxSource.generateBoxes('9', { radix: '2:10' });
+      expect(boxes).toHaveLength(1);
+      const info = boxes[0].props.options?.Info as string;
+      expect(info).toMatch(/invalid|not valid/i);
+    });
+
+    it('returns format hint box when spec has no colon (bare base, no :to)', async () => {
+      const boxes = await RadixBoxSource.generateBoxes('ff', { radix: '16' });
+      expect(boxes).toHaveLength(1);
+      const info = boxes[0].props.options?.Info as string;
+      expect(info).toMatch(/FROM:TO|format/i);
+    });
+
+    it('returns format hint box when option value is bare true (::radix with no =value)', async () => {
+      const boxes = await RadixBoxSource.generateBoxes('ff', { radix: true });
+      expect(boxes).toHaveLength(1);
+      const info = boxes[0].props.options?.Info as string;
+      expect(info).toMatch(/FROM:TO|format/i);
+    });
+
+    it('returns error box when base is out of range (1 or 40)', async () => {
+      const boxes1 = await RadixBoxSource.generateBoxes('ff', {
+        radix: '1:40',
+      });
+      expect(boxes1).toHaveLength(1);
+      const info = boxes1[0].props.options?.Info as string;
+      expect(info).toMatch(/2-36/);
+    });
+
+    it('also triggers on ::baseconvert alias', async () => {
+      const boxes = await RadixBoxSource.generateBoxes('ff', {
+        baseconvert: '16:2',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Result).toBe('11111111');
+    });
+
+    it('handles large values exactly via BigInt', async () => {
+      // 2^64 in decimal = 18446744073709551616; convert to hex
+      const input = '18446744073709551616';
+      const boxes = await RadixBoxSource.generateBoxes(input, {
+        radix: '10:16',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Result).toBe('10000000000000000');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,3 +1,4 @@
+import Adler32BoxSource from './Adler32BoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
@@ -6,15 +7,22 @@ import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DurationParseBoxSource from './DurationParseBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FrequencyBoxSource from './FrequencyBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
+import GrayCodeBoxSource from './GrayCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import IsbnBoxSource from './IsbnBoxSource';
+import JsonPointerBoxSource from './JsonPointerBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PunycodeBoxSource from './PunycodeBoxSource';
+import RadixBoxSource from './RadixBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
@@ -31,17 +39,25 @@ export const boxSources = [
   ColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  Adler32BoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  DurationParseBoxSource,
+  FrequencyBoxSource,
   GenerateQRCodeBoxSource,
+  GrayCodeBoxSource,
   HashBoxSource,
+  IsbnBoxSource,
+  JsonPointerBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  PunycodeBoxSource,
+  RadixBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,


### PR DESCRIPTION
## Summary

Ninth exploration batch — **8 more BoxSource tools** (encoding, checksums, validation, analysis).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Punycode | `::punycode` / `::punycodedecode` | IDN ⇄ `xn--` (RFC 3492 bootstring) |
| Radix Convert | `::radix=FROM:TO` | integer between bases 2–36 (BigInt) |
| Parse Duration | `::parseduration` | `1h30m20s` → total seconds (inverse of the Duration tool) |
| ISBN | `::isbn` | validate ISBN-10/13 + expected check digit |
| Adler-32 | `::adler32` | checksum (hex + decimal) |
| JSON Pointer | `::jsonpointer=/a/b` | RFC 6901 resolution (`~0`/`~1` escapes, own-property walk) |
| Frequency | `::freq` | character frequency analysis, sorted |
| Gray Code | `::gray` / `::graydecode` | integer ⇄ Gray code |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step.
- **Verified vectors**: Punycode `münchen.de`→`xn--mnchen-3ya.de` (subagent confirmed against `new URL`); Radix `ff`/16→2 = `11111111`; ISBN-13/10 + the `X` check digit; Adler-32 `Wikipedia`→`11e60398`; Gray `4`→`110`.
- JSON Pointer applies `Object.hasOwn` (no prototype-chain leak) and the path-cap lesson from #266; carries the `~1`-before-`~0` escape order.
- A self-review caught a **wrong test expectation** for the RFC 6901 `~01` escape (`/~01` correctly resolves to key `~1`, not `~0`) — the implementation was right; the test was corrected.

## Verification

- ✅ `bun run test run` — **435 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#267 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6