### PR TITLE
feat(boxSources): add 8 more tools (iban, json-flatten, tz-convert, px/rem, dotenv, a1z26, fullwidth, bacon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,82 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>IbanBox</b> </summary>
+
+| match rule | description                          | example                           |
+| ---------- | ------------------------------------ | --------------------------------- |
+| `::iban`   | validate an IBAN (mod-97) + country  | `GB82 WEST 1234 5698 7654 32 ::iban` |
+
+</details>
+
+<details>
+<summary> <b>JsonFlattenBox</b> </summary>
+
+| match rule     | description                              | example                       |
+| -------------- | ---------------------------------------- | ----------------------------- |
+| `::flatten`    | flatten nested JSON to dot/bracket keys  | `{"a":{"b":1}} ::flatten`     |
+| `::unflatten`  | rebuild nested JSON from dot keys         | `{"a.b":1} ::unflatten`       |
+
+</details>
+
+<details>
+<summary> <b>TimezoneConvertBox</b> </summary>
+
+| match rule          | description                              | example                                  |
+| ------------------- | ---------------------------------------- | ---------------------------------------- |
+| `::tzconvert=ZONE`  | show a time in a target IANA timezone    | `2024-01-01T12:00:00Z ::tzconvert=Asia/Tokyo` |
+
+</details>
+
+<details>
+<summary> <b>PxRemBox</b> </summary>
+
+| match rule  | description                              | example          |
+| ----------- | ---------------------------------------- | ---------------- |
+| `::pxrem`   | convert between px and rem (base 16)     | `24px ::pxrem`   |
+
+</details>
+
+<details>
+<summary> <b>DotEnvBox</b> </summary>
+
+| match rule   | description                          | example                  |
+| ------------ | ------------------------------------ | ------------------------ |
+| `::dotenv`   | .env ⇄ JSON (auto-direction)         | `API_KEY=abc ::dotenv`   |
+
+</details>
+
+<details>
+<summary> <b>A1Z26Box</b> </summary>
+
+| match rule        | description                          | example              |
+| ----------------- | ------------------------------------ | -------------------- |
+| `::a1z26`         | letters → position numbers (A=1..Z=26) | `hello ::a1z26`    |
+| `::a1z26decode`   | numbers → letters                    | `8-5-12-12-15 ::a1z26decode` |
+
+</details>
+
+<details>
+<summary> <b>FullwidthBox</b> </summary>
+
+| match rule      | description                          | example               |
+| --------------- | ------------------------------------ | --------------------- |
+| `::fullwidth`   | ASCII → fullwidth Unicode            | `Hello 123 ::fullwidth` |
+| `::halfwidth`   | fullwidth → ASCII                    | `Ｈｉ ::halfwidth`     |
+
+</details>
+
+<details>
+<summary> <b>BaconCipherBox</b> </summary>
+
+| match rule       | description                          | example            |
+| ---------------- | ------------------------------------ | ------------------ |
+| `::bacon`        | Baconian cipher (5-letter A/B groups) | `hello ::bacon`   |
+| `::bacondecode`  | decode Baconian back to text          | `aabbb aabaa ababb ababb abbba ::bacondecode` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/A1Z26BoxSource.ts
+++ b/src/modules/boxSources/A1Z26BoxSource.ts
@@ -1,0 +1,116 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// maps a single letter (a-z / A-Z) to its 1-26 position number
+function letterToNumber(char: string): number {
+  return char.toLowerCase().charCodeAt(0) - 96;
+}
+
+// maps a 1-26 number to its corresponding lowercase letter
+function numberToLetter(n: number): string | null {
+  if (n < 1 || n > 26) return null;
+  return String.fromCharCode(96 + n);
+}
+
+// encodes a string using A1Z26: letters → numbers, whitespace → word boundary, others dropped
+function encodeA1Z26(input: string): string {
+  const words = input.split(/(\s+)/);
+  const encodedWords: string[] = [];
+
+  for (const segment of words) {
+    if (/^\s+$/.test(segment)) {
+      // preserve word boundaries as a single space
+      encodedWords.push(' ');
+      continue;
+    }
+
+    const parts: string[] = [];
+    for (const char of segment) {
+      if (/[a-zA-Z]/.test(char)) {
+        parts.push(String(letterToNumber(char)));
+      }
+      // non-letter, non-space characters are dropped
+    }
+
+    if (parts.length > 0) {
+      encodedWords.push(parts.join('-'));
+    }
+  }
+
+  // collapse multiple spaces that arise from adjacent non-letter segments
+  return encodedWords.join('').replace(/ +/g, ' ').trim();
+}
+
+// decodes A1Z26 encoded string: whitespace-separated groups of dash-separated numbers → letters
+function decodeA1Z26(input: string): string {
+  const words = input.trim().split(/\s+/);
+  const decoded = words.map((word) => {
+    const parts = word.split('-');
+    return parts
+      .map((part) => {
+        const n = Number.parseInt(part, 10);
+        if (Number.isNaN(n)) return '?';
+        return numberToLetter(n) ?? '?';
+      })
+      .join('');
+  });
+  return decoded.join(' ');
+}
+
+export const A1Z26BoxSource = {
+  name: 'A1Z26',
+  description:
+    'Encode letters to their position numbers (A=1..Z=26) or decode numbers back to letters.',
+  defaultInput: 'hello ::a1z26',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'a1z26', 'a1z26encode');
+    const wantDecode = hasOptionKeys(options, 'a1z26decode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = encodeA1Z26(input);
+      boxes.push(
+        new BoxBuilder('A1Z26 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decodeA1Z26(input);
+      boxes.push(
+        new BoxBuilder('A1Z26 (Decode)', decoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default A1Z26BoxSource;

--- a/src/modules/boxSources/BaconCipherBoxSource.ts
+++ b/src/modules/boxSources/BaconCipherBoxSource.ts
@@ -26,8 +26,8 @@ function encodeBacon(input: string): string {
 }
 
 function decodeBacon(input: string): string {
-  // normalize: lowercase, collapse whitespace, split into 5-char groups
-  const normalized = input.toLowerCase().replace(/\s+/g, '');
+  // keep only a/b so stray characters don't misalign the 5-char groups
+  const normalized = input.toLowerCase().replace(/[^ab]/g, '');
   const groups: string[] = [];
   for (let i = 0; i + 5 <= normalized.length; i += 5) {
     groups.push(normalized.slice(i, i + 5));

--- a/src/modules/boxSources/BaconCipherBoxSource.ts
+++ b/src/modules/boxSources/BaconCipherBoxSource.ts
@@ -1,0 +1,93 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// maps each letter index (0=A … 25=Z) to its 5-char a/b code (0→'a', 1→'b')
+const ENCODE_TABLE: string[] = Array.from({ length: 26 }, (_, i) =>
+  i.toString(2).padStart(5, '0').replace(/0/g, 'a').replace(/1/g, 'b'),
+);
+
+// reverse lookup: a/b code → letter
+const DECODE_TABLE: Record<string, string> = Object.fromEntries(
+  ENCODE_TABLE.map((code, i) => [code, String.fromCharCode(65 + i)]),
+);
+
+function encodeBacon(input: string): string {
+  return input
+    .toUpperCase()
+    .split('')
+    .filter((ch) => ch >= 'A' && ch <= 'Z')
+    .map((ch) => ENCODE_TABLE[ch.charCodeAt(0) - 65])
+    .join(' ');
+}
+
+function decodeBacon(input: string): string {
+  // normalize: lowercase, collapse whitespace, split into 5-char groups
+  const normalized = input.toLowerCase().replace(/\s+/g, '');
+  const groups: string[] = [];
+  for (let i = 0; i + 5 <= normalized.length; i += 5) {
+    groups.push(normalized.slice(i, i + 5));
+  }
+  return groups
+    .map((g) => {
+      // skip groups with chars other than a/b
+      if (!/^[ab]{5}$/.test(g)) return '';
+      return (DECODE_TABLE[g] ?? '').toLowerCase();
+    })
+    .join('');
+}
+
+export const BaconCipherBoxSource = {
+  name: 'Bacon Cipher',
+  description:
+    "Encode text to Bacon's cipher (5-letter A/B groups) or decode it back.",
+  defaultInput: 'hello ::bacon',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'bacon', 'baconencode');
+    const wantDecode = hasOptionKeys(options, 'bacondecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      boxes.push(
+        new BoxBuilder('Bacon Cipher (Encode)', encodeBacon(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      boxes.push(
+        new BoxBuilder('Bacon Cipher (Decode)', decodeBacon(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default BaconCipherBoxSource;

--- a/src/modules/boxSources/DotEnvBoxSource.ts
+++ b/src/modules/boxSources/DotEnvBoxSource.ts
@@ -1,0 +1,108 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// strips one layer of surrounding single or double quotes from a value
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+// parses .env text into a plain string-keyed object
+function parseEnv(input: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of input.split('\n')) {
+    const trimmed = trim(line);
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+
+    const key = trim(trimmed.slice(0, eqIndex));
+    const rawValue = trim(trimmed.slice(eqIndex + 1));
+    result[key] = stripQuotes(rawValue);
+  }
+  return result;
+}
+
+// serializes a flat object to .env lines, quoting values that need it
+function serializeEnv(obj: Record<string, string>): string {
+  return Object.entries(obj)
+    .map(([key, rawValue]) => {
+      const value = String(rawValue);
+      // quote values that contain spaces, '#', or '=' to avoid ambiguity
+      const needsQuotes = /[ #=]/.test(value);
+      if (needsQuotes) {
+        const escaped = value.replace(/"/g, '\\"');
+        return `${key}="${escaped}"`;
+      }
+      return `${key}=${value}`;
+    })
+    .join('\n');
+}
+
+export const DotEnvBoxSource = {
+  name: 'Dotenv / JSON',
+  description:
+    'Convert a .env file to a JSON object, or a flat JSON object to .env format.',
+  defaultInput: 'API_KEY=abc123\nDEBUG=true ::dotenv',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'dotenv', 'envjson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    // detect direction: JSON-looking input goes JSON→env, otherwise env→JSON
+    if (trimmed.startsWith('{')) {
+      try {
+        const obj = JSON.parse(trimmed) as Record<string, unknown>;
+        const flat: Record<string, string> = {};
+        for (const [k, v] of Object.entries(obj)) {
+          flat[k] = String(v);
+        }
+        const output = serializeEnv(flat);
+        return [
+          new BoxBuilder('JSON → Dotenv', output)
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      } catch {
+        return [
+          new BoxBuilder('JSON → Dotenv', 'Error: invalid JSON input')
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // env→JSON direction
+    const obj = parseEnv(trimmed);
+    const output = JSON.stringify(obj, null, 2);
+    return [
+      new BoxBuilder('Dotenv → JSON', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DotEnvBoxSource;

--- a/src/modules/boxSources/FullwidthBoxSource.ts
+++ b/src/modules/boxSources/FullwidthBoxSource.ts
@@ -1,0 +1,95 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// offset between ASCII printable range (0x21-0x7E) and fullwidth Unicode block (U+FF01-U+FF5E)
+const FULLWIDTH_OFFSET = 0xfee0;
+
+// convert ASCII printable chars to their fullwidth Unicode equivalents
+function toFullwidth(input: string): string {
+  let result = '';
+  for (const ch of input) {
+    const cp = ch.codePointAt(0) ?? 0;
+    if (cp === 0x20) {
+      // ASCII space → ideographic space U+3000
+      result += '　';
+    } else if (cp >= 0x21 && cp <= 0x7e) {
+      // printable ASCII → fullwidth form
+      result += String.fromCodePoint(cp + FULLWIDTH_OFFSET);
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+// reverse fullwidth Unicode forms back to ASCII
+function toHalfwidth(input: string): string {
+  let result = '';
+  for (const ch of input) {
+    const cp = ch.codePointAt(0) ?? 0;
+    if (cp === 0x3000) {
+      // ideographic space → ASCII space
+      result += ' ';
+    } else if (cp >= 0xff01 && cp <= 0xff5e) {
+      // fullwidth form → ASCII printable
+      result += String.fromCodePoint(cp - FULLWIDTH_OFFSET);
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+export const FullwidthBoxSource = {
+  name: 'Fullwidth',
+  description:
+    'Convert ASCII text to fullwidth Unicode forms, or fullwidth back to ASCII.',
+  defaultInput: 'Hello 123 ::fullwidth',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'fullwidth', 'tofullwidth');
+    const wantDecode = hasOptionKeys(options, 'halfwidth', 'fromfullwidth');
+    if (!wantEncode && !wantDecode) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const output = toFullwidth(input);
+      boxes.push(
+        new BoxBuilder('Fullwidth', output)
+          .setTemplate(DefaultBoxTemplate)
+          .setPriority(this.priority)
+          .setShowExpandButton(false)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const output = toHalfwidth(input);
+      boxes.push(
+        new BoxBuilder('Halfwidth', output)
+          .setTemplate(DefaultBoxTemplate)
+          .setPriority(this.priority)
+          .setShowExpandButton(false)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default FullwidthBoxSource;

--- a/src/modules/boxSources/IbanBoxSource.ts
+++ b/src/modules/boxSources/IbanBoxSource.ts
@@ -1,0 +1,72 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// regex for a structurally valid IBAN: 2 uppercase letters, 2 digits, then alphanumeric
+const IBAN_PATTERN = /^[A-Z]{2}\d{2}[A-Z0-9]+$/;
+
+// converts a letter to its numeric equivalent per ISO 7064 (A=10, B=11, ..., Z=35)
+function letterToDigits(ch: string): string {
+  return (ch.charCodeAt(0) - 55).toString();
+}
+
+// validates IBAN checksum via mod-97 using BigInt arithmetic on the full digit string
+function validateMod97(iban: string): boolean {
+  // rearrange: move first 4 chars to end, then convert letters to numeric strings
+  const rearranged = iban.slice(4) + iban.slice(0, 4);
+  const numeric = rearranged
+    .split('')
+    .map((ch) => (/[A-Z]/.test(ch) ? letterToDigits(ch) : ch))
+    .join('');
+  return BigInt(numeric) % 97n === 1n;
+}
+
+export const IbanBoxSource = {
+  name: 'IBAN',
+  description: 'Validate an IBAN (ISO 13616) using the mod-97 check.',
+  defaultInput: 'GB82 WEST 1234 5698 7654 32 ::iban',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'iban')) return [];
+
+    // strip spaces and uppercase
+    const cleaned = trim(input).replace(/\s+/g, '').toUpperCase();
+
+    // structural check: 2 letters, 2 digits, 1–30 alphanumeric chars (total 4–34)
+    if (
+      !IBAN_PATTERN.test(cleaned) ||
+      cleaned.length < 4 ||
+      cleaned.length > 34
+    ) {
+      return [];
+    }
+
+    const country = cleaned.slice(0, 2);
+    const checkDigits = cleaned.slice(2, 4);
+    const valid = validateMod97(cleaned);
+
+    return [
+      new BoxBuilder('IBAN', cleaned)
+        .setOptions({
+          IBAN: cleaned,
+          Country: country,
+          'Check Digits': checkDigits,
+          Valid: valid.toString(),
+        })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default IbanBoxSource;

--- a/src/modules/boxSources/IbanBoxSource.ts
+++ b/src/modules/boxSources/IbanBoxSource.ts
@@ -37,6 +37,8 @@ export const IbanBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'iban')) return [];
+    // an IBAN is at most 34 chars; bound work before the string ops
+    if (input.length > 1000) return [];
 
     // strip spaces and uppercase
     const cleaned = trim(input).replace(/\s+/g, '').toUpperCase();

--- a/src/modules/boxSources/JsonFlattenBoxSource.ts
+++ b/src/modules/boxSources/JsonFlattenBoxSource.ts
@@ -78,12 +78,21 @@ function splitKey(key: string): (string | number)[] {
   return segments;
 }
 
+// keys that would walk into the prototype chain and let a crafted ?input=
+// pollute Object.prototype for the whole session
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 // set a value at a nested path described by segments, creating objects/arrays as needed
 function setPath(
   root: Record<string, unknown> | unknown[],
   segments: (string | number)[],
   value: unknown,
 ): void {
+  // refuse any path that touches a prototype-chain key
+  if (segments.some((s) => typeof s === 'string' && FORBIDDEN_KEYS.has(s))) {
+    return;
+  }
+
   let current: Record<string, unknown> | unknown[] = root;
   for (let i = 0; i < segments.length - 1; i++) {
     const seg = segments[i];

--- a/src/modules/boxSources/JsonFlattenBoxSource.ts
+++ b/src/modules/boxSources/JsonFlattenBoxSource.ts
@@ -1,0 +1,179 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// recursively flatten a nested value into dot/bracket path → leaf entries
+function flattenValue(
+  value: unknown,
+  prefix: string,
+  result: Record<string, unknown>,
+): void {
+  if (value === null || typeof value !== 'object') {
+    result[prefix] = value;
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      result[prefix] = [];
+      return;
+    }
+    for (let i = 0; i < value.length; i++) {
+      flattenValue(value[i], `${prefix}[${i}]`, result);
+    }
+    return;
+  }
+
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length === 0) {
+    result[prefix] = {};
+    return;
+  }
+  for (const key of keys) {
+    const nextPrefix = prefix === '' ? key : `${prefix}.${key}`;
+    flattenValue((value as Record<string, unknown>)[key], nextPrefix, result);
+  }
+}
+
+function flatten(input: unknown): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  if (input === null || typeof input !== 'object') {
+    return result;
+  }
+  if (Array.isArray(input)) {
+    for (let i = 0; i < input.length; i++) {
+      flattenValue(input[i], `[${i}]`, result);
+    }
+    return result;
+  }
+  for (const key of Object.keys(input as Record<string, unknown>)) {
+    flattenValue((input as Record<string, unknown>)[key], key, result);
+  }
+  return result;
+}
+
+// split a flat key like "a.b[0].c[1]" into segments ["a", "b", 0, "c", 1]
+function splitKey(key: string): (string | number)[] {
+  const segments: (string | number)[] = [];
+  // tokenize by '.' and '[n]'
+  const parts = key.split('.');
+  for (const part of parts) {
+    // a part may look like "arr[0][1]" after splitting on '.'
+    const re = /([^[]*)((?:\[\d+\])*)/g;
+    const m = re.exec(part);
+    if (m) {
+      if (m[1] !== '') segments.push(m[1]);
+      const brackets = m[2];
+      if (brackets) {
+        for (const idx of brackets.matchAll(/\[(\d+)\]/g)) {
+          segments.push(Number.parseInt(idx[1], 10));
+        }
+      }
+    }
+  }
+  return segments;
+}
+
+// set a value at a nested path described by segments, creating objects/arrays as needed
+function setPath(
+  root: Record<string, unknown> | unknown[],
+  segments: (string | number)[],
+  value: unknown,
+): void {
+  let current: Record<string, unknown> | unknown[] = root;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    const nextSeg = segments[i + 1];
+    const nextIsIndex = typeof nextSeg === 'number';
+
+    if (typeof seg === 'number') {
+      const arr = current as unknown[];
+      if (arr[seg] == null) {
+        arr[seg] = nextIsIndex ? [] : {};
+      }
+      current = arr[seg] as Record<string, unknown> | unknown[];
+    } else {
+      const obj = current as Record<string, unknown>;
+      if (obj[seg] == null) {
+        obj[seg] = nextIsIndex ? [] : {};
+      }
+      current = obj[seg] as Record<string, unknown> | unknown[];
+    }
+  }
+
+  const last = segments[segments.length - 1];
+  if (typeof last === 'number') {
+    (current as unknown[])[last] = value;
+  } else {
+    (current as Record<string, unknown>)[last] = value;
+  }
+}
+
+function unflatten(flat: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(flat)) {
+    const segments = splitKey(key);
+    if (segments.length === 0) continue;
+    setPath(result, segments, value);
+  }
+  return result;
+}
+
+export const JsonFlattenBoxSource = {
+  name: 'JSON Flatten',
+  description:
+    'Flatten nested JSON to dot-notation keys, or unflatten dot keys back to nested JSON.',
+  defaultInput: '{"a":{"b":1,"c":[2,3]}} ::flatten',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantFlatten = hasOptionKeys(options, 'flatten', 'jsonflatten');
+    const wantUnflatten = hasOptionKeys(options, 'unflatten', 'jsonunflatten');
+    if (!wantFlatten && !wantUnflatten) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      const errorBox = new BoxBuilder(
+        'JSON Flatten',
+        `Invalid JSON: unable to parse input.\n\n${trimmed.slice(0, 200)}`,
+      )
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(Priority)
+        .build();
+      return [errorBox];
+    }
+
+    let output: string;
+    if (wantFlatten) {
+      output = JSON.stringify(flatten(parsed), null, 2);
+    } else {
+      // wantUnflatten — parsed must be a flat object
+      const flat = parsed as Record<string, unknown>;
+      output = JSON.stringify(unflatten(flat), null, 2);
+    }
+
+    const box = new BoxBuilder('JSON Flatten', output)
+      .setOptions({ language: 'json' })
+      .setTemplate(CodeBoxTemplate)
+      .setPriority(Priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default JsonFlattenBoxSource;

--- a/src/modules/boxSources/PxRemBoxSource.ts
+++ b/src/modules/boxSources/PxRemBoxSource.ts
@@ -6,9 +6,10 @@ import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
 const Priority = 10;
 const DEFAULT_BASE = 16;
 
-// strip trailing zeros after decimal, e.g. 1.50000 → "1.5", 24.0 → "24"
+// round to ~10 sig figs and strip trailing zeros without leaking scientific
+// notation (Number().toString() renormalizes e.g. 1e10 → "10000000000")
 function formatNumber(n: number): string {
-  return n.toPrecision(10).replace(/\.?0+$/, '');
+  return Number(n.toPrecision(10)).toString();
 }
 
 export const PxRemBoxSource = {

--- a/src/modules/boxSources/PxRemBoxSource.ts
+++ b/src/modules/boxSources/PxRemBoxSource.ts
@@ -1,0 +1,70 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const DEFAULT_BASE = 16;
+
+// strip trailing zeros after decimal, e.g. 1.50000 → "1.5", 24.0 → "24"
+function formatNumber(n: number): string {
+  return n.toPrecision(10).replace(/\.?0+$/, '');
+}
+
+export const PxRemBoxSource = {
+  name: 'px / rem',
+  description:
+    'Convert between px and rem given a root font size (default 16). e.g. "24px ::pxrem" or "1.5rem ::pxrem".',
+  defaultInput: '24px ::pxrem',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'pxrem', 'rempx')) return [];
+
+    // resolve base font size from option value, falling back to DEFAULT_BASE
+    const rawBase = extractOptionKeys(options, 'pxrem', 'rempx');
+    const base =
+      typeof rawBase === 'string' && rawBase !== ''
+        ? Number.parseFloat(rawBase)
+        : DEFAULT_BASE;
+    if (!Number.isFinite(base) || base <= 0) return [];
+
+    const trimmed = trim(input);
+    const match = /^(-?\d+(?:\.\d+)?)\s*(px|rem)?$/i.exec(trimmed);
+    if (!match) return [];
+
+    const value = Number.parseFloat(match[1]);
+    const unit = (match[2] ?? 'px').toLowerCase();
+
+    let pxValue: number;
+    let remValue: number;
+
+    if (unit === 'rem') {
+      remValue = value;
+      pxValue = value * base;
+    } else {
+      // treat unitless or explicit px as px
+      pxValue = value;
+      remValue = value / base;
+    }
+
+    return [
+      new BoxBuilder('px / rem', formatNumber(pxValue))
+        .setOptions({
+          px: formatNumber(pxValue),
+          rem: formatNumber(remValue),
+          Base: `${formatNumber(base)}px`,
+        })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PxRemBoxSource;

--- a/src/modules/boxSources/TimezoneConvertBoxSource.ts
+++ b/src/modules/boxSources/TimezoneConvertBoxSource.ts
@@ -1,4 +1,7 @@
-import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
 import { trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
@@ -50,8 +53,10 @@ function validateZone(zone: string, date: Date): void {
 }
 
 function errorBox(name: string, message: string): Box {
+  // a plain message box, not a key/value box
   return new BoxBuilder(name, message)
-    .setTemplate(KeyValueBoxTemplate)
+    .setTemplate(DefaultBoxTemplate)
+    .setShowExpandButton(false)
     .setPriority(Priority)
     .build();
 }

--- a/src/modules/boxSources/TimezoneConvertBoxSource.ts
+++ b/src/modules/boxSources/TimezoneConvertBoxSource.ts
@@ -1,0 +1,129 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// extract the zone string from options — tzconvert takes priority over intz
+function getZone(options: BoxOptions): string | null {
+  if (!options) return null;
+  const raw = options.tzconvert ?? options.intz;
+  if (typeof raw === 'string') return raw || null;
+  // bare flag (boolean true) means no value was supplied
+  return null;
+}
+
+// format a date in the given IANA timezone as 'yyyy-MM-dd HH:mm:ss'
+function formatInZone(date: Date, zone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: zone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+
+  const get = (type: string) =>
+    parts.find((p) => p.type === type)?.value ?? '??';
+  return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}:${get('second')}`;
+}
+
+// derive the UTC offset label (e.g. 'GMT+9') for a zone at a given instant
+function getOffset(date: Date, zone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: zone,
+    timeZoneName: 'shortOffset',
+  }).formatToParts(date);
+  return parts.find((p) => p.type === 'timeZoneName')?.value ?? zone;
+}
+
+// validate that the zone string is a recognised IANA timezone
+function validateZone(zone: string, date: Date): void {
+  // Intl throws RangeError on an unknown timeZone
+  new Intl.DateTimeFormat('en-US', { timeZone: zone, year: 'numeric' }).format(
+    date,
+  );
+}
+
+function errorBox(name: string, message: string): Box {
+  return new BoxBuilder(name, message)
+    .setTemplate(KeyValueBoxTemplate)
+    .setPriority(Priority)
+    .build();
+}
+
+export const TimezoneConvertBoxSource = {
+  name: 'Timezone Convert',
+  description:
+    'Show a date/time in a target IANA timezone. Input is an ISO date or "now"; zone via ::tzconvert=Asia/Tokyo.',
+  defaultInput: '2024-01-01T12:00:00Z ::tzconvert=Asia/Tokyo',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'tzconvert', 'intz')) return [];
+
+    const zone = getZone(options);
+
+    // bare flag or empty value — no zone supplied
+    if (!zone) {
+      return [
+        errorBox(
+          'Timezone Convert',
+          'A target timezone is required. Example: ::tzconvert=Asia/Tokyo',
+        ),
+      ];
+    }
+
+    // resolve the source time
+    const s = trim(input);
+    let date: Date;
+    if (s === '' || s.toLowerCase() === 'now') {
+      date = new Date();
+    } else {
+      date = new Date(s);
+      if (Number.isNaN(date.getTime())) {
+        return [
+          errorBox(
+            'Timezone Convert',
+            `"${s}" is not a valid date. Use ISO 8601 or "now".`,
+          ),
+        ];
+      }
+    }
+
+    // validate the timezone before formatting
+    try {
+      validateZone(zone, date);
+    } catch {
+      return [
+        errorBox('Timezone Convert', `"${zone}" is not a valid IANA timezone.`),
+      ];
+    }
+
+    const kvOptions: Record<string, string> = {
+      Zone: zone,
+      'Local Time': formatInZone(date, zone),
+      UTC: date.toISOString(),
+      Offset: getOffset(date, zone),
+    };
+
+    const box = new BoxBuilder('Timezone Convert', '')
+      .setOptions(kvOptions)
+      .setTemplate(KeyValueBoxTemplate)
+      .setPriority(Priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default TimezoneConvertBoxSource;

--- a/src/modules/boxSources/__test__/A1Z26BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/A1Z26BoxSource.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { A1Z26BoxSource } from '../A1Z26BoxSource';
+
+describe('A1Z26BoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input with option set', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('', { a1z26: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('   ', { a1z26: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode (::a1z26)', () => {
+    it('encodes a single word correctly', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('hello', {
+        a1z26: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('A1Z26 (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('8-5-12-12-15');
+    });
+
+    it('encodes two words separated by a space', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('hi there', {
+        a1z26: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('8-9 20-8-5-18-5');
+    });
+
+    it('treats uppercase and lowercase identically', async () => {
+      const lower = await A1Z26BoxSource.generateBoxes('abc', { a1z26: true });
+      const upper = await A1Z26BoxSource.generateBoxes('ABC', { a1z26: true });
+      expect(lower[0].props.plaintextOutput).toBe(
+        upper[0].props.plaintextOutput,
+      );
+    });
+
+    it('accepts ::a1z26encode option alias', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('hello', {
+        a1z26encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('8-5-12-12-15');
+    });
+  });
+
+  describe('decode (::a1z26decode)', () => {
+    it('decodes a single encoded word', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('8-5-12-12-15', {
+        a1z26decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('A1Z26 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decodes two space-separated encoded words', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('8-9 20-8-5-18-5', {
+        a1z26decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hi there');
+    });
+
+    it('replaces out-of-range numbers with "?"', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('0-27', {
+        a1z26decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('??');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encodes then decodes back to the original lowercase word', async () => {
+      const word = 'world';
+      const encoded = await A1Z26BoxSource.generateBoxes(word, { a1z26: true });
+      const encodedText = encoded[0].props.plaintextOutput;
+
+      const decoded = await A1Z26BoxSource.generateBoxes(encodedText, {
+        a1z26decode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe(word);
+    });
+  });
+
+  describe('both options active', () => {
+    it('returns two boxes when both encode and decode options are set', async () => {
+      const boxes = await A1Z26BoxSource.generateBoxes('hello', {
+        a1z26: true,
+        a1z26decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('A1Z26 (Encode)');
+      expect(names).toContain('A1Z26 (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(A1Z26BoxSource.name).toBe('A1Z26');
+      expect(A1Z26BoxSource.tag).toBe('#');
+      expect(A1Z26BoxSource.kind).toBe('Encode');
+      expect(typeof A1Z26BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/BaconCipherBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BaconCipherBoxSource.test.ts
@@ -1,0 +1,159 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { BaconCipherBoxSource } from '../BaconCipherBoxSource';
+
+describe('BaconCipherBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(BaconCipherBoxSource.name).toBe('Bacon Cipher');
+      expect(BaconCipherBoxSource.tag).toBe('#');
+      expect(BaconCipherBoxSource.kind).toBe('Encode');
+      expect(typeof BaconCipherBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is empty string with ::bacon', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('', {
+        bacon: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is whitespace only', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('   ', {
+        bacon: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — individual letters', () => {
+    // A = index 0 = 00000 in 5-bit binary → 'aaaaa'
+    it("encodes 'A' to 'aaaaa'", async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('A', {
+        bacon: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('aaaaa');
+    });
+
+    // B = index 1 = 00001 → 'aaaab'
+    it("encodes 'B' to 'aaaab'", async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('B', {
+        bacon: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('aaaab');
+    });
+
+    // Z = index 25 = 11001 in 5-bit binary → 'bbaab'
+    it("encodes 'Z' to 'bbaab'", async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('Z', {
+        bacon: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('bbaab');
+    });
+  });
+
+  describe('encode — word', () => {
+    // H=7=00111→'aabbb', E=4=00100→'aabaa', L=11=01011→'ababb', O=14=01110→'abbba'
+    it("encodes 'hello' to correct 5-char groups separated by spaces", async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('hello', {
+        bacon: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'aabbb aabaa ababb ababb abbba',
+      );
+      expect(boxes[0].props.name).toBe('Bacon Cipher (Encode)');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('drops non-letter characters during encode', async () => {
+      // "A B" → 'aaaaa aaaab' (space in input dropped, codes space-separated)
+      const boxes = await BaconCipherBoxSource.generateBoxes('A B', {
+        bacon: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('aaaaa aaaab');
+    });
+  });
+
+  describe('decode', () => {
+    it("decodes 'aabbb aabaa ababb ababb abbba' to 'hello'", async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes(
+        'aabbb aabaa ababb ababb abbba',
+        { bacondecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+      expect(boxes[0].props.name).toBe('Bacon Cipher (Decode)');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('decode is case-insensitive for the a/b input', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('AAAAA', {
+        bacondecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a');
+    });
+
+    it('ignores incomplete trailing group', async () => {
+      // 'aaaaa' + 'aa' (incomplete) → 'a'
+      const boxes = await BaconCipherBoxSource.generateBoxes('aaaaaa a', {
+        bacondecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encode then decode returns the original letters lowercased', async () => {
+      const word = 'WORLD';
+      const encoded = await BaconCipherBoxSource.generateBoxes(word, {
+        bacon: true,
+      });
+      const encodedText = encoded[0].props.plaintextOutput;
+
+      const decoded = await BaconCipherBoxSource.generateBoxes(encodedText, {
+        bacondecode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe(word.toLowerCase());
+    });
+  });
+
+  describe('both options', () => {
+    it('returns 2 boxes when both ::bacon and ::bacondecode are set', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('hello', {
+        bacon: true,
+        bacondecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Bacon Cipher (Encode)');
+      expect(names).toContain('Bacon Cipher (Decode)');
+    });
+  });
+
+  describe('::baconencode alias', () => {
+    it('responds to ::baconencode the same as ::bacon', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('A', {
+        baconencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('aaaaa');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/DotEnvBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DotEnvBoxSource.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { DotEnvBoxSource } from '../DotEnvBoxSource';
+
+describe('DotEnvBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no matching option is provided', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('API_KEY=abc', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when unrelated option is provided', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('API_KEY=abc', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert env to JSON with ::dotenv option', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes(
+        'API_KEY=abc123\nDEBUG=true',
+        { dotenv: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Dotenv → JSON');
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ API_KEY: 'abc123', DEBUG: 'true' });
+    });
+
+    it('should skip comment lines and strip surrounding quotes', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes(
+        '# comment\nNAME="John Doe"',
+        { dotenv: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ NAME: 'John Doe' });
+    });
+
+    it('should convert JSON to env with ::dotenv option when input starts with {', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes(
+        '{"PORT":"3000","MSG":"hello world"}',
+        { dotenv: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → Dotenv');
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('PORT=3000');
+      // value with space must be double-quoted
+      expect(output).toContain('MSG="hello world"');
+    });
+
+    it('should split on the first = only, preserving = in the value', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes(
+        'URL=http://a.com?x=1',
+        { dotenv: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed.URL).toBe('http://a.com?x=1');
+    });
+
+    it('should return an error box for invalid JSON-looking input', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('{bad}', {
+        dotenv: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('Error');
+    });
+
+    it('should also trigger on ::envjson option', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('KEY=val', {
+        envjson: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ KEY: 'val' });
+    });
+
+    it('should quote values containing #', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('{"COLOR":"#ff0000"}', {
+        dotenv: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('COLOR="#ff0000"');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/FullwidthBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FullwidthBoxSource.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { FullwidthBoxSource } from '../FullwidthBoxSource';
+
+describe('FullwidthBoxSource', () => {
+  describe('generateBoxes — guard conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is empty string', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('', {
+        fullwidth: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ASCII to fullwidth', () => {
+    it('converts ASCII letters with +0xFEE0 offset', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Hello', {
+        fullwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      // 'H' (0x48) should become U+FF28
+      expect(output.codePointAt(0)).toBe('H'.charCodeAt(0) + 0xfee0);
+      expect(output).toBe('Ｈｅｌｌｏ');
+    });
+
+    it('maps ASCII space to ideographic space U+3000', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('a b', {
+        fullwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      // index 1 should be U+3000
+      expect(output.codePointAt(1)).toBe(0x3000);
+      expect(output).toBe('ａ　ｂ');
+    });
+
+    it('accepts ::tofullwidth alias', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Hi', {
+        tofullwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Fullwidth');
+    });
+  });
+
+  describe('decode — fullwidth to ASCII', () => {
+    it('converts fullwidth letters back to ASCII', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Ｈｉ', {
+        halfwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('accepts ::fromfullwidth alias', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Ｈｉ', {
+        fromfullwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Halfwidth');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('halfwidth(fullwidth(input)) === original for ASCII printable + space', async () => {
+      const original = 'Hello 123!';
+
+      const encoded = await FullwidthBoxSource.generateBoxes(original, {
+        fullwidth: true,
+      });
+      expect(encoded).toHaveLength(1);
+      const fullwidthStr = encoded[0].props.plaintextOutput;
+
+      const decoded = await FullwidthBoxSource.generateBoxes(fullwidthStr, {
+        halfwidth: true,
+      });
+      expect(decoded).toHaveLength(1);
+      expect(decoded[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('both options produce two boxes', () => {
+    it('returns a Fullwidth box and a Halfwidth box', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Hi', {
+        fullwidth: true,
+        halfwidth: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Fullwidth');
+      expect(boxes[1].props.name).toBe('Halfwidth');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets priority and disables expand button', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Hello', {
+        fullwidth: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/IbanBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/IbanBoxSource.test.ts
@@ -1,0 +1,88 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { expect } from 'vitest';
+
+import { IbanBoxSource } from '../IbanBoxSource';
+
+describe('IbanBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no ::iban option is present', async () => {
+      const boxes = await IbanBoxSource.generateBoxes(
+        'GB82 WEST 1234 5698 7654 32',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when a different option is present', async () => {
+      const boxes = await IbanBoxSource.generateBoxes(
+        'GB82 WEST 1234 5698 7654 32',
+        { qr: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — structural validation', () => {
+    it('returns [] for malformed input "12XX"', async () => {
+      const boxes = await IbanBoxSource.generateBoxes('12XX', { iban: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for plaintext "hello"', async () => {
+      const boxes = await IbanBoxSource.generateBoxes('hello', { iban: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — valid IBANs', () => {
+    it('validates GB82 (UK) — mod-97 passes, Valid true', async () => {
+      const boxes = await IbanBoxSource.generateBoxes(
+        'GB82 WEST 1234 5698 7654 32',
+        { iban: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.IBAN).toBe('GB82WEST12345698765432');
+      expect(options?.Country).toBe('GB');
+      expect(options?.['Check Digits']).toBe('82');
+      expect(options?.Valid).toBe('true');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('validates DE89 (Germany) — mod-97 passes, Valid true', async () => {
+      const boxes = await IbanBoxSource.generateBoxes(
+        'DE89 3704 0044 0532 0130 00',
+        { iban: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.IBAN).toBe('DE89370400440532013000');
+      expect(options?.Country).toBe('DE');
+      expect(options?.['Check Digits']).toBe('89');
+      expect(options?.Valid).toBe('true');
+    });
+
+    it('validates FR14 (France, alphanumeric BBAN) — mod-97 passes, Valid true', async () => {
+      const boxes = await IbanBoxSource.generateBoxes(
+        'FR14 2004 1010 0505 0001 3M02 606',
+        { iban: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Valid).toBe('true');
+      expect(boxes[0].props.options?.Country).toBe('FR');
+    });
+  });
+
+  describe('generateBoxes — invalid checksum', () => {
+    it('returns Valid "false" for GB82 WEST 1234 5698 7654 33 (wrong check digit)', async () => {
+      const boxes = await IbanBoxSource.generateBoxes(
+        'GB82 WEST 1234 5698 7654 33',
+        { iban: true },
+      );
+      // structurally valid but mod-97 fails → box is returned with Valid false
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Valid).toBe('false');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JsonFlattenBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonFlattenBoxSource.test.ts
@@ -138,5 +138,16 @@ describe('JsonFlattenBoxSource', () => {
       expect(boxes).toHaveLength(1);
       expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
     });
+
+    it('unflatten does not pollute Object.prototype via __proto__ key', async () => {
+      await JsonFlattenBoxSource.generateBoxes('{"__proto__.polluted":"x"}', {
+        unflatten: true,
+      });
+      await JsonFlattenBoxSource.generateBoxes(
+        '{"constructor.prototype.polluted":"x"}',
+        { unflatten: true },
+      );
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
   });
 });

--- a/src/modules/boxSources/__test__/JsonFlattenBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonFlattenBoxSource.test.ts
@@ -1,0 +1,142 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { JsonFlattenBoxSource } from '../JsonFlattenBoxSource';
+
+describe('JsonFlattenBoxSource', () => {
+  describe('no option → empty array', () => {
+    it('returns [] when no flatten/unflatten option is given', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes(
+        '{"a":{"b":1}}',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are given', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{"a":1}', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('flatten', () => {
+    it('flattens nested JSON to dot/bracket keys', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes(
+        '{"a":{"b":1,"c":[2,3]}}',
+        { flatten: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON Flatten');
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+      expect(boxes[0].props.options).toEqual({ language: 'json' });
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ 'a.b': 1, 'a.c[0]': 2, 'a.c[1]': 3 });
+    });
+
+    it('accepts ::jsonflatten alias', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{"x":{"y":42}}', {
+        jsonflatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ 'x.y': 42 });
+    });
+
+    it('handles empty object as leaf value', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{"a":{}}', {
+        flatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: {} });
+    });
+
+    it('handles empty array as leaf value', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{"a":[]}', {
+        flatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: [] });
+    });
+
+    it('handles null and boolean primitives', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes(
+        '{"a":null,"b":true,"c":false}',
+        { flatten: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: null, b: true, c: false });
+    });
+  });
+
+  describe('unflatten', () => {
+    it('rebuilds nested JSON from flat dot/bracket keys', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes(
+        '{"a.b":1,"a.c[0]":2,"a.c[1]":3}',
+        { unflatten: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON Flatten');
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: { b: 1, c: [2, 3] } });
+    });
+
+    it('accepts ::jsonunflatten alias', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{"x.y":42}', {
+        jsonunflatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ x: { y: 42 } });
+    });
+  });
+
+  describe('round-trip', () => {
+    it('unflatten(flatten(x)) deep-equals x', async () => {
+      const fixture = {
+        a: { b: 1, c: [2, 3] },
+        d: { e: { f: 'hello' } },
+        g: [true, null, 0],
+      };
+      const flatBoxes = await JsonFlattenBoxSource.generateBoxes(
+        JSON.stringify(fixture),
+        { flatten: true },
+      );
+      expect(flatBoxes).toHaveLength(1);
+
+      const flatJson = flatBoxes[0].props.plaintextOutput;
+
+      const unflatBoxes = await JsonFlattenBoxSource.generateBoxes(flatJson, {
+        unflatten: true,
+      });
+      expect(unflatBoxes).toHaveLength(1);
+
+      const result = JSON.parse(unflatBoxes[0].props.plaintextOutput);
+      expect(result).toEqual(fixture);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns an error box for invalid JSON with ::flatten', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{bad}', {
+        flatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON Flatten');
+      // error box output should mention the failure
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+
+    it('returns an error box for invalid JSON with ::unflatten', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{bad}', {
+        unflatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PxRemBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PxRemBoxSource.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { PxRemBoxSource } from '../PxRemBoxSource';
+
+describe('PxRemBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no option key is present', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('24px', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options object lacks pxrem/rempx', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('24px', { foo: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert px to rem with default base (24px → rem 1.5)', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('24px', { pxrem: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.px).toBe('24');
+      expect(opts?.rem).toBe('1.5');
+      expect(opts?.Base).toBe('16px');
+    });
+
+    it('should convert rem to px with default base (1.5rem → px 24)', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('1.5rem', {
+        pxrem: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.px).toBe('24');
+      expect(opts?.rem).toBe('1.5');
+      expect(opts?.Base).toBe('16px');
+    });
+
+    it('should use custom base from option value (20px + ::pxrem=10 → rem 2)', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('20px', { pxrem: '10' });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.px).toBe('20');
+      expect(opts?.rem).toBe('2');
+      expect(opts?.Base).toBe('10px');
+    });
+
+    it('should treat unitless input as px (32 + ::pxrem → rem 2)', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('32', { pxrem: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.px).toBe('32');
+      expect(opts?.rem).toBe('2');
+    });
+
+    it('should return empty array for non-numeric input', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('abc', { pxrem: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should work with rempx option key', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('1rem', { rempx: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.px).toBe('16');
+      expect(opts?.rem).toBe('1');
+    });
+
+    it('should use KeyValueBoxTemplate', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('24px', { pxrem: true });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+
+    it('should set priority from source priority', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('24px', { pxrem: true });
+      expect(boxes[0].props.priority).toBe(PxRemBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/TimezoneConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TimezoneConvertBoxSource.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { TimezoneConvertBoxSource } from '../TimezoneConvertBoxSource';
+
+const { generateBoxes } = TimezoneConvertBoxSource;
+
+describe('TimezoneConvertBoxSource', () => {
+  it('returns [] when no trigger option is present', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', null);
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when unrelated options are present', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', { foo: 'bar' });
+    expect(boxes).toEqual([]);
+  });
+
+  it('converts UTC input to Asia/Tokyo correctly', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', {
+      tzconvert: 'Asia/Tokyo',
+    });
+    expect(boxes).toHaveLength(1);
+
+    const opts = boxes[0].props.options as Record<string, string>;
+    // UTC should round-trip unchanged
+    expect(opts.UTC).toBe('2024-01-01T12:00:00.000Z');
+    // Tokyo is UTC+9, so 12:00 UTC → 21:00 JST on the same calendar date
+    expect(opts['Local Time']).toContain('21:00:00');
+    expect(opts['Local Time']).toContain('2024-01-01');
+    expect(opts.Zone).toBe('Asia/Tokyo');
+  });
+
+  it('handles ::intz alias the same way', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', {
+      intz: 'Asia/Tokyo',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Local Time']).toContain('21:00:00');
+  });
+
+  it('converts to UTC zone correctly', async () => {
+    const boxes = await generateBoxes('2024-06-15T00:00:00Z', {
+      tzconvert: 'UTC',
+    });
+    expect(boxes).toHaveLength(1);
+
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Local Time']).toContain('2024-06-15');
+    expect(opts['Local Time']).toContain('00:00:00');
+  });
+
+  it('returns an error box for an invalid IANA zone', async () => {
+    const boxes = await generateBoxes('2024-01-01T00:00:00Z', {
+      tzconvert: 'Not/AZone',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toMatch(/not a valid.*timezone/i);
+  });
+
+  it('returns an error box for an unparseable date string', async () => {
+    const boxes = await generateBoxes('notadate', { tzconvert: 'UTC' });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toMatch(/not a valid date/i);
+  });
+
+  it('returns an error box when zone value is missing (bare flag)', async () => {
+    // hasOptionKeys returns true for boolean true values, but getZone returns null
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', {
+      tzconvert: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toMatch(/required/i);
+  });
+
+  it('returns an error box when zone is an empty string', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', {
+      tzconvert: '',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toMatch(/required/i);
+  });
+
+  it('treats empty input string as "now" and returns a result', async () => {
+    const boxes = await generateBoxes('', { tzconvert: 'UTC' });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Zone).toBe('UTC');
+    // just verify it produced a date-like string
+    expect(opts['Local Time']).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('treats "now" (case-insensitive) as current time', async () => {
+    const boxes = await generateBoxes('NOW', { tzconvert: 'UTC' });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Local Time']).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('includes Offset in the output options', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', {
+      tzconvert: 'Asia/Tokyo',
+    });
+    const opts = boxes[0].props.options as Record<string, string>;
+    // Tokyo offset is GMT+9
+    expect(opts.Offset).toContain('+9');
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,3 +1,5 @@
+import A1Z26BoxSource from './A1Z26BoxSource';
+import BaconCipherBoxSource from './BaconCipherBoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
@@ -6,20 +8,26 @@ import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DotEnvBoxSource from './DotEnvBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FullwidthBoxSource from './FullwidthBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import IbanBoxSource from './IbanBoxSource';
+import JsonFlattenBoxSource from './JsonFlattenBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PxRemBoxSource from './PxRemBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import TimezoneConvertBoxSource from './TimezoneConvertBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
@@ -31,21 +39,29 @@ export const boxSources = [
   ColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  A1Z26BoxSource,
+  BaconCipherBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  DotEnvBoxSource,
+  FullwidthBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  IbanBoxSource,
+  JsonFlattenBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  PxRemBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
+  TimezoneConvertBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
   TimestampBoxSource,


### PR DESCRIPTION
## Summary

Tenth exploration batch — **8 more BoxSource tools** (validation, JSON, frontend, ciphers).

| Tool | Trigger | What it does |
|------|---------|--------------|
| IBAN | `::iban` | validate IBAN via ISO 7064 mod-97 |
| JSON Flatten | `::flatten` / `::unflatten` | nested JSON ⇄ dot/bracket keys |
| Timezone Convert | `::tzconvert=ZONE` | show a time in a target IANA zone (Intl) |
| px / rem | `::pxrem` | convert with a configurable root font size |
| Dotenv / JSON | `::dotenv` | .env ⇄ JSON, auto-direction |
| A1Z26 | `::a1z26` / `::a1z26decode` | letter ⇄ position-number cipher |
| Fullwidth | `::fullwidth` / `::halfwidth` | ASCII ⇄ fullwidth Unicode |
| Bacon Cipher | `::bacon` / `::bacondecode` | Baconian 5-bit A/B groups |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Each prompt explicitly banned `BigInt(Number.parseInt())` (the bug that recurred in batches 8–9) — IBAN uses `BigInt(numericString)` directly.
- **Verified vectors**: IBAN GB/DE/FR all pass mod-97; Bacon `A`→`aaaaa`, `Z`→`bbaab`, `hello`→`aabbb aabaa ababb ababb abbba`; Fullwidth `+0xFEE0` with space→U+3000.
- Timezone Convert deliberately uses `::tzconvert`/`::intz` to avoid CronExpression's deprecated `::tz`/`::timezone` keys.
- Self-review fixed two error-message test-wording mismatches before opening.

## Verification

- ✅ `bun run test run` — **420 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#268 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6