### PR TITLE
feat(boxSources): add 8 more tools (ascii85, morse, vigenere, binary, spell, subnet, hexdump, color-mix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,82 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>Ascii85Box</b> </summary>
+
+| match rule          | description                          | example          |
+| ------------------- | ------------------------------------ | ---------------- |
+| `::ascii85`         | Ascii85 encode                       | `hello ::ascii85` |
+| `::ascii85decode`   | Ascii85 decode                       | `BOu!rDZ ::ascii85decode` |
+
+</details>
+
+<details>
+<summary> <b>MorseBox</b> </summary>
+
+| match rule        | description                          | example         |
+| ----------------- | ------------------------------------ | --------------- |
+| `::morse`         | encode to International Morse code   | `SOS ::morse`   |
+| `::morsedecode`   | decode Morse back to text            | `... --- ... ::morsedecode` |
+
+</details>
+
+<details>
+<summary> <b>VigenereBox</b> </summary>
+
+| match rule              | description                          | example                       |
+| ----------------------- | ------------------------------------ | ----------------------------- |
+| `::vigenere=KEY`        | Vigenère encrypt                     | `attackatdawn ::vigenere=lemon` |
+| `::vigeneredecode=KEY`  | Vigenère decrypt                     | `lxfopvefrnhr ::vigeneredecode=lemon` |
+
+</details>
+
+<details>
+<summary> <b>BinaryTextBox</b> </summary>
+
+| match rule          | description                          | example          |
+| ------------------- | ------------------------------------ | ---------------- |
+| `::binary`          | text → 8-bit binary (UTF-8)          | `Hi ::binary`    |
+| `::binarydecode`    | binary → text                        | `01001000 01101001 ::binarydecode` |
+
+</details>
+
+<details>
+<summary> <b>NumberSpellBox</b> </summary>
+
+| match rule  | description                          | example            |
+| ----------- | ------------------------------------ | ------------------ |
+| `::spell`   | spell an integer in English words    | `1234567 ::spell`  |
+
+</details>
+
+<details>
+<summary> <b>SubnetBox</b> </summary>
+
+| match rule  | description                          | example                  |
+| ----------- | ------------------------------------ | ------------------------ |
+| `::subnet`  | IPv4 CIDR subnet calculator          | `192.168.1.10/24 ::subnet` |
+
+</details>
+
+<details>
+<summary> <b>HexDumpBox</b> </summary>
+
+| match rule    | description                          | example                  |
+| ------------- | ------------------------------------ | ------------------------ |
+| `::hexdump`   | canonical hex + ASCII dump           | `Hello, World! ::hexdump` |
+
+</details>
+
+<details>
+<summary> <b>ColorMixBox</b> </summary>
+
+| match rule  | description                          | example                       |
+| ----------- | ------------------------------------ | ----------------------------- |
+| `::mix`     | blend two hex colors (`=PERCENT`)    | `#ff0000 #0000ff ::mix`       |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/Ascii85BoxSource.ts
+++ b/src/modules/boxSources/Ascii85BoxSource.ts
@@ -1,0 +1,159 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// encode a byte array to ascii85 (btoa/adobe variant, no <~ ~> delimiters)
+function ascii85Encode(bytes: Uint8Array): string {
+  let result = '';
+
+  for (let i = 0; i < bytes.length; i += 4) {
+    const len = Math.min(4, bytes.length - i);
+
+    // accumulate big-endian uint32 from up to 4 bytes, zero-padding the rest
+    let value = 0;
+    for (let j = 0; j < 4; j++) {
+      value = (value * 256 + (j < len ? bytes[i + j] : 0)) >>> 0;
+    }
+
+    // special-case: full 4-byte all-zero group encodes to single 'z'
+    if (len === 4 && value === 0) {
+      result += 'z';
+      continue;
+    }
+
+    // extract 5 base-85 digits, most-significant first
+    const chars = new Array<string>(5);
+    let v = value;
+    for (let k = 4; k >= 0; k--) {
+      chars[k] = String.fromCharCode((v % 85) + 33);
+      v = Math.floor(v / 85);
+    }
+
+    // partial group: output only (len + 1) chars, dropping the padding tail
+    result += chars.slice(0, len + 1).join('');
+  }
+
+  return result;
+}
+
+// decode an ascii85 string to bytes; returns null on invalid input
+function ascii85Decode(input: string): Uint8Array | null {
+  // strip all whitespace first
+  let s = input.replace(/\s/g, '');
+
+  // strip optional adobe <~ ~> delimiters
+  if (s.startsWith('<~')) s = s.slice(2);
+  if (s.endsWith('~>')) s = s.slice(0, -2);
+
+  const output: number[] = [];
+  let i = 0;
+
+  while (i < s.length) {
+    // 'z' is valid only at a group boundary and expands to 4 zero bytes
+    if (s[i] === 'z') {
+      output.push(0, 0, 0, 0);
+      i++;
+      continue;
+    }
+
+    const groupLen = Math.min(5, s.length - i);
+
+    // a partial group needs at least 2 chars to produce 1 output byte
+    if (groupLen < 2) return null;
+
+    // accumulate value using float64 (safe up to 2^53); 85^5 < 2^53
+    let value = 0;
+    for (let j = 0; j < groupLen; j++) {
+      const digit = s.charCodeAt(i + j) - 33;
+      if (digit < 0 || digit > 84) return null;
+      value = value * 85 + digit;
+    }
+
+    if (groupLen < 5) {
+      // pad missing positions with 'u' (84) to complete the group
+      for (let j = groupLen; j < 5; j++) {
+        value = value * 85 + 84;
+      }
+      // convert to uint32 and extract (groupLen - 1) bytes
+      const u32 = value >>> 0;
+      const count = groupLen - 1;
+      for (let b = 3; b > 3 - count; b--) {
+        output.push((u32 >>> (b * 8)) & 0xff);
+      }
+    } else {
+      // full 5-char group: convert to uint32 and extract all 4 bytes
+      const u32 = value >>> 0;
+      output.push(
+        (u32 >>> 24) & 0xff,
+        (u32 >>> 16) & 0xff,
+        (u32 >>> 8) & 0xff,
+        u32 & 0xff,
+      );
+    }
+
+    i += groupLen;
+  }
+
+  return new Uint8Array(output);
+}
+
+export const Ascii85BoxSource = {
+  name: 'Ascii85',
+  description: 'Encode text to Ascii85 or decode an Ascii85 string.',
+  defaultInput: 'hello ::ascii85',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'ascii85', 'ascii85encode');
+    const wantDecode = hasOptionKeys(options, 'ascii85decode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const bytes = new TextEncoder().encode(input);
+      const encoded = ascii85Encode(bytes);
+      boxes.push(
+        new BoxBuilder('Ascii85 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = ascii85Decode(input);
+      const output =
+        decoded !== null
+          ? new TextDecoder().decode(decoded)
+          : 'invalid Ascii85';
+      boxes.push(
+        new BoxBuilder('Ascii85 (Decode)', output)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default Ascii85BoxSource;

--- a/src/modules/boxSources/Ascii85BoxSource.ts
+++ b/src/modules/boxSources/Ascii85BoxSource.ts
@@ -78,14 +78,16 @@ function ascii85Decode(input: string): Uint8Array | null {
       for (let j = groupLen; j < 5; j++) {
         value = value * 85 + 84;
       }
-      // convert to uint32 and extract (groupLen - 1) bytes
+      // a value above the uint32 range is spec-invalid, not just truncatable
+      if (value > 0xffffffff) return null;
       const u32 = value >>> 0;
       const count = groupLen - 1;
       for (let b = 3; b > 3 - count; b--) {
         output.push((u32 >>> (b * 8)) & 0xff);
       }
     } else {
-      // full 5-char group: convert to uint32 and extract all 4 bytes
+      // full 5-char group: a value above uint32 range is spec-invalid
+      if (value > 0xffffffff) return null;
       const u32 = value >>> 0;
       output.push(
         (u32 >>> 24) & 0xff,

--- a/src/modules/boxSources/BinaryTextBoxSource.ts
+++ b/src/modules/boxSources/BinaryTextBoxSource.ts
@@ -1,0 +1,95 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// converts each byte to its 8-bit binary string, joined by spaces
+function encodeTextToBinary(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  return Array.from(bytes)
+    .map((b) => b.toString(2).padStart(8, '0'))
+    .join(' ');
+}
+
+// decodes a binary string (spaces optional) back to UTF-8 text, or returns null on invalid input
+function decodeBinaryToText(input: string): string | null {
+  const stripped = input.replace(/\s/g, '');
+  if (!/^[01]+$/.test(stripped) || stripped.length % 8 !== 0) {
+    return null;
+  }
+  const bytes = new Uint8Array(stripped.length / 8);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(stripped.slice(i * 8, i * 8 + 8), 2);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+export const BinaryTextBoxSource = {
+  name: 'Text to Binary',
+  description:
+    'Convert text to space-separated 8-bit binary (UTF-8), or binary back to text.',
+  defaultInput: 'Hi ::binary',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'binary', 'tobinary');
+    const wantDecode = hasOptionKeys(options, 'binarydecode', 'frombinary');
+
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const binary = encodeTextToBinary(input);
+      boxes.push(
+        new BoxBuilder('Text to Binary', binary)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const text = decodeBinaryToText(input);
+      if (text === null) {
+        boxes.push(
+          new BoxBuilder(
+            'Binary to Text',
+            'invalid binary: input must be a multiple of 8 bits containing only 0 and 1',
+          )
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        boxes.push(
+          new BoxBuilder('Binary to Text', text)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default BinaryTextBoxSource;

--- a/src/modules/boxSources/ColorMixBoxSource.ts
+++ b/src/modules/boxSources/ColorMixBoxSource.ts
@@ -1,0 +1,140 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// parses #RGB or #RRGGBB hex strings into {r,g,b}, returns null on failure
+function parseHex(raw: string): Rgb | null {
+  const s = trim(raw).toLowerCase();
+  const short = /^#([0-9a-f]{3})$/.exec(s);
+  if (short) {
+    const [, hex] = short;
+    return {
+      r: Number.parseInt(hex[0] + hex[0], 16),
+      g: Number.parseInt(hex[1] + hex[1], 16),
+      b: Number.parseInt(hex[2] + hex[2], 16),
+    };
+  }
+  const full = /^#([0-9a-f]{6})$/.exec(s);
+  if (full) {
+    const [, hex] = full;
+    return {
+      r: Number.parseInt(hex.slice(0, 2), 16),
+      g: Number.parseInt(hex.slice(2, 4), 16),
+      b: Number.parseInt(hex.slice(4, 6), 16),
+    };
+  }
+  return null;
+}
+
+// formats an {r,g,b} value as a lowercase #rrggbb string
+function toHex({ r, g, b }: Rgb): string {
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+}
+
+// linear RGB blend (not gamma-corrected): mixedChannel = round(c1*(1-t) + c2*t)
+function blendChannel(c1: number, c2: number, t: number): number {
+  return Math.round(c1 * (1 - t) + c2 * t);
+}
+
+export const ColorMixBoxSource = {
+  name: 'Color Mix',
+  description:
+    'Blend two hex colors. Two colors in the input; optional ::mix=PERCENT (weight toward the second color, default 50).',
+  defaultInput: '#ff0000 #0000ff ::mix',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'mix', 'blend')) return [];
+
+    const parts = trim(input)
+      .split(/\s+/)
+      .filter((p) => p.startsWith('#'));
+
+    if (parts.length !== 2) {
+      const box = new BoxBuilder(
+        'Color Mix',
+        'Two hex colors are required (e.g. #ff0000 #0000ff).',
+      )
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions({
+          Error: 'Two hex colors are required (e.g. #ff0000 #0000ff).',
+        })
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    const c1 = parseHex(parts[0]);
+    const c2 = parseHex(parts[1]);
+
+    if (!c1 || !c2) {
+      const invalid = !c1 ? parts[0] : parts[1];
+      const box = new BoxBuilder(
+        'Color Mix',
+        `Invalid hex color: ${invalid}. Use #RGB or #RRGGBB format.`,
+      )
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions({
+          Error: `Invalid hex color: ${invalid}. Use #RGB or #RRGGBB format.`,
+        })
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    const rawOption = extractOptionKeys(options, 'mix', 'blend');
+    let ratio = 50;
+    if (typeof rawOption === 'string') {
+      const parsed = Number.parseFloat(rawOption);
+      if (!Number.isNaN(parsed)) {
+        ratio = Math.min(100, Math.max(0, parsed));
+      }
+    }
+
+    const t = ratio / 100;
+    const mixed: Rgb = {
+      r: blendChannel(c1.r, c2.r, t),
+      g: blendChannel(c1.g, c2.g, t),
+      b: blendChannel(c1.b, c2.b, t),
+    };
+
+    const color1Hex = toHex(c1);
+    const color2Hex = toHex(c2);
+    const resultHex = toHex(mixed);
+
+    const kv: Record<string, string> = {
+      'Color 1': color1Hex,
+      'Color 2': color2Hex,
+      Ratio: `${ratio}% toward ${color2Hex}`,
+      Result: resultHex,
+    };
+
+    const plaintext = Object.entries(kv)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Color Mix', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ColorMixBoxSource;

--- a/src/modules/boxSources/ColorMixBoxSource.ts
+++ b/src/modules/boxSources/ColorMixBoxSource.ts
@@ -59,6 +59,8 @@ export const ColorMixBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'mix', 'blend')) return [];
+    // two hex colors are short; bound work before splitting
+    if (input.length > 100) return [];
 
     const parts = trim(input)
       .split(/\s+/)

--- a/src/modules/boxSources/HexDumpBoxSource.ts
+++ b/src/modules/boxSources/HexDumpBoxSource.ts
@@ -1,0 +1,78 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 50_000;
+// number of bytes per row, matching hexdump -C
+const ROW_WIDTH = 16;
+
+// renders one row in hexdump -C format:
+// <offset>  <8 hex bytes>  <8 hex bytes>  |<ascii>|
+function formatRow(offset: number, bytes: Uint8Array): string {
+  const hex: string[] = [];
+  const ascii: string[] = [];
+
+  for (let i = 0; i < ROW_WIDTH; i++) {
+    if (i < bytes.length) {
+      hex.push(bytes[i].toString(16).padStart(2, '0'));
+      // printable ASCII range 0x20–0x7e; everything else shown as '.'
+      ascii.push(
+        bytes[i] >= 0x20 && bytes[i] <= 0x7e
+          ? String.fromCharCode(bytes[i])
+          : '.',
+      );
+    } else {
+      // pad short final row so the ASCII column lines up
+      hex.push('  ');
+    }
+  }
+
+  const firstHalf = hex.slice(0, 8).join(' ');
+  const secondHalf = hex.slice(8, 16).join(' ');
+  const offsetStr = offset.toString(16).padStart(8, '0');
+
+  return `${offsetStr}  ${firstHalf}  ${secondHalf}  |${ascii.join('')}|`;
+}
+
+function hexDump(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  const rows: string[] = [];
+
+  for (let offset = 0; offset < bytes.length; offset += ROW_WIDTH) {
+    rows.push(formatRow(offset, bytes.slice(offset, offset + ROW_WIDTH)));
+  }
+
+  return rows.join('\n');
+}
+
+export const HexDumpBoxSource = {
+  name: 'Hex Dump',
+  description:
+    'Produce a canonical hex + ASCII dump of the input (like hexdump -C).',
+  defaultInput: 'Hello, World! ::hexdump',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hexdump', 'xxd')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const output = hexDump(input);
+
+    return [
+      new BoxBuilder('Hex Dump', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HexDumpBoxSource;

--- a/src/modules/boxSources/MorseBoxSource.ts
+++ b/src/modules/boxSources/MorseBoxSource.ts
@@ -1,0 +1,153 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// maps each character to its ITU-R M.1677-1 morse representation
+const CHAR_TO_MORSE: Record<string, string> = {
+  A: '.-',
+  B: '-...',
+  C: '-.-.',
+  D: '-..',
+  E: '.',
+  F: '..-.',
+  G: '--.',
+  H: '....',
+  I: '..',
+  J: '.---',
+  K: '-.-',
+  L: '.-..',
+  M: '--',
+  N: '-.',
+  O: '---',
+  P: '.--.',
+  Q: '--.-',
+  R: '.-.',
+  S: '...',
+  T: '-',
+  U: '..-',
+  V: '...-',
+  W: '.--',
+  X: '-..-',
+  Y: '-.--',
+  Z: '--..',
+  '0': '-----',
+  '1': '.----',
+  '2': '..---',
+  '3': '...--',
+  '4': '....-',
+  '5': '.....',
+  '6': '-....',
+  '7': '--...',
+  '8': '---..',
+  '9': '----.',
+  '.': '.-.-.-',
+  ',': '--..--',
+  '?': '..--..',
+  "'": '.----.',
+  '!': '-.-.--',
+  '/': '-..-.',
+  '(': '-.--.',
+  ')': '-.--.-',
+  '&': '.-...',
+  ':': '---...',
+  ';': '-.-.-.',
+  '=': '-...-',
+  '+': '.-.-.',
+  '-': '-....-',
+  _: '..--.-',
+  '"': '.-..-.',
+  $: '...-..-',
+  '@': '.--.-.',
+};
+
+// invert CHAR_TO_MORSE for decoding
+const MORSE_TO_CHAR: Record<string, string> = Object.fromEntries(
+  Object.entries(CHAR_TO_MORSE).map(([ch, code]) => [code, ch]),
+);
+
+// encode plaintext to morse; words separated by ' / ', letters by ' '
+function encodeMorse(input: string): string {
+  return input
+    .toUpperCase()
+    .split(/\s+/)
+    .filter((word) => word.length > 0)
+    .map((word) =>
+      word
+        .split('')
+        .map((ch) => CHAR_TO_MORSE[ch] ?? '?')
+        .join(' '),
+    )
+    .join(' / ');
+}
+
+// decode morse to plaintext; word groups separated by ' / ', codes by ' '
+function decodeMorse(input: string): string {
+  return input
+    .split(' / ')
+    .map((wordGroup) =>
+      wordGroup
+        .trim()
+        .split(' ')
+        .filter((code) => code.length > 0)
+        .map((code) => MORSE_TO_CHAR[code] ?? '?')
+        .join(''),
+    )
+    .join(' ');
+}
+
+export const MorseBoxSource = {
+  name: 'Morse Code',
+  description:
+    'Encode text to International Morse code or decode Morse back to text.',
+  defaultInput: 'SOS ::morse',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'morse', 'morseencode');
+    const wantDecode = hasOptionKeys(options, 'morsedecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = encodeMorse(input);
+      boxes.push(
+        new BoxBuilder('Morse Code (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decodeMorse(input);
+      boxes.push(
+        new BoxBuilder('Morse Code (Decode)', decoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default MorseBoxSource;

--- a/src/modules/boxSources/NumberSpellBoxSource.ts
+++ b/src/modules/boxSources/NumberSpellBoxSource.ts
@@ -1,0 +1,138 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// short-scale word tables
+const ONES = [
+  'zero',
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten',
+  'eleven',
+  'twelve',
+  'thirteen',
+  'fourteen',
+  'fifteen',
+  'sixteen',
+  'seventeen',
+  'eighteen',
+  'nineteen',
+];
+
+const TENS = [
+  '',
+  '',
+  'twenty',
+  'thirty',
+  'forty',
+  'fifty',
+  'sixty',
+  'seventy',
+  'eighty',
+  'ninety',
+];
+
+// named powers in ascending order (index 0 = 10^3, 1 = 10^6, ...)
+const SCALE = [
+  'thousand',
+  'million',
+  'billion',
+  'trillion',
+  'quadrillion',
+  'quintillion',
+  'sextillion',
+];
+
+// spell a value in [0, 999]; caller guarantees this range
+function spellHundreds(n: number): string {
+  if (n < 20) return ONES[n];
+  if (n < 100) {
+    const tens = TENS[Math.floor(n / 10)];
+    const unit = n % 10;
+    return unit === 0 ? tens : `${tens}-${ONES[unit]}`;
+  }
+  const hundreds = Math.floor(n / 100);
+  const remainder = n % 100;
+  const base = `${ONES[hundreds]} hundred`;
+  return remainder === 0 ? base : `${base} ${spellHundreds(remainder)}`;
+}
+
+// split a BigInt into groups of 1000, lowest first
+function splitGroups(n: bigint): number[] {
+  const groups: number[] = [];
+  const thousand = 1000n;
+  while (n > 0n) {
+    groups.push(Number(n % thousand));
+    n = n / thousand;
+  }
+  return groups;
+}
+
+// spell a non-negative BigInt as english words
+function spellBigInt(n: bigint): string {
+  if (n === 0n) return 'zero';
+
+  const groups = splitGroups(n);
+  const parts: string[] = [];
+
+  for (let i = groups.length - 1; i >= 0; i--) {
+    const g = groups[i];
+    if (g === 0) continue;
+    const words = spellHundreds(g);
+    if (i === 0) {
+      parts.push(words);
+    } else {
+      parts.push(`${words} ${SCALE[i - 1]}`);
+    }
+  }
+
+  return parts.join(' ');
+}
+
+export const NumberSpellBoxSource = {
+  name: 'Number to Words',
+  description: 'Spell an integer in English words.',
+  defaultInput: '1234567 ::spell',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'spell', 'numwords')) return [];
+
+    const raw = trim(input);
+
+    // validate: optional leading minus followed by digits only, max 40 digits
+    if (!/^-?\d+$/.test(raw)) return [];
+    const digits = raw.startsWith('-') ? raw.slice(1) : raw;
+    if (digits.length > 40) return [];
+
+    const value = BigInt(raw);
+    const negative = value < 0n;
+    const spelled = spellBigInt(negative ? -value : value);
+    const output = negative ? `negative ${spelled}` : spelled;
+
+    return [
+      new BoxBuilder('Number to Words', output)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberSpellBoxSource;

--- a/src/modules/boxSources/NumberSpellBoxSource.ts
+++ b/src/modules/boxSources/NumberSpellBoxSource.ts
@@ -43,6 +43,7 @@ const TENS = [
 ];
 
 // named powers in ascending order (index 0 = 10^3, 1 = 10^6, ...)
+// short-scale group names; 13 entries cover up to 42 digits (> the 40 cap)
 const SCALE = [
   'thousand',
   'million',
@@ -51,6 +52,12 @@ const SCALE = [
   'quadrillion',
   'quintillion',
   'sextillion',
+  'septillion',
+  'octillion',
+  'nonillion',
+  'decillion',
+  'undecillion',
+  'duodecillion',
 ];
 
 // spell a value in [0, 999]; caller guarantees this range
@@ -112,6 +119,8 @@ export const NumberSpellBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'spell', 'numwords')) return [];
+    // bound work before the regex (a valid number is well under this)
+    if (input.length > 100) return [];
 
     const raw = trim(input);
 

--- a/src/modules/boxSources/SubnetBoxSource.ts
+++ b/src/modules/boxSources/SubnetBoxSource.ts
@@ -1,0 +1,125 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// converts a 32-bit integer to dotted-quad notation
+function intToDotted(n: number): string {
+  return [
+    (n >>> 24) & 0xff,
+    (n >>> 16) & 0xff,
+    (n >>> 8) & 0xff,
+    n & 0xff,
+  ].join('.');
+}
+
+// parses an IPv4 CIDR string into { ipInt, prefix } or null if malformed
+function parseCIDR(raw: string): { ipInt: number; prefix: number } | null {
+  const slashIdx = raw.indexOf('/');
+  if (slashIdx === -1) return null;
+
+  const ipPart = raw.slice(0, slashIdx);
+  const prefixPart = raw.slice(slashIdx + 1);
+
+  const octets = ipPart.split('.');
+  if (octets.length !== 4) return null;
+
+  let ipInt = 0;
+  for (const octet of octets) {
+    // reject empty, non-numeric, or out-of-range octets
+    if (!/^\d{1,3}$/.test(octet)) return null;
+    const val = Number.parseInt(octet, 10);
+    if (val < 0 || val > 255) return null;
+    ipInt = ((ipInt << 8) | val) >>> 0;
+  }
+
+  if (!/^\d{1,2}$/.test(prefixPart)) return null;
+  const prefix = Number.parseInt(prefixPart, 10);
+  if (prefix < 0 || prefix > 32) return null;
+
+  return { ipInt, prefix };
+}
+
+// builds a single error box describing an invalid CIDR input
+function buildErrorBox(input: string, priority: number): Box {
+  return new BoxBuilder(
+    'Subnet',
+    `Invalid CIDR notation: "${input}". Expected format: A.B.C.D/0-32`,
+  )
+    .setTemplate(KeyValueBoxTemplate)
+    .setShowExpandButton(false)
+    .setPriority(priority)
+    .build();
+}
+
+export const SubnetBoxSource = {
+  name: 'Subnet',
+  description: 'IPv4 CIDR subnet calculator. e.g. 192.168.1.10/24 ::subnet.',
+  defaultInput: '192.168.1.10/24 ::subnet',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'subnet', 'cidr')) return [];
+
+    const raw = trim(input);
+
+    const parsed = parseCIDR(raw);
+    if (parsed === null) {
+      return [buildErrorBox(raw, this.priority)];
+    }
+
+    const { ipInt, prefix } = parsed;
+
+    // mask is all 1s for prefix bits; special-case /0 to avoid undefined shift behavior
+    const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+    const network = (ipInt & mask) >>> 0;
+    const broadcast = (network | (~mask >>> 0)) >>> 0;
+
+    // total addresses = 2^(32-prefix)
+    const total = 2 ** (32 - prefix);
+
+    // usable host count per RFC 3021: /31 = 2, /32 = 1, otherwise total - 2
+    let usable: number;
+    if (prefix === 32) {
+      usable = 1;
+    } else if (prefix === 31) {
+      usable = 2;
+    } else {
+      usable = Math.max(0, total - 2);
+    }
+
+    // first and last usable hosts
+    const firstHost = prefix >= 31 ? network : (network + 1) >>> 0;
+    const lastHost = prefix >= 31 ? broadcast : (broadcast - 1) >>> 0;
+
+    const kvOptions: BoxOptions = {
+      CIDR: `${intToDotted(network)}/${prefix}`,
+      Netmask: intToDotted(mask),
+      Wildcard: intToDotted(~mask >>> 0),
+      Network: intToDotted(network),
+      Broadcast: intToDotted(broadcast),
+      'First Host': intToDotted(firstHost),
+      'Last Host': intToDotted(lastHost),
+      'Total Addresses': String(total),
+      'Usable Hosts': String(usable),
+    };
+
+    const box = new BoxBuilder('Subnet', JSON.stringify(kvOptions))
+      .setTemplate(KeyValueBoxTemplate)
+      .setOptions(kvOptions)
+      .setShowExpandButton(false)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default SubnetBoxSource;

--- a/src/modules/boxSources/SubnetBoxSource.ts
+++ b/src/modules/boxSources/SubnetBoxSource.ts
@@ -44,11 +44,12 @@ function parseCIDR(raw: string): { ipInt: number; prefix: number } | null {
 
 // builds a single error box describing an invalid CIDR input
 function buildErrorBox(input: string, priority: number): Box {
-  return new BoxBuilder(
-    'Subnet',
-    `Invalid CIDR notation: "${input}". Expected format: A.B.C.D/0-32`,
-  )
+  // truncate so a huge ?input= can't bloat the error string / DOM
+  const shown = input.length > 100 ? `${input.slice(0, 100)}…` : input;
+  const msg = `Invalid CIDR notation: "${shown}". Expected format: A.B.C.D/0-32`;
+  return new BoxBuilder('Subnet', msg)
     .setTemplate(KeyValueBoxTemplate)
+    .setOptions({ Error: msg })
     .setShowExpandButton(false)
     .setPriority(priority)
     .build();
@@ -67,6 +68,8 @@ export const SubnetBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'subnet', 'cidr')) return [];
+    // a CIDR is short; bound work before parsing
+    if (input.length > 100) return [];
 
     const raw = trim(input);
 
@@ -99,7 +102,7 @@ export const SubnetBoxSource = {
     const firstHost = prefix >= 31 ? network : (network + 1) >>> 0;
     const lastHost = prefix >= 31 ? broadcast : (broadcast - 1) >>> 0;
 
-    const kvOptions: BoxOptions = {
+    const kvOptions: Record<string, string> = {
       CIDR: `${intToDotted(network)}/${prefix}`,
       Netmask: intToDotted(mask),
       Wildcard: intToDotted(~mask >>> 0),
@@ -111,7 +114,12 @@ export const SubnetBoxSource = {
       'Usable Hosts': String(usable),
     };
 
-    const box = new BoxBuilder('Subnet', JSON.stringify(kvOptions))
+    // render key/value lines for headless/TUI consumers (not raw JSON)
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    const box = new BoxBuilder('Subnet', plaintext)
       .setTemplate(KeyValueBoxTemplate)
       .setOptions(kvOptions)
       .setShowExpandButton(false)

--- a/src/modules/boxSources/VigenereBoxSource.ts
+++ b/src/modules/boxSources/VigenereBoxSource.ts
@@ -1,0 +1,108 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions, BoxOptionValues } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// extracts only alphabetic characters, uppercased, as the cipher key
+function sanitizeKey(raw: BoxOptionValues): string {
+  if (typeof raw !== 'string') return '';
+  return raw.replace(/[^a-zA-Z]/g, '').toUpperCase();
+}
+
+// applies the Vigenère cipher; direction +1 for encrypt, -1 for decrypt
+function vigenere(text: string, key: string, direction: 1 | -1): string {
+  let keyIndex = 0;
+  return text
+    .split('')
+    .map((ch) => {
+      const isUpper = ch >= 'A' && ch <= 'Z';
+      const isLower = ch >= 'a' && ch <= 'z';
+      if (!isUpper && !isLower) return ch; // non-letters pass through unchanged
+
+      const base = isUpper ? 65 : 97;
+      const charIdx = ch.charCodeAt(0) - base;
+      const keyShift = key.charCodeAt(keyIndex % key.length) - 65;
+      const shifted = ((charIdx + direction * keyShift + 26) % 26) + base;
+      keyIndex++;
+      return String.fromCharCode(shifted);
+    })
+    .join('');
+}
+
+export const VigenereBoxSource = {
+  name: 'Vigenere',
+  description:
+    'Vigenere cipher. Encrypt with ::vigenere=key, decrypt with ::vigeneredecode=key.',
+  defaultInput: 'attackatdawn ::vigenere=lemon',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const encKey = extractOptionKeys(options, 'vigenere', 'vigenereencode');
+    const decKey = extractOptionKeys(options, 'vigeneredecode');
+
+    if (encKey === null && decKey === null) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (encKey !== null) {
+      const key = sanitizeKey(encKey);
+      if (key.length === 0) {
+        // key contained no letters — return an informational box
+        const box = new BoxBuilder(
+          'Vigenere (Encrypt)',
+          'Key must contain at least one alphabetic character.',
+        )
+          .setPriority(Priority)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .build();
+        boxes.push(box);
+      } else {
+        const encrypted = vigenere(input, key, 1);
+        const box = new BoxBuilder('Vigenere (Encrypt)', encrypted)
+          .setPriority(Priority)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .build();
+        boxes.push(box);
+      }
+    }
+
+    if (decKey !== null) {
+      const key = sanitizeKey(decKey);
+      if (key.length === 0) {
+        const box = new BoxBuilder(
+          'Vigenere (Decrypt)',
+          'Key must contain at least one alphabetic character.',
+        )
+          .setPriority(Priority)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .build();
+        boxes.push(box);
+      } else {
+        const decrypted = vigenere(input, key, -1);
+        const box = new BoxBuilder('Vigenere (Decrypt)', decrypted)
+          .setPriority(Priority)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .build();
+        boxes.push(box);
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default VigenereBoxSource;

--- a/src/modules/boxSources/__test__/Ascii85BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Ascii85BoxSource.test.ts
@@ -1,0 +1,208 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Ascii85BoxSource } from '../Ascii85BoxSource';
+
+describe('Ascii85BoxSource', () => {
+  describe('no option → empty', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty input → empty', () => {
+    it('returns empty array for whitespace-only input with encode option', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('   ', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty string with decode option', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('', {
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode (::ascii85)', () => {
+    it('encodes "hello" correctly', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('hello', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('BOu!rDZ');
+      expect(boxes[0].props.name).toBe('Ascii85 (Encode)');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('also triggers on ::ascii85encode option', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('hello', {
+        ascii85encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('BOu!rDZ');
+    });
+
+    it('encodes a string of 4 null bytes as "z" (z-shorthand)', async () => {
+      // produce a string whose UTF-8 bytes are four null bytes
+      const boxes = await Ascii85BoxSource.generateBoxes('\x00\x00\x00\x00', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('z');
+    });
+
+    it('encodes a single byte (partial group)', async () => {
+      // 'A' = 0x41 = 65; padded to [65,0,0,0] = 0x41000000 = 1090519040
+      // 1090519040 / 52200625 = 20 → d0=20, char=53='5'
+      // rem = 1090519040 - 20*52200625 = 1090519040 - 1044012500 = 46506540
+      // 46506540 / 614125 = 75 → d1=75, char=108='l' ... output 2 chars
+      const boxes = await Ascii85BoxSource.generateBoxes('A', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // verify by round-trip rather than hard-coding the two chars
+      expect(boxes[0].props.plaintextOutput).toHaveLength(2);
+    });
+
+    it('does not add <~ ~> delimiters', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('hello', {
+        ascii85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).not.toContain('<~');
+      expect(boxes[0].props.plaintextOutput).not.toContain('~>');
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('hello', {
+        ascii85: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('decode (::ascii85decode)', () => {
+    it('decodes "BOu!rDZ" back to "hello"', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('BOu!rDZ', {
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+      expect(boxes[0].props.name).toBe('Ascii85 (Decode)');
+    });
+
+    it('decodes with optional <~ ~> delimiters', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('<~BOu!rDZ~>', {
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decodes with embedded whitespace', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('BOu!r DZ', {
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('expands "z" to four zero bytes during decode', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('z', {
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // four null bytes decoded by TextDecoder
+      expect(boxes[0].props.plaintextOutput).toBe('\x00\x00\x00\x00');
+    });
+
+    it('returns "invalid Ascii85" box for out-of-range character', async () => {
+      // '~' is char code 126, 126-33=93 which is > 84, so invalid
+      const boxes = await Ascii85BoxSource.generateBoxes('BOu!~DZ', {
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('invalid Ascii85');
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('BOu!rDZ', {
+        ascii85decode: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encode then decode returns original ASCII text', async () => {
+      const original = 'Hello, World!';
+      const encoded = await Ascii85BoxSource.generateBoxes(original, {
+        ascii85: true,
+      });
+      const ascii85Text = encoded[0].props.plaintextOutput;
+
+      const decoded = await Ascii85BoxSource.generateBoxes(ascii85Text, {
+        ascii85decode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe(original);
+    });
+
+    it('round-trips multi-byte UTF-8 text', async () => {
+      const original = 'こんにちは';
+      const encoded = await Ascii85BoxSource.generateBoxes(original, {
+        ascii85: true,
+      });
+      const ascii85Text = encoded[0].props.plaintextOutput;
+
+      const decoded = await Ascii85BoxSource.generateBoxes(ascii85Text, {
+        ascii85decode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe(original);
+    });
+
+    it('round-trips text containing null bytes (z shorthand)', async () => {
+      const original = '\x00\x00\x00\x00test';
+      const encoded = await Ascii85BoxSource.generateBoxes(original, {
+        ascii85: true,
+      });
+      const ascii85Text = encoded[0].props.plaintextOutput;
+
+      // encoded form must start with 'z'
+      expect(ascii85Text.startsWith('z')).toBe(true);
+
+      const decoded = await Ascii85BoxSource.generateBoxes(ascii85Text, {
+        ascii85decode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('both options → 2 boxes', () => {
+    it('returns encode box then decode box when both options are set', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('hello', {
+        ascii85: true,
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Ascii85 (Encode)');
+      expect(boxes[1].props.name).toBe('Ascii85 (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Ascii85BoxSource.name).toBe('Ascii85');
+      expect(Ascii85BoxSource.tag).toBe('#');
+      expect(Ascii85BoxSource.kind).toBe('Encode');
+      expect(typeof Ascii85BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/BinaryTextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BinaryTextBoxSource.test.ts
@@ -1,0 +1,163 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { BinaryTextBoxSource } from '../BinaryTextBoxSource';
+
+describe('BinaryTextBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('Hi', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are provided', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('Hi', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::binary', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('', {
+        binary: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::binary', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('   ', {
+        binary: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ::binary / ::tobinary', () => {
+    it('encodes "Hi" to correct binary via ::binary (H=72=01001000, i=105=01101001)', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('Hi', {
+        binary: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('01001000 01101001');
+    });
+
+    it('encodes "Hi" identically via ::tobinary', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('Hi', {
+        tobinary: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('01001000 01101001');
+    });
+
+    it('encodes "A" (65=01000001)', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('A', {
+        binary: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('01000001');
+    });
+
+    it('sets box name to "Text to Binary"', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('A', {
+        binary: true,
+      });
+      expect(boxes[0].props.name).toBe('Text to Binary');
+    });
+
+    it('uses DefaultBoxTemplate and hides expand button', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('A', {
+        binary: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('decode — ::binarydecode / ::frombinary', () => {
+    it('decodes space-separated binary "01001000 01101001" to "Hi"', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes(
+        '01001000 01101001',
+        { binarydecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('decodes contiguous binary without spaces to "Hi"', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes(
+        '0100100001101001',
+        { binarydecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('decodes via ::frombinary alias', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes(
+        '01001000 01101001',
+        { frombinary: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('sets box name to "Binary to Text"', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('01000001', {
+        binarydecode: true,
+      });
+      expect(boxes[0].props.name).toBe('Binary to Text');
+    });
+
+    it('returns error box for invalid binary containing non-0/1 digits', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('0102', {
+        binarydecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid binary/i);
+    });
+
+    it('returns error box when bit count is not a multiple of 8', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('0100100', {
+        binarydecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid binary/i);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('round-trips "Hello!" through encode then decode', async () => {
+      const encBoxes = await BinaryTextBoxSource.generateBoxes('Hello!', {
+        binary: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await BinaryTextBoxSource.generateBoxes(encoded, {
+        binarydecode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe('Hello!');
+    });
+  });
+
+  describe('both options together', () => {
+    it('returns 2 boxes when both ::binary and ::binarydecode are set', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('01000001', {
+        binary: true,
+        binarydecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Text to Binary');
+      expect(names).toContain('Binary to Text');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(BinaryTextBoxSource.name).toBe('Text to Binary');
+      expect(BinaryTextBoxSource.tag).toBe('#');
+      expect(BinaryTextBoxSource.kind).toBe('Encode');
+      expect(typeof BinaryTextBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ColorMixBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ColorMixBoxSource.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { ColorMixBoxSource } from '../ColorMixBoxSource';
+
+describe('ColorMixBoxSource.generateBoxes', () => {
+  it('returns [] when no mix/blend option is present', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes(
+      '#ff0000 #0000ff',
+      null,
+    );
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] when options exist but no mix/blend key', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+      other: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('blends #ff0000 and #0000ff at 50% → #800080', async () => {
+    // 255 * 0.5 = 127.5 → round → 128 = 0x80; 0 * 0.5 + 0 * 0.5 = 0; 0 + 128 = 128 = 0x80
+    const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+      mix: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Result).toBe('#800080');
+    expect(opts['Color 1']).toBe('#ff0000');
+    expect(opts['Color 2']).toBe('#0000ff');
+    expect(opts.Ratio).toBe('50% toward #0000ff');
+  });
+
+  it('ratio=0 → result equals first color', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+      mix: '0',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Result).toBe('#ff0000');
+  });
+
+  it('ratio=100 → result equals second color', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+      mix: '100',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Result).toBe('#0000ff');
+  });
+
+  it('short hex #f00 and #00f at 50% → #800080', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#f00 #00f', {
+      mix: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Result).toBe('#800080');
+  });
+
+  it('responds to ::blend option as well', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+      blend: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Result).toBe('#800080');
+  });
+
+  it('returns an error box when only one color is provided', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#f00', { mix: true });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Error).toMatch(/two hex colors/i);
+  });
+
+  it('returns an error box for an invalid hex color', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#gg0000 #0000ff', {
+      mix: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Error).toMatch(/invalid hex color/i);
+  });
+
+  it('clamps ratio below 0 to 0', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+      mix: '-10',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Result).toBe('#ff0000');
+  });
+
+  it('clamps ratio above 100 to 100', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+      mix: '150',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Result).toBe('#0000ff');
+  });
+
+  it('box name is Color Mix', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+      mix: true,
+    });
+    expect(boxes[0].props.name).toBe('Color Mix');
+  });
+
+  it('box priority matches ColorMixBoxSource.priority', async () => {
+    const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+      mix: true,
+    });
+    expect(boxes[0].props.priority).toBe(ColorMixBoxSource.priority);
+  });
+});

--- a/src/modules/boxSources/__test__/HexDumpBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HexDumpBoxSource.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { HexDumpBoxSource } from '../HexDumpBoxSource';
+
+describe('HexDumpBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns empty array for empty string with ::hexdump', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('', { hexdump: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty string with ::xxd', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('', { xxd: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - Hello, World! with ::hexdump', () => {
+    it('produces one box', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        hexdump: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('output contains hex bytes for "Hello"', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        hexdump: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('48 65 6c 6c 6f');
+    });
+
+    it('output contains ASCII column with |Hello, World!|', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        hexdump: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('|Hello, World!|');
+    });
+
+    it('output starts with offset 00000000', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        hexdump: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toMatch(/^00000000/);
+    });
+
+    it('box name is "Hex Dump"', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        hexdump: true,
+      });
+      expect(boxes[0].props.name).toBe('Hex Dump');
+    });
+  });
+
+  describe('generateBoxes - ::xxd trigger', () => {
+    it('also triggers on ::xxd option', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('Hello, World!', {
+        xxd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('48 65 6c 6c 6f');
+    });
+  });
+
+  describe('generateBoxes - two-row output', () => {
+    it('20-char input produces exactly 2 rows', async () => {
+      // exactly 20 bytes in ASCII: row 0 (bytes 0-15) + row 1 (bytes 16-19)
+      const input = 'ABCDEFGHIJKLMNOPQRST'; // 20 chars
+      const boxes = await HexDumpBoxSource.generateBoxes(input, {
+        hexdump: true,
+      });
+      const rows = boxes[0].props.plaintextOutput.split('\n');
+      expect(rows).toHaveLength(2);
+    });
+
+    it('second row starts with offset 00000010', async () => {
+      const input = 'ABCDEFGHIJKLMNOPQRST'; // 20 chars
+      const boxes = await HexDumpBoxSource.generateBoxes(input, {
+        hexdump: true,
+      });
+      const rows = boxes[0].props.plaintextOutput.split('\n');
+      expect(rows[1]).toMatch(/^00000010/);
+    });
+  });
+
+  describe('generateBoxes - non-printable characters', () => {
+    it('shows "." for newline (0x0a) in the ASCII column', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('A\nB', {
+        hexdump: true,
+      });
+      // ASCII column should be |A.B|
+      expect(boxes[0].props.plaintextOutput).toContain('|A.B|');
+    });
+
+    it('hex bytes include 0a for the newline', async () => {
+      const boxes = await HexDumpBoxSource.generateBoxes('A\nB', {
+        hexdump: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('41 0a 42');
+    });
+  });
+
+  describe('generateBoxes - gap between 8th and 9th byte', () => {
+    it('has two spaces between the first and second group of 8 hex bytes on a full row', async () => {
+      // 16+ char input ensures a full first row
+      const input = 'ABCDEFGHIJKLMNOPQRST'; // 20 chars
+      const boxes = await HexDumpBoxSource.generateBoxes(input, {
+        hexdump: true,
+      });
+      const firstRow = boxes[0].props.plaintextOutput.split('\n')[0];
+      // pattern: <offset>  <8 bytes separated by spaces>  <8 bytes separated by spaces>  |ascii|
+      // the gap is two spaces between the two groups
+      // check that "XX  XX" pattern (two spaces) appears after the 8th byte
+      const hexSection = firstRow.slice(10); // skip "00000000  "
+      const [firstGroup, secondGroup] = hexSection.split('  ');
+      expect(firstGroup.trim().split(' ')).toHaveLength(8);
+      expect(secondGroup.trim().split(' ')[0]).toHaveLength(2); // first byte of second group
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HexDumpBoxSource.name).toBe('Hex Dump');
+      expect(HexDumpBoxSource.tag).toBe('#');
+      expect(HexDumpBoxSource.kind).toBe('Analyze');
+      expect(typeof HexDumpBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/MorseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MorseBoxSource.test.ts
@@ -1,0 +1,128 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { MorseBoxSource } from '../MorseBoxSource';
+
+describe('MorseBoxSource', () => {
+  describe('no option → empty', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('SOS', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('SOS', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty input → empty', () => {
+    it('returns empty array for whitespace-only input with encode option', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('   ', { morse: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty string with decode option', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('', {
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode (::morse)', () => {
+    it('encodes SOS correctly', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('SOS', { morse: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+      expect(boxes[0].props.name).toBe('Morse Code (Encode)');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('encodes HELLO correctly', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('HELLO', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('.... . .-.. .-.. ---');
+    });
+
+    it('separates words with " / "', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('HI BYE', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('.... .. / -... -.-- .');
+    });
+
+    it('is case-insensitive (lowercase input)', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('sos', { morse: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+    });
+
+    it('also triggers on ::morseencode option', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('SOS', {
+        morseencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+    });
+  });
+
+  describe('decode (::morsedecode)', () => {
+    it('decodes SOS correctly', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('... --- ...', {
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('SOS');
+      expect(boxes[0].props.name).toBe('Morse Code (Decode)');
+    });
+
+    it('decodes multi-word morse separated by " / "', async () => {
+      const boxes = await MorseBoxSource.generateBoxes(
+        '.... .. / -... -.-- .',
+        { morsedecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('HI BYE');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encode then decode returns original text', async () => {
+      const original = 'HELLO WORLD';
+      const encoded = await MorseBoxSource.generateBoxes(original, {
+        morse: true,
+      });
+      const morseText = encoded[0].props.plaintextOutput;
+
+      const decoded = await MorseBoxSource.generateBoxes(morseText, {
+        morsedecode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('both options → 2 boxes', () => {
+    it('returns encode box then decode box when both options are set', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('SOS', {
+        morse: true,
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Morse Code (Encode)');
+      expect(boxes[1].props.name).toBe('Morse Code (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(MorseBoxSource.name).toBe('Morse Code');
+      expect(MorseBoxSource.tag).toBe('#');
+      expect(MorseBoxSource.kind).toBe('Encode');
+      expect(typeof MorseBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NumberSpellBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberSpellBoxSource.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { NumberSpellBoxSource } from '../NumberSpellBoxSource';
+
+describe('NumberSpellBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no trigger option is present', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('42', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for non-integer input', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('abc', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for decimal input', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('1.5', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('spells zero', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('0', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('zero');
+    });
+
+    it('spells single digit seven', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('7', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('seven');
+    });
+
+    it('hyphenates compound tens: 42', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('42', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('forty-two');
+    });
+
+    it('spells round hundred: 100', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('100', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('one hundred');
+    });
+
+    it('spells hundred-and-one (American style, no "and"): 101', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('101', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('one hundred one');
+    });
+
+    it('spells 1234567 exactly', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('1234567', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'one million two hundred thirty-four thousand five hundred sixty-seven',
+      );
+    });
+
+    it('spells negative numbers', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('-5', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('negative five');
+    });
+
+    it('spells one billion', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('1000000000', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('one billion');
+    });
+
+    it('also triggers on ::numwords option key', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('42', {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('forty-two');
+    });
+
+    it('sets correct box name and priority', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('7', {
+        spell: true,
+      });
+      expect(boxes[0].props.name).toBe('Number to Words');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NumberSpellBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberSpellBoxSource.test.ts
@@ -104,5 +104,16 @@ describe('NumberSpellBoxSource', () => {
       expect(boxes[0].props.name).toBe('Number to Words');
       expect(boxes[0].props.priority).toBe(10);
     });
+
+    it('spells a 25-digit number without emitting "undefined"', async () => {
+      // 10^24 needs a scale word beyond sextillion (septillion)
+      const boxes = await NumberSpellBoxSource.generateBoxes(
+        `1${'0'.repeat(24)}`,
+        { spell: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('one septillion');
+      expect(boxes[0].props.plaintextOutput).not.toContain('undefined');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/SubnetBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SubnetBoxSource.test.ts
@@ -145,5 +145,14 @@ describe('SubnetBoxSource', () => {
       expect(SubnetBoxSource.kind).toBe('Analyze');
       expect(typeof SubnetBoxSource.priority).toBe('number');
     });
+
+    it('error box carries an Error option so it renders (not blank)', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('999.1.1.1/24', {
+        subnet: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/invalid cidr/i);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/SubnetBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SubnetBoxSource.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+
+import { SubnetBoxSource } from '../SubnetBoxSource';
+
+describe('SubnetBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no subnet/cidr option is provided', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes(
+        '192.168.1.10/24',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('192.168.1.10/24', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - /24 canonical case', () => {
+    it('computes correct subnet info for 192.168.1.10/24', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('192.168.1.10/24', {
+        subnet: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.CIDR).toBe('192.168.1.0/24');
+      expect(opts.Netmask).toBe('255.255.255.0');
+      expect(opts.Wildcard).toBe('0.0.0.255');
+      expect(opts.Network).toBe('192.168.1.0');
+      expect(opts.Broadcast).toBe('192.168.1.255');
+      expect(opts['First Host']).toBe('192.168.1.1');
+      expect(opts['Last Host']).toBe('192.168.1.254');
+      expect(opts['Total Addresses']).toBe('256');
+      expect(opts['Usable Hosts']).toBe('254');
+    });
+
+    it('also triggers on ::cidr option key', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('192.168.1.10/24', {
+        cidr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Netmask).toBe('255.255.255.0');
+    });
+  });
+
+  describe('generateBoxes - /8 class A', () => {
+    it('computes correct subnet info for 10.0.0.0/8', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('10.0.0.0/8', {
+        subnet: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Netmask).toBe('255.0.0.0');
+      expect(opts.Broadcast).toBe('10.255.255.255');
+      expect(opts['Total Addresses']).toBe('16777216');
+      expect(opts['Usable Hosts']).toBe('16777214');
+    });
+  });
+
+  describe('generateBoxes - /32 host route', () => {
+    it('reports 1 total address and 1 usable host for /32', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('1.2.3.4/32', {
+        subnet: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Addresses']).toBe('1');
+      expect(opts['Usable Hosts']).toBe('1');
+      expect(opts.Network).toBe('1.2.3.4');
+      expect(opts.Broadcast).toBe('1.2.3.4');
+    });
+  });
+
+  describe('generateBoxes - /31 point-to-point (RFC 3021)', () => {
+    it('reports 2 usable hosts for /31', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('1.2.3.4/31', {
+        subnet: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Addresses']).toBe('2');
+      expect(opts['Usable Hosts']).toBe('2');
+    });
+  });
+
+  describe('generateBoxes - /0 default route', () => {
+    it('computes correct values for 0.0.0.0/0', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('0.0.0.0/0', {
+        subnet: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Netmask).toBe('0.0.0.0');
+      expect(opts.Network).toBe('0.0.0.0');
+      expect(opts.Broadcast).toBe('255.255.255.255');
+    });
+  });
+
+  describe('generateBoxes - invalid inputs return error box', () => {
+    it('returns an error box for invalid octet 999.1.1.1/24', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('999.1.1.1/24', {
+        subnet: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+
+    it('returns an error box for non-CIDR string "abc"', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('abc', {
+        subnet: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+
+    it('returns an error box for missing prefix "192.168.1.1"', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('192.168.1.1', {
+        subnet: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+
+    it('returns an error box for prefix out of range /33', async () => {
+      const boxes = await SubnetBoxSource.generateBoxes('192.168.1.1/33', {
+        subnet: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(SubnetBoxSource.name).toBe('Subnet');
+      expect(SubnetBoxSource.tag).toBe('#');
+      expect(SubnetBoxSource.kind).toBe('Analyze');
+      expect(typeof SubnetBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/VigenereBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/VigenereBoxSource.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { VigenereBoxSource } from '../VigenereBoxSource';
+
+describe('VigenereBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is given', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('attackatdawn');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with a valid option', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('', {
+        vigenere: 'lemon',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('encrypts attackatdawn with key lemon → lxfopvefrnhr (canonical vector)', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('attackatdawn', {
+        vigenere: 'lemon',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Vigenere (Encrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('lxfopvefrnhr');
+    });
+
+    it('decrypts lxfopvefrnhr with key lemon → attackatdawn', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('lxfopvefrnhr', {
+        vigeneredecode: 'lemon',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Vigenere (Decrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('attackatdawn');
+    });
+
+    it('preserves case and non-letter characters unchanged', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('Hello, World!', {
+        vigenere: 'key',
+      });
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      // comma, space, and exclamation mark must survive intact
+      expect(output[5]).toBe(',');
+      expect(output[6]).toBe(' ');
+      expect(output[12]).toBe('!');
+      // first letter 'H' is uppercase, so output letter must also be uppercase
+      expect(output[0]).toMatch(/[A-Z]/);
+    });
+
+    it('round-trips Hello, World! through encrypt then decrypt', async () => {
+      const plain = 'Hello, World!';
+      const [encBox] = await VigenereBoxSource.generateBoxes(plain, {
+        vigenere: 'key',
+      });
+      const [decBox] = await VigenereBoxSource.generateBoxes(
+        encBox.props.plaintextOutput,
+        { vigeneredecode: 'key' },
+      );
+      expect(decBox.props.plaintextOutput).toBe(plain);
+    });
+
+    it('returns an error box when the key contains no alphabetic characters', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('hello', {
+        vigenere: '123',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/alphabetic/i);
+    });
+
+    it('round-trips a mixed-case sentence', async () => {
+      const plain = 'The Quick Brown Fox Jumps Over The Lazy Dog!';
+      const [encBox] = await VigenereBoxSource.generateBoxes(plain, {
+        vigenere: 'Secret',
+      });
+      const [decBox] = await VigenereBoxSource.generateBoxes(
+        encBox.props.plaintextOutput,
+        { vigeneredecode: 'Secret' },
+      );
+      expect(decBox.props.plaintextOutput).toBe(plain);
+    });
+
+    it('aliases vigenereencode as an encrypt trigger', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('attackatdawn', {
+        vigenereencode: 'lemon',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Vigenere (Encrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('lxfopvefrnhr');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,27 +1,35 @@
+import Ascii85BoxSource from './Ascii85BoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import BinaryTextBoxSource from './BinaryTextBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import ColorMixBoxSource from './ColorMixBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HexDumpBoxSource from './HexDumpBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
+import MorseBoxSource from './MorseBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberSpellBoxSource from './NumberSpellBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SubnetBoxSource from './SubnetBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
+import VigenereBoxSource from './VigenereBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -29,25 +37,33 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  ColorMixBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  Ascii85BoxSource,
+  BinaryTextBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HexDumpBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
+  MorseBoxSource,
   MyIPBoxSource,
   NowBoxSource,
+  NumberSpellBoxSource,
   PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
+  SubnetBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
+  VigenereBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,


### PR DESCRIPTION
## Summary

Fourteenth exploration batch — **8 more BoxSource tools** (ciphers, encoders, dev utilities).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Ascii85 | `::ascii85` / `::ascii85decode` | btoa/Adobe Ascii85 encode/decode |
| Morse Code | `::morse` / `::morsedecode` | ITU International Morse |
| Vigenère | `::vigenere=KEY` / `::vigeneredecode=KEY` | classic polyalphabetic cipher |
| Text to Binary | `::binary` / `::binarydecode` | UTF-8 ⇄ 8-bit binary |
| Number to Words | `::spell` | integer → English (BigInt-exact) |
| Subnet | `::subnet` | IPv4 CIDR calculator |
| Hex Dump | `::hexdump` / `::xxd` | canonical hex + ASCII dump |
| Color Mix | `::mix` / `::blend` | linear blend of two hex colors |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules (input caps, `this.priority`, `>>> 0` unsigned math, `BigInt(str)` not `BigInt(parseInt)`, UTF-8 via TextEncoder).
- **Verified vectors**: ascii85 `hello`→`BOu!rDZ`; morse `SOS`→`... --- ...`; **vigenère `attackatdawn`+`lemon`→`lxfopvefrnhr`** (the canonical example); binary `Hi`→`01001000 01101001`; subnet `/24`→network `.0` / broadcast `.255` / 254 usable (with `/31`→2 and `/32`→1 per RFC 3021); color mix red+blue@50%→`#800080`.

## Verification

- ✅ `bun run test run` — **447 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#272 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6