### PR TITLE
feat(boxSources): add 8 more tools (text-diff, json-path, ean13, credit-card, ulid, line-numbers, tabs/spaces, isin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>TextDiffBox</b> </summary>
+
+| match rule    | description                          | example                       |
+| ------------- | ------------------------------------ | ----------------------------- |
+| `::textdiff`  | line diff of two texts split by `---` | `foo`<br>`---`<br>`bar ::textdiff` |
+
+</details>
+
+<details>
+<summary> <b>JsonPathBox</b> </summary>
+
+| match rule         | description                          | example                          |
+| ------------------ | ------------------------------------ | -------------------------------- |
+| `::jsonpath=PATH`  | extract a value with a dot/bracket path | `{"a":{"b":[10,20]}} ::jsonpath=$.a.b[1]` |
+
+</details>
+
+<details>
+<summary> <b>Ean13Box</b> </summary>
+
+| match rule  | description                          | example                  |
+| ----------- | ------------------------------------ | ------------------------ |
+| `::ean13`   | validate EAN-13 / UPC-A / EAN-8      | `4006381333931 ::ean13`  |
+
+</details>
+
+<details>
+<summary> <b>CreditCardBox</b> </summary>
+
+| match rule    | description                          | example                       |
+| ------------- | ------------------------------------ | ----------------------------- |
+| `::cardtype`  | detect card brand + Luhn (masks the number) | `4111111111111111 ::cardtype` |
+
+</details>
+
+<details>
+<summary> <b>UlidBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::ulid`    | generate a ULID, or decode an existing one's timestamp | `::ulid` |
+
+</details>
+
+<details>
+<summary> <b>LineNumbersBox</b> </summary>
+
+| match rule        | description                          | example                       |
+| ----------------- | ------------------------------------ | ----------------------------- |
+| `::linenumbers`   | add line numbers (`::stripnumbers` to remove) | `first`<br>`second ::linenumbers` |
+
+</details>
+
+<details>
+<summary> <b>TabsSpacesBox</b> </summary>
+
+| match rule         | description                          | example                  |
+| ------------------ | ------------------------------------ | ------------------------ |
+| `::tabs2spaces`    | leading tabs → spaces (`::spaces2tabs` reverse) | `\tcode ::tabs2spaces` |
+
+</details>
+
+<details>
+<summary> <b>IsinBox</b> </summary>
+
+| match rule  | description                          | example                |
+| ----------- | ------------------------------------ | ---------------------- |
+| `::isin`    | validate an ISIN (ISO 6166)          | `US0378331005 ::isin`  |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/CreditCardBoxSource.ts
+++ b/src/modules/boxSources/CreditCardBoxSource.ts
@@ -1,0 +1,148 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// brand detection result
+interface CardBrand {
+  name: string;
+  // whether the card length falls within the brand's valid set
+  validLength: boolean;
+}
+
+// luhn mod-10 check
+function luhnCheck(digits: string): boolean {
+  let sum = 0;
+  let shouldDouble = false;
+
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = Number.parseInt(digits[i], 10);
+
+    if (shouldDouble) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+
+    sum += d;
+    shouldDouble = !shouldDouble;
+  }
+
+  return sum % 10 === 0;
+}
+
+// detect card brand from digit string; returns name and whether length is valid for that brand
+function detectBrand(digits: string): CardBrand {
+  const len = digits.length;
+  const prefix4 = Number.parseInt(digits.slice(0, 4), 10);
+  const prefix2 = Number.parseInt(digits.slice(0, 2), 10);
+  const prefix3 = Number.parseInt(digits.slice(0, 3), 10);
+
+  // Visa: starts with 4, lengths 13/16/19
+  if (digits[0] === '4') {
+    return {
+      name: 'Visa',
+      validLength: len === 13 || len === 16 || len === 19,
+    };
+  }
+
+  // Mastercard: 51-55 or 2221-2720, length 16
+  if (
+    (prefix2 >= 51 && prefix2 <= 55) ||
+    (prefix4 >= 2221 && prefix4 <= 2720)
+  ) {
+    return { name: 'Mastercard', validLength: len === 16 };
+  }
+
+  // American Express: 34 or 37, length 15
+  if (prefix2 === 34 || prefix2 === 37) {
+    return { name: 'American Express', validLength: len === 15 };
+  }
+
+  // Discover: 6011, 65, or 644-649, lengths 16/19
+  if (
+    digits.startsWith('6011') ||
+    prefix2 === 65 ||
+    (prefix3 >= 644 && prefix3 <= 649)
+  ) {
+    return { name: 'Discover', validLength: len === 16 || len === 19 };
+  }
+
+  // Diners Club: 36, 38, or 300-305, length 14
+  if (prefix2 === 36 || prefix2 === 38 || (prefix3 >= 300 && prefix3 <= 305)) {
+    return { name: 'Diners Club', validLength: len === 14 };
+  }
+
+  // JCB: 3528-3589, lengths 16-19
+  if (prefix4 >= 3528 && prefix4 <= 3589) {
+    return { name: 'JCB', validLength: len >= 16 && len <= 19 };
+  }
+
+  return { name: 'Unknown', validLength: false };
+}
+
+// mask the PAN: show first digit + bullets for middle digits + last 4
+function maskPAN(digits: string): string {
+  if (digits.length <= 5) {
+    // too short to meaningfully mask; replace all but last char
+    return '•'.repeat(digits.length - 1) + digits[digits.length - 1];
+  }
+
+  const first = digits[0];
+  const last4 = digits.slice(-4);
+  const middleLen = digits.length - 1 - 4;
+  return first + '•'.repeat(middleLen) + last4;
+}
+
+export const CreditCardBoxSource = {
+  name: 'Credit Card',
+  description:
+    'Detect the card brand from a number and check Luhn validity (masks the number).',
+  defaultInput: '4111111111111111 ::cardtype',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cardtype', 'creditcard')) return [];
+
+    // strip spaces and hyphens, leaving only digits
+    const cleaned = trim(input).replace(/[\s-]/g, '');
+
+    // if the result is not entirely digits or is outside the valid length range, bail out
+    if (!/^\d+$/.test(cleaned)) return [];
+    if (cleaned.length < 12 || cleaned.length > 19) return [];
+
+    const brand = detectBrand(cleaned);
+    const luhnValid = luhnCheck(cleaned);
+    const masked = maskPAN(cleaned);
+
+    // key-value entries displayed in the box
+    const kvOptions: Record<string, string> = {
+      Masked: masked,
+      Brand: brand.name,
+      Length: String(cleaned.length),
+      'Luhn Valid': String(luhnValid),
+    };
+
+    // plaintextOutput as k:v lines (not JSON)
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Credit Card', plaintextOutput)
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CreditCardBoxSource;

--- a/src/modules/boxSources/CreditCardBoxSource.ts
+++ b/src/modules/boxSources/CreditCardBoxSource.ts
@@ -69,8 +69,13 @@ function detectBrand(digits: string): CardBrand {
     return { name: 'Discover', validLength: len === 16 || len === 19 };
   }
 
-  // Diners Club: 36, 38, or 300-305, length 14
-  if (prefix2 === 36 || prefix2 === 38 || (prefix3 >= 300 && prefix3 <= 305)) {
+  // Diners Club: 36, 38, 39, or 300-305, length 14
+  if (
+    prefix2 === 36 ||
+    prefix2 === 38 ||
+    prefix2 === 39 ||
+    (prefix3 >= 300 && prefix3 <= 305)
+  ) {
     return { name: 'Diners Club', validLength: len === 14 };
   }
 

--- a/src/modules/boxSources/Ean13BoxSource.ts
+++ b/src/modules/boxSources/Ean13BoxSource.ts
@@ -1,0 +1,103 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+type BarcodeType = 'EAN-13' | 'UPC-A' | 'EAN-8';
+
+// compute the check digit for a barcode's data digits (all but the last).
+// iterates from right-to-left, alternating weights 3, 1, 3, 1, ...
+// this single algorithm works uniformly for EAN-8, EAN-13, and UPC-A.
+function computeCheckDigit(dataDigits: string): number {
+  let sum = 0;
+  for (let i = dataDigits.length - 1; i >= 0; i--) {
+    const weight = (dataDigits.length - 1 - i) % 2 === 0 ? 3 : 1;
+    sum += Number.parseInt(dataDigits[i], 10) * weight;
+  }
+  return (10 - (sum % 10)) % 10;
+}
+
+function detectType(len: number): BarcodeType | null {
+  if (len === 13) return 'EAN-13';
+  if (len === 12) return 'UPC-A';
+  if (len === 8) return 'EAN-8';
+  return null;
+}
+
+export const Ean13BoxSource = {
+  name: 'EAN-13 / UPC-A',
+  description:
+    'Validate an EAN-13 or UPC-A barcode and compute its check digit.',
+  defaultInput: '4006381333931 ::ean13',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ean13', 'ean', 'upc')) return [];
+
+    // strip surrounding whitespace, then remove embedded spaces and hyphens
+    const cleaned = trim(input).replace(/[\s-]/g, '');
+
+    if (!/^\d+$/.test(cleaned)) {
+      const output: Record<string, string> = {
+        Input: cleaned,
+        Error: 'input must contain digits only',
+      };
+      const plaintext = `Input: ${cleaned}\nError: input must contain digits only`;
+      return [
+        new BoxBuilder('EAN-13 / UPC-A', plaintext)
+          .setOptions(output)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const barcodeType = detectType(cleaned.length);
+    if (!barcodeType) {
+      const output: Record<string, string> = {
+        Input: cleaned,
+        Error: `length must be 8 (EAN-8), 12 (UPC-A), or 13 (EAN-13); got ${cleaned.length}`,
+      };
+      const plaintext = `Input: ${cleaned}\nError: length must be 8 (EAN-8), 12 (UPC-A), or 13 (EAN-13); got ${cleaned.length}`;
+      return [
+        new BoxBuilder('EAN-13 / UPC-A', plaintext)
+          .setOptions(output)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const dataDigits = cleaned.slice(0, -1);
+    const providedCheck = Number.parseInt(cleaned[cleaned.length - 1], 10);
+    const computedCheck = computeCheckDigit(dataDigits);
+    const isValid = computedCheck === providedCheck;
+
+    const output: Record<string, string> = {
+      Input: cleaned,
+      Type: barcodeType,
+      Valid: String(isValid),
+      'Check Digit': String(computedCheck),
+    };
+    const plaintext = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('EAN-13 / UPC-A', plaintext)
+        .setOptions(output)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Ean13BoxSource;

--- a/src/modules/boxSources/IsinBoxSource.ts
+++ b/src/modules/boxSources/IsinBoxSource.ts
@@ -1,0 +1,128 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// ISIN format: 2-letter country code + 9 alphanumeric NSIN chars + 1 numeric check digit
+const ISIN_REGEX = /^[A-Z]{2}[A-Z0-9]{9}[0-9]$/;
+
+// expand each character: letters become their ISO 6166 numeric equivalent (A=10..Z=35),
+// digits stay as single characters — concatenated into one digit string
+function expandIsin(isin: string): string {
+  let result = '';
+  for (const ch of isin) {
+    if (ch >= 'A' && ch <= 'Z') {
+      result += String(ch.charCodeAt(0) - 55);
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+// standard Luhn verification over the expanded digit string;
+// returns true when the full string (including check digit) is valid
+function luhnVerify(digits: string): boolean {
+  let sum = 0;
+  let shouldDouble = false;
+
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = Number.parseInt(digits[i], 10);
+    if (shouldDouble) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+    shouldDouble = !shouldDouble;
+  }
+
+  return sum % 10 === 0;
+}
+
+// compute the expected check digit from the 11-char prefix;
+// the check digit occupies position 0 from the right (not doubled), so the
+// rightmost char of the 11-char expansion starts with shouldDouble = true
+function computeCheckDigit(isin11: string): number {
+  const expanded = expandIsin(isin11);
+  let sum = 0;
+  let shouldDouble = true;
+
+  for (let i = expanded.length - 1; i >= 0; i--) {
+    let d = Number.parseInt(expanded[i], 10);
+    if (shouldDouble) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+    shouldDouble = !shouldDouble;
+  }
+
+  return (10 - (sum % 10)) % 10;
+}
+
+export const IsinBoxSource = {
+  name: 'ISIN',
+  description: 'Validate an ISIN (ISO 6166) using its Luhn-based check digit.',
+  defaultInput: 'US0378331005 ::isin',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'isin')) return [];
+
+    const cleaned = trim(input).toUpperCase().replace(/\s/g, '');
+
+    // if input doesn't match the ISIN format, return a box explaining the expected format
+    if (!ISIN_REGEX.test(cleaned)) {
+      const kvOptions: Record<string, string> = {
+        ISIN: cleaned || '(empty)',
+        Format: '2-letter country + 9 alphanumeric + 1 digit',
+        Error: 'does not match ISIN format',
+      };
+      const plaintextOutput = Object.entries(kvOptions)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('\n');
+
+      return [
+        new BoxBuilder('ISIN', plaintextOutput)
+          .setOptions(kvOptions)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const country = cleaned.slice(0, 2);
+    const nsin = cleaned.slice(2, 11);
+    const computedCheckDigit = computeCheckDigit(cleaned.slice(0, 11));
+    const isValid = luhnVerify(expandIsin(cleaned));
+
+    const kvOptions: Record<string, string> = {
+      ISIN: cleaned,
+      Country: country,
+      NSIN: nsin,
+      Valid: String(isValid),
+      'Check Digit': String(computedCheckDigit),
+    };
+
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('ISIN', plaintextOutput)
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default IsinBoxSource;

--- a/src/modules/boxSources/JsonPathBoxSource.ts
+++ b/src/modules/boxSources/JsonPathBoxSource.ts
@@ -1,0 +1,191 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// prototype-dangerous keys that must never be traversed
+const PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+type PathSegment =
+  | { type: 'key'; key: string }
+  | { type: 'index'; index: number };
+
+// tokenize a jsonpath expression into typed segments.
+// strips an optional leading `$` and leading `.`, then splits on `.` and `[…]`.
+function parsePath(raw: string): PathSegment[] | null {
+  // strip leading `$` and any leading dot
+  let path = raw.trim();
+  if (path.startsWith('$')) {
+    path = path.slice(1);
+  }
+  if (path.startsWith('.')) {
+    path = path.slice(1);
+  }
+
+  if (path === '') {
+    return [];
+  }
+
+  const segments: PathSegment[] = [];
+  // tokenize using a regex that matches:
+  //   [n]         — numeric index
+  //   ["key"]     — double-quoted bracket key
+  //   ['key']     — single-quoted bracket key
+  //   identifier  — dot-separated key (may be preceded by a dot consumed above)
+  const tokenRe = /\[(\d+)\]|\["([^"]*)"\]|\['([^']*)'\]|([^.[]+)/g;
+  let match: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex loop
+  while ((match = tokenRe.exec(path)) !== null) {
+    if (match[1] !== undefined) {
+      // [n] — numeric index
+      segments.push({ type: 'index', index: Number.parseInt(match[1], 10) });
+    } else if (match[2] !== undefined) {
+      // ["key"]
+      segments.push({ type: 'key', key: match[2] });
+    } else if (match[3] !== undefined) {
+      // ['key']
+      segments.push({ type: 'key', key: match[3] });
+    } else if (match[4] !== undefined) {
+      // dot-separated key
+      segments.push({ type: 'key', key: match[4] });
+    } else {
+      return null;
+    }
+  }
+
+  return segments;
+}
+
+function buildBox(name: string, output: string, priority: number): Box {
+  return new BoxBuilder(name, output)
+    .setTemplate(CodeBoxTemplate)
+    .setOptions({ language: 'json' })
+    .setPriority(priority)
+    .build();
+}
+
+export const JsonPathBoxSource = {
+  name: 'JSON Path',
+  description:
+    'Extract a value from JSON with a dot/bracket path. e.g. ::jsonpath=$.a.b[0] or ::jsonpath=a.b[0].',
+  defaultInput: '{"a":{"b":[10,20]}} ::jsonpath=$.a.b[1]',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonpath', 'jpath')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const rawPath = extractOptionKeys(options, 'jsonpath', 'jpath');
+
+    // bare `::jsonpath` without a string value — narrows rawPath to string below
+    if (typeof rawPath !== 'string' || rawPath === '') {
+      return [
+        buildBox(
+          'JSON Path',
+          'A path is required. Example: ::jsonpath=$.a.b[0]',
+          this.priority,
+        ),
+      ];
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trim(input));
+    } catch {
+      return [
+        buildBox(
+          'JSON Path',
+          'Invalid JSON: could not parse input.',
+          this.priority,
+        ),
+      ];
+    }
+
+    const segments = parsePath(rawPath);
+    if (segments === null) {
+      return [buildBox('JSON Path', `Invalid path: ${rawPath}`, this.priority)];
+    }
+
+    // root value with empty path
+    if (segments.length === 0) {
+      const out =
+        typeof parsed === 'string' ? parsed : JSON.stringify(parsed, null, 2);
+      return [buildBox('JSON Path', out, this.priority)];
+    }
+
+    let current: unknown = parsed;
+    for (const seg of segments) {
+      if (seg.type === 'key') {
+        // block prototype-dangerous keys
+        if (PROTO_KEYS.has(seg.key)) {
+          return [
+            buildBox(
+              'JSON Path',
+              `Path not found: "${seg.key}" is a reserved key.`,
+              this.priority,
+            ),
+          ];
+        }
+        if (
+          current === null ||
+          typeof current !== 'object' ||
+          Array.isArray(current)
+        ) {
+          return [
+            buildBox(
+              'JSON Path',
+              `Path not found at segment "${seg.key}".`,
+              this.priority,
+            ),
+          ];
+        }
+        if (!Object.hasOwn(current as Record<string, unknown>, seg.key)) {
+          return [
+            buildBox(
+              'JSON Path',
+              `Path not found: key "${seg.key}" does not exist.`,
+              this.priority,
+            ),
+          ];
+        }
+        current = (current as Record<string, unknown>)[seg.key];
+      } else {
+        // numeric index
+        if (!Array.isArray(current)) {
+          return [
+            buildBox(
+              'JSON Path',
+              `Path not found: expected an array at index ${seg.index}.`,
+              this.priority,
+            ),
+          ];
+        }
+        if (seg.index < 0 || seg.index >= (current as unknown[]).length) {
+          return [
+            buildBox(
+              'JSON Path',
+              `Path not found: index ${seg.index} out of bounds.`,
+              this.priority,
+            ),
+          ];
+        }
+        current = (current as unknown[])[seg.index];
+      }
+    }
+
+    const output =
+      typeof current === 'string' ? current : JSON.stringify(current, null, 2);
+
+    return [buildBox('JSON Path', output, this.priority)];
+  },
+};
+
+export default JsonPathBoxSource;

--- a/src/modules/boxSources/LineNumbersBoxSource.ts
+++ b/src/modules/boxSources/LineNumbersBoxSource.ts
@@ -1,0 +1,77 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// right-pad a number string with leading spaces to reach the desired width
+function padNumber(n: number, width: number): string {
+  return String(n).padStart(width, ' ');
+}
+
+// add line numbers to text, optionally starting at a custom index
+function addLineNumbers(input: string, start: number): string {
+  const lines = input.split('\n').map((line) => line.replace(/\r$/, ''));
+  const end = start + lines.length - 1;
+  const width = String(end).length;
+  return lines
+    .map((line, i) => `${padNumber(start + i, width)} | ${line}`)
+    .join('\n');
+}
+
+// strip a leading line-number prefix of the form: optional-spaces digits optional-spaces [|│:] optional-space
+function stripLineNumbers(input: string): string {
+  const PREFIX_RE = /^\s*\d+\s*[|│:]?\s?/;
+  return input
+    .split('\n')
+    .map((line) => line.replace(PREFIX_RE, ''))
+    .join('\n');
+}
+
+export const LineNumbersBoxSource = {
+  name: 'Line Numbers',
+  description:
+    'Add line numbers to text (::linenumbers, optional ::linenumbers=<start>) or strip them (::stripnumbers).',
+  defaultInput: 'first\nsecond\nthird ::linenumbers',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantAdd = hasOptionKeys(options, 'linenumbers', 'numberlines');
+    const wantStrip = hasOptionKeys(options, 'stripnumbers');
+    if (!wantAdd && !wantStrip) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    let output: string;
+
+    if (wantAdd) {
+      const rawValue = extractOptionKeys(options, 'linenumbers', 'numberlines');
+      // parse the numeric start value; default to 1 if absent or invalid
+      const parsedStart =
+        typeof rawValue === 'string'
+          ? Number.parseInt(rawValue, 10)
+          : Number.NaN;
+      const start =
+        Number.isFinite(parsedStart) && parsedStart >= 0 ? parsedStart : 1;
+      output = addLineNumbers(input, start);
+    } else {
+      output = stripLineNumbers(input);
+    }
+
+    return [
+      new BoxBuilder('Line Numbers', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LineNumbersBoxSource;

--- a/src/modules/boxSources/LineNumbersBoxSource.ts
+++ b/src/modules/boxSources/LineNumbersBoxSource.ts
@@ -23,7 +23,8 @@ function addLineNumbers(input: string, start: number): string {
 
 // strip a leading line-number prefix of the form: optional-spaces digits optional-spaces [|│:] optional-space
 function stripLineNumbers(input: string): string {
-  const PREFIX_RE = /^\s*\d+\s*[|│:]?\s?/;
+  // require a separator so plain "42 value" lines aren't mangled
+  const PREFIX_RE = /^\s*\d+\s*[|│:.]\s?/;
   return input
     .split('\n')
     .map((line) => line.replace(PREFIX_RE, ''))

--- a/src/modules/boxSources/TabsSpacesBoxSource.ts
+++ b/src/modules/boxSources/TabsSpacesBoxSource.ts
@@ -8,8 +8,8 @@ const MAX_INPUT = 100_000;
 const DEFAULT_WIDTH = 4;
 
 // clamp tab width to a sensible range
-function resolveWidth(options: BoxOptions, key: string): number {
-  const raw = extractOptionKeys(options, key);
+function resolveWidth(options: BoxOptions, ...keys: string[]): number {
+  const raw = extractOptionKeys(options, ...keys);
   if (raw === null || raw === true) return DEFAULT_WIDTH;
   const n = Number.parseInt(String(raw), 10);
   if (Number.isNaN(n)) return DEFAULT_WIDTH;
@@ -65,20 +65,21 @@ export const TabsSpacesBoxSource = {
 
     let output: string;
     if (wantToSpaces) {
-      const width =
-        resolveWidth(options, 'tabs2spaces') ||
-        resolveWidth(options, 'untabify');
-      output = tabsToSpaces(input, width);
+      output = tabsToSpaces(
+        input,
+        resolveWidth(options, 'tabs2spaces', 'untabify'),
+      );
     } else {
-      const width =
-        resolveWidth(options, 'spaces2tabs') || resolveWidth(options, 'tabify');
-      output = spacesToTabs(input, width);
+      output = spacesToTabs(
+        input,
+        resolveWidth(options, 'spaces2tabs', 'tabify'),
+      );
     }
 
     return [
       new BoxBuilder('Tabs / Spaces', output)
         .setTemplate(CodeBoxTemplate)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build(),
     ];
   },

--- a/src/modules/boxSources/TabsSpacesBoxSource.ts
+++ b/src/modules/boxSources/TabsSpacesBoxSource.ts
@@ -1,0 +1,87 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+const DEFAULT_WIDTH = 4;
+
+// clamp tab width to a sensible range
+function resolveWidth(options: BoxOptions, key: string): number {
+  const raw = extractOptionKeys(options, key);
+  if (raw === null || raw === true) return DEFAULT_WIDTH;
+  const n = Number.parseInt(String(raw), 10);
+  if (Number.isNaN(n)) return DEFAULT_WIDTH;
+  return Math.min(16, Math.max(1, n));
+}
+
+// replace leading tabs with spaces (width spaces per tab)
+function tabsToSpaces(input: string, width: number): string {
+  return input
+    .split('\n')
+    .map((line) => {
+      let i = 0;
+      while (i < line.length && line[i] === '\t') i++;
+      if (i === 0) return line;
+      return ' '.repeat(i * width) + line.slice(i);
+    })
+    .join('\n');
+}
+
+// replace groups of `width` leading spaces with tabs; leftover spaces stay
+function spacesToTabs(input: string, width: number): string {
+  return input
+    .split('\n')
+    .map((line) => {
+      let i = 0;
+      while (i < line.length && line[i] === ' ') i++;
+      if (i === 0) return line;
+      const tabs = Math.floor(i / width);
+      const leftover = i % width;
+      return '\t'.repeat(tabs) + ' '.repeat(leftover) + line.slice(i);
+    })
+    .join('\n');
+}
+
+export const TabsSpacesBoxSource = {
+  name: 'Tabs / Spaces',
+  description:
+    'Convert leading tabs to spaces (::tabs2spaces=4) or leading spaces to tabs (::spaces2tabs=4).',
+  defaultInput: '\tindented ::tabs2spaces',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantToSpaces = hasOptionKeys(options, 'tabs2spaces', 'untabify');
+    const wantToTabs = hasOptionKeys(options, 'spaces2tabs', 'tabify');
+    if (!wantToSpaces && !wantToTabs) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    let output: string;
+    if (wantToSpaces) {
+      const width =
+        resolveWidth(options, 'tabs2spaces') ||
+        resolveWidth(options, 'untabify');
+      output = tabsToSpaces(input, width);
+    } else {
+      const width =
+        resolveWidth(options, 'spaces2tabs') || resolveWidth(options, 'tabify');
+      output = spacesToTabs(input, width);
+    }
+
+    return [
+      new BoxBuilder('Tabs / Spaces', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default TabsSpacesBoxSource;

--- a/src/modules/boxSources/TextDiffBoxSource.ts
+++ b/src/modules/boxSources/TextDiffBoxSource.ts
@@ -67,20 +67,39 @@ function buildDiff(left: string[], right: string[]): DiffResult {
   return { added, removed, lines };
 }
 
-function computeDiff(input: string): string | null {
+// the LCS table is O(leftLines * rightLines); bound the line count so a
+// pathological many-short-lines input within MAX_INPUT can't freeze the page
+const MAX_LINES_PER_SIDE = 2_000;
+
+type DiffOutcome =
+  | { ok: true; output: string }
+  | { ok: false; message: string };
+
+function computeDiff(input: string): DiffOutcome {
   const inputLines = input.split('\n');
   const sepIdx = inputLines.findIndex((line) => line.trim() === SEPARATOR);
 
   if (sepIdx === -1) {
-    return null;
+    return {
+      ok: false,
+      message:
+        'No separator found. Separate the two texts with a line containing only "---".',
+    };
   }
 
   const left = inputLines.slice(0, sepIdx);
   const right = inputLines.slice(sepIdx + 1);
 
+  if (left.length > MAX_LINES_PER_SIDE || right.length > MAX_LINES_PER_SIDE) {
+    return {
+      ok: false,
+      message: `Too many lines to diff (limit ${MAX_LINES_PER_SIDE} per side; got ${left.length} / ${right.length}).`,
+    };
+  }
+
   const { added, removed, lines } = buildDiff(left, right);
   const summary = `@@ +${added} -${removed} @@`;
-  return [summary, ...lines].join('\n');
+  return { ok: true, output: [summary, ...lines].join('\n') };
 }
 
 export const TextDiffBoxSource = {
@@ -101,24 +120,21 @@ export const TextDiffBoxSource = {
 
     const result = computeDiff(input);
 
-    if (result === null) {
-      // no separator found — explain the required format
-      const message =
-        'No separator found. Separate the two texts with a line containing only "---".';
+    if (!result.ok) {
+      // plain message box (no diff syntax highlighting)
       return [
-        new BoxBuilder('Text Diff', message)
-          .setOptions({ language: 'diff' })
+        new BoxBuilder('Text Diff', result.message)
           .setTemplate(CodeBoxTemplate)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       ];
     }
 
     return [
-      new BoxBuilder('Text Diff', result)
+      new BoxBuilder('Text Diff', result.output)
         .setOptions({ language: 'diff' })
         .setTemplate(CodeBoxTemplate)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build(),
     ];
   },

--- a/src/modules/boxSources/TextDiffBoxSource.ts
+++ b/src/modules/boxSources/TextDiffBoxSource.ts
@@ -1,0 +1,127 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 20_000;
+
+// separator line that splits left and right texts
+const SEPARATOR = '---';
+
+interface DiffResult {
+  added: number;
+  removed: number;
+  lines: string[];
+}
+
+// compute LCS lengths table for two arrays
+function lcsTable(left: string[], right: string[]): number[][] {
+  const m = left.length;
+  const n = right.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array(n + 1).fill(0),
+  );
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (left[i - 1] === right[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+  return dp;
+}
+
+// backtrack LCS table to produce unified-style diff lines (removals before additions)
+function buildDiff(left: string[], right: string[]): DiffResult {
+  const dp = lcsTable(left, right);
+  const lines: string[] = [];
+  let added = 0;
+  let removed = 0;
+  let i = left.length;
+  let j = right.length;
+
+  // collect in reverse then flip
+  const reversed: string[] = [];
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && left[i - 1] === right[j - 1]) {
+      reversed.push(`  ${left[i - 1]}`);
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      reversed.push(`+ ${right[j - 1]}`);
+      added++;
+      j--;
+    } else {
+      reversed.push(`- ${left[i - 1]}`);
+      removed++;
+      i--;
+    }
+  }
+
+  reversed.reverse();
+  lines.push(...reversed);
+
+  return { added, removed, lines };
+}
+
+function computeDiff(input: string): string | null {
+  const inputLines = input.split('\n');
+  const sepIdx = inputLines.findIndex((line) => line.trim() === SEPARATOR);
+
+  if (sepIdx === -1) {
+    return null;
+  }
+
+  const left = inputLines.slice(0, sepIdx);
+  const right = inputLines.slice(sepIdx + 1);
+
+  const { added, removed, lines } = buildDiff(left, right);
+  const summary = `@@ +${added} -${removed} @@`;
+  return [summary, ...lines].join('\n');
+}
+
+export const TextDiffBoxSource = {
+  name: 'Text Diff',
+  description:
+    'Line diff between two texts separated by a line containing only "---".',
+  defaultInput: 'foo\nbar\n---\nfoo\nbaz ::textdiff',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'textdiff', 'linediff')) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
+
+    const result = computeDiff(input);
+
+    if (result === null) {
+      // no separator found — explain the required format
+      const message =
+        'No separator found. Separate the two texts with a line containing only "---".';
+      return [
+        new BoxBuilder('Text Diff', message)
+          .setOptions({ language: 'diff' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    return [
+      new BoxBuilder('Text Diff', result)
+        .setOptions({ language: 'diff' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default TextDiffBoxSource;

--- a/src/modules/boxSources/UlidBoxSource.ts
+++ b/src/modules/boxSources/UlidBoxSource.ts
@@ -1,0 +1,136 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// Crockford base32 alphabet — excludes I, L, O, U to avoid visual ambiguity
+const ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+// maps a Crockford base32 character to its 5-bit value
+function crockfordCharValue(ch: string): number {
+  const idx = ENCODING.indexOf(ch.toUpperCase());
+  if (idx === -1) {
+    throw new RangeError(`invalid Crockford base32 character: ${ch}`);
+  }
+  return idx;
+}
+
+// encodes a BigInt value into n Crockford base32 characters (most-significant first)
+function encodeBase32(value: bigint, n: number): string {
+  let result = '';
+  let v = value;
+  for (let i = 0; i < n; i++) {
+    result = ENCODING[Number(v & 0x1fn)] + result;
+    v >>= 5n;
+  }
+  return result;
+}
+
+// decodes the first n characters of a Crockford base32 string to a BigInt
+function decodeBase32(chars: string, n: number): bigint {
+  let result = 0n;
+  for (let i = 0; i < n; i++) {
+    result = (result << 5n) | BigInt(crockfordCharValue(chars[i]));
+  }
+  return result;
+}
+
+// generates a new ULID using Date.now() for the timestamp and
+// crypto.getRandomValues for the 80-bit random component
+function generateUlid(): string {
+  const tsMs = BigInt(Date.now());
+
+  // 10 Crockford base32 chars encode 50 bits; the 48-bit ms timestamp
+  // fits with room to spare (max 48-bit value = 281474976710655 ms ≈ year 10889)
+  const tsPart = encodeBase32(tsMs, 10);
+
+  // 80 bits of randomness → 16 base32 chars (each char = 5 bits)
+  const randBytes = new Uint8Array(10);
+  crypto.getRandomValues(randBytes);
+
+  // pack 10 bytes into a bigint for base32 encoding
+  let randBits = 0n;
+  for (const byte of randBytes) {
+    randBits = (randBits << 8n) | BigInt(byte);
+  }
+
+  const randPart = encodeBase32(randBits, 16);
+  return tsPart + randPart;
+}
+
+// 26-character Crockford base32 ULID pattern (case-insensitive)
+const ULID_REGEX = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
+
+export const UlidBoxSource = {
+  name: 'ULID',
+  description:
+    'Generate a ULID (::ulid) or decode the timestamp of an existing ULID (::ulid=<ulid> or ::ulidparse).',
+  defaultInput: ' ::ulid',
+  tag: '#',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ulid', 'ulidparse')) return [];
+
+    const trimmed = trim(input).toUpperCase();
+
+    if (ULID_REGEX.test(trimmed)) {
+      // decode path: extract the 48-bit millisecond timestamp from the first 10 chars
+      const tsMs = Number(decodeBase32(trimmed, 10));
+      const isoTimestamp = new Date(tsMs).toISOString();
+
+      const content = `ULID: ${trimmed}\nTimestamp: ${isoTimestamp}\nUnix (ms): ${tsMs}`;
+      const kvOptions: Record<string, string> = {
+        ULID: trimmed,
+        Timestamp: isoTimestamp,
+        'Unix (ms)': tsMs.toString(),
+      };
+
+      return [
+        new BoxBuilder('ULID', content)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kvOptions)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // generate path: produce a fresh ULID
+    if (
+      typeof crypto === 'undefined' ||
+      typeof crypto.getRandomValues !== 'function'
+    ) {
+      const errorContent = 'ULID generation requires a secure context (HTTPS).';
+      return [
+        new BoxBuilder('ULID', errorContent).setPriority(this.priority).build(),
+      ];
+    }
+
+    const ulid = generateUlid();
+    const tsMs = Number(decodeBase32(ulid, 10));
+    const isoTimestamp = new Date(tsMs).toISOString();
+
+    const content = `ULID: ${ulid}\nTimestamp: ${isoTimestamp}\nUnix (ms): ${tsMs}`;
+    const kvOptions: Record<string, string> = {
+      ULID: ulid,
+      Timestamp: isoTimestamp,
+      'Unix (ms)': tsMs.toString(),
+    };
+
+    return [
+      new BoxBuilder('ULID', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UlidBoxSource;

--- a/src/modules/boxSources/__test__/CreditCardBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CreditCardBoxSource.test.ts
@@ -1,0 +1,273 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { CreditCardBoxSource } from '../CreditCardBoxSource';
+
+describe('CreditCardBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(CreditCardBoxSource.name).toBe('Credit Card');
+      expect(CreditCardBoxSource.tag).toBe('#');
+      expect(CreditCardBoxSource.kind).toBe('Validate');
+      expect(typeof CreditCardBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - trigger guard', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(
+        '4111111111111111',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(
+        '4111111111111111',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is provided', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(
+        '4111111111111111',
+        { hash: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - input validation', () => {
+    it('returns empty array for non-digit input', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes('not-a-number', {
+        cardtype: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for digit string shorter than 12', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes('41111111111', {
+        cardtype: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for digit string longer than 19', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(
+        '41111111111111111111',
+        {
+          cardtype: true,
+        },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('accepts input with spaces and hyphens', async () => {
+      // spaced grouping of 4111111111111111
+      const boxes = await CreditCardBoxSource.generateBoxes(
+        '4111 1111 1111 1111',
+        { cardtype: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes - Visa', () => {
+    const pan = '4111111111111111';
+
+    it('detects Visa brand', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Brand: 'Visa' });
+    });
+
+    it('reports Luhn Valid true', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Luhn Valid': 'true' });
+    });
+
+    it('masks the number — last 4 are visible', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      const masked = (boxes[0].props.options as Record<string, string>).Masked;
+      expect(masked).toMatch(/1111$/);
+    });
+
+    it('masked value does NOT contain the full PAN', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      const masked = (boxes[0].props.options as Record<string, string>).Masked;
+      expect(masked).not.toBe(pan);
+      expect(masked).not.toContain(pan);
+    });
+
+    it('no option value exposes the full PAN', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      for (const value of Object.values(opts)) {
+        expect(value).not.toContain(pan);
+      }
+      expect(boxes[0].props.plaintextOutput).not.toContain(pan);
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+
+  describe('generateBoxes - Mastercard', () => {
+    const pan = '5555555555554444';
+
+    it('detects Mastercard brand', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Brand: 'Mastercard' });
+    });
+
+    it('reports Luhn Valid true', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Luhn Valid': 'true' });
+    });
+
+    it('no option value exposes the full PAN', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        creditcard: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      for (const value of Object.values(opts)) {
+        expect(value).not.toContain(pan);
+      }
+      expect(boxes[0].props.plaintextOutput).not.toContain(pan);
+    });
+  });
+
+  describe('generateBoxes - American Express', () => {
+    const pan = '378282246310005';
+
+    it('detects American Express brand', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Brand: 'American Express',
+      });
+    });
+
+    it('reports length 15', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Length: '15' });
+    });
+
+    it('reports Luhn Valid true', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Luhn Valid': 'true' });
+    });
+
+    it('no option value exposes the full PAN', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      for (const value of Object.values(opts)) {
+        expect(value).not.toContain(pan);
+      }
+      expect(boxes[0].props.plaintextOutput).not.toContain(pan);
+    });
+  });
+
+  describe('generateBoxes - Discover', () => {
+    const pan = '6011111111111117';
+
+    it('detects Discover brand', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Brand: 'Discover' });
+    });
+
+    it('reports Luhn Valid true', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Luhn Valid': 'true' });
+    });
+
+    it('no option value exposes the full PAN', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      for (const value of Object.values(opts)) {
+        expect(value).not.toContain(pan);
+      }
+      expect(boxes[0].props.plaintextOutput).not.toContain(pan);
+    });
+  });
+
+  describe('generateBoxes - invalid Luhn', () => {
+    it('reports Luhn Valid false for 4111111111111112', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(
+        '4111111111111112',
+        { cardtype: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ 'Luhn Valid': 'false' });
+    });
+  });
+
+  describe('generateBoxes - ::creditcard trigger key', () => {
+    it('responds to ::creditcard option key', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(
+        '4111111111111111',
+        { creditcard: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Brand: 'Visa' });
+    });
+  });
+
+  describe('generateBoxes - plaintextOutput format', () => {
+    it('uses k:v lines (not JSON)', async () => {
+      const boxes = await CreditCardBoxSource.generateBoxes(
+        '4111111111111111',
+        { cardtype: true },
+      );
+      const text = boxes[0].props.plaintextOutput;
+      // must contain colon-separated lines
+      expect(text).toMatch(/^Masked: /m);
+      expect(text).toMatch(/^Brand: /m);
+      expect(text).toMatch(/^Length: /m);
+      expect(text).toMatch(/^Luhn Valid: /m);
+      // must NOT be parseable as JSON object
+      expect(() => JSON.parse(text)).toThrow();
+    });
+
+    it('does not contain the full PAN in plaintextOutput', async () => {
+      const pan = '4111111111111111';
+      const boxes = await CreditCardBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.plaintextOutput).not.toContain(pan);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/Ean13BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Ean13BoxSource.test.ts
@@ -1,0 +1,143 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Ean13BoxSource } from '../Ean13BoxSource';
+
+describe('Ean13BoxSource', () => {
+  describe('metadata', () => {
+    it('has expected name, tag, kind, and numeric priority', () => {
+      expect(Ean13BoxSource.name).toBe('EAN-13 / UPC-A');
+      expect(Ean13BoxSource.tag).toBe('#');
+      expect(Ean13BoxSource.kind).toBe('Validate');
+      expect(typeof Ean13BoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes — option guard', () => {
+    it('returns [] when no option keys are present', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('4006381333931', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are present', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('4006381333931', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::ean13', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('4006381333931', {
+        ean13: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('triggers on ::ean', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('4006381333931', {
+        ean: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('triggers on ::upc', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('036000291452', {
+        upc: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes — valid EAN-13 barcodes', () => {
+    it('validates 4006381333931 as EAN-13 with check digit 1', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('4006381333931', {
+        ean13: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Type).toBe('EAN-13');
+      expect(options?.Valid).toBe('true');
+      expect(options?.['Check Digit']).toBe('1');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('validates 5901234123457 as EAN-13 with check digit 7', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('5901234123457', {
+        ean13: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Type).toBe('EAN-13');
+      expect(options?.Valid).toBe('true');
+      expect(options?.['Check Digit']).toBe('7');
+    });
+  });
+
+  describe('generateBoxes — valid UPC-A barcode', () => {
+    it('validates 036000291452 as UPC-A with check digit 2', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('036000291452', {
+        upc: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Type).toBe('UPC-A');
+      expect(options?.Valid).toBe('true');
+      expect(options?.['Check Digit']).toBe('2');
+    });
+  });
+
+  describe('generateBoxes — invalid check digit', () => {
+    it('flags 4006381333930 (wrong check digit) as invalid', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('4006381333930', {
+        ean13: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Valid).toBe('false');
+      expect(options?.['Check Digit']).toBe('1');
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns a box mentioning length for a 5-digit input', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('12345', {
+        ean13: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const plaintext = boxes[0].props.plaintextOutput;
+      expect(plaintext).toMatch(/length/i);
+    });
+
+    it('returns a box mentioning digits for non-digit input', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('abc', { ean13: true });
+      expect(boxes).toHaveLength(1);
+      const plaintext = boxes[0].props.plaintextOutput;
+      expect(plaintext).toMatch(/digit/i);
+    });
+
+    it('strips spaces and hyphens before validation', async () => {
+      // 036000291452 with spaces and hyphens — still valid UPC-A
+      const boxes = await Ean13BoxSource.generateBoxes('0360 00-291452', {
+        upc: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Valid).toBe('true');
+      expect(options?.Input).toBe('036000291452');
+    });
+  });
+
+  describe('generateBoxes — plaintextOutput format', () => {
+    it('renders key: value lines (not JSON)', async () => {
+      const boxes = await Ean13BoxSource.generateBoxes('4006381333931', {
+        ean13: true,
+      });
+      const plaintext = boxes[0].props.plaintextOutput;
+      expect(plaintext).toContain('Input: 4006381333931');
+      expect(plaintext).toContain('Type: EAN-13');
+      expect(plaintext).toContain('Valid: true');
+      expect(plaintext).toContain('Check Digit: 1');
+      expect(plaintext).not.toContain('{');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/IsinBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/IsinBoxSource.test.ts
@@ -1,0 +1,185 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { IsinBoxSource } from '../IsinBoxSource';
+
+describe('IsinBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(IsinBoxSource.name).toBe('ISIN');
+      expect(IsinBoxSource.tag).toBe('#');
+      expect(IsinBoxSource.kind).toBe('Validate');
+      expect(typeof IsinBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - trigger guard', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is provided', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - valid ISIN: Apple (US0378331005)', () => {
+    it('returns one box', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', {
+        isin: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('reports Valid as true', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', {
+        isin: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Valid).toBe('true');
+    });
+
+    it('extracts Country as US', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', {
+        isin: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Country).toBe('US');
+    });
+
+    it('extracts NSIN correctly', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', {
+        isin: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.NSIN).toBe('037833100');
+    });
+
+    it('computes Check Digit as 5', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', {
+        isin: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Check Digit']).toBe('5');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', {
+        isin: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('uses k:v plaintext lines (not JSON)', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', {
+        isin: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toMatch(/^ISIN: /m);
+      expect(text).toMatch(/^Country: /m);
+      expect(text).toMatch(/^NSIN: /m);
+      expect(text).toMatch(/^Valid: /m);
+      expect(text).toMatch(/^Check Digit: /m);
+      expect(() => JSON.parse(text)).toThrow();
+    });
+
+    it('strips surrounding whitespace from input', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('  US0378331005  ', {
+        isin: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.ISIN).toBe('US0378331005');
+      expect(opts.Valid).toBe('true');
+    });
+
+    it('accepts lowercase input and uppercases it', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('us0378331005', {
+        isin: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Valid).toBe('true');
+    });
+  });
+
+  describe('generateBoxes - valid ISIN: BAE Systems (GB0002634946)', () => {
+    it('reports Valid as true', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('GB0002634946', {
+        isin: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Valid).toBe('true');
+    });
+
+    it('extracts Country as GB', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('GB0002634946', {
+        isin: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Country).toBe('GB');
+    });
+
+    it('computes Check Digit as 6', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('GB0002634946', {
+        isin: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Check Digit']).toBe('6');
+    });
+  });
+
+  describe('generateBoxes - invalid check digit', () => {
+    it('reports Valid as false for US0378331006 (bad check digit)', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331006', {
+        isin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Valid).toBe('false');
+    });
+  });
+
+  describe('generateBoxes - malformed input', () => {
+    it('returns a format-explanation box for "123"', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('123', { isin: true });
+      expect(boxes).toHaveLength(1);
+      // the box should mention format information, not a valid result
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts).toHaveProperty('Format');
+    });
+
+    it('returns a format-explanation box for "USXXX"', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('USXXX', { isin: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts).toHaveProperty('Format');
+    });
+
+    it('format box name is still ISIN', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('123', { isin: true });
+      expect(boxes[0].props.name).toBe('ISIN');
+    });
+
+    it('format box uses KeyValueBoxTemplate', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('123', { isin: true });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+
+  describe('generateBoxes - priority', () => {
+    it('box carries the source priority', async () => {
+      const boxes = await IsinBoxSource.generateBoxes('US0378331005', {
+        isin: true,
+      });
+      expect(boxes[0].props.priority).toBe(IsinBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JsonPathBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonPathBoxSource.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonPathBoxSource } from '../JsonPathBoxSource';
+
+describe('JsonPathBoxSource', () => {
+  describe('trigger guard', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes('{"a":1}', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated options are provided', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes('{"a":1}', {
+        sha256: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('path resolution', () => {
+    it('extracts a nested array element with leading $', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes(
+        '{"a":{"b":[10,20]}}',
+        { jsonpath: '$.a.b[1]' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('20');
+    });
+
+    it('works without leading $ (bare path)', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes(
+        '{"a":{"b":[10,20]}}',
+        { jsonpath: 'a.b[0]' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('10');
+    });
+
+    it('resolves bracket-quoted key with spaces', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes('{"x":{"y z":1}}', {
+        jsonpath: 'x["y z"]',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1');
+    });
+
+    it('returns object result as pretty-printed JSON', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes('{"a":{"b":1}}', {
+        jsonpath: 'a',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(JSON.parse(boxes[0].props.plaintextOutput)).toStrictEqual({
+        b: 1,
+      });
+    });
+
+    it('accepts ::jpath alias', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes('{"a":42}', {
+        jpath: 'a',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('42');
+    });
+  });
+
+  describe('not found cases', () => {
+    it('returns a not-found box when path does not exist', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes('{"a":1}', {
+        jsonpath: 'a.b.c',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(/not found/);
+    });
+  });
+
+  describe('prototype safety', () => {
+    it('does not return Object.prototype for __proto__ path', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes('{"a":1}', {
+        jsonpath: '__proto__',
+      });
+      expect(boxes).toHaveLength(1);
+      // must not resolve to Object.prototype — output is a not-found message, not an object dump
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(
+        /not found|reserved/,
+      );
+    });
+
+    it('does not follow constructor segment', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes('{"a":1}', {
+        jsonpath: 'constructor',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(
+        /not found|reserved/,
+      );
+    });
+  });
+
+  describe('error cases', () => {
+    it('returns an error box for invalid JSON', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes('{bad', {
+        jsonpath: 'a',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(
+        /invalid json/,
+      );
+    });
+
+    it('returns a path-required box when ::jsonpath is bare (boolean true)', async () => {
+      const boxes = await JsonPathBoxSource.generateBoxes('{"a":1}', {
+        jsonpath: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(
+        /path is required/,
+      );
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(JsonPathBoxSource.name).toBe('JSON Path');
+      expect(JsonPathBoxSource.tag).toBe('#');
+      expect(JsonPathBoxSource.kind).toBe('Analyze');
+      expect(typeof JsonPathBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LineNumbersBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LineNumbersBoxSource.test.ts
@@ -1,0 +1,171 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { LineNumbersBoxSource } from '../LineNumbersBoxSource';
+
+describe('LineNumbersBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LineNumbersBoxSource.name).toBe('Line Numbers');
+      expect(LineNumbersBoxSource.tag).toBe('#');
+      expect(LineNumbersBoxSource.kind).toBe('Transform');
+      expect(typeof LineNumbersBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - guard conditions', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\nsecond\nthird',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\nsecond\nthird',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input string with ::linenumbers', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('', {
+        linenumbers: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for input exceeding MAX_INPUT', async () => {
+      const huge = 'a'.repeat(100_001);
+      const boxes = await LineNumbersBoxSource.generateBoxes(huge, {
+        linenumbers: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - add line numbers (::linenumbers)', () => {
+    it('numbers three lines starting at 1 with width 1', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\nsecond\nthird',
+        { linenumbers: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '1 | first\n2 | second\n3 | third',
+      );
+    });
+
+    it('uses CodeBoxTemplate', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('hello', {
+        linenumbers: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+
+    it('sets box name to "Line Numbers"', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('hello', {
+        linenumbers: true,
+      });
+      expect(boxes[0].props.name).toBe('Line Numbers');
+    });
+
+    it('sets priority from the source', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('hello', {
+        linenumbers: true,
+      });
+      expect(boxes[0].props.priority).toBe(LineNumbersBoxSource.priority);
+    });
+
+    it('accepts ::numberlines as alias for ::linenumbers', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\nsecond\nthird',
+        { numberlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '1 | first\n2 | second\n3 | third',
+      );
+    });
+
+    it('supports custom start index via ::linenumbers=10', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\nsecond\nthird',
+        { linenumbers: '10' },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '10 | first\n11 | second\n12 | third',
+      );
+    });
+
+    it('right-aligns with space padding when max width is 2 (10 lines from 1)', async () => {
+      const input = Array.from({ length: 10 }, (_, i) =>
+        String.fromCharCode(97 + i),
+      ).join('\n');
+      const boxes = await LineNumbersBoxSource.generateBoxes(input, {
+        linenumbers: true,
+      });
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      // line 1 should be ' 1 | a' (leading space, width 2)
+      expect(lines[0]).toBe(' 1 | a');
+      // line 10 should be '10 | j' (no leading space)
+      expect(lines[9]).toBe('10 | j');
+    });
+
+    it('strips trailing \\r from each line before numbering', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\r\nsecond\r\nthird',
+        { linenumbers: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '1 | first\n2 | second\n3 | third',
+      );
+    });
+
+    it('falls back to start=1 when ::linenumbers value is not a valid integer', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('a\nb', {
+        linenumbers: 'abc',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('1 | a\n2 | b');
+    });
+
+    it('falls back to start=1 when ::linenumbers is boolean true', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('a\nb', {
+        linenumbers: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('1 | a\n2 | b');
+    });
+  });
+
+  describe('generateBoxes - strip line numbers (::stripnumbers)', () => {
+    it('strips leading "N | " prefix from each line', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        '1 | first\n2 | second',
+        { stripnumbers: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('first\nsecond');
+    });
+
+    it('strips wide number prefix with space-padded numbers', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        ' 1 | first\n 2 | second\n10 | tenth',
+        { stripnumbers: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('first\nsecond\ntenth');
+    });
+
+    it('round-trips add then strip back to original', async () => {
+      const original = 'alpha\nbeta\ngamma';
+      const numbered = await LineNumbersBoxSource.generateBoxes(original, {
+        linenumbers: true,
+      });
+      const stripped = await LineNumbersBoxSource.generateBoxes(
+        numbered[0].props.plaintextOutput,
+        { stripnumbers: true },
+      );
+      expect(stripped[0].props.plaintextOutput).toBe(original);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/TabsSpacesBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TabsSpacesBoxSource.test.ts
@@ -1,0 +1,117 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { TabsSpacesBoxSource } from '../TabsSpacesBoxSource';
+
+describe('TabsSpacesBoxSource', () => {
+  describe('gate conditions', () => {
+    it('returns [] when no option is set', async () => {
+      const boxes = await TabsSpacesBoxSource.generateBoxes('\tindented', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await TabsSpacesBoxSource.generateBoxes('', {
+        tabs2spaces: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const huge = 'a'.repeat(100_001);
+      const boxes = await TabsSpacesBoxSource.generateBoxes(huge, {
+        tabs2spaces: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('tabs2spaces', () => {
+    it('converts a single leading tab to 4 spaces (default width)', async () => {
+      const boxes = await TabsSpacesBoxSource.generateBoxes('\tindented', {
+        tabs2spaces: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('    indented');
+    });
+
+    it('converts two leading tabs using width=2 option', async () => {
+      const boxes = await TabsSpacesBoxSource.generateBoxes('\t\tx', {
+        tabs2spaces: '2',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('    x');
+    });
+
+    it('accepts ::untabify alias', async () => {
+      const boxes = await TabsSpacesBoxSource.generateBoxes('\tline', {
+        untabify: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('    line');
+    });
+
+    it('does not touch interior tabs — only leading whitespace is affected', async () => {
+      // 'a\tb' has no leading whitespace; interior tab must stay intact
+      const boxes = await TabsSpacesBoxSource.generateBoxes('a\tb', {
+        tabs2spaces: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a\tb');
+    });
+
+    it('handles multi-line input', async () => {
+      const input = '\tline1\n\t\tline2\nno-indent';
+      const boxes = await TabsSpacesBoxSource.generateBoxes(input, {
+        tabs2spaces: '2',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '  line1\n    line2\nno-indent',
+      );
+    });
+  });
+
+  describe('spaces2tabs', () => {
+    it('converts 4 leading spaces to 1 tab', async () => {
+      const boxes = await TabsSpacesBoxSource.generateBoxes('    code', {
+        spaces2tabs: '4',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('\tcode');
+    });
+
+    it('keeps leftover spaces that do not fill a full tab width', async () => {
+      // 5 spaces with width=4 → 1 tab + 1 leftover space
+      const boxes = await TabsSpacesBoxSource.generateBoxes('     x', {
+        spaces2tabs: '4',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('\t x');
+    });
+
+    it('accepts ::tabify alias', async () => {
+      const boxes = await TabsSpacesBoxSource.generateBoxes('    val', {
+        tabify: '4',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('\tval');
+    });
+
+    it('handles multi-line input', async () => {
+      const input = '    a\n        b\nno-indent';
+      const boxes = await TabsSpacesBoxSource.generateBoxes(input, {
+        spaces2tabs: '4',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('\ta\n\t\tb\nno-indent');
+    });
+  });
+
+  describe('box shape', () => {
+    it('uses CodeBoxTemplate', async () => {
+      const boxes = await TabsSpacesBoxSource.generateBoxes('\tx', {
+        tabs2spaces: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+
+    it('names the box "Tabs / Spaces"', async () => {
+      const boxes = await TabsSpacesBoxSource.generateBoxes('\tx', {
+        tabs2spaces: true,
+      });
+      expect(boxes[0].props.name).toBe('Tabs / Spaces');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/TextDiffBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TextDiffBoxSource.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { TextDiffBoxSource } from '../TextDiffBoxSource';
+
+describe('TextDiffBoxSource', () => {
+  it('returns [] when no matching option is provided', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      null,
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for unrelated options', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      { json: true },
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('triggers on ::textdiff option', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      { textdiff: true },
+    );
+    expect(boxes.length).toBe(1);
+  });
+
+  it('triggers on ::linediff option', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      { linediff: true },
+    );
+    expect(boxes.length).toBe(1);
+  });
+
+  it('produces correct diff lines for foo/bar vs foo/baz', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      { textdiff: true },
+    );
+    const output: string = boxes[0].props.plaintextOutput;
+    expect(output).toContain('  foo');
+    expect(output).toContain('- bar');
+    expect(output).toContain('+ baz');
+  });
+
+  it('summary shows +1 -1 for foo/bar vs foo/baz', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      { textdiff: true },
+    );
+    const output: string = boxes[0].props.plaintextOutput;
+    expect(output).toMatch(/@@ \+1 -1 @@/);
+  });
+
+  it('identical texts produce no + or - lines and summary +0 -0', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes('a\nb\n---\na\nb', {
+      textdiff: true,
+    });
+    const output: string = boxes[0].props.plaintextOutput;
+    const diffLines = output
+      .split('\n')
+      .filter((l) => l.startsWith('+ ') || l.startsWith('- '));
+    expect(diffLines).toHaveLength(0);
+    expect(output).toContain('@@ +0 -0 @@');
+  });
+
+  it('empty left side produces all added lines', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes('\n---\nx', {
+      textdiff: true,
+    });
+    const output: string = boxes[0].props.plaintextOutput;
+    expect(output).toContain('+ x');
+  });
+
+  it('no separator returns a box mentioning --- separator', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes('just one text', {
+      textdiff: true,
+    });
+    expect(boxes.length).toBe(1);
+    const output: string = boxes[0].props.plaintextOutput;
+    expect(output).toContain('---');
+  });
+
+  it('returns [] for non-string input', async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional type coercion for test
+    const boxes = await TextDiffBoxSource.generateBoxes(null as any, {
+      textdiff: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for input exceeding MAX_INPUT', async () => {
+    const huge = 'a'.repeat(20_001);
+    const boxes = await TextDiffBoxSource.generateBoxes(huge, {
+      textdiff: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+});

--- a/src/modules/boxSources/__test__/TextDiffBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TextDiffBoxSource.test.ts
@@ -98,4 +98,19 @@ describe('TextDiffBoxSource', () => {
     });
     expect(boxes).toEqual([]);
   });
+
+  it('refuses to diff more lines than the per-side cap (no LCS freeze)', async () => {
+    // many short lines stays within MAX_INPUT but would be a huge LCS table
+    const side = Array.from({ length: 2500 }, () => 'a').join('\n');
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      `${side}\n---\n${side}`,
+      {
+        textdiff: true,
+      },
+    );
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain(
+      'too many lines',
+    );
+  });
 });

--- a/src/modules/boxSources/__test__/UlidBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UlidBoxSource.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { UlidBoxSource } from '../UlidBoxSource';
+
+// canonical ULID from the ULID spec — timestamp encodes 1469922850259 ms
+const CANONICAL_ULID = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+const CANONICAL_TS_MS = 1469922850259;
+const CANONICAL_ISO = '2016-07-30T23:54:10.259Z';
+
+// valid Crockford base32 alphabet (26 chars, uppercase)
+const ULID_REGEX = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+describe('UlidBoxSource', () => {
+  describe('no matching option', () => {
+    it('returns [] when no relevant option is present', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are present', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', { foo: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generate path', () => {
+    it('generates a 26-char Crockford base32 ULID', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', { ulid: true });
+      expect(boxes).toHaveLength(1);
+
+      const ulid = (boxes[0].props.options as Record<string, string>).ULID;
+      expect(ulid).toMatch(ULID_REGEX);
+    });
+
+    it('Unix (ms) is within a few seconds of Date.now()', async () => {
+      const before = Date.now();
+      const boxes = await UlidBoxSource.generateBoxes('', { ulid: true });
+      const after = Date.now();
+
+      const ms = Number.parseInt(
+        (boxes[0].props.options as Record<string, string>)['Unix (ms)'],
+        10,
+      );
+      expect(ms).toBeGreaterThanOrEqual(before);
+      expect(ms).toBeLessThanOrEqual(after + 1000);
+    });
+
+    it('two consecutive calls produce different ULIDs', async () => {
+      const [b1, b2] = await Promise.all([
+        UlidBoxSource.generateBoxes('', { ulid: true }),
+        UlidBoxSource.generateBoxes('', { ulid: true }),
+      ]);
+
+      const u1 = (b1[0].props.options as Record<string, string>).ULID;
+      const u2 = (b2[0].props.options as Record<string, string>).ULID;
+      expect(u1).not.toBe(u2);
+    });
+
+    it('Timestamp is a valid ISO string', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', { ulidparse: true });
+      const ts = (boxes[0].props.options as Record<string, string>).Timestamp;
+      expect(() => new Date(ts).toISOString()).not.toThrow();
+    });
+  });
+
+  describe('decode path', () => {
+    it('decodes the canonical ULID timestamp to 1469922850259 ms', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(CANONICAL_ULID, {
+        ulid: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Unix (ms)']).toBe(CANONICAL_TS_MS.toString());
+    });
+
+    it('decodes the canonical ULID to the correct ISO timestamp', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(CANONICAL_ULID, {
+        ulid: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Timestamp).toBe(CANONICAL_ISO);
+    });
+
+    it('normalises the decoded ULID to uppercase', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(CANONICAL_ULID, {
+        ulid: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.ULID).toBe(CANONICAL_ULID.toUpperCase());
+    });
+
+    it('decode is case-insensitive', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(
+        CANONICAL_ULID.toLowerCase(),
+        { ulid: true },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Unix (ms)']).toBe(CANONICAL_TS_MS.toString());
+    });
+
+    it('uses KeyValueBoxTemplate for decoded output', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(CANONICAL_ULID, {
+        ulid: true,
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+
+    it('box name is ULID', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(CANONICAL_ULID, {
+        ulid: true,
+      });
+      expect(boxes[0].props.name).toBe('ULID');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -3,14 +3,19 @@ import {
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CreditCardBoxSource from './CreditCardBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import Ean13BoxSource from './Ean13BoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import IsinBoxSource from './IsinBoxSource';
+import JsonPathBoxSource from './JsonPathBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LineNumbersBoxSource from './LineNumbersBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
@@ -18,8 +23,11 @@ import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import TabsSpacesBoxSource from './TabsSpacesBoxSource';
+import TextDiffBoxSource from './TextDiffBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import UlidBoxSource from './UlidBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
@@ -29,15 +37,20 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  CreditCardBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  Ean13BoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  IsinBoxSource,
+  JsonPathBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LineNumbersBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
@@ -45,7 +58,10 @@ export const boxSources = [
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
+  TabsSpacesBoxSource,
+  TextDiffBoxSource,
   TimeFormatBoxSource,
+  UlidBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
   TimestampBoxSource,


### PR DESCRIPTION
## Summary

Sixteenth exploration batch — **8 more BoxSource tools** (data, validation, dev utilities).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Text Diff | `::textdiff` | line LCS diff of two texts split by `---` |
| JSON Path | `::jsonpath=$.a.b[0]` | extract a value via dot/bracket path (prototype-safe) |
| EAN-13 / UPC-A | `::ean13` | barcode check-digit validation |
| Credit Card | `::cardtype` | brand detect + Luhn (**masks the PAN**) |
| ULID | `::ulid` | generate a ULID or decode an existing one's timestamp |
| Line Numbers | `::linenumbers` / `::stripnumbers` | add/strip line numbers |
| Tabs / Spaces | `::tabs2spaces` / `::spaces2tabs` | convert leading indentation |
| ISIN | `::isin` | ISO 6166 securities-id check |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules — input caps, `this.priority`, KeyValue sources render `k: v` plaintext (not JSON), **prototype-safe path walking** (JSON Path skips `__proto__`/`constructor`/`prototype`), **secret masking** (Credit Card never emits the full PAN).
- **Verified vectors**: EAN `4006381333931`/`5901234123457`/`036000291452`; ISIN `US0378331005` + `GB0002634946`; **ULID `01ARZ3NDEK…`→`1469922850259`ms** (spec example); Visa/MC/Amex/Discover brand detection; `$.a.b[1]`→`20`.
- Self-review before opening fixed a JsonPath type-narrowing error (`string | false`), an unused var in Isin, and a `\t`-vs-`\nt` typo in a LineNumbers test.

## Verification

- ✅ `bun run test run` — **461 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#274 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6