### PR TITLE
feat(boxSources): add 8 more tools (json→ts, json→go, curl→fetch, time-ago, color-adjust, sql-in, currency, csv-column)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,79 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>JsonToTypescriptBox</b> </summary>
+
+| match rule       | description                          | example                  |
+| ---------------- | ------------------------------------ | ------------------------ |
+| `::tsinterface`  | generate a TypeScript interface from JSON | `{"id":1} ::tsinterface` |
+
+</details>
+
+<details>
+<summary> <b>JsonToGoBox</b> </summary>
+
+| match rule     | description                          | example               |
+| -------------- | ------------------------------------ | --------------------- |
+| `::gostruct`   | generate a Go struct from JSON       | `{"id":1} ::gostruct` |
+
+</details>
+
+<details>
+<summary> <b>CurlToFetchBox</b> </summary>
+
+| match rule       | description                          | example                       |
+| ---------------- | ------------------------------------ | ----------------------------- |
+| `::curl2fetch`   | convert a curl command to fetch()    | `curl https://api.x.com ::curl2fetch` |
+
+</details>
+
+<details>
+<summary> <b>TimeAgoBox</b> </summary>
+
+| match rule    | description                          | example                       |
+| ------------- | ------------------------------------ | ----------------------------- |
+| `::timeago`   | relative time of a date ("3 days ago") | `2020-01-01 ::timeago`      |
+
+</details>
+
+<details>
+<summary> <b>ColorAdjustBox</b> </summary>
+
+| match rule       | description                          | example               |
+| ---------------- | ------------------------------------ | --------------------- |
+| `::lighten=N`    | lighten a hex color by N%            | `#ff6347 ::lighten=20` |
+| `::darken=N`     | darken a hex color by N%             | `#ff6347 ::darken=20`  |
+
+</details>
+
+<details>
+<summary> <b>SqlInBox</b> </summary>
+
+| match rule  | description                          | example                  |
+| ----------- | ------------------------------------ | ------------------------ |
+| `::sqlin`   | list → SQL `IN (...)` clause         | `apple,banana ::sqlin`   |
+
+</details>
+
+<details>
+<summary> <b>NumberToCurrencyBox</b> </summary>
+
+| match rule          | description                          | example                  |
+| ------------------- | ------------------------------------ | ------------------------ |
+| `::currency[=CODE]` | format a number as currency (default USD) | `1234.5 ::currency=EUR` |
+
+</details>
+
+<details>
+<summary> <b>CsvColumnBox</b> </summary>
+
+| match rule        | description                              | example                            |
+| ----------------- | ---------------------------------------- | ---------------------------------- |
+| `::csvcol=COL`    | extract a CSV column by index or header  | `name,email\nAlice,a@x.com ::csvcol=email` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/ColorAdjustBoxSource.ts
+++ b/src/modules/boxSources/ColorAdjustBoxSource.ts
@@ -131,6 +131,7 @@ export const ColorAdjustBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'lighten', 'darken')) return [];
+    if (input.length > 50) return [];
 
     const normalized = trim(input).toLowerCase();
     const rgb = parseHex(normalized);

--- a/src/modules/boxSources/ColorAdjustBoxSource.ts
+++ b/src/modules/boxSources/ColorAdjustBoxSource.ts
@@ -1,0 +1,174 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+interface HSL {
+  h: number;
+  s: number;
+  l: number;
+}
+
+// expand #RGB to #RRGGBB and validate; returns null for non-hex input
+function parseHex(input: string): RGB | null {
+  const m = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(input);
+  if (!m) return null;
+  const h = m[1];
+
+  if (h.length === 3) {
+    return {
+      r: Number.parseInt(h[0] + h[0], 16),
+      g: Number.parseInt(h[1] + h[1], 16),
+      b: Number.parseInt(h[2] + h[2], 16),
+    };
+  }
+
+  return {
+    r: Number.parseInt(h.slice(0, 2), 16),
+    g: Number.parseInt(h.slice(2, 4), 16),
+    b: Number.parseInt(h.slice(4, 6), 16),
+  };
+}
+
+// convert rgb (0-255 each) to hsl (h in degrees, s/l in 0-100)
+function rgbToHsl(r: number, g: number, b: number): HSL {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rn) {
+      h = 60 * (((gn - bn) / delta) % 6);
+    } else if (max === gn) {
+      h = 60 * ((bn - rn) / delta + 2);
+    } else {
+      h = 60 * ((rn - gn) / delta + 4);
+    }
+  }
+  if (h < 0) h += 360;
+
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  return {
+    h: Math.round(h),
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+}
+
+// convert hsl (h degrees, s/l percent 0-100) to rgb (0-255 each)
+function hslToRgb(h: number, s: number, l: number): RGB {
+  const sn = s / 100;
+  const ln = l / 100;
+  const c = (1 - Math.abs(2 * ln - 1)) * sn;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = ln - c / 2;
+
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  if (h < 60) {
+    [r, g, b] = [c, x, 0];
+  } else if (h < 120) {
+    [r, g, b] = [x, c, 0];
+  } else if (h < 180) {
+    [r, g, b] = [0, c, x];
+  } else if (h < 240) {
+    [r, g, b] = [0, x, c];
+  } else if (h < 300) {
+    [r, g, b] = [x, 0, c];
+  } else {
+    [r, g, b] = [c, 0, x];
+  }
+
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255),
+  };
+}
+
+// format an rgb value as a lowercase 6-digit hex string
+function rgbToHex({ r, g, b }: RGB): string {
+  const hex = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+// parse the option value as a percentage point integer (0-100); falls back to 10
+function parsePercent(val: string | boolean | null): number {
+  if (val === null || val === true || val === false) return 10;
+  const n = Number.parseFloat(String(val));
+  if (!Number.isFinite(n)) return 10;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+export const ColorAdjustBoxSource = {
+  name: 'Color Adjust',
+  description:
+    'Lighten or darken a hex color by a percentage. e.g. "#ff6347 ::lighten=20".',
+  defaultInput: '#ff6347 ::lighten=20',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'lighten', 'darken')) return [];
+
+    const normalized = trim(input).toLowerCase();
+    const rgb = parseHex(normalized);
+    if (!rgb) return [];
+
+    const lightenVal = extractOptionKeys(options, 'lighten');
+    const darkenVal = extractOptionKeys(options, 'darken');
+
+    // lighten takes precedence when both are present
+    const isDarken = lightenVal === null && darkenVal !== null;
+    const delta = isDarken ? parsePercent(darkenVal) : parsePercent(lightenVal);
+    const operation = isDarken ? 'darken' : 'lighten';
+
+    const hsl = rgbToHsl(rgb.r, rgb.g, rgb.b);
+    const newL = isDarken
+      ? Math.max(0, hsl.l - delta)
+      : Math.min(100, hsl.l + delta);
+
+    const adjustedRgb = hslToRgb(hsl.h, hsl.s, newL);
+    const originalHex = rgbToHex(rgb);
+    const adjustedHex = rgbToHex(adjustedRgb);
+
+    const outputOptions: Record<string, string> = {
+      Original: originalHex,
+      Adjusted: adjustedHex,
+      Operation: `${operation} ${delta}%`,
+    };
+
+    const plaintextOutput = `Original: ${originalHex}\nAdjusted: ${adjustedHex}\nOperation: ${operation} ${delta}%`;
+
+    return [
+      new BoxBuilder('Color Adjust', plaintextOutput)
+        .setOptions(outputOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ColorAdjustBoxSource;

--- a/src/modules/boxSources/CsvColumnBoxSource.ts
+++ b/src/modules/boxSources/CsvColumnBoxSource.ts
@@ -1,0 +1,129 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// parses a single CSV row, handling quoted fields and "" escapes
+function parseCsvRow(row: string): string[] {
+  const fields: string[] = [];
+  let i = 0;
+
+  while (i < row.length) {
+    if (row[i] === '"') {
+      // quoted field: consume until closing quote, unescape "" → "
+      let field = '';
+      i++; // skip opening quote
+      while (i < row.length) {
+        if (row[i] === '"') {
+          if (row[i + 1] === '"') {
+            field += '"';
+            i += 2;
+          } else {
+            i++; // skip closing quote
+            break;
+          }
+        } else {
+          field += row[i];
+          i++;
+        }
+      }
+      // skip optional comma after the closing quote
+      if (row[i] === ',') i++;
+      fields.push(field);
+    } else {
+      // unquoted field: read until next comma
+      const end = row.indexOf(',', i);
+      if (end === -1) {
+        fields.push(row.slice(i));
+        break;
+      }
+      fields.push(row.slice(i, end));
+      i = end + 1;
+    }
+  }
+
+  return fields;
+}
+
+export const CsvColumnBoxSource = {
+  name: 'CSV Column',
+  description:
+    'Extract one column from CSV by 0-based index or header name. e.g. ::csvcol=1 or ::csvcol=email.',
+  defaultInput: 'name,email\nAlice,a@x.com\nBob,b@y.com ::csvcol=email',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'csvcol', 'csvcolumn')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // selector is the option value (column index or header name)
+    const selectorRaw = extractOptionKeys(options, 'csvcol', 'csvcolumn');
+
+    // bare flag (true) means the option was provided without a value
+    if (selectorRaw === true || selectorRaw === null || selectorRaw === '') {
+      return [
+        new BoxBuilder(
+          'CSV Column',
+          'A column index or header name is required. e.g. ::csvcol=0 or ::csvcol=email',
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const selector = trim(String(selectorRaw));
+
+    // split lines, drop blanks
+    const lines = input.split('\n').filter((l) => l.trim() !== '');
+    if (lines.length === 0) return [];
+
+    const headerRow = parseCsvRow(lines[0]);
+    const dataRows = lines.slice(1).map(parseCsvRow);
+
+    // resolve column index
+    let colIndex: number;
+    if (/^\d+$/.test(selector)) {
+      colIndex = Number.parseInt(selector, 10);
+    } else {
+      // find header by trimmed case-sensitive match
+      colIndex = headerRow.findIndex((h) => trim(h) === selector);
+    }
+
+    if (colIndex < 0 || colIndex >= headerRow.length) {
+      return [
+        new BoxBuilder(
+          'CSV Column',
+          `Column not found: "${selector}". Available headers: ${headerRow.map(trim).join(', ')}`,
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const values = dataRows
+      .map((row) => (colIndex < row.length ? row[colIndex] : ''))
+      .join('\n');
+
+    return [
+      new BoxBuilder('CSV Column', values)
+        .setTemplate(CodeBoxTemplate)
+        .setShowExpandButton(true)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CsvColumnBoxSource;

--- a/src/modules/boxSources/CurlToFetchBoxSource.ts
+++ b/src/modules/boxSources/CurlToFetchBoxSource.ts
@@ -1,0 +1,206 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// flags that consume the next token as their value (skip both flag + value when unknown)
+const VALUE_FLAGS = new Set([
+  '-u',
+  '--user',
+  '-A',
+  '--user-agent',
+  '-o',
+  '--output',
+  '-m',
+  '--max-time',
+  '--connect-timeout',
+  '--max-redirs',
+  '-e',
+  '--referer',
+  '--cacert',
+  '--capath',
+  '--cert',
+  '--key',
+  '-x',
+  '--proxy',
+  '--proxy-user',
+  '-F',
+  '--form',
+  '--cookie',
+  '-b',
+  '--cookie-jar',
+  '-c',
+]);
+
+// tokenize a shell-like string respecting single/double quotes
+function tokenize(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let i = 0;
+  const len = input.length;
+
+  while (i < len) {
+    const ch = input[i];
+
+    if (ch === "'" || ch === '"') {
+      // collect until matching closing quote
+      const quote = ch;
+      i++;
+      while (i < len && input[i] !== quote) {
+        current += input[i];
+        i++;
+      }
+      i++; // skip closing quote
+    } else if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+      i++;
+    } else {
+      current += ch;
+      i++;
+    }
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+interface ParsedCurl {
+  url: string | null;
+  method: string | null;
+  headers: Record<string, string>;
+  body: string | null;
+}
+
+function parseCurl(raw: string): ParsedCurl {
+  const tokens = tokenize(raw);
+
+  let url: string | null = null;
+  let method: string | null = null;
+  const headers: Record<string, string> = {};
+  let body: string | null = null;
+
+  // skip the leading 'curl' token
+  let i = tokens[0]?.toLowerCase() === 'curl' ? 1 : 0;
+
+  while (i < tokens.length) {
+    const tok = tokens[i];
+
+    if (tok === '-X' || tok === '--request') {
+      i++;
+      if (i < tokens.length) {
+        method = tokens[i].toUpperCase();
+      }
+    } else if (tok === '-H' || tok === '--header') {
+      i++;
+      if (i < tokens.length) {
+        const colon = tokens[i].indexOf(':');
+        if (colon !== -1) {
+          const key = tokens[i].slice(0, colon).trim();
+          const val = tokens[i].slice(colon + 1).trim();
+          headers[key] = val;
+        }
+      }
+    } else if (tok === '-d' || tok === '--data' || tok === '--data-raw') {
+      i++;
+      if (i < tokens.length) {
+        body = tokens[i];
+      }
+    } else if (VALUE_FLAGS.has(tok)) {
+      // skip the value token
+      i++;
+    } else if (tok.startsWith('-')) {
+      // unknown flag, skip just the flag token
+    } else {
+      // bare token: treat as URL if we haven't found one yet
+      if (url === null) {
+        url = tok;
+      }
+    }
+
+    i++;
+  }
+
+  return { url, method, headers, body };
+}
+
+function buildFetchSnippet(parsed: ParsedCurl): string {
+  const { url, method, headers, body } = parsed;
+
+  // resolve the effective method
+  let effectiveMethod = method;
+  if (effectiveMethod === null) {
+    effectiveMethod = body !== null ? 'POST' : 'GET';
+  }
+
+  const lines: string[] = [];
+  lines.push(`fetch("${url}", {`);
+
+  const optionLines: string[] = [];
+  optionLines.push(`  method: "${effectiveMethod}"`);
+
+  const headerKeys = Object.keys(headers);
+  if (headerKeys.length > 0) {
+    const headerLines = headerKeys.map((k) => `    "${k}": "${headers[k]}"`);
+    optionLines.push(`  headers: {\n${headerLines.join(',\n')}\n  }`);
+  }
+
+  if (body !== null) {
+    optionLines.push(`  body: '${body}'`);
+  }
+
+  lines.push(optionLines.join(',\n'));
+  lines.push('});');
+
+  return lines.join('\n');
+}
+
+export const CurlToFetchBoxSource = {
+  name: 'curl to fetch',
+  description: 'Convert a curl command into a JavaScript fetch() snippet.',
+  defaultInput:
+    "curl -X POST https://api.example.com -H 'Content-Type: application/json' -d '{\"a\":1}' ::curl2fetch",
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'curl2fetch', 'curltofetch')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const raw = trim(input);
+    const parsed = parseCurl(raw);
+
+    if (parsed.url === null) {
+      const errorOutput = 'Error: no URL found in the curl command.';
+      return [
+        new BoxBuilder('curl to fetch', errorOutput)
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    const snippet = buildFetchSnippet(parsed);
+
+    return [
+      new BoxBuilder('curl to fetch', snippet)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default CurlToFetchBoxSource;

--- a/src/modules/boxSources/CurlToFetchBoxSource.ts
+++ b/src/modules/boxSources/CurlToFetchBoxSource.ts
@@ -46,12 +46,18 @@ function tokenize(input: string): string[] {
     const ch = input[i];
 
     if (ch === "'" || ch === '"') {
-      // collect until matching closing quote
+      // collect until matching closing quote; honor backslash escapes inside
+      // double quotes (e.g. -d "{\"k\":1}")
       const quote = ch;
       i++;
       while (i < len && input[i] !== quote) {
-        current += input[i];
-        i++;
+        if (quote === '"' && input[i] === '\\' && i + 1 < len) {
+          current += input[i + 1];
+          i += 2;
+        } else {
+          current += input[i];
+          i++;
+        }
       }
       i++; // skip closing quote
     } else if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
@@ -142,19 +148,23 @@ function buildFetchSnippet(parsed: ParsedCurl): string {
   }
 
   const lines: string[] = [];
-  lines.push(`fetch("${url}", {`);
+  // JSON.stringify every interpolated value so quotes/specials in the curl
+  // command can't produce broken JavaScript
+  lines.push(`fetch(${JSON.stringify(url)}, {`);
 
   const optionLines: string[] = [];
-  optionLines.push(`  method: "${effectiveMethod}"`);
+  optionLines.push(`  method: ${JSON.stringify(effectiveMethod)}`);
 
   const headerKeys = Object.keys(headers);
   if (headerKeys.length > 0) {
-    const headerLines = headerKeys.map((k) => `    "${k}": "${headers[k]}"`);
+    const headerLines = headerKeys.map(
+      (k) => `    ${JSON.stringify(k)}: ${JSON.stringify(headers[k])}`,
+    );
     optionLines.push(`  headers: {\n${headerLines.join(',\n')}\n  }`);
   }
 
   if (body !== null) {
-    optionLines.push(`  body: '${body}'`);
+    optionLines.push(`  body: ${JSON.stringify(body)}`);
   }
 
   lines.push(optionLines.join(',\n'));
@@ -187,7 +197,7 @@ export const CurlToFetchBoxSource = {
       return [
         new BoxBuilder('curl to fetch', errorOutput)
           .setTemplate(CodeBoxTemplate)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       ];
     }

--- a/src/modules/boxSources/JsonToGoBoxSource.ts
+++ b/src/modules/boxSources/JsonToGoBoxSource.ts
@@ -1,0 +1,154 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// common initialisms golint expects fully upper-cased in Go identifiers
+const INITIALISMS = new Set([
+  'ID',
+  'URL',
+  'URI',
+  'API',
+  'HTTP',
+  'HTTPS',
+  'JSON',
+  'XML',
+  'HTML',
+  'SQL',
+  'UUID',
+  'IP',
+  'TCP',
+  'UDP',
+  'DB',
+]);
+
+// converts a JSON key to a PascalCase Go identifier, upper-casing known
+// initialisms (id → ID) per Go naming conventions
+function toPascalCase(key: string): string {
+  const pascal = key
+    .replace(/[-_\s]+(.)/g, (_, ch: string) => ch.toUpperCase())
+    .replace(/^(.)/, (ch: string) => ch.toUpperCase());
+  return INITIALISMS.has(pascal.toUpperCase()) ? pascal.toUpperCase() : pascal;
+}
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+// returns the Go type string for a JSON value, collecting nested struct definitions into structs
+function goTypeOf(
+  value: JsonValue,
+  fieldName: string,
+  structs: Map<string, string>,
+): string {
+  if (value === null) return 'interface{}';
+  if (typeof value === 'boolean') return 'bool';
+  if (typeof value === 'string') return 'string';
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? 'int' : 'float64';
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]interface{}';
+    const elemType = goTypeOf(value[0], fieldName, structs);
+    return `[]${elemType}`;
+  }
+  // object — generate a nested named struct
+  const structName = toPascalCase(fieldName);
+  collectStructs(value as { [key: string]: JsonValue }, structName, structs);
+  return structName;
+}
+
+// recursively builds struct definitions, depositing them into structs in dependency order
+function collectStructs(
+  obj: { [key: string]: JsonValue },
+  structName: string,
+  structs: Map<string, string>,
+): void {
+  const lines: string[] = [`type ${structName} struct {`];
+  for (const [key, value] of Object.entries(obj)) {
+    const goField = toPascalCase(key);
+    const goType = goTypeOf(value, key, structs);
+    lines.push(`\t${goField} ${goType} \`json:"${key}"\``);
+  }
+  lines.push('}');
+  // insert before any struct that references this one (depth-first post-order)
+  structs.set(structName, lines.join('\n'));
+}
+
+// generates Go struct code from a parsed JSON object
+function jsonToGo(parsed: { [key: string]: JsonValue }): string {
+  const structs = new Map<string, string>();
+  collectStructs(parsed, 'Root', structs);
+
+  // emit nested structs first (insertion order preserves depth-first post-order),
+  // then the Root struct last for readability
+  const entries = Array.from(structs.entries());
+  const rootIdx = entries.findIndex(([name]) => name === 'Root');
+  const [rootEntry] = entries.splice(rootIdx, 1);
+  entries.push(rootEntry);
+
+  return entries.map(([, def]) => def).join('\n\n');
+}
+
+export const JsonToGoBoxSource = {
+  name: 'JSON to Go',
+  description: 'Generate a Go struct from a JSON sample.',
+  defaultInput: '{"id":1,"name":"Bob"} ::gostruct',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'gostruct', 'jsontogo')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      const errorBox = new BoxBuilder('JSON to Go', 'Error: invalid JSON input')
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build();
+      return [errorBox];
+    }
+
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      const errorBox = new BoxBuilder(
+        'JSON to Go',
+        'Error: root value must be a JSON object',
+      )
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build();
+      return [errorBox];
+    }
+
+    const output = jsonToGo(parsed as { [key: string]: JsonValue });
+
+    const box = new BoxBuilder('JSON to Go', output)
+      .setTemplate(CodeBoxTemplate)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default JsonToGoBoxSource;

--- a/src/modules/boxSources/JsonToGoBoxSource.ts
+++ b/src/modules/boxSources/JsonToGoBoxSource.ts
@@ -26,12 +26,32 @@ const INITIALISMS = new Set([
 ]);
 
 // converts a JSON key to a PascalCase Go identifier, upper-casing known
-// initialisms (id → ID) per Go naming conventions
+// initialisms per word (user_id / userId → UserID) per Go naming conventions
 function toPascalCase(key: string): string {
-  const pascal = key
-    .replace(/[-_\s]+(.)/g, (_, ch: string) => ch.toUpperCase())
-    .replace(/^(.)/, (ch: string) => ch.toUpperCase());
-  return INITIALISMS.has(pascal.toUpperCase()) ? pascal.toUpperCase() : pascal;
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // split camelCase boundaries
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean);
+  const pascal = words
+    .map((w) => {
+      const upper = w.toUpperCase();
+      if (INITIALISMS.has(upper)) return upper;
+      return w.charAt(0).toUpperCase() + w.slice(1).toLowerCase();
+    })
+    .join('');
+  return pascal.length > 0 ? pascal : '_';
+}
+
+// make an identifier unique within a set (Foo, Foo2, Foo3, ...)
+function uniqueName(base: string, used: Set<string>): string {
+  let candidate = base;
+  let n = 2;
+  while (used.has(candidate)) {
+    candidate = `${base}${n}`;
+    n++;
+  }
+  used.add(candidate);
+  return candidate;
 }
 
 type JsonValue =
@@ -47,6 +67,7 @@ function goTypeOf(
   value: JsonValue,
   fieldName: string,
   structs: Map<string, string>,
+  usedStructNames: Set<string>,
 ): string {
   if (value === null) return 'interface{}';
   if (typeof value === 'boolean') return 'bool';
@@ -56,12 +77,17 @@ function goTypeOf(
   }
   if (Array.isArray(value)) {
     if (value.length === 0) return '[]interface{}';
-    const elemType = goTypeOf(value[0], fieldName, structs);
+    const elemType = goTypeOf(value[0], fieldName, structs, usedStructNames);
     return `[]${elemType}`;
   }
-  // object — generate a nested named struct
-  const structName = toPascalCase(fieldName);
-  collectStructs(value as { [key: string]: JsonValue }, structName, structs);
+  // object — generate a nested named struct with a unique name
+  const structName = uniqueName(toPascalCase(fieldName), usedStructNames);
+  collectStructs(
+    value as { [key: string]: JsonValue },
+    structName,
+    structs,
+    usedStructNames,
+  );
   return structName;
 }
 
@@ -70,11 +96,15 @@ function collectStructs(
   obj: { [key: string]: JsonValue },
   structName: string,
   structs: Map<string, string>,
+  usedStructNames: Set<string>,
 ): void {
   const lines: string[] = [`type ${structName} struct {`];
+  // dedupe field identifiers so keys that collide after PascalCase don't
+  // produce two fields with the same Go name (illegal Go)
+  const usedFields = new Set<string>();
   for (const [key, value] of Object.entries(obj)) {
-    const goField = toPascalCase(key);
-    const goType = goTypeOf(value, key, structs);
+    const goField = uniqueName(toPascalCase(key), usedFields);
+    const goType = goTypeOf(value, key, structs, usedStructNames);
     lines.push(`\t${goField} ${goType} \`json:"${key}"\``);
   }
   lines.push('}');
@@ -85,7 +115,8 @@ function collectStructs(
 // generates Go struct code from a parsed JSON object
 function jsonToGo(parsed: { [key: string]: JsonValue }): string {
   const structs = new Map<string, string>();
-  collectStructs(parsed, 'Root', structs);
+  const usedStructNames = new Set<string>(['Root']);
+  collectStructs(parsed, 'Root', structs, usedStructNames);
 
   // emit nested structs first (insertion order preserves depth-first post-order),
   // then the Root struct last for readability

--- a/src/modules/boxSources/JsonToTypescriptBoxSource.ts
+++ b/src/modules/boxSources/JsonToTypescriptBoxSource.ts
@@ -31,11 +31,28 @@ interface InterfaceDef {
   body: string;
 }
 
+// coerce a candidate name into a valid TS identifier, then make it unique so
+// keys that collide after PascalCase (e.g. my_data and myData) don't emit two
+// interfaces with the same name
+function uniqueIdentifier(name: string, used: Set<string>): string {
+  let base = name.replace(/[^A-Za-z0-9$]/g, '').replace(/^[0-9]/, '_$&');
+  if (base.length === 0) base = 'Anon';
+  let candidate = base;
+  let n = 2;
+  while (used.has(candidate)) {
+    candidate = `${base}${n}`;
+    n++;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
 // infers the TypeScript type string for a JSON value, collecting nested interface definitions
 function inferType(
   value: JsonValue,
   name: string,
   defs: InterfaceDef[],
+  used: Set<string>,
 ): string {
   if (value === null) return 'null';
   if (typeof value === 'string') return 'string';
@@ -44,18 +61,18 @@ function inferType(
 
   if (Array.isArray(value)) {
     if (value.length === 0) return 'unknown[]';
-    const elementType = inferType(value[0], `${name}Item`, defs);
+    const elementType = inferType(value[0], `${name}Item`, defs, used);
     return `${elementType}[]`;
   }
 
-  // object — emit a named interface
-  const ifaceName = name;
+  // object — emit a named interface with a guaranteed-unique, valid identifier
+  const ifaceName = uniqueIdentifier(name, used);
   const lines: string[] = [];
 
   for (const key of Object.keys(value as JsonObject)) {
     const fieldValue = (value as JsonObject)[key];
     const fieldTypeName = toPascalCase(key);
-    const fieldType = inferType(fieldValue, fieldTypeName, defs);
+    const fieldType = inferType(fieldValue, fieldTypeName, defs, used);
     const formattedKey = needsQuoting(key) ? `'${key}'` : key;
     lines.push(`  ${formattedKey}: ${fieldType};`);
   }
@@ -67,7 +84,7 @@ function inferType(
 // generates all TypeScript interface declarations from a parsed JSON object
 function generateInterfaces(parsed: JsonValue): string {
   const defs: InterfaceDef[] = [];
-  inferType(parsed, 'Root', defs);
+  inferType(parsed, 'Root', defs, new Set<string>());
 
   // emit nested interfaces before the root so references are declared first
   return defs.map((d) => `interface ${d.name} {\n${d.body}\n}`).join('\n\n');

--- a/src/modules/boxSources/JsonToTypescriptBoxSource.ts
+++ b/src/modules/boxSources/JsonToTypescriptBoxSource.ts
@@ -1,0 +1,120 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// reserved keys that would cause prototype pollution if written into a plain object
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+// returns a valid TS identifier check — keys containing spaces or special chars need quoting
+function needsQuoting(key: string): boolean {
+  return !/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) || UNSAFE_KEYS.has(key);
+}
+
+// converts a string to PascalCase for use as an interface name
+function toPascalCase(str: string): string {
+  return str
+    .replace(/[^A-Za-z0-9]+(.)/g, (_, ch: string) => ch.toUpperCase())
+    .replace(/^[a-z]/, (c) => c.toUpperCase());
+}
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+interface InterfaceDef {
+  name: string;
+  body: string;
+}
+
+// infers the TypeScript type string for a JSON value, collecting nested interface definitions
+function inferType(
+  value: JsonValue,
+  name: string,
+  defs: InterfaceDef[],
+): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return 'string';
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'boolean') return 'boolean';
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return 'unknown[]';
+    const elementType = inferType(value[0], `${name}Item`, defs);
+    return `${elementType}[]`;
+  }
+
+  // object — emit a named interface
+  const ifaceName = name;
+  const lines: string[] = [];
+
+  for (const key of Object.keys(value as JsonObject)) {
+    const fieldValue = (value as JsonObject)[key];
+    const fieldTypeName = toPascalCase(key);
+    const fieldType = inferType(fieldValue, fieldTypeName, defs);
+    const formattedKey = needsQuoting(key) ? `'${key}'` : key;
+    lines.push(`  ${formattedKey}: ${fieldType};`);
+  }
+
+  defs.push({ name: ifaceName, body: lines.join('\n') });
+  return ifaceName;
+}
+
+// generates all TypeScript interface declarations from a parsed JSON object
+function generateInterfaces(parsed: JsonValue): string {
+  const defs: InterfaceDef[] = [];
+  inferType(parsed, 'Root', defs);
+
+  // emit nested interfaces before the root so references are declared first
+  return defs.map((d) => `interface ${d.name} {\n${d.body}\n}`).join('\n\n');
+}
+
+export const JsonToTypescriptBoxSource = {
+  name: 'JSON to TypeScript',
+  description: 'Generate a TypeScript interface from a JSON sample.',
+  defaultInput:
+    '{"id":1,"name":"Bob","tags":["a"],"meta":{"ok":true}} ::tsinterface',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'tsinterface', 'jsontots')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    let parsed: JsonValue;
+    try {
+      parsed = JSON.parse(trimmed) as JsonValue;
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return [
+        new BoxBuilder(
+          'JSON to TypeScript',
+          `// invalid JSON — cannot generate TypeScript interface\n// ${message}`,
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const output = generateInterfaces(parsed);
+    return [
+      new BoxBuilder('JSON to TypeScript', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonToTypescriptBoxSource;

--- a/src/modules/boxSources/NumberToCurrencyBoxSource.ts
+++ b/src/modules/boxSources/NumberToCurrencyBoxSource.ts
@@ -1,0 +1,106 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length guard against pathological strings
+const MAX_INPUT_LENGTH = 50;
+
+// ISO 4217 currency code must be exactly 3 letters
+const CURRENCY_CODE_RE = /^[A-Za-z]{3}$/;
+
+// only accept plain decimal numbers (no exponents, no currency symbols)
+const NUMBER_RE = /^-?\d+(\.\d+)?$/;
+
+function resolveCurrencyCode(raw: string | boolean | null): string {
+  if (typeof raw === 'string' && CURRENCY_CODE_RE.test(raw)) {
+    return raw.toUpperCase();
+  }
+  return 'USD';
+}
+
+export const NumberToCurrencyBoxSource = {
+  name: 'Currency Format',
+  description:
+    'Format a number as currency. Use ::currency=EUR for a specific ISO 4217 code (default USD).',
+  defaultInput: '1234567.5 ::currency',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'currency')) return [];
+
+    const text = trim(input);
+    if (!text || text.length > MAX_INPUT_LENGTH) return [];
+    if (!NUMBER_RE.test(text)) return [];
+
+    const n = Number.parseFloat(text);
+    if (!Number.isFinite(n)) return [];
+
+    const rawCode = extractOptionKeys(options, 'currency');
+    // a present but malformed code (e.g. "US", "dollars") is an error; a bare
+    // flag / missing value defaults to USD. Intl accepts any well-formed
+    // 3-letter code, so this is the only reachable "invalid code" path.
+    if (
+      typeof rawCode === 'string' &&
+      rawCode.length > 0 &&
+      !CURRENCY_CODE_RE.test(rawCode)
+    ) {
+      const errorOutput = `Invalid currency code: "${rawCode}"`;
+      return [
+        new BoxBuilder('Currency Format', errorOutput)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: errorOutput })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+    const code = resolveCurrencyCode(rawCode ?? null);
+
+    // belt-and-suspenders: an unknown code throws RangeError from Intl.NumberFormat
+    let formatter: Intl.NumberFormat;
+    try {
+      formatter = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: code,
+      });
+    } catch {
+      // invalid ISO 4217 code — surface an error box rather than silently falling back
+      const errorOutput = `Invalid currency code: "${code}"`;
+      return [
+        new BoxBuilder('Currency Format', errorOutput)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: errorOutput })
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    const formatted = formatter.format(n);
+
+    // plain grouped number without currency symbol
+    const plain = new Intl.NumberFormat('en-US').format(n);
+
+    const output: Record<string, string> = {
+      Formatted: formatted,
+      Currency: code,
+      Plain: plain,
+    };
+
+    return [
+      new BoxBuilder('Currency Format', formatted)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberToCurrencyBoxSource;

--- a/src/modules/boxSources/NumberToCurrencyBoxSource.ts
+++ b/src/modules/boxSources/NumberToCurrencyBoxSource.ts
@@ -77,7 +77,7 @@ export const NumberToCurrencyBoxSource = {
         new BoxBuilder('Currency Format', errorOutput)
           .setTemplate(KeyValueBoxTemplate)
           .setOptions({ Error: errorOutput })
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       ];
     }

--- a/src/modules/boxSources/SqlInBoxSource.ts
+++ b/src/modules/boxSources/SqlInBoxSource.ts
@@ -1,0 +1,61 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// regex that matches pure integers and decimals (no leading sign other than minus)
+const NUMBER_RE = /^-?\d+(\.\d+)?$/;
+
+// format a single token for use inside a SQL IN list
+function formatToken(token: string): string {
+  if (NUMBER_RE.test(token)) {
+    return token;
+  }
+  // escape embedded single-quotes by doubling them
+  return `'${token.replaceAll("'", "''")}'`;
+}
+
+export const SqlInBoxSource = {
+  name: 'SQL IN Clause',
+  description:
+    'Turn a list of values (newline/comma separated) into a SQL IN (...) clause.',
+  defaultInput: 'apple\nbanana\ncherry ::sqlin',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'sqlin')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const items = trim(input)
+      .split(/[\n,]+/)
+      .map((item) => trim(item))
+      .filter((item) => item.length > 0);
+
+    if (items.length === 0) return [];
+
+    const clause = `IN (${items.map(formatToken).join(', ')})`;
+
+    return [
+      new BoxBuilder('SQL IN Clause', clause)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default SqlInBoxSource;

--- a/src/modules/boxSources/TimeAgoBoxSource.ts
+++ b/src/modules/boxSources/TimeAgoBoxSource.ts
@@ -1,0 +1,91 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// thresholds in milliseconds for choosing the largest sensible unit
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const MONTH_MS = 30 * DAY_MS;
+const YEAR_MS = 365 * DAY_MS;
+
+type RelativeUnit = 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second';
+
+// picks the largest sensible unit and returns value + unit for Intl.RelativeTimeFormat
+function pickUnit(diffMs: number): [number, RelativeUnit] {
+  const abs = Math.abs(diffMs);
+  const sign = diffMs < 0 ? -1 : 1;
+
+  if (abs >= YEAR_MS) return [sign * Math.round(abs / YEAR_MS), 'year'];
+  if (abs >= MONTH_MS) return [sign * Math.round(abs / MONTH_MS), 'month'];
+  if (abs >= DAY_MS) return [sign * Math.round(abs / DAY_MS), 'day'];
+  if (abs >= HOUR_MS) return [sign * Math.round(abs / HOUR_MS), 'hour'];
+  if (abs >= MINUTE_MS) return [sign * Math.round(abs / MINUTE_MS), 'minute'];
+  return [sign * Math.round(abs / 1000), 'second'];
+}
+
+// parses the trimmed input as a unix timestamp (10 = seconds, 13 = ms) or an ISO/parseable date string
+function parseInput(s: string): Date {
+  if (/^\d{10}$/.test(s)) {
+    return new Date(Number.parseInt(s, 10) * 1000);
+  }
+  if (/^\d{13}$/.test(s)) {
+    return new Date(Number.parseInt(s, 10));
+  }
+  return new Date(s);
+}
+
+export const TimeAgoBoxSource = {
+  name: 'Time Ago',
+  description:
+    'Show the relative time of a date (e.g. "3 days ago"). Accepts ISO dates or unix timestamps.',
+  defaultInput: '2020-01-01T00:00:00Z ::timeago',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'timeago', 'relativetime')) return [];
+
+    const raw = trim(input);
+    const date = parseInput(raw);
+
+    if (Number.isNaN(date.getTime())) {
+      const box = new BoxBuilder('Time Ago', `Invalid date: "${raw}"`)
+        .setOptions({ Error: `"${raw}" could not be parsed as a date` })
+        .setTemplate(KeyValueBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    const diffMs = date.getTime() - Date.now();
+    const [value, unit] = pickUnit(diffMs);
+    const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+    const relative = rtf.format(value, unit);
+
+    const direction = diffMs < -500 ? 'past' : diffMs > 500 ? 'future' : 'now';
+
+    const box = new BoxBuilder('Time Ago', relative)
+      .setOptions({
+        Relative: relative,
+        ISO: date.toISOString(),
+        Direction: direction,
+      })
+      .setTemplate(KeyValueBoxTemplate)
+      .setShowExpandButton(false)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default TimeAgoBoxSource;

--- a/src/modules/boxSources/TimeAgoBoxSource.ts
+++ b/src/modules/boxSources/TimeAgoBoxSource.ts
@@ -52,6 +52,7 @@ export const TimeAgoBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'timeago', 'relativetime')) return [];
+    if (input.length > 100) return [];
 
     const raw = trim(input);
     const date = parseInput(raw);

--- a/src/modules/boxSources/__test__/ColorAdjustBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ColorAdjustBoxSource.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { ColorAdjustBoxSource } from '../ColorAdjustBoxSource';
+
+describe('ColorAdjustBoxSource.generateBoxes', () => {
+  it('returns [] when no lighten/darken option is present', async () => {
+    const boxes = await ColorAdjustBoxSource.generateBoxes('#ff6347', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] for invalid color input', async () => {
+    const boxes = await ColorAdjustBoxSource.generateBoxes('notacolor', {
+      lighten: '20',
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('#000000 + ::lighten=50 → Adjusted #808080 (L 0%→50%)', async () => {
+    const boxes = await ColorAdjustBoxSource.generateBoxes('#000000', {
+      lighten: '50',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Original).toBe('#000000');
+    expect(opts.Adjusted).toBe('#808080');
+    expect(opts.Operation).toBe('lighten 50%');
+  });
+
+  it('#ffffff + ::darken=100 → Adjusted #000000', async () => {
+    const boxes = await ColorAdjustBoxSource.generateBoxes('#ffffff', {
+      darken: '100',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Adjusted).toBe('#000000');
+    expect(opts.Operation).toBe('darken 100%');
+  });
+
+  it('#ff6347 + ::lighten=0 → Adjusted equals original', async () => {
+    const boxes = await ColorAdjustBoxSource.generateBoxes('#ff6347', {
+      lighten: '0',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Original).toBe('#ff6347');
+    expect(opts.Adjusted).toBe('#ff6347');
+  });
+
+  it('short hex #f00 + ::darken=0 → Original #ff0000', async () => {
+    const boxes = await ColorAdjustBoxSource.generateBoxes('#f00', {
+      darken: '0',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Original).toBe('#ff0000');
+  });
+
+  it('lighten takes precedence when both lighten and darken are present', async () => {
+    const boxes = await ColorAdjustBoxSource.generateBoxes('#808080', {
+      lighten: '10',
+      darken: '10',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Operation).toMatch(/^lighten/);
+  });
+
+  it('box uses KeyValueBoxTemplate and correct priority', async () => {
+    const boxes = await ColorAdjustBoxSource.generateBoxes('#ff0000', {
+      lighten: '10',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.priority).toBe(10);
+    expect(boxes[0].boxTemplate).toBeDefined();
+  });
+});

--- a/src/modules/boxSources/__test__/CsvColumnBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CsvColumnBoxSource.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { CsvColumnBoxSource } from '../CsvColumnBoxSource';
+
+const CSV = 'name,email\nAlice,a@x.com\nBob,b@y.com';
+
+describe('CsvColumnBoxSource', () => {
+  describe('trigger guard', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('column selection by header name', () => {
+    it('extracts the email column by name', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: 'email',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a@x.com\nb@y.com');
+    });
+
+    it('extracts the name column by name', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: 'name',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Alice\nBob');
+    });
+  });
+
+  describe('column selection by index', () => {
+    it('extracts column 0 by index', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: '0',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Alice\nBob');
+    });
+
+    it('extracts column 1 by index', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a@x.com\nb@y.com');
+    });
+  });
+
+  describe('quoted fields', () => {
+    it('handles a field with an embedded comma inside quotes', async () => {
+      const input = 'a,b\n"x,y",2';
+      const boxes = await CsvColumnBoxSource.generateBoxes(input, {
+        csvcol: '0',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('x,y');
+    });
+
+    it('unescapes "" inside quoted fields', async () => {
+      const input = 'a,b\n"say ""hi""",2';
+      const boxes = await CsvColumnBoxSource.generateBoxes(input, {
+        csvcol: '0',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('say "hi"');
+    });
+  });
+
+  describe('error cases', () => {
+    it('returns an error box when header is not found', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: 'zzz',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/not found/i);
+    });
+
+    it('returns an error box for an out-of-range index', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: '5',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/not found/i);
+    });
+
+    it('returns an informational box when csvcol has no value (bare flag)', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/required/i);
+    });
+  });
+
+  describe('alternate trigger key', () => {
+    it('accepts ::csvcolumn as an alias', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcolumn: 'email',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a@x.com\nb@y.com');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(CsvColumnBoxSource.name).toBe('CSV Column');
+      expect(CsvColumnBoxSource.tag).toBe('#');
+      expect(CsvColumnBoxSource.kind).toBe('Analyze');
+      expect(typeof CsvColumnBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CurlToFetchBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CurlToFetchBoxSource.test.ts
@@ -50,7 +50,8 @@ describe('CurlToFetchBoxSource', () => {
     expect(out).toContain('method: "POST"');
     expect(out).toContain('"Content-Type": "application/json"');
     expect(out).toContain('body:');
-    expect(out).toContain('{"a":1}');
+    // the body is emitted as a properly-escaped JS string literal
+    expect(out).toContain(`body: ${JSON.stringify('{"a":1}')}`);
   });
 
   it('defaults to POST when -d is present but no -X', async () => {

--- a/src/modules/boxSources/__test__/CurlToFetchBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CurlToFetchBoxSource.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { CurlToFetchBoxSource } from '../CurlToFetchBoxSource';
+
+describe('CurlToFetchBoxSource', () => {
+  it('returns [] when option is absent', async () => {
+    const boxes = await CurlToFetchBoxSource.generateBoxes(
+      'curl https://api.example.com',
+      null,
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when unrelated options are present', async () => {
+    const boxes = await CurlToFetchBoxSource.generateBoxes(
+      'curl https://api.example.com',
+      { json: true },
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('handles a plain GET with ::curl2fetch', async () => {
+    const boxes = await CurlToFetchBoxSource.generateBoxes(
+      'curl https://api.example.com',
+      { curl2fetch: true },
+    );
+    expect(boxes).toHaveLength(1);
+    const out = boxes[0].props.plaintextOutput;
+    expect(out).toContain('fetch("https://api.example.com"');
+    expect(out).toContain('method: "GET"');
+  });
+
+  it('handles a plain GET with ::curltofetch alias', async () => {
+    const boxes = await CurlToFetchBoxSource.generateBoxes(
+      'curl https://api.example.com',
+      { curltofetch: true },
+    );
+    expect(boxes).toHaveLength(1);
+    const out = boxes[0].props.plaintextOutput;
+    expect(out).toContain('fetch("https://api.example.com"');
+  });
+
+  it('handles POST with method, header, and body', async () => {
+    const boxes = await CurlToFetchBoxSource.generateBoxes(
+      "curl -X POST https://x.com -H 'Content-Type: application/json' -d '{\"a\":1}'",
+      { curl2fetch: true },
+    );
+    expect(boxes).toHaveLength(1);
+    const out = boxes[0].props.plaintextOutput;
+    expect(out).toContain('fetch("https://x.com"');
+    expect(out).toContain('method: "POST"');
+    expect(out).toContain('"Content-Type": "application/json"');
+    expect(out).toContain('body:');
+    expect(out).toContain('{"a":1}');
+  });
+
+  it('defaults to POST when -d is present but no -X', async () => {
+    const boxes = await CurlToFetchBoxSource.generateBoxes(
+      "curl https://x.com -d 'hi'",
+      { curl2fetch: true },
+    );
+    expect(boxes).toHaveLength(1);
+    const out = boxes[0].props.plaintextOutput;
+    expect(out).toContain('method: "POST"');
+  });
+
+  it('returns an error box when no URL is found', async () => {
+    const boxes = await CurlToFetchBoxSource.generateBoxes('curl -X GET', {
+      curl2fetch: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const out = boxes[0].props.plaintextOutput;
+    expect(out.toLowerCase()).toContain('url');
+  });
+
+  it('respects --request as an alias for -X', async () => {
+    const boxes = await CurlToFetchBoxSource.generateBoxes(
+      'curl --request DELETE https://x.com/1',
+      { curl2fetch: true },
+    );
+    expect(boxes).toHaveLength(1);
+    const out = boxes[0].props.plaintextOutput;
+    expect(out).toContain('method: "DELETE"');
+  });
+
+  it('handles --header alias', async () => {
+    const boxes = await CurlToFetchBoxSource.generateBoxes(
+      "curl https://x.com --header 'Authorization: Bearer tok'",
+      { curl2fetch: true },
+    );
+    expect(boxes).toHaveLength(1);
+    const out = boxes[0].props.plaintextOutput;
+    expect(out).toContain('"Authorization": "Bearer tok"');
+  });
+
+  it('skips known value-taking flags without misidentifying their value as URL', async () => {
+    const boxes = await CurlToFetchBoxSource.generateBoxes(
+      'curl -u user:pass https://secure.example.com',
+      { curl2fetch: true },
+    );
+    expect(boxes).toHaveLength(1);
+    const out = boxes[0].props.plaintextOutput;
+    expect(out).toContain('fetch("https://secure.example.com"');
+  });
+});

--- a/src/modules/boxSources/__test__/JsonToGoBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonToGoBoxSource.test.ts
@@ -83,5 +83,25 @@ describe('JsonToGoBoxSource', () => {
       expect(boxes).toHaveLength(1);
       expect(boxes[0].props.plaintextOutput).toContain('Error:');
     });
+
+    it('upper-cases initialisms inside compound names (user_id → UserID)', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes('{"user_id":1}', {
+        gostruct: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain(
+        'UserID int `json:"user_id"`',
+      );
+    });
+
+    it('disambiguates fields that collide after PascalCase', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes(
+        '{"user_id":1,"userId":2}',
+        { gostruct: true },
+      );
+      const out = boxes[0].props.plaintextOutput;
+      // both keys map to UserID; the second is suffixed to stay valid Go
+      expect(out).toContain('UserID int `json:"user_id"`');
+      expect(out).toContain('UserID2 int `json:"userId"`');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/JsonToGoBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonToGoBoxSource.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonToGoBoxSource } from '../JsonToGoBoxSource';
+
+describe('JsonToGoBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no matching option is provided', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes('{"id":1}', null);
+      expect(boxes).toEqual([]);
+    });
+
+    it('should return [] when options do not include gostruct or jsontogo', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes('{"id":1}', {
+        json: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('should generate a Go struct for a simple object with ::gostruct', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes(
+        '{"id":1,"name":"Bob"}',
+        { gostruct: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('type Root struct {');
+      expect(out).toContain('ID int `json:"id"`');
+      expect(out).toContain('Name string `json:"name"`');
+    });
+
+    it('should also trigger on ::jsontogo', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes('{"id":1}', {
+        jsontogo: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('type Root struct {');
+    });
+
+    it('should use float64 for non-integer numbers', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes('{"price":1.5}', {
+        gostruct: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain(
+        'Price float64 `json:"price"`',
+      );
+    });
+
+    it('should use bool for boolean fields', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes('{"ok":true}', {
+        gostruct: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('Ok bool `json:"ok"`');
+    });
+
+    it('should use []string for string array fields', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes('{"tags":["a"]}', {
+        gostruct: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain(
+        'Tags []string `json:"tags"`',
+      );
+    });
+
+    it('should generate nested structs for object fields', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes(
+        '{"meta":{"ok":true}}',
+        { gostruct: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('type Meta struct {');
+      expect(out).toContain('Ok bool `json:"ok"`');
+      expect(out).toContain('Meta Meta `json:"meta"`');
+    });
+
+    it('should return an error box for invalid JSON', async () => {
+      const boxes = await JsonToGoBoxSource.generateBoxes('not-json', {
+        gostruct: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('Error:');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JsonToTypescriptBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonToTypescriptBoxSource.test.ts
@@ -95,5 +95,16 @@ describe('JsonToTypescriptBoxSource', () => {
       expect(boxes).toHaveLength(1);
       expect(boxes[0].props.plaintextOutput).toContain("'my-key': number;");
     });
+
+    it('disambiguates interface names that collide after PascalCase', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"my_data":{"x":1},"myData":{"y":"a"}}',
+        { tsinterface: true },
+      );
+      const out = boxes[0].props.plaintextOutput;
+      // two distinct interfaces, no duplicate name
+      expect(out).toContain('interface MyData {');
+      expect(out).toContain('interface MyData2 {');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/JsonToTypescriptBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonToTypescriptBoxSource.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonToTypescriptBoxSource } from '../JsonToTypescriptBoxSource';
+
+describe('JsonToTypescriptBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no matching option is provided', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"id":1}',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes('{"id":1}', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should generate a Root interface with primitive fields via ::tsinterface', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"id":1,"name":"Bob"}',
+        { tsinterface: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('interface Root {');
+      expect(output).toContain('id: number;');
+      expect(output).toContain('name: string;');
+    });
+
+    it('should also trigger via ::jsontots option key', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"active":true}',
+        { jsontots: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('interface Root {');
+    });
+
+    it('should emit a nested interface for object values', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"meta":{"ok":true}}',
+        { tsinterface: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('interface Meta {');
+      expect(output).toContain('ok: boolean;');
+      expect(output).toContain('meta: Meta;');
+    });
+
+    it('should type string arrays correctly', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"tags":["a","b"]}',
+        { tsinterface: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('tags: string[];');
+    });
+
+    it('should type empty arrays as unknown[]', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes('{"xs":[]}', {
+        tsinterface: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('xs: unknown[];');
+    });
+
+    it('should return an error box for invalid JSON', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes('{bad}', {
+        tsinterface: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      expect(output.toLowerCase()).toContain('invalid');
+    });
+
+    it('should handle null field values', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"nothing":null}',
+        { tsinterface: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('nothing: null;');
+    });
+
+    it('should quote keys that are not valid identifiers', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"my-key":1}',
+        { tsinterface: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain("'my-key': number;");
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NumberToCurrencyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberToCurrencyBoxSource.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { NumberToCurrencyBoxSource } from '../NumberToCurrencyBoxSource';
+
+describe('NumberToCurrencyBoxSource', () => {
+  it('returns [] when ::currency option is absent', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes(
+      '1234567.5',
+      null,
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('formats with USD by default when ::currency has no value', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('1234567.5', {
+      currency: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Formatted).toBe('$1,234,567.50');
+    expect(opts.Currency).toBe('USD');
+    expect(opts.Plain).toBe('1,234,567.5');
+  });
+
+  it('formats with EUR when ::currency=EUR', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('1000', {
+      currency: 'EUR',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Formatted).toBe('€1,000.00');
+    expect(opts.Currency).toBe('EUR');
+  });
+
+  it('formats with JPY (0 decimals, rounds) when ::currency=JPY', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('1234.5', {
+      currency: 'JPY',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Formatted).toBe('¥1,235');
+    expect(opts.Currency).toBe('JPY');
+  });
+
+  it('returns an error box for an invalid currency code', async () => {
+    // a malformed (non-3-letter) code makes Intl throw; a well-formed but
+    // unknown 3-letter code like ZZZ is accepted by Intl, so use 'US'
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('100', {
+      currency: 'US',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Error).toMatch(/invalid currency code/i);
+    expect(opts.Error).toContain('US');
+  });
+
+  it('returns [] for non-numeric input', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('abc', {
+      currency: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for empty input', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('', {
+      currency: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for input exceeding max length', async () => {
+    const long = '1'.repeat(51);
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes(long, {
+      currency: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('handles negative numbers', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('-500', {
+      currency: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Formatted).toBe('-$500.00');
+    expect(opts.Currency).toBe('USD');
+  });
+
+  it('uses boxTemplate KeyValueBoxTemplate', async () => {
+    const { KeyValueBoxTemplate } = await import('@components/BoxTemplate');
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('1', {
+      currency: true,
+    });
+    expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+  });
+});

--- a/src/modules/boxSources/__test__/SqlInBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SqlInBoxSource.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { SqlInBoxSource } from '../SqlInBoxSource';
+
+describe('SqlInBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('apple\nbanana', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is provided', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('apple\nbanana', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty / blank input', () => {
+    it('returns [] for empty string', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('', { sqlin: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only string', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('   \n  ', {
+        sqlin: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when all tokens are empty after splitting', async () => {
+      // input is only delimiters
+      const boxes = await SqlInBoxSource.generateBoxes(',,,\n,,', {
+        sqlin: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('string values', () => {
+    it('wraps newline-separated strings in single quotes', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('apple\nbanana', {
+        sqlin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe("IN ('apple', 'banana')");
+    });
+
+    it('trims whitespace around each token', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes(
+        '  apple  \n  banana  ',
+        {
+          sqlin: true,
+        },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe("IN ('apple', 'banana')");
+    });
+  });
+
+  describe('numeric values', () => {
+    it('emits integers unquoted', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('1,2,3', {
+        sqlin: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('IN (1, 2, 3)');
+    });
+
+    it('emits decimal numbers unquoted', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('1.5,2.75', {
+        sqlin: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('IN (1.5, 2.75)');
+    });
+
+    it('emits negative numbers unquoted', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('-1,-2', {
+        sqlin: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('IN (-1, -2)');
+    });
+  });
+
+  describe('mixed values', () => {
+    it('quotes strings and leaves numbers bare in the same list', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('a,2,b', {
+        sqlin: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe("IN ('a', 2, 'b')");
+    });
+  });
+
+  describe('single-quote escaping', () => {
+    it("doubles embedded single quotes (O'Brien → O''Brien)", async () => {
+      const boxes = await SqlInBoxSource.generateBoxes("O'Brien", {
+        sqlin: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe("IN ('O''Brien')");
+    });
+
+    it('handles multiple quotes in one token', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes("it's a test", {
+        sqlin: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe("IN ('it''s a test')");
+    });
+  });
+
+  describe('splitting delimiters', () => {
+    it('splits on commas', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('a,b,c', {
+        sqlin: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe("IN ('a', 'b', 'c')");
+    });
+
+    it('splits on newlines', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('a\nb\nc', {
+        sqlin: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe("IN ('a', 'b', 'c')");
+    });
+
+    it('handles mixed comma and newline delimiters', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('a,b\nc', {
+        sqlin: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe("IN ('a', 'b', 'c')");
+    });
+
+    it('collapses consecutive delimiters', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('a,,\nb', {
+        sqlin: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe("IN ('a', 'b')");
+    });
+  });
+
+  describe('box metadata', () => {
+    it('box name is "SQL IN Clause"', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('x', { sqlin: true });
+      expect(boxes[0].props.name).toBe('SQL IN Clause');
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('x', { sqlin: true });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await SqlInBoxSource.generateBoxes('x', { sqlin: true });
+      expect(boxes[0].props.priority).toBe(SqlInBoxSource.priority);
+    });
+  });
+
+  describe('static metadata', () => {
+    it('has expected properties', () => {
+      expect(SqlInBoxSource.name).toBe('SQL IN Clause');
+      expect(SqlInBoxSource.tag).toBe('#');
+      expect(SqlInBoxSource.kind).toBe('Convert');
+      expect(typeof SqlInBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/TimeAgoBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TimeAgoBoxSource.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { TimeAgoBoxSource } from '../TimeAgoBoxSource';
+
+describe('TimeAgoBoxSource', () => {
+  it('returns [] when no option key is present', async () => {
+    const boxes = await TimeAgoBoxSource.generateBoxes(
+      '2000-01-01T00:00:00Z',
+      null,
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when an unrelated option is present', async () => {
+    const boxes = await TimeAgoBoxSource.generateBoxes('2000-01-01T00:00:00Z', {
+      qrcode: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('shows "ago" for a clearly past date with ::timeago', async () => {
+    const boxes = await TimeAgoBoxSource.generateBoxes('2000-01-01T00:00:00Z', {
+      timeago: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options;
+    expect(opts?.Relative).toContain('ago');
+    expect(opts?.Direction).toBe('past');
+    expect(opts?.ISO).toBe('2000-01-01T00:00:00.000Z');
+  });
+
+  it('shows "in" for a clearly future date with ::timeago', async () => {
+    const boxes = await TimeAgoBoxSource.generateBoxes('2999-01-01T00:00:00Z', {
+      timeago: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options;
+    expect(opts?.Relative).toContain('in ');
+    expect(opts?.Direction).toBe('future');
+  });
+
+  it('accepts ::relativetime option key', async () => {
+    const boxes = await TimeAgoBoxSource.generateBoxes('2000-01-01T00:00:00Z', {
+      relativetime: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options?.Direction).toBe('past');
+  });
+
+  it('parses a 10-digit unix timestamp (seconds) as a past date', async () => {
+    // 1577836800 = 2020-01-01T00:00:00Z in seconds (10 digits)
+    const boxes = await TimeAgoBoxSource.generateBoxes('1577836800', {
+      timeago: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options?.Direction).toBe('past');
+  });
+
+  it('parses a 13-digit unix timestamp (milliseconds) as a past date', async () => {
+    // 1577836800000 = 2020-01-01T00:00:00Z in milliseconds (13 digits)
+    const boxes = await TimeAgoBoxSource.generateBoxes('1577836800000', {
+      timeago: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options?.Direction).toBe('past');
+  });
+
+  it('returns an error box for an invalid date string', async () => {
+    const boxes = await TimeAgoBoxSource.generateBoxes('notadate', {
+      timeago: true,
+    });
+    expect(boxes).toHaveLength(1);
+    // error box carries an Error key explaining the problem
+    const opts = boxes[0].props.options;
+    expect(opts?.Error).toBeTruthy();
+    expect((opts?.Error as string).toLowerCase()).toContain('not be parsed');
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -2,22 +2,30 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import ColorAdjustBoxSource from './ColorAdjustBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
+import CsvColumnBoxSource from './CsvColumnBoxSource';
+import CurlToFetchBoxSource from './CurlToFetchBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import JsonToGoBoxSource from './JsonToGoBoxSource';
+import JsonToTypescriptBoxSource from './JsonToTypescriptBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberToCurrencyBoxSource from './NumberToCurrencyBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SqlInBoxSource from './SqlInBoxSource';
+import TimeAgoBoxSource from './TimeAgoBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
@@ -29,22 +37,30 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  ColorAdjustBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
+  CsvColumnBoxSource,
+  CurlToFetchBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  JsonToGoBoxSource,
+  JsonToTypescriptBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
+  NumberToCurrencyBoxSource,
   PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
+  SqlInBoxSource,
+  TimeAgoBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,


### PR DESCRIPTION
## Summary

Eleventh exploration batch — **8 more BoxSource tools**, dev-workflow oriented.

| Tool | Trigger | What it does |
|------|---------|--------------|
| JSON to TypeScript | `::tsinterface` | interface(s) from a JSON sample |
| JSON to Go | `::gostruct` | struct + `json:` tags, golint initialisms (`id`→`ID`) |
| curl to fetch | `::curl2fetch` | curl command → `fetch()` snippet |
| Time Ago | `::timeago` | relative time via `Intl.RelativeTimeFormat` |
| Color Adjust | `::lighten=N` / `::darken=N` | HSL lightness (self-contained hex↔hsl) |
| SQL IN Clause | `::sqlin` | list → `IN (...)` with quoting/escaping |
| Currency Format | `::currency=CODE` | `Intl` currency |
| CSV Column | `::csvcol=COL` | extract a column by index or header |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules — no `BigInt(parseInt)`, input caps, no prototype-pollution, no partial-delimiter regex classes — so the automated review burden should be lighter.
- **Self-review caught 3 real issues before opening**: Go `Id`→`ID` initialism casing (golint idiom); an *unreachable* currency error path (`Intl` accepts any well-formed 3-letter code like `ZZZ`, so the genuine error case is a malformed non-3-letter code — fixed to surface that); and TimeAgo unix-timestamp test vectors that were 9/12 digits instead of the real 10/13.

## Verification

- ✅ `bun run test run` — **418 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#269 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6