### PR TITLE
feat(boxSources): add 8 more tools (jwt-sign, semver, cron-next, levenshtein, color-contrast, mac, snowflake, invisibles)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>JwtSignBox</b> </summary>
+
+| match rule         | description                          | example                          |
+| ------------------ | ------------------------------------ | -------------------------------- |
+| `::jwtsign=SECRET` | sign a JSON payload into an HS256 JWT | `{"sub":"1"} ::jwtsign=secret`  |
+
+</details>
+
+<details>
+<summary> <b>SemverBox</b> </summary>
+
+| match rule   | description                          | example               |
+| ------------ | ------------------------------------ | --------------------- |
+| `::semver`   | parse/validate a semantic version    | `1.2.3-beta.1 ::semver` |
+
+</details>
+
+<details>
+<summary> <b>CronNextBox</b> </summary>
+
+| match rule     | description                          | example                  |
+| -------------- | ------------------------------------ | ------------------------ |
+| `::cronnext`   | next run times of a cron expression (opt. `::from=ISO`, `::count=N`) | `*/15 * * * * ::cronnext` |
+
+</details>
+
+<details>
+<summary> <b>LevenshteinBox</b> </summary>
+
+| match rule        | description                          | example                  |
+| ----------------- | ------------------------------------ | ------------------------ |
+| `::levenshtein`   | edit distance between two newline-separated strings | `kitten`<br>`sitting ::levenshtein` |
+
+</details>
+
+<details>
+<summary> <b>ColorContrastBox</b> </summary>
+
+| match rule    | description                          | example                       |
+| ------------- | ------------------------------------ | ----------------------------- |
+| `::contrast`  | WCAG contrast ratio of two hex colors | `#000000 #ffffff ::contrast` |
+
+</details>
+
+<details>
+<summary> <b>MacAddressBox</b> </summary>
+
+| match rule | description                          | example                       |
+| ---------- | ------------------------------------ | ----------------------------- |
+| `::mac`    | validate + normalize a MAC address   | `00:1B:44:11:3A:B7 ::mac`     |
+
+</details>
+
+<details>
+<summary> <b>SnowflakeBox</b> </summary>
+
+| match rule     | description                          | example                       |
+| -------------- | ------------------------------------ | ----------------------------- |
+| `::snowflake`  | parse a Discord/Twitter snowflake ID (opt. `::snowflake=twitter`) | `175928847299117063 ::snowflake` |
+
+</details>
+
+<details>
+<summary> <b>InvisibleCharsBox</b> </summary>
+
+| match rule       | description                          | example                  |
+| ---------------- | ------------------------------------ | ------------------------ |
+| `::invisibles`   | detect/reveal hidden characters (zero-width, NBSP, BOM…) | `text ::invisibles` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/functions/__test__/shareLink.test.ts
+++ b/src/functions/__test__/shareLink.test.ts
@@ -65,4 +65,15 @@ describe('buildShareLink', () => {
     const url = new URL(result);
     expect(url.origin).toBe(window.location.origin);
   });
+
+  it('redacts a ::jwtsign secret so it does not leak into the URL', () => {
+    const result = buildShareLink({
+      input: '{"sub":"1"}\n::jwtsign=super-secret-key',
+      pathname: '/',
+      origin: 'http://localhost:3000',
+    });
+    const input = new URL(result).searchParams.get('input') ?? '';
+    expect(input).not.toContain('super-secret-key');
+    expect(input).toContain('::jwtsign=***');
+  });
 });

--- a/src/functions/shareLink.ts
+++ b/src/functions/shareLink.ts
@@ -16,6 +16,13 @@ const setParamIfPresent = (
   }
 };
 
+// option values that carry secret material must not leak into shareable URLs
+// (browser history, referrer headers, chat logs). redact them before sharing.
+const SECRET_OPTION_PATTERNS = [/(::jwtsign=)\S+/gi];
+
+const redactSecrets = (input: string): string =>
+  SECRET_OPTION_PATTERNS.reduce((acc, re) => acc.replace(re, '$1***'), input);
+
 export const buildShareLink = ({
   box,
   input,
@@ -24,6 +31,10 @@ export const buildShareLink = ({
 }: ShareLinkParams & { origin?: string }): string => {
   const url = new URL(pathname, origin);
   setParamIfPresent(url.searchParams, 'box', box);
-  setParamIfPresent(url.searchParams, 'input', input);
+  setParamIfPresent(
+    url.searchParams,
+    'input',
+    input ? redactSecrets(input) : input,
+  );
   return url.toString();
 };

--- a/src/modules/boxSources/ColorContrastBoxSource.ts
+++ b/src/modules/boxSources/ColorContrastBoxSource.ts
@@ -1,0 +1,129 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// parses #RGB or #RRGGBB into [r, g, b] integers 0-255, or null if invalid
+function parseHexColor(raw: string): [number, number, number] | null {
+  const m = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(raw);
+  if (!m) return null;
+  const h = m[1];
+  if (h.length === 3) {
+    return [
+      Number.parseInt(h[0] + h[0], 16),
+      Number.parseInt(h[1] + h[1], 16),
+      Number.parseInt(h[2] + h[2], 16),
+    ];
+  }
+  return [
+    Number.parseInt(h.slice(0, 2), 16),
+    Number.parseInt(h.slice(2, 4), 16),
+    Number.parseInt(h.slice(4, 6), 16),
+  ];
+}
+
+// WCAG 2.x relative luminance for a single channel value in [0,255]
+function channelLuminance(c: number): number {
+  const sRGB = c / 255;
+  return sRGB <= 0.03928 ? sRGB / 12.92 : ((sRGB + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(r: number, g: number, b: number): number {
+  return (
+    0.2126 * channelLuminance(r) +
+    0.7152 * channelLuminance(g) +
+    0.0722 * channelLuminance(b)
+  );
+}
+
+// formats the contrast ratio as '21:1' when it's exactly a whole number, else '4.48'
+function formatRatio(ratio: number): string {
+  const rounded = Math.round(ratio * 100) / 100;
+  if (Number.isInteger(rounded)) {
+    return `${rounded}:1`;
+  }
+  return rounded.toFixed(2);
+}
+
+function passOrFail(ratio: number, threshold: number): string {
+  return ratio >= threshold ? 'pass' : 'fail';
+}
+
+export const ColorContrastBoxSource = {
+  name: 'Color Contrast',
+  description:
+    'WCAG contrast ratio between two hex colors (space- or newline-separated).',
+  defaultInput: '#000000 #ffffff ::contrast',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'contrast')) return [];
+
+    const parts = trim(input).split(/\s+/).filter(Boolean);
+
+    // when not exactly two tokens, return an explanatory box
+    if (parts.length !== 2) {
+      const errorOutput = 'two hex colors required (e.g. #000000 #ffffff)';
+      return [
+        new BoxBuilder('Color Contrast', errorOutput)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: 'two hex colors are required' })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const color1 = parseHexColor(parts[0]);
+    const color2 = parseHexColor(parts[1]);
+
+    if (color1 === null || color2 === null) {
+      const errorOutput = 'invalid hex color — use #RGB or #RRGGBB format';
+      return [
+        new BoxBuilder('Color Contrast', errorOutput)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({
+            Error: 'invalid hex color — use #RGB or #RRGGBB format',
+          })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const L1 = relativeLuminance(...color1);
+    const L2 = relativeLuminance(...color2);
+    const lighter = Math.max(L1, L2);
+    const darker = Math.min(L1, L2);
+    const ratio = (lighter + 0.05) / (darker + 0.05);
+
+    const ratioStr = formatRatio(ratio);
+
+    const kvOptions: Record<string, string> = {
+      Ratio: ratioStr,
+      'AA Normal': passOrFail(ratio, 4.5),
+      'AA Large': passOrFail(ratio, 3),
+      'AAA Normal': passOrFail(ratio, 7),
+      'AAA Large': passOrFail(ratio, 4.5),
+    };
+
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Color Contrast', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ColorContrastBoxSource;

--- a/src/modules/boxSources/ColorContrastBoxSource.ts
+++ b/src/modules/boxSources/ColorContrastBoxSource.ts
@@ -38,13 +38,10 @@ function relativeLuminance(r: number, g: number, b: number): number {
   );
 }
 
-// formats the contrast ratio as '21:1' when it's exactly a whole number, else '4.48'
+// formats the contrast ratio in WCAG 'N:1' form (e.g. '21:1', '4.48:1')
 function formatRatio(ratio: number): string {
   const rounded = Math.round(ratio * 100) / 100;
-  if (Number.isInteger(rounded)) {
-    return `${rounded}:1`;
-  }
-  return rounded.toFixed(2);
+  return Number.isInteger(rounded) ? `${rounded}:1` : `${rounded.toFixed(2)}:1`;
 }
 
 function passOrFail(ratio: number, threshold: number): string {

--- a/src/modules/boxSources/ColorContrastBoxSource.ts
+++ b/src/modules/boxSources/ColorContrastBoxSource.ts
@@ -27,7 +27,7 @@ function parseHexColor(raw: string): [number, number, number] | null {
 // WCAG 2.x relative luminance for a single channel value in [0,255]
 function channelLuminance(c: number): number {
   const sRGB = c / 255;
-  return sRGB <= 0.03928 ? sRGB / 12.92 : ((sRGB + 0.055) / 1.055) ** 2.4;
+  return sRGB <= 0.04045 ? sRGB / 12.92 : ((sRGB + 0.055) / 1.055) ** 2.4;
 }
 
 function relativeLuminance(r: number, g: number, b: number): number {

--- a/src/modules/boxSources/CronNextBoxSource.ts
+++ b/src/modules/boxSources/CronNextBoxSource.ts
@@ -5,15 +5,17 @@ import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 
-// maximum minutes to scan forward before giving up (≈5 years)
-const MAX_SEARCH_MINUTES = 5 * 365 * 24 * 60;
+// maximum minutes to scan forward before giving up (≈1 year + leap margin).
+// bounds the main-thread cost for impossible expressions like "0 0 30 2 *".
+const MAX_SEARCH_MINUTES = 366 * 24 * 60;
 
 interface CronFields {
-  minute: number[];
-  hour: number[];
-  dom: number[];
-  month: number[];
-  dow: number[];
+  // sets for O(1) membership in the per-minute scan
+  minute: Set<number>;
+  hour: Set<number>;
+  dom: Set<number>;
+  month: Set<number>;
+  dow: Set<number>;
   // whether the field was explicitly restricted (not a bare '*')
   domRestricted: boolean;
   dowRestricted: boolean;
@@ -73,19 +75,19 @@ function parseCron(expr: string): CronFields | null {
   const dom = expandField(domTok, 1, 31);
   // month is 1–12 in cron; we keep it that way and compare against getUTCMonth()+1
   const month = expandField(monthTok, 1, 12);
-  // allow 7 as Sunday alias — normalise to 0
-  const dowRaw = expandField(dowTok.replace(/\b7\b/g, '0'), 0, 6);
+  // allow 7 as a Sunday alias; expand with max 7 then normalise 7→0 AFTER
+  // expansion so ranges like "5-7" stay valid (pre-substitution broke them)
+  const dowRaw = expandField(dowTok, 0, 7);
 
   if (!minute || !hour || !dom || !month || !dowRaw) return null;
 
-  // deduplicate after 7→0 normalisation
-  const dow = [...new Set(dowRaw)].sort((a, b) => a - b);
+  const dow = new Set(dowRaw.map((v) => (v === 7 ? 0 : v)));
 
   return {
-    minute,
-    hour,
-    dom,
-    month,
+    minute: new Set(minute),
+    hour: new Set(hour),
+    dom: new Set(dom),
+    month: new Set(month),
     dow,
     domRestricted: domTok !== '*',
     dowRestricted: dowTok !== '*' && dowTok !== '*/1',
@@ -101,16 +103,16 @@ function matches(date: Date, fields: CronFields): boolean {
   const month = date.getUTCMonth() + 1;
   const dow = date.getUTCDay();
 
-  if (!fields.minute.includes(m)) return false;
-  if (!fields.hour.includes(h)) return false;
-  if (!fields.month.includes(month)) return false;
+  if (!fields.minute.has(m)) return false;
+  if (!fields.hour.has(h)) return false;
+  if (!fields.month.has(month)) return false;
 
   // Vixie cron dom/dow rule:
   // if BOTH are restricted → match when EITHER dom OR dow matches
   // if only one is restricted → that one must match
   // if neither is restricted → always matches (already covered by '*' expanding to full range)
-  const domMatch = fields.dom.includes(dom);
-  const dowMatch = fields.dow.includes(dow);
+  const domMatch = fields.dom.has(dom);
+  const dowMatch = fields.dow.has(dow);
 
   if (fields.domRestricted && fields.dowRestricted) {
     return domMatch || dowMatch;
@@ -147,9 +149,11 @@ export const CronNextBoxSource = {
     if (!hasOptionKeys(options, 'cronnext')) return [];
 
     const expr = trim(input);
+    // cron expressions are short; bound work before splitting
+    if (expr.length > 200) return [];
 
     // parse ::count option, clamp to [1, 20], default 5
-    const countRaw = extractOptionKeys(options, 'count');
+    const countRaw = extractOptionKeys(options, 'cronnextcount', 'count');
     const count = Math.min(
       20,
       Math.max(
@@ -161,7 +165,7 @@ export const CronNextBoxSource = {
     );
 
     // parse ::from option as base time, fall back to now
-    const fromRaw = extractOptionKeys(options, 'from');
+    const fromRaw = extractOptionKeys(options, 'cronnextfrom', 'from');
     let base: Date;
     if (fromRaw !== null && fromRaw !== true) {
       const parsed = new Date(String(fromRaw));

--- a/src/modules/boxSources/CronNextBoxSource.ts
+++ b/src/modules/boxSources/CronNextBoxSource.ts
@@ -1,0 +1,215 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// maximum minutes to scan forward before giving up (≈5 years)
+const MAX_SEARCH_MINUTES = 5 * 365 * 24 * 60;
+
+interface CronFields {
+  minute: number[];
+  hour: number[];
+  dom: number[];
+  month: number[];
+  dow: number[];
+  // whether the field was explicitly restricted (not a bare '*')
+  domRestricted: boolean;
+  dowRestricted: boolean;
+}
+
+/** Expands a single cron field token into a sorted array of allowed values. */
+function expandField(token: string, min: number, max: number): number[] | null {
+  const values = new Set<number>();
+
+  for (const part of token.split(',')) {
+    // */step
+    if (part.startsWith('*/')) {
+      const step = Number.parseInt(part.slice(2), 10);
+      if (Number.isNaN(step) || step < 1) return null;
+      for (let v = min; v <= max; v += step) values.add(v);
+      continue;
+    }
+
+    // range with optional step: a-b or a-b/step
+    if (part.includes('-')) {
+      const [rangePart, stepStr] = part.split('/');
+      const [aStr, bStr] = rangePart.split('-');
+      const a = Number.parseInt(aStr, 10);
+      const b = Number.parseInt(bStr, 10);
+      if (Number.isNaN(a) || Number.isNaN(b) || a < min || b > max || a > b)
+        return null;
+      const step = stepStr !== undefined ? Number.parseInt(stepStr, 10) : 1;
+      if (Number.isNaN(step) || step < 1) return null;
+      for (let v = a; v <= b; v += step) values.add(v);
+      continue;
+    }
+
+    // bare '*'
+    if (part === '*') {
+      for (let v = min; v <= max; v++) values.add(v);
+      continue;
+    }
+
+    // single number
+    const n = Number.parseInt(part, 10);
+    if (Number.isNaN(n) || n < min || n > max) return null;
+    values.add(n);
+  }
+
+  return [...values].sort((a, b) => a - b);
+}
+
+/** Parses a 5-field cron string into expanded field arrays. */
+function parseCron(expr: string): CronFields | null {
+  const fields = expr.split(/\s+/);
+  if (fields.length !== 5) return null;
+
+  const [minuteTok, hourTok, domTok, monthTok, dowTok] = fields;
+
+  const minute = expandField(minuteTok, 0, 59);
+  const hour = expandField(hourTok, 0, 23);
+  const dom = expandField(domTok, 1, 31);
+  // month is 1–12 in cron; we keep it that way and compare against getUTCMonth()+1
+  const month = expandField(monthTok, 1, 12);
+  // allow 7 as Sunday alias — normalise to 0
+  const dowRaw = expandField(dowTok.replace(/\b7\b/g, '0'), 0, 6);
+
+  if (!minute || !hour || !dom || !month || !dowRaw) return null;
+
+  // deduplicate after 7→0 normalisation
+  const dow = [...new Set(dowRaw)].sort((a, b) => a - b);
+
+  return {
+    minute,
+    hour,
+    dom,
+    month,
+    dow,
+    domRestricted: domTok !== '*',
+    dowRestricted: dowTok !== '*' && dowTok !== '*/1',
+  };
+}
+
+/** Returns true when the UTC time represented by `date` matches the parsed cron. */
+function matches(date: Date, fields: CronFields): boolean {
+  const m = date.getUTCMinutes();
+  const h = date.getUTCHours();
+  const dom = date.getUTCDate();
+  // getUTCMonth is 0-based; cron month field is 1-based
+  const month = date.getUTCMonth() + 1;
+  const dow = date.getUTCDay();
+
+  if (!fields.minute.includes(m)) return false;
+  if (!fields.hour.includes(h)) return false;
+  if (!fields.month.includes(month)) return false;
+
+  // Vixie cron dom/dow rule:
+  // if BOTH are restricted → match when EITHER dom OR dow matches
+  // if only one is restricted → that one must match
+  // if neither is restricted → always matches (already covered by '*' expanding to full range)
+  const domMatch = fields.dom.includes(dom);
+  const dowMatch = fields.dow.includes(dow);
+
+  if (fields.domRestricted && fields.dowRestricted) {
+    return domMatch || dowMatch;
+  }
+  if (fields.domRestricted) {
+    return domMatch;
+  }
+  if (fields.dowRestricted) {
+    return dowMatch;
+  }
+  // neither restricted — both are full ranges, always true here
+  return true;
+}
+
+/** Advances `date` by one minute in-place and returns it. */
+function addMinute(date: Date): Date {
+  date.setUTCMinutes(date.getUTCMinutes() + 1, 0, 0);
+  return date;
+}
+
+export const CronNextBoxSource = {
+  name: 'Cron Next Runs',
+  description:
+    'Compute the next run times of a 5-field cron expression. Optionally ::from=ISO and ::count=N.',
+  defaultInput: '*/15 * * * * ::cronnext',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cronnext')) return [];
+
+    const expr = trim(input);
+
+    // parse ::count option, clamp to [1, 20], default 5
+    const countRaw = extractOptionKeys(options, 'count');
+    const count = Math.min(
+      20,
+      Math.max(
+        1,
+        countRaw !== null && countRaw !== true
+          ? Number.parseInt(String(countRaw), 10) || 5
+          : 5,
+      ),
+    );
+
+    // parse ::from option as base time, fall back to now
+    const fromRaw = extractOptionKeys(options, 'from');
+    let base: Date;
+    if (fromRaw !== null && fromRaw !== true) {
+      const parsed = new Date(String(fromRaw));
+      base = Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+    } else {
+      base = new Date();
+    }
+
+    const fields = parseCron(expr);
+    if (fields === null) {
+      const box = new BoxBuilder(
+        'Cron Next Runs',
+        `Invalid cron expression: "${expr}"\nExpected 5 fields: minute hour day-of-month month day-of-week`,
+      )
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    // scan forward from base+1min
+    const results: string[] = [];
+    const cursor = new Date(base.getTime());
+    // zero out seconds and ms, then add one minute
+    cursor.setUTCSeconds(0, 0);
+    addMinute(cursor);
+
+    let scanned = 0;
+    while (results.length < count && scanned < MAX_SEARCH_MINUTES) {
+      if (matches(cursor, fields)) {
+        results.push(cursor.toISOString());
+      }
+      addMinute(cursor);
+      scanned++;
+    }
+
+    const output =
+      results.length > 0
+        ? results.join('\n')
+        : 'No matching times found within 5 years.';
+
+    const box = new BoxBuilder('Cron Next Runs', output)
+      .setTemplate(CodeBoxTemplate)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default CronNextBoxSource;

--- a/src/modules/boxSources/CronNextBoxSource.ts
+++ b/src/modules/boxSources/CronNextBoxSource.ts
@@ -133,6 +133,22 @@ function addMinute(date: Date): Date {
   return date;
 }
 
+// max day each month can have (29 allows leap February)
+const DAYS_IN_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+// cheap static check: when dom is the only date constraint (dow unrestricted),
+// an impossible day/month pair (e.g. Feb 30) never matches. only prune in that
+// case — under the Vixie OR-rule a restricted dow could still match.
+function isDateSatisfiable(fields: CronFields): boolean {
+  if (!fields.domRestricted || fields.dowRestricted) return true;
+  for (const mo of fields.month) {
+    for (const d of fields.dom) {
+      if (d <= DAYS_IN_MONTH[mo - 1]) return true;
+    }
+  }
+  return false;
+}
+
 export const CronNextBoxSource = {
   name: 'Cron Next Runs',
   description:
@@ -186,6 +202,21 @@ export const CronNextBoxSource = {
       return [box];
     }
 
+    // O(1) guard: when day-of-month is the sole date constraint, a value like
+    // Feb 30 can never occur — bail before the scan instead of running it to
+    // the cap (avoids a multi-ms main-thread block on impossible expressions)
+    if (!isDateSatisfiable(fields)) {
+      return [
+        new BoxBuilder(
+          'Cron Next Runs',
+          'No matching times found within 1 year.',
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
     // scan forward from base+1min
     const results: string[] = [];
     const cursor = new Date(base.getTime());
@@ -205,7 +236,7 @@ export const CronNextBoxSource = {
     const output =
       results.length > 0
         ? results.join('\n')
-        : 'No matching times found within 5 years.';
+        : 'No matching times found within 1 year.';
 
     const box = new BoxBuilder('Cron Next Runs', output)
       .setTemplate(CodeBoxTemplate)

--- a/src/modules/boxSources/InvisibleCharsBoxSource.ts
+++ b/src/modules/boxSources/InvisibleCharsBoxSource.ts
@@ -52,6 +52,8 @@ function isInvisible(cp: number): boolean {
   if (cp < 0x20) return true;
   // allow normal printable ASCII (0x20-0x7e)
   if (cp >= 0x20 && cp <= 0x7e) return false;
+  // flag DEL and the C1 control block (common homograph-attack injects)
+  if (cp === 0x7f || (cp >= 0x80 && cp <= 0x9f)) return true;
   // flag all specifically listed invisible unicode chars
   if (INVISIBLE_CHARS.has(cp)) return true;
   return false;

--- a/src/modules/boxSources/InvisibleCharsBoxSource.ts
+++ b/src/modules/boxSources/InvisibleCharsBoxSource.ts
@@ -1,0 +1,123 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// well-known invisible/zero-width character metadata
+const INVISIBLE_CHARS: Map<number, string> = new Map([
+  [0x00a0, 'NO-BREAK SPACE'],
+  [0x00ad, 'SOFT HYPHEN'],
+  [0x200b, 'ZERO WIDTH SPACE'],
+  [0x200c, 'ZERO WIDTH NON-JOINER'],
+  [0x200d, 'ZERO WIDTH JOINER'],
+  [0x2060, 'WORD JOINER'],
+  [0x2000, 'EN QUAD'],
+  [0x2001, 'EM QUAD'],
+  [0x2002, 'EN SPACE'],
+  [0x2003, 'EM SPACE'],
+  [0x2004, 'THREE-PER-EM SPACE'],
+  [0x2005, 'FOUR-PER-EM SPACE'],
+  [0x2006, 'SIX-PER-EM SPACE'],
+  [0x2007, 'FIGURE SPACE'],
+  [0x2008, 'PUNCTUATION SPACE'],
+  [0x2009, 'THIN SPACE'],
+  [0x200a, 'HAIR SPACE'],
+  [0x202f, 'NARROW NO-BREAK SPACE'],
+  [0x205f, 'MEDIUM MATHEMATICAL SPACE'],
+  [0x3000, 'IDEOGRAPHIC SPACE'],
+  [0xfeff, 'BYTE ORDER MARK'],
+]);
+
+// format a code point as U+XXXX with at least 4 hex digits
+function toUPlus(cp: number): string {
+  return `U+${cp.toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
+// get a display name for a code point
+function charName(cp: number): string {
+  const known = INVISIBLE_CHARS.get(cp);
+  if (known) return known;
+  // control chars below 0x20 (excluding normal whitespace \t \n \r)
+  return `CONTROL CHAR`;
+}
+
+// returns true if a code point should be flagged as invisible/hidden
+function isInvisible(cp: number): boolean {
+  // allow normal whitespace
+  if (cp === 0x09 || cp === 0x0a || cp === 0x0d) return false;
+  // flag control chars below 0x20
+  if (cp < 0x20) return true;
+  // allow normal printable ASCII (0x20-0x7e)
+  if (cp >= 0x20 && cp <= 0x7e) return false;
+  // flag all specifically listed invisible unicode chars
+  if (INVISIBLE_CHARS.has(cp)) return true;
+  return false;
+}
+
+export const InvisibleCharsBoxSource = {
+  name: 'Invisible Characters',
+  description:
+    'Detect and reveal hidden/invisible characters (zero-width, non-breaking space, BOM, etc.).',
+  defaultInput: 'hello​world ::invisibles',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'invisibles', 'hiddenchars')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    // scan input by unicode code point
+    const counts = new Map<number, number>();
+    let revealed = '';
+
+    for (const char of input) {
+      const cp = char.codePointAt(0) as number;
+      if (isInvisible(cp)) {
+        const token = toUPlus(cp);
+        counts.set(cp, (counts.get(cp) ?? 0) + 1);
+        revealed += `[${token}]`;
+      } else {
+        revealed += char;
+      }
+    }
+
+    if (counts.size === 0) {
+      const box = new BoxBuilder(
+        'Invisible Characters',
+        'No invisible characters found.',
+      )
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    // build header: one line per distinct flagged char
+    const headerLines: string[] = [];
+    for (const [cp, count] of counts) {
+      const uplus = toUPlus(cp);
+      const name = charName(cp);
+      headerLines.push(`${name} (${uplus}): ${count}`);
+    }
+
+    const output = [...headerLines, '', revealed].join('\n');
+
+    const box = new BoxBuilder('Invisible Characters', output)
+      .setTemplate(CodeBoxTemplate)
+      .setShowExpandButton(true)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default InvisibleCharsBoxSource;

--- a/src/modules/boxSources/JwtSignBoxSource.ts
+++ b/src/modules/boxSources/JwtSignBoxSource.ts
@@ -1,0 +1,130 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 20;
+const MAX_INPUT = 100_000;
+
+// encodes a Uint8Array to base64url (no padding)
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+// encodes a UTF-8 string to base64url via TextEncoder to handle all Unicode code points
+function stringToBase64url(str: string): string {
+  return bytesToBase64url(new TextEncoder().encode(str));
+}
+
+async function signHs256(
+  signingInput: string,
+  secret: string,
+): Promise<string> {
+  const keyBytes = new TextEncoder().encode(secret);
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signingInputBytes = new TextEncoder().encode(signingInput);
+  const signatureBuf = await crypto.subtle.sign(
+    'HMAC',
+    cryptoKey,
+    signingInputBytes,
+  );
+  return bytesToBase64url(new Uint8Array(signatureBuf));
+}
+
+export const JwtSignBoxSource = {
+  name: 'JWT Sign',
+  description:
+    'Sign a JSON payload into an HS256 JWT using a secret. e.g. payload ::jwtsign=secret',
+  defaultInput:
+    '{"sub":"1234567890","name":"John Doe","iat":1516239022} ::jwtsign=your-256-bit-secret',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jwtsign')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // guard for non-secure contexts where crypto.subtle is unavailable
+    if (typeof crypto === 'undefined' || !crypto.subtle) {
+      return [
+        new BoxBuilder(
+          'JWT Sign',
+          'JWT signing requires a secure context (HTTPS). crypto.subtle is not available.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const secretValue = extractOptionKeys(options, 'jwtsign');
+    if (
+      !secretValue ||
+      typeof secretValue !== 'string' ||
+      secretValue.trim() === ''
+    ) {
+      return [
+        new BoxBuilder(
+          'JWT Sign',
+          'A secret is required: use ::jwtsign=your-secret',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(trim(input));
+    } catch {
+      return [
+        new BoxBuilder(
+          'JWT Sign',
+          'Invalid JSON payload. Please provide a valid JSON object.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const header = { alg: 'HS256', typ: 'JWT' };
+    const b64Header = stringToBase64url(JSON.stringify(header));
+    // re-stringify the parsed payload so key order is insertion order (V8 behaviour)
+    const b64Payload = stringToBase64url(JSON.stringify(payload));
+    const signingInput = `${b64Header}.${b64Payload}`;
+    const b64Sig = await signHs256(signingInput, secretValue);
+    const token = `${signingInput}.${b64Sig}`;
+
+    return [
+      new BoxBuilder('JWT Sign', token)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JwtSignBoxSource;

--- a/src/modules/boxSources/JwtSignBoxSource.ts
+++ b/src/modules/boxSources/JwtSignBoxSource.ts
@@ -109,6 +109,24 @@ export const JwtSignBoxSource = {
       ];
     }
 
+    // RFC 7519 claims set must be a JSON object, not a primitive or array
+    if (
+      typeof payload !== 'object' ||
+      payload === null ||
+      Array.isArray(payload)
+    ) {
+      return [
+        new BoxBuilder(
+          'JWT Sign',
+          'JWT payload must be a JSON object (not a primitive or array).',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
     const header = { alg: 'HS256', typ: 'JWT' };
     const b64Header = stringToBase64url(JSON.stringify(header));
     // re-stringify the parsed payload so key order is insertion order (V8 behaviour)

--- a/src/modules/boxSources/LevenshteinBoxSource.ts
+++ b/src/modules/boxSources/LevenshteinBoxSource.ts
@@ -1,0 +1,111 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 5_000;
+
+// two-row DP: O(n*m) time, O(min(n,m)) space
+function levenshtein(a: string, b: string): number {
+  // ensure `a` is the shorter string so we allocate the smaller row
+  if (a.length > b.length) {
+    return levenshtein(b, a);
+  }
+
+  const m = a.length;
+  const n = b.length;
+
+  let prev = new Array<number>(m + 1);
+  let curr = new Array<number>(m + 1);
+
+  for (let i = 0; i <= m; i++) {
+    prev[i] = i;
+  }
+
+  for (let j = 1; j <= n; j++) {
+    curr[0] = j;
+    for (let i = 1; i <= m; i++) {
+      if (a.charCodeAt(i - 1) === b.charCodeAt(j - 1)) {
+        curr[i] = prev[i - 1];
+      } else {
+        curr[i] =
+          1 +
+          Math.min(
+            prev[i - 1], // substitution
+            prev[i], // deletion
+            curr[i - 1], // insertion
+          );
+      }
+    }
+    // swap rows without allocation
+    const tmp = prev;
+    prev = curr;
+    curr = tmp;
+  }
+
+  return prev[m];
+}
+
+export const LevenshteinBoxSource = {
+  name: 'Levenshtein',
+  description:
+    'Compute the Levenshtein edit distance between two newline-separated strings.',
+  defaultInput: 'kitten\nsitting ::levenshtein',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'levenshtein', 'editdistance')) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
+
+    // split input into exactly two strings on the first newline
+    const newlineIdx = input.indexOf('\n');
+    if (newlineIdx === -1) {
+      return [
+        new BoxBuilder(
+          'Levenshtein',
+          'Two newline-separated strings are required (e.g. "abc\\nxyz ::levenshtein").',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const a = input.slice(0, newlineIdx);
+    const b = input.slice(newlineIdx + 1);
+
+    const distance = levenshtein(a, b);
+    const maxLen = Math.max(a.length, b.length);
+    // similarity is 1 when both strings are empty
+    const similarity = maxLen === 0 ? 1 : 1 - distance / maxLen;
+    const similarityPct = `${(similarity * 100).toFixed(1)}%`;
+
+    const output: Record<string, string> = {
+      Distance: String(distance),
+      Similarity: similarityPct,
+      'Length A': String(a.length),
+      'Length B': String(b.length),
+    };
+
+    const plaintextOutput = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Levenshtein', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LevenshteinBoxSource;

--- a/src/modules/boxSources/LevenshteinBoxSource.ts
+++ b/src/modules/boxSources/LevenshteinBoxSource.ts
@@ -4,7 +4,9 @@ import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
-const MAX_INPUT = 5_000;
+// the DP is O(n*m); cap total input so the worst case (two ~500-char
+// strings → 250k cells) stays well under a frame budget
+const MAX_INPUT = 1_000;
 
 // two-row DP: O(n*m) time, O(min(n,m)) space
 function levenshtein(a: string, b: string): number {

--- a/src/modules/boxSources/MacAddressBoxSource.ts
+++ b/src/modules/boxSources/MacAddressBoxSource.ts
@@ -1,0 +1,72 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// extracts raw hex from colon, hyphen, cisco-dot, or bare formats
+function parseHex(input: string): string | null {
+  const raw = trim(input).replace(/[:\-.]/g, '');
+  if (!/^[0-9a-fA-F]{12}$/.test(raw)) return null;
+  return raw.toLowerCase();
+}
+
+// determines unicast/multicast and universal/local from the first octet
+function macType(hex: string): string {
+  const firstOctet = Number.parseInt(hex.slice(0, 2), 16);
+  const multicast = (firstOctet & 0x01) === 1 ? 'multicast' : 'unicast';
+  const local = (firstOctet & 0x02) === 2 ? 'local' : 'universal';
+  return `${multicast}, ${local}`;
+}
+
+export const MacAddressBoxSource = {
+  name: 'MAC Address',
+  description:
+    'Validate a MAC address and show it in colon, hyphen, dot, and bare formats.',
+  defaultInput: '00:1B:44:11:3A:B7 ::mac',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'mac', 'macaddress')) return [];
+
+    const hex = parseHex(input);
+    if (!hex) return [];
+
+    // build the four canonical representations
+    const octets = hex.match(/.{2}/g) as string[];
+    const colon = octets.join(':');
+    const hyphen = octets.join('-');
+    const dot = `${hex.slice(0, 4)}.${hex.slice(4, 8)}.${hex.slice(8, 12)}`;
+    const bare = hex;
+    const type = macType(hex);
+
+    const kvOptions: Record<string, string> = {
+      Colon: colon,
+      Hyphen: hyphen,
+      Dot: dot,
+      Bare: bare,
+      Type: type,
+    };
+
+    const lines = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('MAC Address', lines)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default MacAddressBoxSource;

--- a/src/modules/boxSources/SemverBoxSource.ts
+++ b/src/modules/boxSources/SemverBoxSource.ts
@@ -1,0 +1,93 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// official semver 2.0.0 regex from https://semver.org/#is-there-a-suggested-regexp-to-check-a-semver-string
+const SEMVER_REGEX =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+interface SemverMatch {
+  major: string;
+  minor: string;
+  patch: string;
+  prerelease: string | null;
+  build: string | null;
+}
+
+function parseSemver(raw: string): SemverMatch | null {
+  // strip optional leading 'v' before matching
+  const normalized = raw.startsWith('v') ? raw.slice(1) : raw;
+  const m = SEMVER_REGEX.exec(normalized);
+  if (!m) return null;
+
+  return {
+    major: m[1],
+    minor: m[2],
+    patch: m[3],
+    prerelease: m[4] ?? null,
+    build: m[5] ?? null,
+  };
+}
+
+export const SemverBoxSource = {
+  name: 'Semver',
+  description:
+    'Parse and validate a Semantic Version string into its components.',
+  defaultInput: '1.2.3-beta.1+build.5 ::semver',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'semver')) return [];
+
+    const raw = trim(input);
+    const parsed = parseSemver(raw);
+
+    if (!parsed) {
+      const content = `"${raw}" is not a valid semver string`;
+      return [
+        new BoxBuilder('Semver', content)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Valid: 'false', Input: raw })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const kvOptions: Record<string, string> = {
+      Major: parsed.major,
+      Minor: parsed.minor,
+      Patch: parsed.patch,
+      Prerelease: parsed.prerelease ?? '',
+      Valid: 'true',
+    };
+
+    // omit Build key entirely when absent
+    if (parsed.build !== null) {
+      kvOptions.Build = parsed.build;
+    }
+
+    const lines = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Semver', lines)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default SemverBoxSource;

--- a/src/modules/boxSources/SemverBoxSource.ts
+++ b/src/modules/boxSources/SemverBoxSource.ts
@@ -66,14 +66,16 @@ export const SemverBoxSource = {
       Major: parsed.major,
       Minor: parsed.minor,
       Patch: parsed.patch,
-      Prerelease: parsed.prerelease ?? '',
-      Valid: 'true',
     };
 
-    // omit Build key entirely when absent
+    // omit Prerelease / Build keys entirely when absent (consistent handling)
+    if (parsed.prerelease !== null) {
+      kvOptions.Prerelease = parsed.prerelease;
+    }
     if (parsed.build !== null) {
       kvOptions.Build = parsed.build;
     }
+    kvOptions.Valid = 'true';
 
     const lines = Object.entries(kvOptions)
       .map(([k, v]) => `${k}: ${v}`)

--- a/src/modules/boxSources/SnowflakeBoxSource.ts
+++ b/src/modules/boxSources/SnowflakeBoxSource.ts
@@ -5,7 +5,7 @@ import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 
-// epochs: discord = 2015-01-01, twitter = 2010-11-04T01:00:00Z
+// epochs: discord = 2015-01-01T00:00:00Z, twitter = 2010-11-04T01:42:54.657Z
 const DISCORD_EPOCH = 1420070400000n;
 const TWITTER_EPOCH = 1288834974657n;
 
@@ -41,21 +41,26 @@ export const SnowflakeBoxSource = {
 
     const timestampMs = Number((id >> 22n) + epoch);
     const timestamp = new Date(timestampMs).toISOString();
-    const workerId = ((id >> 17n) & 0x1fn).toString();
-    const processId = ((id >> 12n) & 0x1fn).toString();
+    // the 5+5 internal bits mean different things per platform
+    const highId = ((id >> 17n) & 0x1fn).toString();
+    const lowId = ((id >> 12n) & 0x1fn).toString();
     const increment = (id & 0xfffn).toString();
 
-    const kvOptions: BoxOptions = {
+    const kvOptions: Record<string, string> = {
       Timestamp: timestamp,
       'Unix (ms)': timestampMs.toString(),
-      'Worker ID': workerId,
-      'Process ID': processId,
+      [useTwitter ? 'Datacenter ID' : 'Worker ID']: highId,
+      [useTwitter ? 'Worker ID' : 'Process ID']: lowId,
       Increment: increment,
       Epoch: epochLabel,
     };
 
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
     return [
-      new BoxBuilder('Snowflake', timestamp)
+      new BoxBuilder('Snowflake', plaintext)
         .setOptions(kvOptions)
         .setTemplate(KeyValueBoxTemplate)
         .setPriority(this.priority)

--- a/src/modules/boxSources/SnowflakeBoxSource.ts
+++ b/src/modules/boxSources/SnowflakeBoxSource.ts
@@ -9,8 +9,9 @@ const Priority = 10;
 const DISCORD_EPOCH = 1420070400000n;
 const TWITTER_EPOCH = 1288834974657n;
 
-// max safe snowflake length: 64-bit uint fits within ~20 digits; cap at 25 to reject junk
-const MAX_SNOWFLAKE_LENGTH = 25;
+// u64 max (18446744073709551615) is exactly 20 decimal digits
+const MAX_SNOWFLAKE_LENGTH = 20;
+const MAX_SNOWFLAKE = 18446744073709551615n;
 
 export const SnowflakeBoxSource = {
   name: 'Snowflake',
@@ -31,6 +32,7 @@ export const SnowflakeBoxSource = {
     if (!/^\d+$/.test(raw) || raw.length > MAX_SNOWFLAKE_LENGTH) return [];
 
     const id = BigInt(raw);
+    if (id > MAX_SNOWFLAKE) return [];
 
     const epochOption = extractOptionKeys(options, 'snowflake', 'epoch');
     const useTwitter = epochOption === 'twitter';
@@ -56,7 +58,7 @@ export const SnowflakeBoxSource = {
       new BoxBuilder('Snowflake', timestamp)
         .setOptions(kvOptions)
         .setTemplate(KeyValueBoxTemplate)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build(),
     ];
   },

--- a/src/modules/boxSources/SnowflakeBoxSource.ts
+++ b/src/modules/boxSources/SnowflakeBoxSource.ts
@@ -1,0 +1,65 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// epochs: discord = 2015-01-01, twitter = 2010-11-04T01:00:00Z
+const DISCORD_EPOCH = 1420070400000n;
+const TWITTER_EPOCH = 1288834974657n;
+
+// max safe snowflake length: 64-bit uint fits within ~20 digits; cap at 25 to reject junk
+const MAX_SNOWFLAKE_LENGTH = 25;
+
+export const SnowflakeBoxSource = {
+  name: 'Snowflake',
+  description:
+    'Parse a Snowflake ID (Discord/Twitter) into its timestamp and components.',
+  defaultInput: '175928847299117063 ::snowflake',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'snowflake')) return [];
+
+    const raw = trim(input);
+    if (!/^\d+$/.test(raw) || raw.length > MAX_SNOWFLAKE_LENGTH) return [];
+
+    const id = BigInt(raw);
+
+    const epochOption = extractOptionKeys(options, 'snowflake', 'epoch');
+    const useTwitter = epochOption === 'twitter';
+    const epoch = useTwitter ? TWITTER_EPOCH : DISCORD_EPOCH;
+    const epochLabel = useTwitter ? 'Twitter' : 'Discord';
+
+    const timestampMs = Number((id >> 22n) + epoch);
+    const timestamp = new Date(timestampMs).toISOString();
+    const workerId = ((id >> 17n) & 0x1fn).toString();
+    const processId = ((id >> 12n) & 0x1fn).toString();
+    const increment = (id & 0xfffn).toString();
+
+    const kvOptions: BoxOptions = {
+      Timestamp: timestamp,
+      'Unix (ms)': timestampMs.toString(),
+      'Worker ID': workerId,
+      'Process ID': processId,
+      Increment: increment,
+      Epoch: epochLabel,
+    };
+
+    return [
+      new BoxBuilder('Snowflake', timestamp)
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default SnowflakeBoxSource;

--- a/src/modules/boxSources/__test__/ColorContrastBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ColorContrastBoxSource.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import { ColorContrastBoxSource } from '../ColorContrastBoxSource';
+
+describe('ColorContrastBoxSource.generateBoxes', () => {
+  it('returns [] when ::contrast option is absent', async () => {
+    const boxes = await ColorContrastBoxSource.generateBoxes(
+      '#000000 #ffffff',
+      null,
+    );
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] when options object has no contrast key', async () => {
+    const boxes = await ColorContrastBoxSource.generateBoxes(
+      '#000000 #ffffff',
+      { qr: true },
+    );
+    expect(boxes).toHaveLength(0);
+  });
+
+  describe('black vs white (#000000 #ffffff)', () => {
+    it('produces exactly one box', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#000000 #ffffff',
+        { contrast: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('ratio is 21:1 (exactly 21)', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#000000 #ffffff',
+        { contrast: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Ratio).toBe('21:1');
+    });
+
+    it('AA Normal passes', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#000000 #ffffff',
+        { contrast: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['AA Normal']).toBe('pass');
+    });
+
+    it('AAA Normal passes', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#000000 #ffffff',
+        { contrast: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['AAA Normal']).toBe('pass');
+    });
+
+    it('all four WCAG levels pass', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#000000 #ffffff',
+        { contrast: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['AA Normal']).toBe('pass');
+      expect(opts['AA Large']).toBe('pass');
+      expect(opts['AAA Normal']).toBe('pass');
+      expect(opts['AAA Large']).toBe('pass');
+    });
+  });
+
+  describe('#777777 vs #ffffff (ratio ~4.48)', () => {
+    it('ratio is 4.48', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#777777 #ffffff',
+        { contrast: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Ratio).toBe('4.48');
+    });
+
+    it('AA Normal fails (4.48 < 4.5)', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#777777 #ffffff',
+        { contrast: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['AA Normal']).toBe('fail');
+    });
+
+    it('AA Large passes (4.48 >= 3)', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#777777 #ffffff',
+        { contrast: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['AA Large']).toBe('pass');
+    });
+
+    it('AAA levels fail', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#777777 #ffffff',
+        { contrast: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['AAA Normal']).toBe('fail');
+      expect(opts['AAA Large']).toBe('fail');
+    });
+  });
+
+  describe('#ffffff vs #ffffff (ratio 1)', () => {
+    it('ratio is 1:1', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#ffffff #ffffff',
+        { contrast: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Ratio).toBe('1:1');
+    });
+
+    it('all WCAG levels fail', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#ffffff #ffffff',
+        { contrast: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['AA Normal']).toBe('fail');
+      expect(opts['AA Large']).toBe('fail');
+      expect(opts['AAA Normal']).toBe('fail');
+      expect(opts['AAA Large']).toBe('fail');
+    });
+  });
+
+  describe('newline-separated short hex (#000\\n#fff)', () => {
+    it('parses short hex and produces correct ratio', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes('#000\n#fff', {
+        contrast: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Ratio).toBe('21:1');
+    });
+  });
+
+  describe('error cases', () => {
+    it('one color only returns an explanatory box mentioning two colors', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes('#000000', {
+        contrast: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // the box should mention two colors in either the output or options
+      const box = boxes[0];
+      const mentionsTwoColors =
+        box.props.plaintextOutput.includes('two') ||
+        JSON.stringify(box.props.options).includes('two');
+      expect(mentionsTwoColors).toBe(true);
+    });
+
+    it('priority matches source priority (10)', async () => {
+      const boxes = await ColorContrastBoxSource.generateBoxes(
+        '#000000 #ffffff',
+        { contrast: true },
+      );
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ColorContrastBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ColorContrastBoxSource.test.ts
@@ -75,7 +75,7 @@ describe('ColorContrastBoxSource.generateBoxes', () => {
         { contrast: true },
       );
       const opts = boxes[0].props.options as Record<string, string>;
-      expect(opts.Ratio).toBe('4.48');
+      expect(opts.Ratio).toBe('4.48:1');
     });
 
     it('AA Normal fails (4.48 < 4.5)', async () => {

--- a/src/modules/boxSources/__test__/CronNextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CronNextBoxSource.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { CronNextBoxSource } from '../CronNextBoxSource';
+
+describe('CronNextBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::cronnext option is absent', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('*/15 * * * *', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is an empty object without cronnext', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('*/15 * * * *', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('computes next 3 runs of */15 * * * * from 2024-01-01T00:00:00Z', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('*/15 * * * *', {
+        cronnext: true,
+        from: '2024-01-01T00:00:00Z',
+        count: '3',
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toEqual([
+        '2024-01-01T00:15:00.000Z',
+        '2024-01-01T00:30:00.000Z',
+        '2024-01-01T00:45:00.000Z',
+      ]);
+    });
+
+    it('computes daily midnight runs (0 0 * * *) from 2024-01-01T12:00:00Z count 2', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('0 0 * * *', {
+        cronnext: true,
+        from: '2024-01-01T12:00:00Z',
+        count: '2',
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toEqual([
+        '2024-01-02T00:00:00.000Z',
+        '2024-01-03T00:00:00.000Z',
+      ]);
+    });
+
+    it('computes 9am Mondays (0 9 * * 1) from 2024-01-01T00:00:00Z — 2024-01-01 is Monday', async () => {
+      // 2024-01-01 is indeed a Monday (day=1)
+      const boxes = await CronNextBoxSource.generateBoxes('0 9 * * 1', {
+        cronnext: true,
+        from: '2024-01-01T00:00:00Z',
+        count: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toEqual(['2024-01-01T09:00:00.000Z']);
+    });
+
+    it('returns an invalid-expression box for non-cron input', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('not a cron', {
+        cronnext: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+
+    it('defaults count to 5 when ::count is absent', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('* * * * *', {
+        cronnext: true,
+        from: '2024-01-01T00:00:00Z',
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toHaveLength(5);
+    });
+
+    it('clamps count to 20 when ::count exceeds maximum', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('* * * * *', {
+        cronnext: true,
+        from: '2024-01-01T00:00:00Z',
+        count: '100',
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toHaveLength(20);
+    });
+
+    it('accepts 7 as Sunday alias in dow field', async () => {
+      // 2024-01-07 is a Sunday
+      const boxes = await CronNextBoxSource.generateBoxes('0 12 * * 7', {
+        cronnext: true,
+        from: '2024-01-06T00:00:00Z',
+        count: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('2024-01-07T12:00:00.000Z');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CronNextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CronNextBoxSource.test.ts
@@ -94,5 +94,30 @@ describe('CronNextBoxSource', () => {
       expect(boxes).toHaveLength(1);
       expect(boxes[0].props.plaintextOutput).toBe('2024-01-07T12:00:00.000Z');
     });
+
+    it('handles a dow range that wraps through 7 (5-7 = Fri/Sat/Sun)', async () => {
+      // 2024-01-05 is a Friday; 5-7 covers Fri(5), Sat(6), Sun(0)
+      const boxes = await CronNextBoxSource.generateBoxes('0 0 * * 5-7', {
+        cronnext: true,
+        from: '2024-01-04T12:00:00Z',
+        count: '3',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe(
+        [
+          '2024-01-05T00:00:00.000Z', // Friday
+          '2024-01-06T00:00:00.000Z', // Saturday
+          '2024-01-07T00:00:00.000Z', // Sunday
+        ].join('\n'),
+      );
+    });
+
+    it('bails cleanly on an impossible expression (Feb 30)', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('0 0 30 2 *', {
+        cronnext: true,
+        from: '2024-01-01T00:00:00Z',
+      });
+      // no matches within the search window — surfaces a box, does not hang
+      expect(boxes).toHaveLength(1);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/InvisibleCharsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/InvisibleCharsBoxSource.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { InvisibleCharsBoxSource } from '../InvisibleCharsBoxSource';
+
+describe('InvisibleCharsBoxSource', () => {
+  it('returns [] when no option is provided', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes(
+      'hello​world',
+      null,
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when an unrelated option is provided', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('hello​world', {
+      base64: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for empty input', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('', {
+      invisibles: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('detects zero-width space U+200B with ::invisibles', async () => {
+    // 'hello​world' contains U+200B between hello and world
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('hello​world', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const output = boxes[0].props.plaintextOutput;
+    expect(output).toContain('U+200B');
+    expect(output).toContain('hello[U+200B]world');
+  });
+
+  it('detects zero-width space with ::hiddenchars alias', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('hello​world', {
+      hiddenchars: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toContain('U+200B');
+  });
+
+  it('detects non-breaking space U+00A0 (NBSP)', async () => {
+    // 'a b' — non-breaking space between a and b
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('a b', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const output = boxes[0].props.plaintextOutput;
+    expect(output).toContain('U+00A0');
+    expect(output).toContain('NO-BREAK SPACE');
+  });
+
+  it('reports no invisible characters for clean ASCII', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('hello world', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe(
+      'No invisible characters found.',
+    );
+  });
+
+  it('does not flag visible unicode letters and emoji (café 😀)', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('café 😀', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe(
+      'No invisible characters found.',
+    );
+  });
+
+  it('detects BOM U+FEFF', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('﻿hello', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const output = boxes[0].props.plaintextOutput;
+    expect(output).toContain('U+FEFF');
+    expect(output).toContain('BYTE ORDER MARK');
+  });
+
+  it('counts multiple occurrences of the same invisible char', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('a​b​c', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const output = boxes[0].props.plaintextOutput;
+    // count should be 2
+    expect(output).toContain('ZERO WIDTH SPACE (U+200B): 2');
+  });
+
+  it('revealed text replaces each invisible char with its token', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('x‌y‍z', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const output = boxes[0].props.plaintextOutput;
+    expect(output).toContain('x[U+200C]y[U+200D]z');
+  });
+
+  it('allows normal tab, newline, and carriage return', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('a\tb\nc\rd', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe(
+      'No invisible characters found.',
+    );
+  });
+});

--- a/src/modules/boxSources/__test__/InvisibleCharsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/InvisibleCharsBoxSource.test.ts
@@ -112,4 +112,13 @@ describe('InvisibleCharsBoxSource', () => {
       'No invisible characters found.',
     );
   });
+
+  it('flags DEL and C1 control characters', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('a\x7fb\x9fc', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toContain('U+007F');
+    expect(boxes[0].props.plaintextOutput).toContain('U+009F');
+  });
 });

--- a/src/modules/boxSources/__test__/JwtSignBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JwtSignBoxSource.test.ts
@@ -110,5 +110,17 @@ describe('JwtSignBoxSource', () => {
       expect(JwtSignBoxSource.kind).toBe('Encode');
       expect(typeof JwtSignBoxSource.priority).toBe('number');
     });
+
+    it('rejects a non-object JSON payload (array / primitive)', async () => {
+      for (const payload of ['[1,2,3]', '123', '"hi"', 'true']) {
+        const boxes = await JwtSignBoxSource.generateBoxes(payload, {
+          jwtsign: 'secret',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain(
+          'must be a json object',
+        );
+      }
+    });
   });
 });

--- a/src/modules/boxSources/__test__/JwtSignBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JwtSignBoxSource.test.ts
@@ -1,0 +1,114 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { JwtSignBoxSource } from '../JwtSignBoxSource';
+
+// canonical jwt.io HS256 example token
+const CANONICAL_PAYLOAD =
+  '{"sub":"1234567890","name":"John Doe","iat":1516239022}';
+const CANONICAL_SECRET = 'your-256-bit-secret';
+const CANONICAL_TOKEN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+
+describe('JwtSignBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no jwtsign option is provided', async () => {
+      const boxes = await JwtSignBoxSource.generateBoxes(
+        CANONICAL_PAYLOAD,
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await JwtSignBoxSource.generateBoxes(CANONICAL_PAYLOAD, {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - canonical jwt.io token', () => {
+    it('produces the exact canonical HS256 token', async () => {
+      const boxes = await JwtSignBoxSource.generateBoxes(CANONICAL_PAYLOAD, {
+        jwtsign: CANONICAL_SECRET,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(CANONICAL_TOKEN);
+      expect(boxes[0].props.name).toBe('JWT Sign');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('header segment is eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9', async () => {
+      const boxes = await JwtSignBoxSource.generateBoxes(CANONICAL_PAYLOAD, {
+        jwtsign: CANONICAL_SECRET,
+      });
+      const [header] = boxes[0].props.plaintextOutput.split('.');
+      expect(header).toBe('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+    });
+
+    it('signature segment is SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c', async () => {
+      const boxes = await JwtSignBoxSource.generateBoxes(CANONICAL_PAYLOAD, {
+        jwtsign: CANONICAL_SECRET,
+      });
+      const parts = boxes[0].props.plaintextOutput.split('.');
+      expect(parts[2]).toBe('SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c');
+    });
+  });
+
+  describe('generateBoxes - missing secret', () => {
+    it('returns a box mentioning secret required when ::jwtsign has no value (boolean true)', async () => {
+      const boxes = await JwtSignBoxSource.generateBoxes('{"a":1}', {
+        jwtsign: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/secret/i);
+    });
+  });
+
+  describe('generateBoxes - invalid JSON payload', () => {
+    it('returns a box mentioning invalid JSON when payload is not parseable', async () => {
+      const boxes = await JwtSignBoxSource.generateBoxes('not-json', {
+        jwtsign: 'x',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+  });
+
+  describe('generateBoxes - non-secure context fallback', () => {
+    const originalCrypto = globalThis.crypto;
+
+    beforeEach(() => {
+      // simulate environment without crypto.subtle
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { subtle: undefined },
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('returns a box mentioning secure context when crypto.subtle is unavailable', async () => {
+      const boxes = await JwtSignBoxSource.generateBoxes('{"a":1}', {
+        jwtsign: 'secret',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(JwtSignBoxSource.name).toBe('JWT Sign');
+      expect(JwtSignBoxSource.tag).toBe('#');
+      expect(JwtSignBoxSource.kind).toBe('Encode');
+      expect(typeof JwtSignBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LevenshteinBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LevenshteinBoxSource.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { LevenshteinBoxSource } from '../LevenshteinBoxSource';
+
+describe('LevenshteinBoxSource', () => {
+  describe('generateBoxes - option gate', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes(
+        'kitten\nsitting',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes(
+        'kitten\nsitting',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::levenshtein trigger', () => {
+    it('kitten vs sitting yields distance 3', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes(
+        'kitten\nsitting',
+        { levenshtein: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Distance).toBe('3');
+    });
+
+    it('identical strings yield distance 0 and similarity 100.0%', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes('abc\nabc', {
+        levenshtein: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.Distance).toBe('0');
+      expect(opts?.Similarity).toBe('100.0%');
+    });
+
+    it('fully different strings of equal length yield distance 3 and similarity 0.0%', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes('abc\nxyz', {
+        levenshtein: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.Distance).toBe('3');
+      expect(opts?.Similarity).toBe('0.0%');
+    });
+
+    it('flaw vs lawn yields distance 2', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes('flaw\nlawn', {
+        levenshtein: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Distance).toBe('2');
+    });
+  });
+
+  describe('generateBoxes - ::editdistance alias', () => {
+    it('accepts ::editdistance option', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes(
+        'kitten\nsitting',
+        { editdistance: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Distance).toBe('3');
+    });
+  });
+
+  describe('generateBoxes - single line without newline', () => {
+    it('returns an informational box when input has no newline', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes('abc', {
+        levenshtein: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/two.*strings.*required/i);
+    });
+  });
+
+  describe('generateBoxes - length fields', () => {
+    it('reports correct Length A and Length B', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes(
+        'kitten\nsitting',
+        { levenshtein: true },
+      );
+      const opts = boxes[0].props.options;
+      expect(opts?.['Length A']).toBe('6');
+      expect(opts?.['Length B']).toBe('7');
+    });
+  });
+
+  describe('generateBoxes - both-empty edge case', () => {
+    it('both empty strings yield distance 0 and similarity 100.0%', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes('\n', {
+        levenshtein: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.Distance).toBe('0');
+      expect(opts?.Similarity).toBe('100.0%');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LevenshteinBoxSource.name).toBe('Levenshtein');
+      expect(LevenshteinBoxSource.tag).toBe('#');
+      expect(LevenshteinBoxSource.kind).toBe('Analyze');
+      expect(typeof LevenshteinBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/MacAddressBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MacAddressBoxSource.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import { MacAddressBoxSource } from '../MacAddressBoxSource';
+
+describe('MacAddressBoxSource', () => {
+  describe('no option', () => {
+    it('returns [] when no mac option is provided', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '00:1B:44:11:3A:B7',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '00:1B:44:11:3A:B7',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('colon format', () => {
+    it('normalizes colon-separated MAC to all formats', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '00:1B:44:11:3A:B7',
+        { mac: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('00:1b:44:11:3a:b7');
+      expect(opts.Hyphen).toBe('00-1b-44-11-3a-b7');
+      expect(opts.Dot).toBe('001b.4411.3ab7');
+      expect(opts.Bare).toBe('001b44113ab7');
+    });
+  });
+
+  describe('hyphen format', () => {
+    it('accepts hyphen-separated input and produces same colon output', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '00-1b-44-11-3a-b7',
+        { mac: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('00:1b:44:11:3a:b7');
+    });
+  });
+
+  describe('bare format', () => {
+    it('accepts bare 12-digit hex input', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('001B44113AB7', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('00:1b:44:11:3a:b7');
+      expect(opts.Bare).toBe('001b44113ab7');
+    });
+  });
+
+  describe('cisco dot format', () => {
+    it('accepts cisco-style dot-separated input', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('001b.4411.3ab7', {
+        macaddress: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('00:1b:44:11:3a:b7');
+    });
+  });
+
+  describe('Type field', () => {
+    it('reports unicast + universal for 0x00 first octet', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '00:1b:44:11:3a:b7',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toBe('unicast, universal');
+    });
+
+    it('reports multicast for first octet with LSB set (0x01)', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:00:5e:00:00:01',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toMatch(/^multicast/);
+    });
+
+    it('reports local for first octet with 2nd-LSB set (0x02)', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '02:00:00:00:00:01',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toMatch(/local$/);
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns [] for non-hex string', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('xyz', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for wrong length', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('001b44', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('', { mac: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(MacAddressBoxSource.name).toBe('MAC Address');
+      expect(MacAddressBoxSource.tag).toBe('#');
+      expect(MacAddressBoxSource.kind).toBe('Convert');
+      expect(typeof MacAddressBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/SemverBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SemverBoxSource.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'vitest';
+
+import { SemverBoxSource } from '../SemverBoxSource';
+
+describe('SemverBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::semver option is absent', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('1.2.3');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is null', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('1.2.3', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('parses a basic semver string', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('1.2.3', {
+        semver: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Major).toBe('1');
+      expect(opts.Minor).toBe('2');
+      expect(opts.Patch).toBe('3');
+      expect(opts.Valid).toBe('true');
+    });
+
+    it('parses prerelease and build metadata', async () => {
+      const boxes = await SemverBoxSource.generateBoxes(
+        '1.2.3-beta.1+build.5',
+        { semver: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Prerelease).toBe('beta.1');
+      expect(opts.Build).toBe('build.5');
+      expect(opts.Valid).toBe('true');
+    });
+
+    it('strips a leading v before parsing', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('v2.0.0', {
+        semver: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Major).toBe('2');
+      expect(opts.Valid).toBe('true');
+    });
+
+    it('returns an invalid box for a non-semver string', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('1.2', {
+        semver: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const content = boxes[0].props.plaintextOutput;
+      expect(content).toMatch(/not a valid semver/i);
+    });
+
+    it('rejects leading zeros in numeric identifiers', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('01.2.3', {
+        semver: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const content = boxes[0].props.plaintextOutput;
+      expect(content).toMatch(/not a valid semver/i);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/SnowflakeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SnowflakeBoxSource.test.ts
@@ -105,5 +105,14 @@ describe('SnowflakeBoxSource', () => {
       });
       expect(boxes).toHaveLength(0);
     });
+
+    it('rejects values above the 64-bit range (would crash toISOString)', async () => {
+      // 21 digits, > u64 max
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '999999999999999999999',
+        { snowflake: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/SnowflakeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SnowflakeBoxSource.test.ts
@@ -1,0 +1,109 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { SnowflakeBoxSource } from '../SnowflakeBoxSource';
+
+describe('SnowflakeBoxSource', () => {
+  describe('no ::snowflake option', () => {
+    it('returns [] when options are null', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '175928847299117063',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when ::snowflake key is absent', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '175928847299117063',
+        { other: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('discord epoch (default)', () => {
+    // verified: 175928847299117063n >> 22n = 41944705796n
+    // 41944705796 + 1420070400000 = 1462015105796 → 2016-04-30T11:18:25.796Z
+    // worker: (id >> 17n) & 0x1fn = 1n, process: (id >> 12n) & 0x1fn = 0n, increment: id & 0xfffn = 7n
+    it('parses discord snowflake into correct components', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '175928847299117063',
+        { snowflake: true },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Timestamp).toBe('2016-04-30T11:18:25.796Z');
+      expect(options?.['Unix (ms)']).toBe('1462015105796');
+      expect(options?.['Worker ID']).toBe('1');
+      expect(options?.['Process ID']).toBe('0');
+      expect(options?.Increment).toBe('7');
+      expect(options?.Epoch).toBe('Discord');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '175928847299117063',
+        { snowflake: true },
+      );
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '175928847299117063',
+        { snowflake: true },
+      );
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('twitter epoch via ::snowflake=twitter', () => {
+    it('reports Epoch as Twitter and returns a plausible date', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '1234567890123456789',
+        { snowflake: 'twitter' },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Epoch).toBe('Twitter');
+
+      // plausibility: twitter launched 2006, snowflakes appeared ~2010; date must be after epoch
+      const ts = Number(options?.['Unix (ms)']);
+      expect(ts).toBeGreaterThan(1288834974657); // after twitter epoch
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes('abc', {
+        snowflake: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty string', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes('', {
+        snowflake: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding max length', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '12345678901234567890123456', // 26 digits, over cap
+        { snowflake: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for mixed alphanumeric input', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes('175928abc', {
+        snowflake: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -3,21 +3,29 @@ import {
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import ColorContrastBoxSource from './ColorContrastBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
+import CronNextBoxSource from './CronNextBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import InvisibleCharsBoxSource from './InvisibleCharsBoxSource';
 import JWTBoxSource from './JWTBoxSource';
+import JwtSignBoxSource from './JwtSignBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LevenshteinBoxSource from './LevenshteinBoxSource';
+import MacAddressBoxSource from './MacAddressBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import SemverBoxSource from './SemverBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SnowflakeBoxSource from './SnowflakeBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
@@ -29,22 +37,30 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  ColorContrastBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
+  CronNextBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  InvisibleCharsBoxSource,
+  JwtSignBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LevenshteinBoxSource,
+  MacAddressBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
+  SemverBoxSource,
   ShortenURLBoxSource,
+  SnowflakeBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,


### PR DESCRIPTION
## Summary

Twelfth exploration batch — **8 more BoxSource tools** (crypto, dev-ops, text analysis).

| Tool | Trigger | What it does |
|------|---------|--------------|
| JWT Sign | `::jwtsign=SECRET` | HS256 JWT from a JSON payload (Web Crypto) |
| Semver | `::semver` | parse/validate against the official SemVer 2.0 regex |
| Cron Next Runs | `::cronnext` | next N fire times of a 5-field cron (`::from`/`::count`) |
| Levenshtein | `::levenshtein` | edit distance + similarity between two lines |
| Color Contrast | `::contrast` | WCAG ratio + AA/AAA pass/fail |
| MAC Address | `::mac` | validate + normalize (colon/hyphen/dot/bare) + type |
| Snowflake | `::snowflake` | parse a Discord/Twitter ID into timestamp + parts |
| Invisible Characters | `::invisibles` | reveal zero-width / NBSP / BOM / control chars |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules (no `BigInt(parseInt)`, input caps, `this.priority`, deterministic tests).
- **Determinism for the time/crypto tools**: JWT Sign verified against the canonical jwt.io HS256 token (exact match incl. signature `SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`); Cron Next takes a `::from` base time so its tests are clock-independent; Snowflake parses via `BigInt(str)` (the recurring `BigInt(parseInt)` bug stays absent).
- **Verified vectors**: snowflake `175928847299117063` → `2016-04-30T11:18:25.796Z` (worker 1 / proc 0 / incr 7); black/white contrast = 21; kitten/sitting = 3.
- Levenshtein capped at 5000 chars (the DP is O(n·m)).

## Verification

- ✅ `bun run test run` — **416 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#270 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6