### PR TITLE
feat(boxSources): add 8 more tools (base32, crc32, luhn, hmac, url-parse, query-string, unicode-escape, sort-lines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,81 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>Base32Box</b> </summary>
+
+| match rule         | description                          | example          |
+| ------------------ | ------------------------------------ | ---------------- |
+| `::base32`         | Base32 encode (RFC 4648)             | `hello ::base32` |
+| `::base32decode`   | Base32 decode                        | `NBSWY3DP ::base32decode` |
+
+</details>
+
+<details>
+<summary> <b>Crc32Box</b> </summary>
+
+| match rule   | description                          | example          |
+| ------------ | ------------------------------------ | ---------------- |
+| `::crc32`    | CRC-32 (IEEE 802.3) checksum         | `hello ::crc32`  |
+
+</details>
+
+<details>
+<summary> <b>LuhnBox</b> </summary>
+
+| match rule | description                          | example                |
+| ---------- | ------------------------------------ | ---------------------- |
+| `::luhn`   | Luhn (mod-10) validate + check digit | `79927398713 ::luhn`   |
+
+</details>
+
+<details>
+<summary> <b>HmacBox</b> </summary>
+
+| match rule      | description                          | example                       |
+| --------------- | ------------------------------------ | ----------------------------- |
+| `::hmac=KEY`    | HMAC of input (SHA-256 default; `::hmacalg=sha1\|sha256\|sha512`) | `message ::hmac=secret` |
+
+</details>
+
+<details>
+<summary> <b>UrlParseBox</b> </summary>
+
+| match rule     | description                          | example                              |
+| -------------- | ------------------------------------ | ------------------------------------ |
+| `::urlparse`   | break a URL into its components      | `https://x.com:8080/a?b=1 ::urlparse` |
+
+</details>
+
+<details>
+<summary> <b>QueryStringBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::qs`      | query string ⇄ JSON (auto-direction) | `a=1&b=2 ::qs`   |
+
+</details>
+
+<details>
+<summary> <b>UnicodeEscapeBox</b> </summary>
+
+| match rule              | description                          | example                |
+| ----------------------- | ------------------------------------ | ---------------------- |
+| `::unicodeescape`       | escape text to `\uXXXX`              | `héllo ::unicodeescape` |
+| `::unicodeunescape`     | unescape `\uXXXX` / `\u{...}`        | `€ ::unicodeunescape` |
+
+</details>
+
+<details>
+<summary> <b>SortLinesBox</b> </summary>
+
+| match rule        | description                          | example                       |
+| ----------------- | ------------------------------------ | ----------------------------- |
+| `::sortlines`     | sort lines (`=desc`, `=num`, `=numdesc`) | `banana`<br>`apple ::sortlines` |
+| `::uniqlines`     | remove duplicate lines               | `a`<br>`a`<br>`b ::uniqlines` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/Base32BoxSource.ts
+++ b/src/modules/boxSources/Base32BoxSource.ts
@@ -9,6 +9,8 @@ const MAX_INPUT = 100_000;
 // RFC 4648 Base32 alphabet
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 const ALPHABET_SET = new Set(ALPHABET);
+// reverse lookup for O(1) decode (avoids ALPHABET.indexOf per char)
+const CHAR_VALUE = new Map([...ALPHABET].map((ch, i) => [ch, i]));
 
 // encodes bytes to RFC 4648 Base32 with = padding to a multiple of 8 chars
 function encodeBase32(bytes: Uint8Array): string {
@@ -53,7 +55,7 @@ function decodeBase32(input: string): Uint8Array {
   let value = 0;
 
   for (const ch of clean) {
-    value = (value << 5) | ALPHABET.indexOf(ch);
+    value = (value << 5) | (CHAR_VALUE.get(ch) ?? 0);
     bits += 5;
     if (bits >= 8) {
       bits -= 8;

--- a/src/modules/boxSources/Base32BoxSource.ts
+++ b/src/modules/boxSources/Base32BoxSource.ts
@@ -1,0 +1,130 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// RFC 4648 Base32 alphabet
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const ALPHABET_SET = new Set(ALPHABET);
+
+// encodes bytes to RFC 4648 Base32 with = padding to a multiple of 8 chars
+function encodeBase32(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let output = '';
+
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      output += ALPHABET[(value >> bits) & 0x1f];
+    }
+  }
+
+  // handle remaining bits by left-aligning them in the final group
+  if (bits > 0) {
+    output += ALPHABET[(value << (5 - bits)) & 0x1f];
+  }
+
+  // pad to a multiple of 8
+  while (output.length % 8 !== 0) {
+    output += '=';
+  }
+
+  return output;
+}
+
+// decodes RFC 4648 Base32 string to bytes; throws on invalid characters
+function decodeBase32(input: string): Uint8Array {
+  const clean = input.toUpperCase().replace(/=+$/, '').replace(/\s/g, '');
+
+  for (const ch of clean) {
+    if (!ALPHABET_SET.has(ch)) {
+      throw new Error(`invalid Base32 character: ${ch}`);
+    }
+  }
+
+  const bytes: number[] = [];
+  let bits = 0;
+  let value = 0;
+
+  for (const ch of clean) {
+    value = (value << 5) | ALPHABET.indexOf(ch);
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((value >> bits) & 0xff);
+    }
+  }
+
+  return new Uint8Array(bytes);
+}
+
+export const Base32BoxSource = {
+  name: 'Base32',
+  description: 'Encode text to Base32 (RFC 4648) or decode a Base32 string.',
+  defaultInput: 'hello ::base32',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'base32', 'base32encode');
+    const wantDecode = hasOptionKeys(options, 'base32decode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const bytes = new TextEncoder().encode(input);
+      const encoded = encodeBase32(bytes);
+      boxes.push(
+        new BoxBuilder('Base32 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      try {
+        const bytes = decodeBase32(input);
+        const decoded = new TextDecoder().decode(bytes);
+        boxes.push(
+          new BoxBuilder('Base32 (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        boxes.push(
+          new BoxBuilder('Base32 (Decode)', `invalid Base32 input: ${message}`)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Base32BoxSource;

--- a/src/modules/boxSources/Base32BoxSource.ts
+++ b/src/modules/boxSources/Base32BoxSource.ts
@@ -42,7 +42,9 @@ function encodeBase32(bytes: Uint8Array): string {
 
 // decodes RFC 4648 Base32 string to bytes; throws on invalid characters
 function decodeBase32(input: string): Uint8Array {
-  const clean = input.toUpperCase().replace(/=+$/, '').replace(/\s/g, '');
+  // remove whitespace first so trailing newlines/spaces after the padding
+  // don't leave a stray '=' for the per-char validation to reject
+  const clean = input.toUpperCase().replace(/\s/g, '').replace(/=+$/, '');
 
   for (const ch of clean) {
     if (!ALPHABET_SET.has(ch)) {

--- a/src/modules/boxSources/Crc32BoxSource.ts
+++ b/src/modules/boxSources/Crc32BoxSource.ts
@@ -1,0 +1,71 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// precompute the IEEE 802.3 (reflected) CRC-32 lookup table once at module load
+const CRC32_TABLE: Uint32Array = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let j = 0; j < 8; j++) {
+      // reflected polynomial 0xEDB88320 (bit-reversed 0x04C11DB7)
+      c = c & 1 ? (0xedb88320 ^ (c >>> 1)) >>> 0 : (c >>> 1) >>> 0;
+    }
+    table[i] = c;
+  }
+  return table;
+})();
+
+function computeCrc32(input: string): number {
+  const bytes = new TextEncoder().encode(input);
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = (CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8)) >>> 0;
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+export const Crc32BoxSource = {
+  name: 'CRC-32',
+  description: 'Compute the CRC-32 (IEEE 802.3) checksum of the input text.',
+  defaultInput: 'hello ::crc32',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'crc32')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const checksum = computeCrc32(input);
+    const hex = checksum.toString(16).padStart(8, '0');
+
+    const output: Record<string, string> = {
+      Hex: hex,
+      Decimal: checksum.toString(10),
+      Uppercase: hex.toUpperCase(),
+    };
+
+    return [
+      new BoxBuilder('CRC-32', hex)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Crc32BoxSource;

--- a/src/modules/boxSources/HmacBoxSource.ts
+++ b/src/modules/boxSources/HmacBoxSource.ts
@@ -1,4 +1,5 @@
 import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
 
@@ -55,7 +56,7 @@ export const HmacBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'hmac')) return [];
-    if (input.length > MAX_INPUT) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
 
     // guard for non-secure contexts where crypto.subtle is unavailable
     if (typeof crypto === 'undefined' || !crypto.subtle) {
@@ -90,8 +91,21 @@ export const HmacBoxSource = {
         ? ALG_MAP[algAlias.toLowerCase()]
         : 'SHA-256';
 
-    const algorithmLabel = `HMAC-${hashName.replace('-', '')}`;
-    const hex = await computeHmac(hashName, keyValue, input);
+    const algorithmLabel = `HMAC-${hashName.replace(/-/g, '')}`;
+
+    let hex: string;
+    try {
+      hex = await computeHmac(hashName, keyValue, input);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return [
+        new BoxBuilder('HMAC', `HMAC computation failed: ${message}`)
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
 
     return [
       new BoxBuilder('HMAC', hex)

--- a/src/modules/boxSources/HmacBoxSource.ts
+++ b/src/modules/boxSources/HmacBoxSource.ts
@@ -1,0 +1,107 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 20;
+const MAX_INPUT = 100_000;
+
+// supported HMAC hash algorithms mapped from user-facing alias to Web Crypto name
+type SupportedHash = 'SHA-1' | 'SHA-256' | 'SHA-512';
+
+const ALG_MAP: Record<string, SupportedHash> = {
+  sha1: 'SHA-1',
+  sha256: 'SHA-256',
+  sha512: 'SHA-512',
+};
+
+function bufToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function computeHmac(
+  hashName: SupportedHash,
+  key: string,
+  message: string,
+): Promise<string> {
+  const enc = new TextEncoder();
+  const keyBytes = enc.encode(key);
+  const msgBytes = enc.encode(message);
+
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'HMAC', hash: hashName },
+    false,
+    ['sign'],
+  );
+
+  const sig = await crypto.subtle.sign('HMAC', cryptoKey, msgBytes);
+  return bufToHex(sig);
+}
+
+export const HmacBoxSource = {
+  name: 'HMAC',
+  description:
+    'Compute an HMAC of the input using a secret key. ::hmac=key (SHA-256 default), or ::hmac=key ::hmacalg=sha1|sha256|sha512.',
+  defaultInput: 'message ::hmac=secret',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hmac')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // guard for non-secure contexts where crypto.subtle is unavailable
+    if (typeof crypto === 'undefined' || !crypto.subtle) {
+      return [
+        new BoxBuilder(
+          'HMAC',
+          'HMAC requires a secure context (HTTPS). crypto.subtle is not available.',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const keyValue = extractOptionKeys(options, 'hmac');
+    // key must be a non-empty string (boolean true means bare ::hmac with no value)
+    if (!keyValue || keyValue === true || keyValue === '') {
+      return [
+        new BoxBuilder('HMAC', 'A secret key is required. Use ::hmac=yourkey.')
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const algAlias = extractOptionKeys(options, 'hmacalg');
+    // unknown or missing alias defaults to SHA-256
+    const hashName: SupportedHash =
+      typeof algAlias === 'string' && ALG_MAP[algAlias.toLowerCase()]
+        ? ALG_MAP[algAlias.toLowerCase()]
+        : 'SHA-256';
+
+    const algorithmLabel = `HMAC-${hashName.replace('-', '')}`;
+    const hex = await computeHmac(hashName, keyValue, input);
+
+    return [
+      new BoxBuilder('HMAC', hex)
+        .setOptions({ Algorithm: algorithmLabel, Hex: hex })
+        .setTemplate(KeyValueBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HmacBoxSource;

--- a/src/modules/boxSources/LuhnBoxSource.ts
+++ b/src/modules/boxSources/LuhnBoxSource.ts
@@ -1,0 +1,97 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max digits accepted to avoid pathological inputs
+const MAX_INPUT_LENGTH = 40;
+
+// computes the Luhn sum for the given digit string.
+// positions are counted from the right (1-based). even positions are doubled;
+// values > 9 have 9 subtracted.
+function luhnSum(digits: string): number {
+  let sum = 0;
+  const len = digits.length;
+  for (let i = 0; i < len; i++) {
+    const pos = len - i; // 1-based position from the right
+    let d = Number.parseInt(digits[i], 10);
+    if (pos % 2 === 0) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+  }
+  return sum;
+}
+
+// computes the check digit that, when appended to `payload`, yields a Luhn-valid number.
+// the payload digits shift to positions 2..n+1 once the check digit occupies position 1.
+function computeCheckDigit(payload: string): number {
+  const len = payload.length;
+  let payloadSum = 0;
+  for (let i = 0; i < len; i++) {
+    const pos = len - i + 1; // +1 because check digit will sit at position 1
+    let d = Number.parseInt(payload[i], 10);
+    if (pos % 2 === 0) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    payloadSum += d;
+  }
+  return (10 - (payloadSum % 10)) % 10;
+}
+
+export const LuhnBoxSource = {
+  name: 'Luhn',
+  description:
+    'Validate a number with the Luhn (mod-10) algorithm and compute its check digit.',
+  defaultInput: '79927398713 ::luhn',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'luhn')) return [];
+
+    // strip spaces and hyphens; require digits only
+    const cleaned = trim(input).replace(/[\s-]/g, '');
+
+    if (
+      cleaned.length === 0 ||
+      cleaned.length > MAX_INPUT_LENGTH ||
+      !/^\d+$/.test(cleaned)
+    ) {
+      return [];
+    }
+
+    const sum = luhnSum(cleaned);
+    const isValid = sum % 10 === 0;
+    const checkDigit = computeCheckDigit(cleaned);
+
+    const outputOptions: Record<string, string> = {
+      Input: cleaned,
+      Valid: String(isValid),
+      'Check Digit': String(checkDigit),
+      Sum: String(sum),
+    };
+
+    const plaintextOutput = Object.entries(outputOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Luhn', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(outputOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LuhnBoxSource;

--- a/src/modules/boxSources/LuhnBoxSource.ts
+++ b/src/modules/boxSources/LuhnBoxSource.ts
@@ -57,6 +57,8 @@ export const LuhnBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'luhn')) return [];
+    // bound work before the string ops (a valid number is well under this)
+    if (input.length > 200) return [];
 
     // strip spaces and hyphens; require digits only
     const cleaned = trim(input).replace(/[\s-]/g, '');
@@ -71,12 +73,20 @@ export const LuhnBoxSource = {
 
     const sum = luhnSum(cleaned);
     const isValid = sum % 10 === 0;
-    const checkDigit = computeCheckDigit(cleaned);
 
+    // for a valid number the embedded check digit IS its last digit; for an
+    // invalid one, report the digit to append to make it valid (avoids the
+    // contradictory "Valid: true" + extension-digit display)
     const outputOptions: Record<string, string> = {
       Input: cleaned,
       Valid: String(isValid),
-      'Check Digit': String(checkDigit),
+      ...(isValid
+        ? { 'Check Digit': cleaned[cleaned.length - 1] }
+        : {
+            'Check Digit (append to validate)': String(
+              computeCheckDigit(cleaned),
+            ),
+          }),
       Sum: String(sum),
     };
 

--- a/src/modules/boxSources/QueryStringBoxSource.ts
+++ b/src/modules/boxSources/QueryStringBoxSource.ts
@@ -1,5 +1,5 @@
 import { CodeBoxTemplate } from '@components/BoxTemplate';
-import { trim } from '@functions/helper';
+import { isString, trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
@@ -70,12 +70,12 @@ export const QueryStringBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'qs', 'querystring')) return [];
-    if (input.length > MAX_INPUT) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
 
     const trimmed = trim(input);
 
     // json → qs when input looks like a json object
-    if (trimmed.startsWith('{')) {
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
       try {
         const output = jsonToQs(trimmed);
         return [

--- a/src/modules/boxSources/QueryStringBoxSource.ts
+++ b/src/modules/boxSources/QueryStringBoxSource.ts
@@ -48,6 +48,9 @@ function jsonToQs(input: string): string {
       for (const item of value) {
         parts.push(`${encodedKey}=${encodeURIComponent(String(item))}`);
       }
+    } else if (value !== null && typeof value === 'object') {
+      // a nested object can't be a query-string value; the contract is flat
+      throw new Error('Input must be a flat JSON object');
     } else {
       parts.push(`${encodedKey}=${encodeURIComponent(String(value))}`);
     }

--- a/src/modules/boxSources/QueryStringBoxSource.ts
+++ b/src/modules/boxSources/QueryStringBoxSource.ts
@@ -1,0 +1,123 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// keys that must not be set on a plain object to prevent prototype pollution
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function qsToJson(input: string): string {
+  const stripped = input.startsWith('?') ? input.slice(1) : input;
+  const params = new URLSearchParams(stripped);
+
+  // use Object.create(null) so the result has no inherited prototype
+  const obj = Object.create(null) as Record<string, string | string[]>;
+
+  for (const [key, value] of params.entries()) {
+    if (FORBIDDEN_KEYS.has(key)) continue;
+
+    const existing = obj[key];
+    if (existing === undefined) {
+      obj[key] = value;
+    } else if (Array.isArray(existing)) {
+      existing.push(value);
+    } else {
+      obj[key] = [existing, value];
+    }
+  }
+
+  return JSON.stringify(obj, null, 2);
+}
+
+function jsonToQs(input: string): string {
+  const parsed: unknown = JSON.parse(input);
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Input must be a flat JSON object');
+  }
+
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(
+    parsed as Record<string, unknown>,
+  )) {
+    const encodedKey = encodeURIComponent(key);
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        parts.push(`${encodedKey}=${encodeURIComponent(String(item))}`);
+      }
+    } else {
+      parts.push(`${encodedKey}=${encodeURIComponent(String(value))}`);
+    }
+  }
+
+  return parts.join('&');
+}
+
+export const QueryStringBoxSource = {
+  name: 'Query String',
+  description:
+    'Convert a URL query string to JSON, or a flat JSON object to a query string.',
+  defaultInput: 'a=1&b=2&b=3 ::qs',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'qs', 'querystring')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    // json → qs when input looks like a json object
+    if (trimmed.startsWith('{')) {
+      try {
+        const output = jsonToQs(trimmed);
+        return [
+          new BoxBuilder('JSON → Query String', output)
+            .setTemplate(CodeBoxTemplate)
+            .setShowExpandButton(true)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return [
+          new BoxBuilder('JSON → Query String (error)', message)
+            .setTemplate(CodeBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // qs → json
+    try {
+      const output = qsToJson(trimmed);
+      return [
+        new BoxBuilder('Query String → JSON', output)
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(true)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return [
+        new BoxBuilder('Query String → JSON (error)', message)
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+  },
+};
+
+export default QueryStringBoxSource;

--- a/src/modules/boxSources/SortLinesBoxSource.ts
+++ b/src/modules/boxSources/SortLinesBoxSource.ts
@@ -1,0 +1,120 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// strips a trailing \r so both \n and \r\n line endings are handled
+function splitLines(input: string): string[] {
+  return input
+    .split('\n')
+    .map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line));
+}
+
+type SortMode = 'asc' | 'desc' | 'num' | 'numdesc';
+
+function resolveSortMode(raw: string | boolean | null): SortMode {
+  if (raw === true || raw === '' || raw === 'asc') return 'asc';
+  if (raw === 'desc') return 'desc';
+  if (raw === 'num') return 'num';
+  if (raw === 'numdesc') return 'numdesc';
+  return 'asc';
+}
+
+function dedupeLines(lines: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const line of lines) {
+    if (!seen.has(line)) {
+      seen.add(line);
+      result.push(line);
+    }
+  }
+  return result;
+}
+
+function sortLines(lines: string[], mode: SortMode): string[] {
+  const sorted = [...lines];
+  switch (mode) {
+    case 'asc':
+      sorted.sort((a, b) => a.localeCompare(b));
+      break;
+    case 'desc':
+      sorted.sort((a, b) => b.localeCompare(a));
+      break;
+    case 'num': {
+      sorted.sort((a, b) => {
+        const na = Number(a);
+        const nb = Number(b);
+        const aNaN = Number.isNaN(na);
+        const bNaN = Number.isNaN(nb);
+        if (aNaN && bNaN) return 0;
+        if (aNaN) return 1;
+        if (bNaN) return -1;
+        return na - nb;
+      });
+      break;
+    }
+    case 'numdesc': {
+      sorted.sort((a, b) => {
+        const na = Number(a);
+        const nb = Number(b);
+        const aNaN = Number.isNaN(na);
+        const bNaN = Number.isNaN(nb);
+        if (aNaN && bNaN) return 0;
+        if (aNaN) return 1;
+        if (bNaN) return -1;
+        return nb - na;
+      });
+      break;
+    }
+  }
+  return sorted;
+}
+
+export const SortLinesBoxSource = {
+  name: 'Sort Lines',
+  description:
+    'Sort lines of text (::sortlines, ::sortlines=desc, ::sortlines=num) and/or remove duplicates (::uniqlines).',
+  defaultInput: 'banana\napple\ncherry\napple ::sortlines',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantSort = hasOptionKeys(options, 'sortlines');
+    const wantUniq = hasOptionKeys(options, 'uniqlines', 'dedupelines');
+    if (!wantSort && !wantUniq) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    let lines = splitLines(input);
+
+    // dedupe first so sort sees the already-reduced set
+    if (wantUniq) {
+      lines = dedupeLines(lines);
+    }
+
+    if (wantSort) {
+      const rawValue = extractOptionKeys(options, 'sortlines');
+      const mode = resolveSortMode(rawValue);
+      lines = sortLines(lines, mode);
+    }
+
+    const output = lines.join('\n');
+
+    return [
+      new BoxBuilder('Sort Lines', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default SortLinesBoxSource;

--- a/src/modules/boxSources/SortLinesBoxSource.ts
+++ b/src/modules/boxSources/SortLinesBoxSource.ts
@@ -8,9 +8,13 @@ const MAX_INPUT = 100_000;
 
 // strips a trailing \r so both \n and \r\n line endings are handled
 function splitLines(input: string): string[] {
-  return input
+  const lines = input
     .split('\n')
     .map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line));
+  // a single trailing newline is a terminator, not a phantom blank line that
+  // would otherwise sort to the top
+  if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop();
+  return lines;
 }
 
 type SortMode = 'asc' | 'desc' | 'num' | 'numdesc';

--- a/src/modules/boxSources/UnicodeEscapeBoxSource.ts
+++ b/src/modules/boxSources/UnicodeEscapeBoxSource.ts
@@ -1,3 +1,4 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
 import { isString } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
@@ -60,6 +61,7 @@ export const UnicodeEscapeBoxSource = {
       const escaped = escapeUnicode(input);
       return [
         new BoxBuilder('Unicode Escape', escaped)
+          .setTemplate(DefaultBoxTemplate)
           .setShowExpandButton(false)
           .setPriority(this.priority)
           .build(),
@@ -70,6 +72,7 @@ export const UnicodeEscapeBoxSource = {
     const unescaped = unescapeUnicode(input);
     return [
       new BoxBuilder('Unicode Unescape', unescaped)
+        .setTemplate(DefaultBoxTemplate)
         .setShowExpandButton(false)
         .setPriority(this.priority)
         .build(),

--- a/src/modules/boxSources/UnicodeEscapeBoxSource.ts
+++ b/src/modules/boxSources/UnicodeEscapeBoxSource.ts
@@ -1,0 +1,80 @@
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// escape each UTF-16 code unit: keep printable ASCII (0x20–0x7e), \uXXXX everything else.
+// astral chars (e.g. emoji) are naturally emitted as surrogate pairs (\uD800–\uDFFF).
+function escapeUnicode(input: string): string {
+  let result = '';
+  for (let i = 0; i < input.length; i++) {
+    const cp = input.charCodeAt(i);
+    if (cp >= 0x20 && cp <= 0x7e) {
+      result += input[i];
+    } else {
+      result += `\\u${cp.toString(16).padStart(4, '0')}`;
+    }
+  }
+  return result;
+}
+
+// unescape \u{XXXXX} (1–6 hex, cp <= 0x10ffff) and \uXXXX (exactly 4 hex) sequences.
+// unrecognised text is passed through unchanged.
+function unescapeUnicode(input: string): string {
+  // replace braces form first so \u{...} does not conflict with the 4-hex pattern
+  let result = input.replace(/\\u\{([0-9a-fA-F]{1,6})\}/g, (match, hex) => {
+    const cp = Number.parseInt(hex, 16);
+    if (cp > 0x10ffff) return match; // guard against invalid code point
+    return String.fromCodePoint(cp);
+  });
+
+  result = result.replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => {
+    return String.fromCharCode(Number.parseInt(hex, 16));
+  });
+
+  return result;
+}
+
+export const UnicodeEscapeBoxSource = {
+  name: 'Unicode Escape',
+  description:
+    'Escape text to \\uXXXX sequences, or unescape \\uXXXX / \\u{...} back to text.',
+  defaultInput: 'héllo 😀 ::unicodeescape',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEscape = hasOptionKeys(options, 'unicodeescape', 'uescape');
+    const wantUnescape = hasOptionKeys(options, 'unicodeunescape', 'uunescape');
+    if (!wantEscape && !wantUnescape) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    if (wantEscape) {
+      const escaped = escapeUnicode(input);
+      return [
+        new BoxBuilder('Unicode Escape', escaped)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // wantUnescape
+    const unescaped = unescapeUnicode(input);
+    return [
+      new BoxBuilder('Unicode Unescape', unescaped)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UnicodeEscapeBoxSource;

--- a/src/modules/boxSources/UrlParseBoxSource.ts
+++ b/src/modules/boxSources/UrlParseBoxSource.ts
@@ -1,5 +1,5 @@
 import { KeyValueBoxTemplate } from '@components/BoxTemplate';
-import { trim } from '@functions/helper';
+import { isString, trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
@@ -20,7 +20,7 @@ export const UrlParseBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'urlparse', 'parseurl')) return [];
-    if (input.length > MAX_INPUT) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
 
     const raw = trim(input);
     let url: URL;

--- a/src/modules/boxSources/UrlParseBoxSource.ts
+++ b/src/modules/boxSources/UrlParseBoxSource.ts
@@ -1,0 +1,89 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+export const UrlParseBoxSource = {
+  name: 'URL Parse',
+  description: 'Break a URL into protocol, host, port, path, query, and hash.',
+  defaultInput:
+    'https://user:pass@example.com:8080/a/b?x=1&y=2#frag ::urlparse',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'urlparse', 'parseurl')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const raw = trim(input);
+    let url: URL;
+
+    try {
+      url = new URL(raw);
+    } catch {
+      // invalid url — return a box explaining the failure
+      return [
+        new BoxBuilder('URL Parse', `Invalid URL: ${raw}`)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: `"${raw}" is not a valid URL` })
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    // default ports by scheme so we can fall back when url.port is empty
+    const defaultPorts: Record<string, string> = {
+      'http:': '80',
+      'https:': '443',
+      'ftp:': '21',
+      'ftps:': '990',
+      'ws:': '80',
+      'wss:': '443',
+    };
+
+    const port = url.port || defaultPorts[url.protocol] || '';
+
+    // build the output record; only include optional fields when non-empty
+    const output: Record<string, string> = {
+      Protocol: url.protocol.replace(/:$/, ''),
+      Host: url.hostname,
+      Port: port,
+      Path: url.pathname,
+    };
+
+    if (url.username) output.Username = decodeURIComponent(url.username);
+    if (url.password) output.Password = decodeURIComponent(url.password);
+
+    const query = url.search.replace(/^\?/, '');
+    if (query) output.Query = query;
+
+    const hash = url.hash.replace(/^#/, '');
+    if (hash) output.Hash = hash;
+
+    // include decoded query params as a convenience key when present
+    if (url.searchParams.size > 0) {
+      const parts: string[] = [];
+      for (const [k, v] of url.searchParams.entries()) {
+        parts.push(`${k}=${v}`);
+      }
+      output.Params = parts.join(', ');
+    }
+
+    return [
+      new BoxBuilder('URL Parse', raw)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default UrlParseBoxSource;

--- a/src/modules/boxSources/__test__/Base32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base32BoxSource.test.ts
@@ -137,5 +137,14 @@ describe('Base32BoxSource', () => {
       expect(Base32BoxSource.kind).toBe('Encode');
       expect(typeof Base32BoxSource.priority).toBe('number');
     });
+
+    it('decodes input with trailing whitespace after the padding', async () => {
+      // common copy-paste shape: a newline after the padded value
+      const boxes = await Base32BoxSource.generateBoxes('MY======\n', {
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('f');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/Base32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base32BoxSource.test.ts
@@ -1,0 +1,141 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Base32BoxSource } from '../Base32BoxSource';
+
+describe('Base32BoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input with encode option', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('', { base32: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('   ', {
+        base32: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('RFC 4648 encode vectors', () => {
+    it('encodes "foobar" to MZXW6YTBOI======', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', {
+        base32: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('MZXW6YTBOI======');
+      expect(boxes[0].props.name).toBe('Base32 (Encode)');
+    });
+
+    it('encodes "f" to MY======', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('f', { base32: true });
+      expect(boxes[0].props.plaintextOutput).toBe('MY======');
+    });
+
+    it('encodes "fo" to MZXQ====', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('fo', { base32: true });
+      expect(boxes[0].props.plaintextOutput).toBe('MZXQ====');
+    });
+
+    it('encodes "foo" to MZXW6===', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foo', {
+        base32: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('MZXW6===');
+    });
+
+    it('also encodes via ::base32encode option', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', {
+        base32encode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('MZXW6YTBOI======');
+    });
+  });
+
+  describe('RFC 4648 decode vectors', () => {
+    it('decodes MZXW6YTBOI====== to "foobar"', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('MZXW6YTBOI======', {
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('foobar');
+      expect(boxes[0].props.name).toBe('Base32 (Decode)');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('round-trips "hello world"', async () => {
+      const encodeBoxes = await Base32BoxSource.generateBoxes('hello world', {
+        base32: true,
+      });
+      expect(encodeBoxes).toHaveLength(1);
+      const encoded = encodeBoxes[0].props.plaintextOutput;
+
+      const decodeBoxes = await Base32BoxSource.generateBoxes(encoded, {
+        base32decode: true,
+      });
+      expect(decodeBoxes).toHaveLength(1);
+      expect(decodeBoxes[0].props.plaintextOutput).toBe('hello world');
+    });
+  });
+
+  describe('invalid decode', () => {
+    it('returns an error box for invalid Base32 input "!!!"', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('!!!', {
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+      expect(boxes[0].props.name).toBe('Base32 (Decode)');
+    });
+  });
+
+  describe('both options produce 2 boxes', () => {
+    it('returns encode and decode boxes when both options are set', async () => {
+      const encoded = 'MZXW6YTBOI======';
+      const boxes = await Base32BoxSource.generateBoxes(encoded, {
+        base32: true,
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Base32 (Encode)');
+      expect(boxes[1].props.name).toBe('Base32 (Decode)');
+    });
+  });
+
+  describe('box properties', () => {
+    it('uses DefaultBoxTemplate for encode box', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('hello', {
+        base32: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('sets showExpandButton to false', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('hello', {
+        base32: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Base32BoxSource.name).toBe('Base32');
+      expect(Base32BoxSource.tag).toBe('#');
+      expect(Base32BoxSource.kind).toBe('Encode');
+      expect(typeof Base32BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/Crc32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Crc32BoxSource.test.ts
@@ -1,0 +1,94 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Crc32BoxSource } from '../Crc32BoxSource';
+
+describe('Crc32BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no crc32 option is provided', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns empty array for empty string', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('', { crc32: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only string', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('   ', { crc32: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - known CRC-32 vectors', () => {
+    it('produces canonical check value cbf43926 for "123456789"', async () => {
+      // canonical CRC-32 check value per ISO 3309 / ITU-T V.42
+      const boxes = await Crc32BoxSource.generateBoxes('123456789', {
+        crc32: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Hex: 'cbf43926',
+        Decimal: (0xcbf43926).toString(10),
+        Uppercase: 'CBF43926',
+      });
+    });
+
+    it('produces 414fa339 for the quick-brown-fox sentence', async () => {
+      const input = 'The quick brown fox jumps over the lazy dog';
+      const boxes = await Crc32BoxSource.generateBoxes(input, { crc32: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Hex: '414fa339',
+        Uppercase: '414FA339',
+      });
+    });
+  });
+
+  describe('generateBoxes - output format', () => {
+    it('Hex is exactly 8 lowercase hex characters for "hello"', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        crc32: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { Hex, Uppercase, Decimal } = boxes[0].props.options as Record<
+        string,
+        string
+      >;
+      expect(Hex).toMatch(/^[0-9a-f]{8}$/);
+      expect(Uppercase).toBe(Hex.toUpperCase());
+      expect(Number.parseInt(Decimal, 10)).toBe(Number.parseInt(Hex, 16));
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        crc32: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        crc32: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Crc32BoxSource.name).toBe('CRC-32');
+      expect(Crc32BoxSource.tag).toBe('#');
+      expect(Crc32BoxSource.kind).toBe('Encode');
+      expect(Crc32BoxSource.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HmacBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HmacBoxSource.test.ts
@@ -1,0 +1,177 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { HmacBoxSource } from '../HmacBoxSource';
+
+// RFC 4231 / well-known HMAC test vectors
+// key = 'key', message = 'The quick brown fox jumps over the lazy dog'
+const FOX_MSG = 'The quick brown fox jumps over the lazy dog';
+const FOX_KEY = 'key';
+const FOX_SHA256 =
+  'f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8';
+const FOX_SHA1 = 'de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9';
+
+describe('HmacBoxSource', () => {
+  describe('no trigger option', () => {
+    it('returns empty array when hmac option is absent', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated options are present', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', { sha256: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('key validation', () => {
+    it('returns a key-required box when ::hmac has no value (boolean true)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', { hmac: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/key.*required/i);
+    });
+
+    it('returns a key-required box when key is an empty string', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', { hmac: '' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/key.*required/i);
+    });
+  });
+
+  describe('RFC 4231 / known vectors — SHA-256 default', () => {
+    it('produces correct HMAC-SHA256 for the fox message (default algorithm)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(FOX_MSG, {
+        hmac: FOX_KEY,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Hex).toBe(FOX_SHA256);
+      expect(boxes[0].props.options?.Algorithm).toBe('HMAC-SHA256');
+    });
+
+    it('produces correct HMAC-SHA256 when explicitly selected via ::hmacalg=sha256', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(FOX_MSG, {
+        hmac: FOX_KEY,
+        hmacalg: 'sha256',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Hex).toBe(FOX_SHA256);
+    });
+  });
+
+  describe('RFC 4231 / known vectors — SHA-1', () => {
+    it('produces correct HMAC-SHA1 for the fox message', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(FOX_MSG, {
+        hmac: FOX_KEY,
+        hmacalg: 'sha1',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Hex).toBe(FOX_SHA1);
+      expect(boxes[0].props.options?.Algorithm).toBe('HMAC-SHA1');
+    });
+  });
+
+  describe('algorithm selection', () => {
+    it('falls back to SHA-256 for an unrecognised algorithm alias', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', {
+        hmac: 'secret',
+        hmacalg: 'md5',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Algorithm).toBe('HMAC-SHA256');
+    });
+
+    it('selects SHA-512 when ::hmacalg=sha512', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', {
+        hmac: 'secret',
+        hmacalg: 'sha512',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Algorithm).toBe('HMAC-SHA512');
+      // SHA-512 HMAC produces 128-char hex
+      expect(boxes[0].props.options?.Hex).toHaveLength(128);
+    });
+  });
+
+  describe('security — key not exposed in output', () => {
+    it('does not include the key value in any option', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(FOX_MSG, {
+        hmac: FOX_KEY,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options ?? {};
+      for (const v of Object.values(opts)) {
+        expect(v).not.toBe(FOX_KEY);
+      }
+    });
+
+    it('only exposes Algorithm and Hex keys in options', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', {
+        hmac: 'topsecret',
+      });
+      expect(boxes).toHaveLength(1);
+      const keys = Object.keys(boxes[0].props.options ?? {});
+      expect(keys).toEqual(['Algorithm', 'Hex']);
+    });
+  });
+
+  describe('box shape', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', { hmac: 'k' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to the source priority', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', { hmac: 'k' });
+      expect(boxes[0].props.priority).toBe(HmacBoxSource.priority);
+    });
+  });
+
+  describe('input cap', () => {
+    it('returns empty array when input exceeds MAX_INPUT', async () => {
+      const large = 'x'.repeat(100_001);
+      const boxes = await HmacBoxSource.generateBoxes(large, { hmac: 'k' });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('non-secure context fallback', () => {
+    const originalCrypto = globalThis.crypto;
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { subtle: undefined },
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('returns a single informational box mentioning secure context', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('msg', { hmac: 'k' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HmacBoxSource.name).toBe('HMAC');
+      expect(HmacBoxSource.tag).toBe('#');
+      expect(HmacBoxSource.kind).toBe('Encode');
+      expect(typeof HmacBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LuhnBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LuhnBoxSource.test.ts
@@ -107,7 +107,10 @@ describe('LuhnBoxSource', () => {
         luhn: true,
       });
       expect(boxes).toHaveLength(1);
-      expect(boxes[0].props.options).toMatchObject({ 'Check Digit': '3' });
+      // 7992739871 is not valid on its own, so the append-digit is reported
+      expect(boxes[0].props.options).toMatchObject({
+        'Check Digit (append to validate)': '3',
+      });
     });
 
     it('check digit of a valid number makes input+digit Luhn-valid', async () => {
@@ -115,7 +118,8 @@ describe('LuhnBoxSource', () => {
       const payload = '453201511283036';
       const boxes = await LuhnBoxSource.generateBoxes(payload, { luhn: true });
       expect(boxes).toHaveLength(1);
-      const checkDigit = boxes[0].props.options?.['Check Digit'];
+      const checkDigit =
+        boxes[0].props.options?.['Check Digit (append to validate)'];
 
       // appending the check digit must produce a valid number
       const full = payload + checkDigit;

--- a/src/modules/boxSources/__test__/LuhnBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LuhnBoxSource.test.ts
@@ -1,0 +1,164 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { LuhnBoxSource } from '../LuhnBoxSource';
+
+describe('LuhnBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LuhnBoxSource.name).toBe('Luhn');
+      expect(LuhnBoxSource.tag).toBe('#');
+      expect(LuhnBoxSource.kind).toBe('Validate');
+      expect(typeof LuhnBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - option guard', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('79927398713', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options is empty object', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('79927398713', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when an unrelated option is provided', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('79927398713', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - input validation', () => {
+    it('returns empty array for non-digit input', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('abc', { luhn: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('', { luhn: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for input exceeding 40 digits', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('1'.repeat(41), {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for mixed alpha-numeric input', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('1234abc5678', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - Luhn validation', () => {
+    it('identifies 79927398713 as Luhn-valid', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('79927398713', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Valid: 'true',
+        Input: '79927398713',
+      });
+    });
+
+    it('identifies 79927398710 as Luhn-invalid', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('79927398710', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Valid: 'false' });
+    });
+
+    it('strips spaces before validation — "7992 7398 713" is valid', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('7992 7398 713', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Valid: 'true',
+        Input: '79927398713',
+      });
+    });
+
+    it('strips hyphens before validation', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('7992-7398-713', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Valid: 'true',
+        Input: '79927398713',
+      });
+    });
+  });
+
+  describe('generateBoxes - check digit', () => {
+    it('computes check digit 3 for payload 7992739871', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('7992739871', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ 'Check Digit': '3' });
+    });
+
+    it('check digit of a valid number makes input+digit Luhn-valid', async () => {
+      // using a different known number: 4532015112830366 (Visa test number)
+      const payload = '453201511283036';
+      const boxes = await LuhnBoxSource.generateBoxes(payload, { luhn: true });
+      expect(boxes).toHaveLength(1);
+      const checkDigit = boxes[0].props.options?.['Check Digit'];
+
+      // appending the check digit must produce a valid number
+      const full = payload + checkDigit;
+      const validBoxes = await LuhnBoxSource.generateBoxes(full, {
+        luhn: true,
+      });
+      expect(validBoxes[0].props.options).toMatchObject({ Valid: 'true' });
+    });
+  });
+
+  describe('generateBoxes - output structure', () => {
+    it('returns a single box with KeyValueBoxTemplate', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('79927398713', {
+        luhn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box options contain all required keys', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('79927398713', {
+        luhn: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts).toHaveProperty('Input');
+      expect(opts).toHaveProperty('Valid');
+      expect(opts).toHaveProperty('Check Digit');
+      expect(opts).toHaveProperty('Sum');
+    });
+
+    it('Sum is the correct Luhn sum of the input', async () => {
+      // luhn sum of 79927398713 is 70
+      const boxes = await LuhnBoxSource.generateBoxes('79927398713', {
+        luhn: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Sum: '70' });
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await LuhnBoxSource.generateBoxes('79927398713', {
+        luhn: true,
+      });
+      expect(boxes[0].props.priority).toBe(LuhnBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/QueryStringBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/QueryStringBoxSource.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import { QueryStringBoxSource } from '../QueryStringBoxSource';
+
+describe('QueryStringBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('a=1&b=2', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated options are provided', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('a=1', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('qs → JSON', () => {
+    it('converts a simple query string to JSON', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('a=1&b=2', {
+        qs: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Query String → JSON');
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ a: '1', b: '2' });
+    });
+
+    it('collects repeated keys into an array', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('b=2&b=3', {
+        qs: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ b: ['2', '3'] });
+    });
+
+    it('strips a leading ? and decodes percent-encoded values', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes(
+        '?x=hello%20world',
+        { qs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ x: 'hello world' });
+    });
+
+    it('accepts ::querystring as an alias', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('a=1', {
+        querystring: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('JSON → qs', () => {
+    it('converts a flat JSON object to a query string', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes(
+        '{"a":"1","b":"2"}',
+        { qs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → Query String');
+      expect(boxes[0].props.plaintextOutput).toBe('a=1&b=2');
+    });
+
+    it('emits repeated pairs for array values', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes(
+        '{"b":["2","3"]}',
+        { qs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('b=2&b=3');
+    });
+
+    it('returns an error box for invalid JSON', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes(
+        '{not valid json}',
+        { qs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toContain('error');
+    });
+  });
+
+  describe('prototype pollution guard', () => {
+    it('skips __proto__ key and does not pollute Object.prototype', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes(
+        '__proto__=polluted&a=1',
+        { qs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      // the legitimate key survives
+      expect(parsed.a).toBe('1');
+      // the dangerous key is absent from the result
+      expect(Object.keys(parsed)).not.toContain('__proto__');
+      // Object.prototype is clean
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('skips constructor key', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes(
+        'constructor=evil&x=ok',
+        { qs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed.x).toBe('ok');
+      expect(Object.hasOwn(parsed, 'constructor')).toBe(false);
+    });
+  });
+
+  describe('encoding round-trip', () => {
+    it('round-trips a value with spaces through qs → JSON → qs', async () => {
+      const jsonBoxes = await QueryStringBoxSource.generateBoxes(
+        'a=hello%20world',
+        { qs: true },
+      );
+      expect(jsonBoxes).toHaveLength(1);
+      const parsed = JSON.parse(jsonBoxes[0].props.plaintextOutput);
+      expect(parsed.a).toBe('hello world');
+
+      // re-encode back to query string
+      const qsBoxes = await QueryStringBoxSource.generateBoxes(
+        JSON.stringify(parsed),
+        { qs: true },
+      );
+      expect(qsBoxes).toHaveLength(1);
+      expect(qsBoxes[0].props.plaintextOutput).toBe('a=hello%20world');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(QueryStringBoxSource.name).toBe('Query String');
+      expect(QueryStringBoxSource.tag).toBe('#');
+      expect(QueryStringBoxSource.kind).toBe('Convert');
+      expect(typeof QueryStringBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/QueryStringBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/QueryStringBoxSource.test.ts
@@ -140,5 +140,16 @@ describe('QueryStringBoxSource', () => {
       expect(QueryStringBoxSource.kind).toBe('Convert');
       expect(typeof QueryStringBoxSource.priority).toBe('number');
     });
+
+    it('routes a JSON array to the JSON→qs path and reports an error', async () => {
+      const boxes = await QueryStringBoxSource.generateBoxes('[1,2,3]', {
+        qs: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // an array is not a flat object — should not be parsed as a query string
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(
+        /object|error|invalid/,
+      );
+    });
   });
 });

--- a/src/modules/boxSources/__test__/SortLinesBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SortLinesBoxSource.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import { SortLinesBoxSource } from '../SortLinesBoxSource';
+
+describe('SortLinesBoxSource', () => {
+  describe('generateBoxes — gating', () => {
+    it('returns [] when no relevant option is present', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\napple',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with ::sortlines', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('', {
+        sortlines: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const huge = 'a'.repeat(100_001);
+      const boxes = await SortLinesBoxSource.generateBoxes(huge, {
+        sortlines: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — sort ascending (default)', () => {
+    it('sorts lines lexicographically ascending with ::sortlines=true', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        {
+          sortlines: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nbanana\ncherry');
+    });
+
+    it('sorts ascending with ::sortlines=asc', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        {
+          sortlines: 'asc',
+        },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nbanana\ncherry');
+    });
+  });
+
+  describe('generateBoxes — sort descending', () => {
+    it('sorts lines descending with ::sortlines=desc', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        {
+          sortlines: 'desc',
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('cherry\nbanana\napple');
+    });
+  });
+
+  describe('generateBoxes — numeric sort', () => {
+    it('sorts numerically ascending with ::sortlines=num', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('10\n2\n1', {
+        sortlines: 'num',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1\n2\n10');
+    });
+
+    it('sorts numerically descending with ::sortlines=numdesc', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('10\n2\n1', {
+        sortlines: 'numdesc',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('10\n2\n1');
+    });
+
+    it('places NaN lines last in numeric sort', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('foo\n2\n1', {
+        sortlines: 'num',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('1\n2\nfoo');
+    });
+  });
+
+  describe('generateBoxes — dedupe only', () => {
+    it('removes duplicate lines preserving first-occurrence order with ::uniqlines', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('a\nb\na\nc', {
+        uniqlines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb\nc');
+    });
+
+    it('accepts ::dedupelines as an alias', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('a\nb\na\nc', {
+        dedupelines: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb\nc');
+    });
+  });
+
+  describe('generateBoxes — sort + dedupe combined', () => {
+    it('dedupes then sorts ascending', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('b\na\nb', {
+        sortlines: true,
+        uniqlines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb');
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('sets name to "Sort Lines" and uses CodeBoxTemplate', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('banana\napple', {
+        sortlines: true,
+      });
+      expect(boxes[0].props.name).toBe('Sort Lines');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+  });
+
+  describe('generateBoxes — line ending handling', () => {
+    it('handles \\r\\n line endings', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\r\napple\r\ncherry',
+        {
+          sortlines: true,
+        },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nbanana\ncherry');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/SortLinesBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SortLinesBoxSource.test.ts
@@ -137,5 +137,13 @@ describe('SortLinesBoxSource', () => {
       );
       expect(boxes[0].props.plaintextOutput).toBe('apple\nbanana\ncherry');
     });
+
+    it('treats a trailing newline as a terminator, not a phantom blank line', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('banana\napple\n', {
+        sortlines: true,
+      });
+      // no leading blank line from the trailing \n
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nbanana');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/UnicodeEscapeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UnicodeEscapeBoxSource.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import { UnicodeEscapeBoxSource } from '../UnicodeEscapeBoxSource';
+
+describe('UnicodeEscapeBoxSource', () => {
+  describe('generateBoxes - option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty string even with option', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('', {
+        unicodeescape: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - escape', () => {
+    it('escapes non-ASCII: A€ → A\\u20ac', async () => {
+      // '\\u20ac' here is the literal 6-character string backslash-u-2-0-a-c
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('A€', {
+        unicodeescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('A\\u20ac');
+    });
+
+    it('keeps printable ASCII unchanged: hi! stays hi!', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('hi!', {
+        unicodeescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hi!');
+    });
+
+    it('escapes astral char 😀 (U+1F600) as surrogate pair \\ud83d\\ude00', async () => {
+      // 😀 = U+1F600 splits into surrogates U+D83D U+DE00
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('😀', {
+        unicodeescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('\\ud83d\\ude00');
+    });
+
+    it('accepts ::uescape alias', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('€', {
+        uescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('\\u20ac');
+    });
+
+    it('sets box name to "Unicode Escape"', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('A', {
+        unicodeescape: true,
+      });
+      expect(boxes[0].props.name).toBe('Unicode Escape');
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('A', {
+        unicodeescape: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes - unescape', () => {
+    it('unescapes \\u20ac back to €', async () => {
+      // the input string contains literal backslash-u-20ac
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u20ac', {
+        unicodeunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('€');
+    });
+
+    it('unescapes braces form \\u{1f600} back to 😀', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u{1f600}', {
+        unicodeunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('😀');
+    });
+
+    it('leaves text outside escape sequences unchanged', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes(
+        'hi \\u0021 there',
+        { unicodeunescape: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hi ! there');
+    });
+
+    it('guards invalid braces code point > 0x10ffff and leaves it literal', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u{110000}', {
+        unicodeunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // code point is out of range — the sequence must remain as-is
+      expect(boxes[0].props.plaintextOutput).toBe('\\u{110000}');
+    });
+
+    it('accepts ::uunescape alias', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u0041', {
+        uunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('A');
+    });
+
+    it('sets box name to "Unicode Unescape"', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u0041', {
+        unicodeunescape: true,
+      });
+      expect(boxes[0].props.name).toBe('Unicode Unescape');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('héllo escapes and unescapes back to the original', async () => {
+      const original = 'héllo';
+
+      const escapeBoxes = await UnicodeEscapeBoxSource.generateBoxes(original, {
+        unicodeescape: true,
+      });
+      expect(escapeBoxes).toHaveLength(1);
+      const escaped = escapeBoxes[0].props.plaintextOutput;
+
+      const unescapeBoxes = await UnicodeEscapeBoxSource.generateBoxes(
+        escaped,
+        { unicodeunescape: true },
+      );
+      expect(unescapeBoxes).toHaveLength(1);
+      expect(unescapeBoxes[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(UnicodeEscapeBoxSource.name).toBe('Unicode Escape');
+      expect(UnicodeEscapeBoxSource.tag).toBe('#');
+      expect(UnicodeEscapeBoxSource.kind).toBe('Encode');
+      expect(UnicodeEscapeBoxSource.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/UrlParseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UrlParseBoxSource.test.ts
@@ -1,0 +1,126 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { UrlParseBoxSource } from '../UrlParseBoxSource';
+
+describe('UrlParseBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no matching option key is present', async () => {
+      const boxes = await UrlParseBoxSource.generateBoxes(
+        'https://example.com/',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option key is given', async () => {
+      const boxes = await UrlParseBoxSource.generateBoxes(
+        'https://example.com/',
+        { base64: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('parses a full URL with auth, port, path, query, and hash', async () => {
+      const boxes = await UrlParseBoxSource.generateBoxes(
+        'https://user:pass@example.com:8080/a/b?x=1&y=2#frag',
+        { urlparse: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('URL Parse');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.options).toMatchObject({
+        Protocol: 'https',
+        Host: 'example.com',
+        Port: '8080',
+        Path: '/a/b',
+        Query: 'x=1&y=2',
+        Hash: 'frag',
+        Username: 'user',
+        Password: 'pass',
+      });
+    });
+
+    it('parses a simple URL without optional fields', async () => {
+      const boxes = await UrlParseBoxSource.generateBoxes(
+        'https://example.com/',
+        {
+          urlparse: true,
+        },
+      );
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Protocol: 'https',
+        Host: 'example.com',
+        Path: '/',
+      });
+
+      // Query, Hash, Username, Password must not be present when empty
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Query).toBeUndefined();
+      expect(opts.Hash).toBeUndefined();
+      expect(opts.Username).toBeUndefined();
+      expect(opts.Password).toBeUndefined();
+    });
+
+    it('triggers on ::parseurl alias', async () => {
+      const boxes = await UrlParseBoxSource.generateBoxes(
+        'https://example.com/',
+        {
+          parseurl: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Protocol: 'https' });
+    });
+
+    it('returns an error box for an invalid URL', async () => {
+      const boxes = await UrlParseBoxSource.generateBoxes('not a url', {
+        urlparse: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('URL Parse');
+      // the error box must reference "invalid" in some form
+      const opts = boxes[0].props.options as Record<string, string>;
+      const combined = JSON.stringify(opts).toLowerCase();
+      expect(combined).toMatch(/not a valid|invalid/);
+    });
+
+    it('includes Params key when query string is present', async () => {
+      const boxes = await UrlParseBoxSource.generateBoxes(
+        'https://example.com/path?x=1&y=2',
+        { urlparse: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Params).toBeDefined();
+      expect(opts.Params).toContain('x=1');
+      expect(opts.Params).toContain('y=2');
+    });
+
+    it('uses default port when url.port is empty', async () => {
+      const boxes = await UrlParseBoxSource.generateBoxes(
+        'https://example.com/path',
+        {
+          urlparse: true,
+        },
+      );
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Port).toBe('443');
+    });
+
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const longInput = `https://example.com/${'a'.repeat(100_001)}`;
+      const boxes = await UrlParseBoxSource.generateBoxes(longInput, {
+        urlparse: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,26 +1,34 @@
+import Base32BoxSource from './Base32BoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import Crc32BoxSource from './Crc32BoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HmacBoxSource from './HmacBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LuhnBoxSource from './LuhnBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import QueryStringBoxSource from './QueryStringBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SortLinesBoxSource from './SortLinesBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import UnicodeEscapeBoxSource from './UnicodeEscapeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UrlParseBoxSource from './UrlParseBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 
@@ -31,22 +39,30 @@ export const boxSources = [
   ColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  Base32BoxSource,
+  Crc32BoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HmacBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LuhnBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  QueryStringBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
+  SortLinesBoxSource,
   TimeFormatBoxSource,
+  UnicodeEscapeBoxSource,
   URLDecodeBoxSource,
+  UrlParseBoxSource,
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,


### PR DESCRIPTION
## Summary

Thirteenth exploration batch — **8 more BoxSource tools** (encoders, checksums, text ops).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Base32 | `::base32` / `::base32decode` | RFC 4648 encode/decode |
| CRC-32 | `::crc32` | IEEE 802.3 checksum (table-driven) |
| Luhn | `::luhn` | mod-10 validate + check digit |
| HMAC | `::hmac=KEY` | Web Crypto HMAC (SHA-1/256/512); key never echoed |
| URL Parse | `::urlparse` | break a URL into components |
| Query String | `::qs` | query string ⇄ JSON (auto-direction) |
| Unicode Escape | `::unicodeescape` / `::unicodeunescape` | `\uXXXX` / `\u{...}` |
| Sort Lines | `::sortlines` / `::uniqlines` | sort + dedupe lines |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules — input caps, `this.priority`, no `BigInt(parseInt)`, **prototype-pollution guard** on the qs→JSON object build (the bug from batch 10), **supra-Unicode guard** before `String.fromCodePoint` (batch 4), and **secrets never in output** for HMAC (the share-link leak from batch 12 is handled separately by the redactor).
- **Verified vectors**: Base32 `foobar`→`MZXW6YTBOI======`; CRC-32 `"123456789"`→`cbf43926` (canonical check value) and the fox→`414fa339`; HMAC-SHA256/SHA1 canonical fox vectors; Luhn `79927398713` valid.

## Verification

- ✅ `bun run test run` — **443 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#271 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6