### PR TITLE
feat(boxSources): add 8 more tools (json-csv, number-bases, atbash, rot47, nato, humanize, leet, password-strength)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,79 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>JsonCsvBox</b> </summary>
+
+| match rule   | description                          | example                       |
+| ------------ | ------------------------------------ | ----------------------------- |
+| `::jsoncsv`  | JSON array of objects ⇄ CSV (auto)   | `[{"a":1,"b":2}] ::jsoncsv`   |
+
+</details>
+
+<details>
+<summary> <b>NumberBasesBox</b> </summary>
+
+| match rule  | description                          | example         |
+| ----------- | ------------------------------------ | --------------- |
+| `::bases`   | show an integer in bin/oct/dec/hex   | `255 ::bases`   |
+
+</details>
+
+<details>
+<summary> <b>AtbashBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::atbash`  | Atbash cipher (A↔Z, self-inverse)    | `hello ::atbash` |
+
+</details>
+
+<details>
+<summary> <b>Rot47Box</b> </summary>
+
+| match rule  | description                          | example                   |
+| ----------- | ------------------------------------ | ------------------------- |
+| `::rot47`   | ROT47 cipher (self-inverse)          | `Hello, World! ::rot47`   |
+
+</details>
+
+<details>
+<summary> <b>NatoPhoneticBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::nato`    | spell with the NATO phonetic alphabet | `AB12 ::nato`   |
+
+</details>
+
+<details>
+<summary> <b>HumanizeDurationBox</b> </summary>
+
+| match rule     | description                          | example              |
+| -------------- | ------------------------------------ | -------------------- |
+| `::humanize`   | seconds → "1d 1h 1m 1s" (`=ms` for ms) | `90061 ::humanize` |
+
+</details>
+
+<details>
+<summary> <b>LeetSpeakBox</b> </summary>
+
+| match rule      | description                          | example         |
+| --------------- | ------------------------------------ | --------------- |
+| `::leet`        | convert text to leetspeak            | `leet ::leet`   |
+| `::leetdecode`  | decode leet back to letters          | `1337 ::leetdecode` |
+
+</details>
+
+<details>
+<summary> <b>PasswordStrengthBox</b> </summary>
+
+| match rule    | description                          | example                  |
+| ------------- | ------------------------------------ | ------------------------ |
+| `::strength`  | estimate password entropy + rating (never echoes the password) | `P@ssw0rd123 ::strength` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/AtbashBoxSource.ts
+++ b/src/modules/boxSources/AtbashBoxSource.ts
@@ -1,0 +1,59 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// apply the atbash substitution: A↔Z, B↔Y, ...; non-alpha chars pass through unchanged
+function applyAtbash(input: string): string {
+  let result = '';
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code >= 65 && code <= 90) {
+      // uppercase A-Z
+      result += String.fromCharCode(90 - (code - 65));
+    } else if (code >= 97 && code <= 122) {
+      // lowercase a-z
+      result += String.fromCharCode(122 - (code - 97));
+    } else {
+      result += input[i];
+    }
+  }
+  return result;
+}
+
+export const AtbashBoxSource = {
+  name: 'Atbash',
+  description: 'Apply the Atbash cipher (A↔Z, B↔Y, ...). Self-inverse.',
+  defaultInput: 'hello ::atbash',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'atbash')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const output = applyAtbash(input);
+
+    const box = new BoxBuilder('Atbash', output)
+      .setTemplate(DefaultBoxTemplate)
+      .setShowExpandButton(false)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default AtbashBoxSource;

--- a/src/modules/boxSources/HumanizeDurationBoxSource.ts
+++ b/src/modules/boxSources/HumanizeDurationBoxSource.ts
@@ -1,0 +1,102 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length guard against runaway regex backtracking
+const MAX_INPUT_LENGTH = 50;
+
+interface DurationParts {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  totalSeconds: number;
+}
+
+function decompose(totalSeconds: number): DurationParts {
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return { days, hours, minutes, seconds, totalSeconds };
+}
+
+function toCompact({ days, hours, minutes, seconds }: DurationParts): string {
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+  return parts.join(' ');
+}
+
+function pluralize(value: number, unit: string): string {
+  return value === 1 ? `${value} ${unit}` : `${value} ${unit}s`;
+}
+
+function toLong({ days, hours, minutes, seconds }: DurationParts): string {
+  const parts: string[] = [];
+  if (days > 0) parts.push(pluralize(days, 'day'));
+  if (hours > 0) parts.push(pluralize(hours, 'hour'));
+  if (minutes > 0) parts.push(pluralize(minutes, 'minute'));
+  if (seconds > 0 || parts.length === 0)
+    parts.push(pluralize(seconds, 'second'));
+  return parts.join(', ');
+}
+
+export const HumanizeDurationBoxSource = {
+  name: 'Humanize Duration',
+  description:
+    'Turn a number of seconds into a human-readable duration. Use ::humanize=ms to treat the input as milliseconds.',
+  defaultInput: '90061 ::humanize',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'humanize', 'duration')) return [];
+
+    const raw = trim(input);
+    if (raw.length === 0 || raw.length > MAX_INPUT_LENGTH) return [];
+    if (!/^\d+(\.\d+)?$/.test(raw)) return [];
+
+    const parsed = Number.parseFloat(raw);
+    if (!Number.isFinite(parsed) || parsed < 0) return [];
+
+    // treat as milliseconds when the option value is the string 'ms'
+    const unitValue = extractOptionKeys(options, 'humanize', 'duration');
+    const isMs = unitValue === 'ms';
+
+    const totalSeconds = Math.floor(isMs ? parsed / 1000 : parsed);
+    const parts = decompose(totalSeconds);
+
+    const compact = toCompact(parts);
+    const long = toLong(parts);
+    const totalSecondsStr = totalSeconds.toString();
+
+    // plaintext summary shown when no template renders
+    const plaintextOutput = `Compact: ${compact}\nLong: ${long}\nTotal Seconds: ${totalSecondsStr}`;
+
+    const outputOptions: Record<string, string> = {
+      Compact: compact,
+      Long: long,
+      'Total Seconds': totalSecondsStr,
+    };
+
+    return [
+      new BoxBuilder('Humanize Duration', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(outputOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HumanizeDurationBoxSource;

--- a/src/modules/boxSources/HumanizeDurationBoxSource.ts
+++ b/src/modules/boxSources/HumanizeDurationBoxSource.ts
@@ -1,5 +1,5 @@
 import { KeyValueBoxTemplate } from '@components/BoxTemplate';
-import { trim } from '@functions/helper';
+import { isString, trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
 
@@ -61,6 +61,7 @@ export const HumanizeDurationBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'humanize', 'duration')) return [];
+    if (!isString(input)) return [];
 
     const raw = trim(input);
     if (raw.length === 0 || raw.length > MAX_INPUT_LENGTH) return [];

--- a/src/modules/boxSources/JsonCsvBoxSource.ts
+++ b/src/modules/boxSources/JsonCsvBoxSource.ts
@@ -1,0 +1,234 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// prototype pollution guard: skip keys that would mutate Object.prototype
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+// RFC 4180 CSV field quoting: wrap in double quotes and double any internal quotes
+function csvQuote(value: string): string {
+  if (
+    value.includes(',') ||
+    value.includes('"') ||
+    value.includes('\n') ||
+    value.includes('\r')
+  ) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+// stringify a single cell value for CSV output
+function cellValue(v: unknown): string {
+  if (v === null || v === undefined) return '';
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+// collect union of keys across all rows in first-seen order
+function unionKeys(rows: Record<string, unknown>[]): string[] {
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const row of rows) {
+    for (const k of Object.keys(row)) {
+      if (!seen.has(k)) {
+        seen.add(k);
+        keys.push(k);
+      }
+    }
+  }
+  return keys;
+}
+
+// convert an array of objects to a CSV string
+function jsonToCsv(data: unknown): string {
+  let rows: Record<string, unknown>[];
+
+  if (Array.isArray(data)) {
+    // must be an array of objects
+    if (data.length === 0) return '';
+    rows = data as Record<string, unknown>[];
+  } else if (data !== null && typeof data === 'object') {
+    // single object → treat as one-row array
+    rows = [data as Record<string, unknown>];
+  } else {
+    throw new Error('Input must be a JSON object or array of objects.');
+  }
+
+  for (const row of rows) {
+    if (row === null || typeof row !== 'object' || Array.isArray(row)) {
+      throw new Error('Each element in the JSON array must be an object.');
+    }
+  }
+
+  const headers = unionKeys(rows);
+  const headerRow = headers.map(csvQuote).join(',');
+  const dataRows = rows.map((row) =>
+    headers.map((h) => csvQuote(cellValue(row[h]))).join(','),
+  );
+
+  return [headerRow, ...dataRows].join('\n');
+}
+
+// RFC 4180 CSV parser that handles quoted fields with escaped quotes and embedded newlines/commas
+function parseCsv(input: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let i = 0;
+  const n = input.length;
+
+  while (i < n) {
+    // quoted field
+    if (input[i] === '"') {
+      i++; // skip opening quote
+      let field = '';
+      while (i < n) {
+        if (input[i] === '"') {
+          if (i + 1 < n && input[i + 1] === '"') {
+            // escaped double-quote
+            field += '"';
+            i += 2;
+          } else {
+            i++; // skip closing quote
+            break;
+          }
+        } else {
+          field += input[i];
+          i++;
+        }
+      }
+      row.push(field);
+      // after closing quote, expect , or end-of-field
+      if (i < n && input[i] === ',') {
+        i++;
+      } else if (
+        i < n &&
+        (input[i] === '\n' || (input[i] === '\r' && input[i + 1] === '\n'))
+      ) {
+        if (input[i] === '\r') i++;
+        i++;
+        rows.push(row);
+        row = [];
+      } else if (i < n && input[i] === '\r') {
+        i++;
+        rows.push(row);
+        row = [];
+      }
+    } else {
+      // unquoted field: read until , or newline
+      let field = '';
+      while (
+        i < n &&
+        input[i] !== ',' &&
+        input[i] !== '\n' &&
+        input[i] !== '\r'
+      ) {
+        field += input[i];
+        i++;
+      }
+      row.push(field);
+      if (i < n && input[i] === ',') {
+        i++;
+      } else if (i < n && (input[i] === '\r' || input[i] === '\n')) {
+        if (input[i] === '\r' && i + 1 < n && input[i + 1] === '\n') i++;
+        i++;
+        rows.push(row);
+        row = [];
+      }
+    }
+  }
+
+  // push last row if it has content
+  if (row.length > 0) {
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+// convert CSV to a JSON array of objects; first row is treated as headers
+function csvToJson(input: string): string {
+  const rows = parseCsv(input);
+  if (rows.length < 1) throw new Error('CSV input is empty.');
+
+  const headers = rows[0];
+  const dataRows = rows.slice(1);
+
+  const result = dataRows.map((cells) => {
+    const obj: Record<string, string> = {};
+    for (let i = 0; i < headers.length; i++) {
+      const key = headers[i];
+      // skip forbidden keys to prevent prototype pollution
+      if (FORBIDDEN_KEYS.has(key)) continue;
+      obj[key] = cells[i] ?? '';
+    }
+    return obj;
+  });
+
+  return JSON.stringify(result, null, 2);
+}
+
+function errorBox(message: string, priority: number): Box {
+  return new BoxBuilder('JSON / CSV Error', message)
+    .setTemplate(CodeBoxTemplate)
+    .setPriority(priority)
+    .build();
+}
+
+export const JsonCsvBoxSource = {
+  name: 'JSON / CSV',
+  description:
+    'Convert a JSON array of objects to CSV, or CSV to a JSON array of objects.',
+  defaultInput: '[{"a":1,"b":2},{"a":3,"b":4}] ::jsoncsv',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsoncsv', 'csvjson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    const looksLikeJson = trimmed.startsWith('[') || trimmed.startsWith('{');
+
+    if (looksLikeJson) {
+      // attempt JSON→CSV
+      try {
+        const parsed = JSON.parse(trimmed);
+        const csv = jsonToCsv(parsed);
+        return [
+          new BoxBuilder('JSON → CSV', csv)
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return [errorBox(msg, this.priority)];
+      }
+    }
+
+    // attempt CSV→JSON
+    try {
+      const json = csvToJson(trimmed);
+      return [
+        new BoxBuilder('CSV → JSON', json)
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return [errorBox(msg, this.priority)];
+    }
+  },
+};
+
+export default JsonCsvBoxSource;

--- a/src/modules/boxSources/LeetSpeakBoxSource.ts
+++ b/src/modules/boxSources/LeetSpeakBoxSource.ts
@@ -1,0 +1,98 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// encode map: a→4, e→3, l→1, o→0, s→5, t→7, b→8, g→9
+// l→1 is chosen over i→1 so that '1337' round-trips cleanly through decode
+const ENCODE_MAP: Record<string, string> = {
+  a: '4',
+  e: '3',
+  l: '1',
+  o: '0',
+  s: '5',
+  t: '7',
+  b: '8',
+  g: '9',
+};
+
+// decode map: inverse of encode map above
+const DECODE_MAP: Record<string, string> = {
+  '4': 'a',
+  '3': 'e',
+  '1': 'l',
+  '0': 'o',
+  '5': 's',
+  '7': 't',
+  '8': 'b',
+  '9': 'g',
+};
+
+function encodeLeet(input: string): string {
+  const lower = input.toLowerCase();
+  let result = '';
+  for (let i = 0; i < lower.length; i++) {
+    result += ENCODE_MAP[lower[i]] ?? lower[i];
+  }
+  return result;
+}
+
+function decodeLeet(input: string): string {
+  let result = '';
+  for (let i = 0; i < input.length; i++) {
+    result += DECODE_MAP[input[i]] ?? input[i];
+  }
+  return result;
+}
+
+export const LeetSpeakBoxSource = {
+  name: 'Leetspeak',
+  description:
+    'Convert text to leetspeak, or decode common leet back to letters.',
+  defaultInput: 'leet ::leet',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'leet', 'leetencode');
+    const wantDecode = hasOptionKeys(options, 'leetdecode', 'unleet');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const box = new BoxBuilder('Leetspeak (Encode)', encodeLeet(input))
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build();
+      boxes.push(box);
+    }
+
+    if (wantDecode) {
+      const box = new BoxBuilder('Leetspeak (Decode)', decodeLeet(input))
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build();
+      boxes.push(box);
+    }
+
+    return boxes;
+  },
+};
+
+export default LeetSpeakBoxSource;

--- a/src/modules/boxSources/NatoPhoneticBoxSource.ts
+++ b/src/modules/boxSources/NatoPhoneticBoxSource.ts
@@ -1,3 +1,4 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
 import { isString, trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
@@ -83,6 +84,7 @@ export const NatoPhoneticBoxSource = {
 
     return [
       new BoxBuilder('NATO Phonetic', output)
+        .setTemplate(DefaultBoxTemplate)
         .setShowExpandButton(false)
         .setPriority(this.priority)
         .build(),

--- a/src/modules/boxSources/NatoPhoneticBoxSource.ts
+++ b/src/modules/boxSources/NatoPhoneticBoxSource.ts
@@ -1,0 +1,93 @@
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 10_000;
+
+// official NATO phonetic alphabet words per ICAO/ITU standard
+const NATO_LETTERS: Record<string, string> = {
+  A: 'Alfa',
+  B: 'Bravo',
+  C: 'Charlie',
+  D: 'Delta',
+  E: 'Echo',
+  F: 'Foxtrot',
+  G: 'Golf',
+  H: 'Hotel',
+  I: 'India',
+  J: 'Juliett',
+  K: 'Kilo',
+  L: 'Lima',
+  M: 'Mike',
+  N: 'November',
+  O: 'Oscar',
+  P: 'Papa',
+  Q: 'Quebec',
+  R: 'Romeo',
+  S: 'Sierra',
+  T: 'Tango',
+  U: 'Uniform',
+  V: 'Victor',
+  W: 'Whiskey',
+  X: 'X-ray',
+  Y: 'Yankee',
+  Z: 'Zulu',
+};
+
+const NATO_DIGITS: Record<string, string> = {
+  '0': 'Zero',
+  '1': 'One',
+  '2': 'Two',
+  '3': 'Three',
+  '4': 'Four',
+  '5': 'Five',
+  '6': 'Six',
+  '7': 'Seven',
+  '8': 'Eight',
+  '9': 'Nine',
+};
+
+function spellNato(input: string): string {
+  return Array.from(input)
+    .map((char) => {
+      if (char === ' ') return '(space)';
+      const upper = char.toUpperCase();
+      return NATO_LETTERS[upper] ?? NATO_DIGITS[char] ?? char;
+    })
+    .join(' ');
+}
+
+export const NatoPhoneticBoxSource = {
+  name: 'NATO Phonetic',
+  description:
+    'Spell text using the NATO phonetic alphabet (A → Alfa, B → Bravo, ...).',
+  defaultInput: 'AB12 ::nato',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'nato', 'phonetic')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const output = spellNato(input);
+
+    return [
+      new BoxBuilder('NATO Phonetic', output)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NatoPhoneticBoxSource;

--- a/src/modules/boxSources/NumberBasesBoxSource.ts
+++ b/src/modules/boxSources/NumberBasesBoxSource.ts
@@ -1,5 +1,5 @@
 import { KeyValueBoxTemplate } from '@components/BoxTemplate';
-import { trim } from '@functions/helper';
+import { isString, trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
@@ -68,6 +68,7 @@ export const NumberBasesBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'bases', 'numbase')) return [];
+    if (!isString(input)) return [];
 
     const raw = trim(input);
     const n = parseIntoBigInt(raw);
@@ -75,8 +76,13 @@ export const NumberBasesBoxSource = {
 
     const bases = formatBases(n);
 
+    // key/value lines for headless/TUI consumers (not raw JSON)
+    const plaintext = Object.entries(bases)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
     return [
-      new BoxBuilder('Number Bases', JSON.stringify(bases))
+      new BoxBuilder('Number Bases', plaintext)
         .setOptions(bases)
         .setTemplate(KeyValueBoxTemplate)
         .setPriority(this.priority)

--- a/src/modules/boxSources/NumberBasesBoxSource.ts
+++ b/src/modules/boxSources/NumberBasesBoxSource.ts
@@ -1,0 +1,88 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// regex patterns for each supported prefix
+const HEX_RE = /^[0-9a-fA-F]+$/;
+const OCT_RE = /^[0-7]+$/;
+const BIN_RE = /^[01]+$/;
+const DEC_RE = /^[0-9]+$/;
+
+// parse the input string into a BigInt, return undefined on invalid input
+function parseIntoBigInt(raw: string): bigint | undefined {
+  if (raw.length > 256) return undefined;
+
+  const negative = raw.startsWith('-');
+  const unsigned = negative ? raw.slice(1) : raw;
+
+  let value: bigint;
+
+  if (unsigned.startsWith('0x') || unsigned.startsWith('0X')) {
+    const digits = unsigned.slice(2);
+    if (!digits || !HEX_RE.test(digits)) return undefined;
+    value = BigInt(`0x${digits}`);
+  } else if (unsigned.startsWith('0o') || unsigned.startsWith('0O')) {
+    const digits = unsigned.slice(2);
+    if (!digits || !OCT_RE.test(digits)) return undefined;
+    value = BigInt(`0o${digits}`);
+  } else if (unsigned.startsWith('0b') || unsigned.startsWith('0B')) {
+    const digits = unsigned.slice(2);
+    if (!digits || !BIN_RE.test(digits)) return undefined;
+    value = BigInt(`0b${digits}`);
+  } else {
+    if (!unsigned || !DEC_RE.test(unsigned)) return undefined;
+    value = BigInt(unsigned);
+  }
+
+  return negative ? -value : value;
+}
+
+// format a BigInt into the four base representations
+function formatBases(n: bigint): Record<string, string> {
+  const negative = n < 0n;
+  const abs = negative ? -n : n;
+  const sign = negative ? '-' : '';
+
+  return {
+    Decimal: `${sign}${abs.toString(10)}`,
+    Hex: `${sign}0x${abs.toString(16)}`,
+    Octal: `${sign}0o${abs.toString(8)}`,
+    Binary: `${sign}0b${abs.toString(2)}`,
+  };
+}
+
+export const NumberBasesBoxSource = {
+  name: 'Number Bases',
+  description:
+    'Show an integer in binary, octal, decimal, and hex. Accepts 0x, 0o, 0b prefixes.',
+  defaultInput: '255 ::bases',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'bases', 'numbase')) return [];
+
+    const raw = trim(input);
+    const n = parseIntoBigInt(raw);
+    if (n === undefined) return [];
+
+    const bases = formatBases(n);
+
+    return [
+      new BoxBuilder('Number Bases', JSON.stringify(bases))
+        .setOptions(bases)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberBasesBoxSource;

--- a/src/modules/boxSources/PasswordStrengthBoxSource.ts
+++ b/src/modules/boxSources/PasswordStrengthBoxSource.ts
@@ -1,0 +1,165 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 10_000;
+
+// character-class pool sizes per NIST SP 800-63B appendix A
+const POOL_LOWERCASE = 26;
+const POOL_UPPERCASE = 26;
+const POOL_DIGITS = 10;
+// printable ASCII symbols: 33-126 excluding a-z, A-Z, 0-9 (95 - 26 - 26 - 10 = 33)
+const POOL_SYMBOLS = 33;
+const POOL_SPACE = 1;
+// rough estimate for any non-ASCII unicode character
+const POOL_NON_ASCII = 100;
+
+// guesses per second for a modern offline attack (bcrypt-equivalent rates are lower;
+// this models fast hashing like MD5/NTLM to give a conservative estimate)
+const GUESSES_PER_SECOND = 1e10;
+
+interface CharacterClasses {
+  hasLower: boolean;
+  hasUpper: boolean;
+  hasDigits: boolean;
+  hasSymbols: boolean;
+  hasSpace: boolean;
+  hasNonAscii: boolean;
+}
+
+function detectClasses(password: string): CharacterClasses {
+  let hasLower = false;
+  let hasUpper = false;
+  let hasDigits = false;
+  let hasSymbols = false;
+  let hasSpace = false;
+  let hasNonAscii = false;
+
+  for (const ch of password) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code > 126 || code < 32) {
+      hasNonAscii = true;
+    } else if (ch === ' ') {
+      hasSpace = true;
+    } else if (ch >= 'a' && ch <= 'z') {
+      hasLower = true;
+    } else if (ch >= 'A' && ch <= 'Z') {
+      hasUpper = true;
+    } else if (ch >= '0' && ch <= '9') {
+      hasDigits = true;
+    } else {
+      // printable ASCII 33-126 non-alnum
+      hasSymbols = true;
+    }
+  }
+
+  return { hasLower, hasUpper, hasDigits, hasSymbols, hasSpace, hasNonAscii };
+}
+
+function poolSize(classes: CharacterClasses): number {
+  let pool = 0;
+  if (classes.hasLower) pool += POOL_LOWERCASE;
+  if (classes.hasUpper) pool += POOL_UPPERCASE;
+  if (classes.hasDigits) pool += POOL_DIGITS;
+  if (classes.hasSymbols) pool += POOL_SYMBOLS;
+  if (classes.hasSpace) pool += POOL_SPACE;
+  if (classes.hasNonAscii) pool += POOL_NON_ASCII;
+  return pool;
+}
+
+function characterSetLabel(classes: CharacterClasses): string {
+  const parts: string[] = [];
+  if (classes.hasLower) parts.push('lowercase');
+  if (classes.hasUpper) parts.push('uppercase');
+  if (classes.hasDigits) parts.push('digits');
+  if (classes.hasSymbols) parts.push('symbols');
+  if (classes.hasSpace) parts.push('space');
+  if (classes.hasNonAscii) parts.push('non-ASCII');
+  return parts.length > 0 ? parts.join(', ') : 'none';
+}
+
+function entropyBits(length: number, pool: number): number {
+  if (pool <= 0 || length <= 0) return 0;
+  return length * Math.log2(pool);
+}
+
+function rating(bits: number): string {
+  if (bits < 28) return 'Very Weak';
+  if (bits < 36) return 'Weak';
+  if (bits < 60) return 'Reasonable';
+  if (bits < 128) return 'Strong';
+  return 'Very Strong';
+}
+
+// formats a finite crack-time duration in human-readable form
+function formatTime(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)} seconds`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)} minutes`;
+  if (seconds < 86_400) return `${Math.round(seconds / 3600)} hours`;
+  if (seconds < 365.25 * 86_400) return `${Math.round(seconds / 86_400)} days`;
+  const years = seconds / (365.25 * 86_400);
+  if (years < 1_000) return `${Math.round(years)} years`;
+  if (years < 1_000_000) return `${Math.round(years / 1_000)}k years`;
+  return 'centuries+';
+}
+
+function estimateCrackTime(length: number, pool: number): string {
+  if (pool <= 0 || length <= 0) return '< 1 second';
+  // average guesses = pool^length / 2
+  const guesses = pool ** length / 2;
+  if (!Number.isFinite(guesses) || guesses > Number.MAX_SAFE_INTEGER * 1e10) {
+    return 'effectively uncrackable';
+  }
+  const seconds = guesses / GUESSES_PER_SECOND;
+  if (!Number.isFinite(seconds) || seconds > 1e15) {
+    return '> centuries';
+  }
+  return formatTime(seconds);
+}
+
+export const PasswordStrengthBoxSource = {
+  name: 'Password Strength',
+  description:
+    'Estimate password entropy and strength (character-set size × length).',
+  defaultInput: 'P@ssw0rd123 ::strength',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'strength', 'pwstrength')) return [];
+    if (input.length === 0 || input.length > MAX_INPUT) return [];
+
+    const classes = detectClasses(input);
+    const pool = poolSize(classes);
+    const bits = entropyBits(input.length, pool);
+
+    const outputOptions: Record<string, string> = {
+      Length: input.length.toString(),
+      'Character Set': characterSetLabel(classes),
+      'Pool Size': pool.toString(),
+      Entropy: `${bits.toFixed(1)} bits`,
+      Rating: rating(bits),
+      'Est. Crack Time': estimateCrackTime(input.length, pool),
+    };
+
+    // plaintext summary for headless/TUI consumers — no password echoed
+    const content = Object.entries(outputOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Password Strength', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(outputOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PasswordStrengthBoxSource;

--- a/src/modules/boxSources/PasswordStrengthBoxSource.ts
+++ b/src/modules/boxSources/PasswordStrengthBoxSource.ts
@@ -1,4 +1,5 @@
 import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
@@ -122,7 +123,9 @@ export const PasswordStrengthBoxSource = {
   name: 'Password Strength',
   description:
     'Estimate password entropy and strength (character-set size × length).',
-  defaultInput: 'P@ssw0rd123 ::strength',
+  // a famously-public example password, so the default doesn't nudge users
+  // toward typing a real one (which would land in the page URL)
+  defaultInput: 'correcthorsebatterystaple ::strength',
   tag: '#',
   kind: 'Analyze',
   priority: Priority,
@@ -132,7 +135,8 @@ export const PasswordStrengthBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'strength', 'pwstrength')) return [];
-    if (input.length === 0 || input.length > MAX_INPUT) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
 
     const classes = detectClasses(input);
     const pool = poolSize(classes);
@@ -145,6 +149,7 @@ export const PasswordStrengthBoxSource = {
       Entropy: `${bits.toFixed(1)} bits`,
       Rating: rating(bits),
       'Est. Crack Time': estimateCrackTime(input.length, pool),
+      Note: 'your password is in the page URL — do not share this link',
     };
 
     // plaintext summary for headless/TUI consumers — no password echoed

--- a/src/modules/boxSources/Rot47BoxSource.ts
+++ b/src/modules/boxSources/Rot47BoxSource.ts
@@ -1,0 +1,55 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// rotate printable ASCII characters (! to ~, codes 33-126) by 47 positions
+function rot47(input: string): string {
+  let result = '';
+  for (let i = 0; i < input.length; i++) {
+    const c = input.charCodeAt(i);
+    if (c >= 33 && c <= 126) {
+      result += String.fromCharCode(33 + ((c - 33 + 47) % 94));
+    } else {
+      result += input[i];
+    }
+  }
+  return result;
+}
+
+export const Rot47BoxSource = {
+  name: 'ROT47',
+  description:
+    'Apply the ROT47 cipher (rotates printable ASCII ! to ~ by 47). Self-inverse.',
+  defaultInput: 'Hello, World! ::rot47',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'rot47')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const output = rot47(input);
+    return [
+      new BoxBuilder('ROT47', output)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Rot47BoxSource;

--- a/src/modules/boxSources/__test__/AtbashBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AtbashBoxSource.test.ts
@@ -1,0 +1,107 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { AtbashBoxSource } from '../AtbashBoxSource';
+
+describe('AtbashBoxSource', () => {
+  describe('generateBoxes - gate conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no atbash key', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::atbash', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('', { atbash: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::atbash', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('   ', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - cipher correctness', () => {
+    it('transforms "hello" to "svool"', async () => {
+      // h→s, e→v, l→o, l→o, o→l
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('svool');
+    });
+
+    it('transforms "ABC" to "ZYX"', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('ABC', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ZYX');
+    });
+
+    it('preserves case and punctuation: "Hello, World!" → "Svool, Dliow!"', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('Hello, World!', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Svool, Dliow!');
+    });
+
+    it('is self-inverse: atbash(atbash(x)) === x', async () => {
+      const original = 'The quick brown fox jumps over the lazy dog.';
+      const once = await AtbashBoxSource.generateBoxes(original, {
+        atbash: true,
+      });
+      const twice = await AtbashBoxSource.generateBoxes(
+        once[0].props.plaintextOutput,
+        { atbash: true },
+      );
+      expect(twice[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('generateBoxes - box properties', () => {
+    it('sets name to "Atbash"', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {
+        atbash: true,
+      });
+      expect(boxes[0].props.name).toBe('Atbash');
+    });
+
+    it('uses DefaultBoxTemplate', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {
+        atbash: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('sets showExpandButton to false', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {
+        atbash: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {
+        atbash: true,
+      });
+      expect(boxes[0].props.priority).toBe(AtbashBoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(AtbashBoxSource.name).toBe('Atbash');
+      expect(AtbashBoxSource.kind).toBe('Encode');
+      expect(typeof AtbashBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HumanizeDurationBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HumanizeDurationBoxSource.test.ts
@@ -1,0 +1,196 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { HumanizeDurationBoxSource } from '../HumanizeDurationBoxSource';
+
+describe('HumanizeDurationBoxSource', () => {
+  describe('gate conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes(
+        '90061',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options has neither humanize nor duration key', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90061', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('abc', {
+        humanize: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('', {
+        humanize: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding 50 characters', async () => {
+      const long = '1'.repeat(51);
+      const boxes = await HumanizeDurationBoxSource.generateBoxes(long, {
+        humanize: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for negative-looking input (sign not in pattern)', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('-1', {
+        humanize: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('seconds mode (default)', () => {
+    it('90061s → Compact "1d 1h 1m 1s"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90061', {
+        humanize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1d 1h 1m 1s');
+    });
+
+    it('90061s → Total Seconds "90061"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90061', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('90061');
+    });
+
+    it('60s → Compact "1m"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('60', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1m');
+    });
+
+    it('3661s → Compact "1h 1m 1s"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('3661', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1h 1m 1s');
+    });
+
+    it('0s → Compact "0s"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('0', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('0s');
+    });
+
+    it('3600s → Compact "1h"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('3600', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1h');
+    });
+  });
+
+  describe('milliseconds mode (::humanize=ms)', () => {
+    it('90000ms → 90s → Compact "1m 30s"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90000', {
+        humanize: 'ms',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1m 30s');
+    });
+
+    it('90000ms → Total Seconds "90"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90000', {
+        humanize: 'ms',
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('90');
+    });
+  });
+
+  describe('::duration option key also triggers', () => {
+    it('60s with ::duration → Compact "1m"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('60', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1m');
+    });
+  });
+
+  describe('Long form pluralization', () => {
+    it('3661s → Long "1 hour, 1 minute, 1 second"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('3661', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Long).toBe('1 hour, 1 minute, 1 second');
+    });
+
+    it('7200s → Long "2 hours"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('7200', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Long).toBe('2 hours');
+    });
+
+    it('90061s → Long "1 day, 1 hour, 1 minute, 1 second"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90061', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Long).toBe('1 day, 1 hour, 1 minute, 1 second');
+    });
+
+    it('0s → Long "0 seconds"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('0', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Long).toBe('0 seconds');
+    });
+  });
+
+  describe('box properties', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('60', {
+        humanize: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets name to "Humanize Duration"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('60', {
+        humanize: true,
+      });
+      expect(boxes[0].props.name).toBe('Humanize Duration');
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('60', {
+        humanize: true,
+      });
+      expect(boxes[0].props.priority).toBe(HumanizeDurationBoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HumanizeDurationBoxSource.name).toBe('Humanize Duration');
+      expect(HumanizeDurationBoxSource.kind).toBe('Convert');
+      expect(typeof HumanizeDurationBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JsonCsvBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonCsvBoxSource.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonCsvBoxSource } from '../JsonCsvBoxSource';
+
+describe('JsonCsvBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes('[{"a":1}]', null);
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes('[{"a":1}]', {
+        yaml: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('converts JSON array to CSV', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes(
+        '[{"a":1,"b":2},{"a":3,"b":4}]',
+        { jsoncsv: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → CSV');
+      expect(boxes[0].props.plaintextOutput).toBe('a,b\n1,2\n3,4');
+    });
+
+    it('CSV-quotes fields containing commas', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes(
+        '[{"name":"a,b","x":1}]',
+        { jsoncsv: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('name,x\n"a,b",1');
+    });
+
+    it('produces union of keys across rows, missing values become empty', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes('[{"a":1},{"b":2}]', {
+        jsoncsv: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a,b\n1,\n,2');
+    });
+
+    it('converts CSV to JSON array (::jsoncsv direction auto-detect)', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes('a,b\n1,2\n3,4', {
+        jsoncsv: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('CSV → JSON');
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual([
+        { a: '1', b: '2' },
+        { a: '3', b: '4' },
+      ]);
+    });
+
+    it('converts CSV to JSON array (::csvjson option)', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes('a,b\n1,2\n3,4', {
+        csvjson: true,
+      });
+      expect(boxes[0].props.name).toBe('CSV → JSON');
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual([
+        { a: '1', b: '2' },
+        { a: '3', b: '4' },
+      ]);
+    });
+
+    it('handles quoted CSV fields with embedded commas', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes('name,x\n"a,b",1', {
+        jsoncsv: true,
+      });
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual([{ name: 'a,b', x: '1' }]);
+    });
+
+    it('handles quoted CSV fields with escaped double-quotes', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes('val\n"say ""hi"""', {
+        jsoncsv: true,
+      });
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual([{ val: 'say "hi"' }]);
+    });
+
+    it('skips forbidden prototype-pollution keys in CSV headers', async () => {
+      const csv = '__proto__,name\nbad,Alice';
+      const boxes = await JsonCsvBoxSource.generateBoxes(csv, {
+        jsoncsv: true,
+      });
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      // __proto__ key must be absent; name key must be present
+      expect(parsed[0]).not.toHaveProperty('__proto__');
+      expect(parsed[0].name).toBe('Alice');
+      // object prototype must be unpolluted
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('returns an error box for invalid JSON-looking input', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes('[bad', {
+        jsoncsv: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON / CSV Error');
+      // error box uses CodeBoxTemplate; message is in plaintextOutput
+      expect(boxes[0].props.plaintextOutput.length).toBeGreaterThan(0);
+    });
+
+    it('converts a single JSON object (not array) as a one-row CSV', async () => {
+      const boxes = await JsonCsvBoxSource.generateBoxes('{"a":1,"b":2}', {
+        jsoncsv: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a,b\n1,2');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LeetSpeakBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LeetSpeakBoxSource.test.ts
@@ -1,0 +1,204 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { LeetSpeakBoxSource } from '../LeetSpeakBoxSource';
+
+describe('LeetSpeakBoxSource', () => {
+  describe('gate conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no leet key', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::leet', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('', { leet: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::leet', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('   ', {
+        leet: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::leetdecode', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('', {
+        leetdecode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode correctness', () => {
+    it('encodes "leet" to "1337"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1337');
+    });
+
+    it('encodes "hello" to "h3110"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('hello', {
+        leet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('h3110');
+    });
+
+    it('encodes "goat" to "9047"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('goat', {
+        leet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('9047');
+    });
+
+    it('preserves non-mapped characters: "a b!" → "4 8!"', async () => {
+      // a→4, space preserved, b→8, !→!
+      const boxes = await LeetSpeakBoxSource.generateBoxes('a b!', {
+        leet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('4 8!');
+    });
+
+    it('lowercases input before encoding: "LEET" → "1337"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('LEET', {
+        leet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('1337');
+    });
+
+    it('accepts ::leetencode as an alias for ::leet', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leetencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1337');
+    });
+  });
+
+  describe('decode correctness', () => {
+    it('decodes "1337" to "leet"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('1337', {
+        leetdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('leet');
+    });
+
+    it('decodes "h3110" to "hello"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('h3110', {
+        leetdecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('accepts ::unleet as an alias for ::leetdecode', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('1337', {
+        unleet: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('leet');
+    });
+
+    it('preserves unmapped chars during decode: "h3110!" → "hello!"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('h3110!', {
+        leetdecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hello!');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encode then decode round-trips "leet" back to "leet"', async () => {
+      const encoded = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+      });
+      const decoded = await LeetSpeakBoxSource.generateBoxes(
+        encoded[0].props.plaintextOutput,
+        { leetdecode: true },
+      );
+      expect(decoded[0].props.plaintextOutput).toBe('leet');
+    });
+
+    it('encode then decode round-trips "goat" back to "goat"', async () => {
+      const encoded = await LeetSpeakBoxSource.generateBoxes('goat', {
+        leet: true,
+      });
+      const decoded = await LeetSpeakBoxSource.generateBoxes(
+        encoded[0].props.plaintextOutput,
+        { leetdecode: true },
+      );
+      expect(decoded[0].props.plaintextOutput).toBe('goat');
+    });
+  });
+
+  describe('both options produce two boxes', () => {
+    it('returns 2 boxes when both ::leet and ::leetdecode are set', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+        leetdecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+    });
+
+    it('first box is encode, second is decode', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+        leetdecode: true,
+      });
+      expect(boxes[0].props.name).toBe('Leetspeak (Encode)');
+      expect(boxes[1].props.name).toBe('Leetspeak (Decode)');
+    });
+  });
+
+  describe('box properties', () => {
+    it('encode box name is "Leetspeak (Encode)"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+      });
+      expect(boxes[0].props.name).toBe('Leetspeak (Encode)');
+    });
+
+    it('decode box name is "Leetspeak (Decode)"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('1337', {
+        leetdecode: true,
+      });
+      expect(boxes[0].props.name).toBe('Leetspeak (Decode)');
+    });
+
+    it('uses DefaultBoxTemplate', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('sets showExpandButton to false', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+      });
+      expect(boxes[0].props.priority).toBe(LeetSpeakBoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LeetSpeakBoxSource.name).toBe('Leetspeak');
+      expect(LeetSpeakBoxSource.kind).toBe('Transform');
+      expect(typeof LeetSpeakBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NatoPhoneticBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NatoPhoneticBoxSource.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { NatoPhoneticBoxSource } from '../NatoPhoneticBoxSource';
+
+describe('NatoPhoneticBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no option is provided', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('AB12', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array for empty input even with option', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array for whitespace-only input', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('   ', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should spell "AB12" correctly with ::nato option', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('AB12', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa Bravo One Two');
+    });
+
+    it('should also trigger with ::phonetic option', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('AB12', {
+        phonetic: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa Bravo One Two');
+    });
+
+    it('should handle lowercase input case-insensitively', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('sos', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Sierra Oscar Sierra');
+    });
+
+    it('should use official spellings: Alfa, Juliett, X-ray', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('AJX', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa Juliett X-ray');
+    });
+
+    it('should render spaces as "(space)"', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('A B', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa (space) Bravo');
+    });
+
+    it('should pass through unrecognised punctuation literally', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('A!', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa !');
+    });
+
+    it('should set box name to "NATO Phonetic"', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('A', {
+        nato: true,
+      });
+      expect(boxes[0].props.name).toBe('NATO Phonetic');
+    });
+
+    it('should set priority to 10', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('A', {
+        nato: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('should disable expand button', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('A', {
+        nato: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NumberBasesBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberBasesBoxSource.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { NumberBasesBoxSource } from '../NumberBasesBoxSource';
+
+describe('NumberBasesBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no matching option key is provided', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('255', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option key is provided', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('255', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — decimal input', () => {
+    it('converts 255 to all four bases', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('255', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('255');
+      expect(opts.Hex).toBe('0xff');
+      expect(opts.Octal).toBe('0o377');
+      expect(opts.Binary).toBe('0b11111111');
+    });
+
+    it('converts 0 correctly', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('0', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('0');
+      expect(opts.Hex).toBe('0x0');
+      expect(opts.Octal).toBe('0o0');
+      expect(opts.Binary).toBe('0b0');
+    });
+  });
+
+  describe('generateBoxes — prefixed input', () => {
+    it('parses hex input 0xff', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('0xff', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('255');
+      expect(opts.Hex).toBe('0xff');
+    });
+
+    it('parses binary input 0b1010', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('0b1010', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('10');
+      expect(opts.Hex).toBe('0xa');
+    });
+
+    it('parses octal input 0o17', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('0o17', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('15');
+    });
+
+    it('accepts uppercase prefixes 0X, 0O, 0B', async () => {
+      const hexBoxes = await NumberBasesBoxSource.generateBoxes('0XFF', {
+        bases: true,
+      });
+      expect(
+        (hexBoxes[0].props.options as Record<string, string>).Decimal,
+      ).toBe('255');
+
+      const octBoxes = await NumberBasesBoxSource.generateBoxes('0O17', {
+        bases: true,
+      });
+      expect(
+        (octBoxes[0].props.options as Record<string, string>).Decimal,
+      ).toBe('15');
+
+      const binBoxes = await NumberBasesBoxSource.generateBoxes('0B1010', {
+        bases: true,
+      });
+      expect(
+        (binBoxes[0].props.options as Record<string, string>).Decimal,
+      ).toBe('10');
+    });
+  });
+
+  describe('generateBoxes — negative numbers', () => {
+    it('handles negative decimal -16', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('-16', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('-16');
+      expect(opts.Hex).toBe('-0x10');
+      expect(opts.Octal).toBe('-0o20');
+      expect(opts.Binary).toBe('-0b10000');
+    });
+  });
+
+  describe('generateBoxes — BigInt precision beyond Number', () => {
+    it('handles 9007199254740993 (> 2^53) with exact precision', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes(
+        '9007199254740993',
+        { bases: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('9007199254740993');
+      expect(opts.Hex).toBe('0x20000000000001');
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns [] for "xyz"', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('xyz', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for bare prefix "0x" with no digits', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('0x', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for floating point "12.5"', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('12.5', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty string', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('accepts ::numbase option key as well', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('10', {
+        numbase: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('sets box name to "Number Bases"', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('255', {
+        bases: true,
+      });
+      expect(boxes[0].props.name).toBe('Number Bases');
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('255', {
+        bases: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PasswordStrengthBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PasswordStrengthBoxSource.test.ts
@@ -1,0 +1,121 @@
+import { PasswordStrengthBoxSource } from '@modules/boxSources/PasswordStrengthBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('PasswordStrengthBoxSource', () => {
+  it('returns [] when no option key is present', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('abc', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] for empty input even with ::strength', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('', {
+      strength: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] for input exceeding MAX_INPUT', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes(
+      'a'.repeat(10_001),
+      { strength: true },
+    );
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('accepts ::pwstrength as trigger', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('abc', {
+      pwstrength: true,
+    });
+    expect(boxes).toHaveLength(1);
+  });
+
+  describe("'abc' with ::strength", () => {
+    it('produces correct Length, Character Set, Pool Size, and Entropy', async () => {
+      const boxes = await PasswordStrengthBoxSource.generateBoxes('abc', {
+        strength: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Length).toBe('3');
+      expect(opts['Character Set']).toContain('lowercase');
+      expect(opts['Character Set']).not.toContain('uppercase');
+      expect(opts['Character Set']).not.toContain('digits');
+      expect(opts['Pool Size']).toBe('26');
+
+      // entropy = 3 * log2(26) ≈ 14.1 bits
+      const expectedBits = 3 * Math.log2(26);
+      expect(opts.Entropy).toBe(`${expectedBits.toFixed(1)} bits`);
+      // 14.1 < 28, so rating must be Very Weak
+      expect(opts.Rating).toBe('Very Weak');
+    });
+  });
+
+  describe("'P@ssw0rd123' with ::strength", () => {
+    it('detects lowercase, uppercase, digits, and symbols; pool 95; has a Rating', async () => {
+      const boxes = await PasswordStrengthBoxSource.generateBoxes(
+        'P@ssw0rd123',
+        { strength: true },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Character Set']).toContain('lowercase');
+      expect(opts['Character Set']).toContain('uppercase');
+      expect(opts['Character Set']).toContain('digits');
+      expect(opts['Character Set']).toContain('symbols');
+      // pool = 26+26+10+33 = 95
+      expect(opts['Pool Size']).toBe('95');
+      expect(opts.Rating).toBeTruthy();
+    });
+
+    it('does NOT echo the password in any option value', async () => {
+      const password = 'P@ssw0rd123';
+      const boxes = await PasswordStrengthBoxSource.generateBoxes(password, {
+        strength: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      for (const value of Object.values(opts)) {
+        expect(value).not.toBe(password);
+      }
+    });
+  });
+
+  describe("'Tr0ub4dour&3xtra!Longg' with ::strength", () => {
+    it('rates as Strong or Very Strong', async () => {
+      const boxes = await PasswordStrengthBoxSource.generateBoxes(
+        'Tr0ub4dour&3xtra!Longg',
+        { strength: true },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(['Strong', 'Very Strong']).toContain(opts.Rating);
+    });
+  });
+
+  it('entropy equals length * log2(poolSize)', async () => {
+    // 'abc' → pool=26, length=3
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('abc', {
+      strength: true,
+    });
+    const opts = boxes[0].props.options as Record<string, string>;
+    const length = Number.parseInt(opts.Length, 10);
+    const pool = Number.parseInt(opts['Pool Size'], 10);
+    const expected = `${(length * Math.log2(pool)).toFixed(1)} bits`;
+    expect(opts.Entropy).toBe(expected);
+  });
+
+  it('space character counts as its own pool class', async () => {
+    const boxes = await PasswordStrengthBoxSource.generateBoxes('a b', {
+      strength: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Character Set']).toContain('space');
+    // pool = 26 (lower) + 1 (space) = 27
+    expect(opts['Pool Size']).toBe('27');
+  });
+});

--- a/src/modules/boxSources/__test__/Rot47BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Rot47BoxSource.test.ts
@@ -1,0 +1,108 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Rot47BoxSource } from '../Rot47BoxSource';
+
+describe('Rot47BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('Hello, World!', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('Hello, World!', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns empty array for empty string', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('', { rot47: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('   ', { rot47: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - known vector', () => {
+    it('produces canonical ROT47 output for "Hello, World!"', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('Hello, World!', {
+        rot47: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('w6==@[ (@C=5P');
+      expect(boxes[0].props.name).toBe('ROT47');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('produces correct ROT47 for "ABC"', async () => {
+      // A(65)→p, B(66)→q, C(67)→r
+      const boxes = await Rot47BoxSource.generateBoxes('ABC', { rot47: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('pqr');
+    });
+  });
+
+  describe('generateBoxes - self-inverse property', () => {
+    it('rot47(rot47(x)) === x for "Hello, World!"', async () => {
+      const first = await Rot47BoxSource.generateBoxes('Hello, World!', {
+        rot47: true,
+      });
+      const encoded = first[0].props.plaintextOutput as string;
+      const second = await Rot47BoxSource.generateBoxes(encoded, {
+        rot47: true,
+      });
+      expect(second[0].props.plaintextOutput).toBe('Hello, World!');
+    });
+
+    it('rot47(rot47(x)) === x for arbitrary printable ASCII', async () => {
+      const input =
+        '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+      const first = await Rot47BoxSource.generateBoxes(input, { rot47: true });
+      const second = await Rot47BoxSource.generateBoxes(
+        first[0].props.plaintextOutput as string,
+        { rot47: true },
+      );
+      expect(second[0].props.plaintextOutput).toBe(input);
+    });
+  });
+
+  describe('generateBoxes - boundary characters', () => {
+    it('preserves spaces (code 32, below range 33-126)', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('A B', { rot47: true });
+      expect(boxes).toHaveLength(1);
+      // A→p, space→space, B→q
+      expect(boxes[0].props.plaintextOutput).toBe('p q');
+    });
+
+    it('preserves newline and tab (control characters below 33)', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('A\nB\tC', {
+        rot47: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('p\nq\tr');
+    });
+
+    it('preserves non-ASCII characters (codes > 126)', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('héllo', {
+        rot47: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // lowercase h(104)→9, é unchanged (code 233), l→=, l→=, o→@
+      expect(boxes[0].props.plaintextOutput).toBe('9é==@');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Rot47BoxSource.name).toBe('ROT47');
+      expect(Rot47BoxSource.tag).toBe('#');
+      expect(Rot47BoxSource.kind).toBe('Encode');
+      expect(typeof Rot47BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,3 +1,4 @@
+import AtbashBoxSource from './AtbashBoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
@@ -9,14 +10,21 @@ import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HumanizeDurationBoxSource from './HumanizeDurationBoxSource';
+import JsonCsvBoxSource from './JsonCsvBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LeetSpeakBoxSource from './LeetSpeakBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
+import NatoPhoneticBoxSource from './NatoPhoneticBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberBasesBoxSource from './NumberBasesBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PasswordStrengthBoxSource from './PasswordStrengthBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import Rot47BoxSource from './Rot47BoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
@@ -31,19 +39,27 @@ export const boxSources = [
   ColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  AtbashBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HumanizeDurationBoxSource,
+  JsonCsvBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LeetSpeakBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
+  NatoPhoneticBoxSource,
   NowBoxSource,
+  NumberBasesBoxSource,
   PasswordBoxSource,
+  PasswordStrengthBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
+  Rot47BoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,


### PR DESCRIPTION
## Summary

Fifteenth exploration batch — **8 more BoxSource tools** (data, ciphers, dev utilities).

| Tool | Trigger | What it does |
|------|---------|--------------|
| JSON / CSV | `::jsoncsv` / `::csvjson` | array of objects ⇄ CSV (auto-direction) |
| Number Bases | `::bases` | integer in binary/octal/decimal/hex |
| Atbash | `::atbash` | self-inverse substitution cipher |
| ROT47 | `::rot47` | printable-ASCII rotation, self-inverse |
| NATO Phonetic | `::nato` | spell with the NATO alphabet |
| Humanize Duration | `::humanize` | seconds → "1d 1h 1m 1s" (`=ms` for ms) |
| Leetspeak | `::leet` / `::leetdecode` | text ⇄ leet |
| Password Strength | `::strength` | entropy + rating (never echoes the password) |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules — input caps, `this.priority`, `BigInt(str)` not `BigInt(parseInt)`, **prototype-pollution guard** on the CSV→JSON object build (batch 10 bug), and **secret-not-echoed** for Password Strength (it reports length/classes/entropy/rating, never the password).
- **Verified vectors**: jsoncsv round-trip + union-keys + RFC 4180 quoting; `255`→`0xff`/`0o377`/`0b11111111` (and `9007199254740993` BigInt-exact); atbash `hello`→`svool`; **ROT47 `Hello, World!`→`w6==@[ (@C=5P`**; nato `AB12`→`Alfa Bravo One Two`; `90061s`→`1d 1h 1m 1s`; `leet`→`1337` round-trip; entropy = `len·log2(pool)`.

## Verification

- ✅ `bun run test run` — **453 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#273 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6