### PR TITLE
feat(boxSources): add 8 more tools (uuid-v5, soundex, caesar, cmyk, md-toc, prime-factors, json→python, week-number)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,79 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>UuidV5Box</b> </summary>
+
+| match rule           | description                          | example                       |
+| -------------------- | ------------------------------------ | ----------------------------- |
+| `::uuidv5=NAMESPACE` | deterministic name-based UUID v5 (SHA-1) | `example.com ::uuidv5=dns` |
+
+</details>
+
+<details>
+<summary> <b>SoundexBox</b> </summary>
+
+| match rule   | description                          | example            |
+| ------------ | ------------------------------------ | ------------------ |
+| `::soundex`  | American Soundex phonetic code       | `Robert ::soundex` |
+
+</details>
+
+<details>
+<summary> <b>CaesarBox</b> </summary>
+
+| match rule        | description                          | example            |
+| ----------------- | ------------------------------------ | ------------------ |
+| `::caesar=N`      | Caesar shift cipher                  | `Hello ::caesar=3` |
+| `::caesarcrack`   | show all 25 shifts                   | `Khoor ::caesarcrack` |
+
+</details>
+
+<details>
+<summary> <b>CmykBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::cmyk`    | convert a hex/rgb color to CMYK + HSV | `#ff6347 ::cmyk` |
+
+</details>
+
+<details>
+<summary> <b>MarkdownTocBox</b> </summary>
+
+| match rule  | description                          | example                       |
+| ----------- | ------------------------------------ | ----------------------------- |
+| `::toc`     | table of contents from MD headings   | `# Title`<br>`## Section ::toc` |
+
+</details>
+
+<details>
+<summary> <b>PrimeFactorBox</b> </summary>
+
+| match rule    | description                          | example          |
+| ------------- | ------------------------------------ | ---------------- |
+| `::isprime`   | primality test + factorization (≤10¹²) | `360 ::isprime` |
+
+</details>
+
+<details>
+<summary> <b>JsonToPythonBox</b> </summary>
+
+| match rule        | description                          | example                  |
+| ----------------- | ------------------------------------ | ------------------------ |
+| `::pydataclass`   | Python @dataclass from JSON          | `{"id":1} ::pydataclass` |
+
+</details>
+
+<details>
+<summary> <b>WeekNumberBox</b> </summary>
+
+| match rule   | description                          | example               |
+| ------------ | ------------------------------------ | --------------------- |
+| `::weeknum`  | ISO 8601 week number of a date       | `2024-01-01 ::weeknum` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/CaesarBoxSource.ts
+++ b/src/modules/boxSources/CaesarBoxSource.ts
@@ -1,0 +1,92 @@
+import { CodeBoxTemplate, DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// shift a single character by n positions within a-z or A-Z; non-letters pass through unchanged
+function shiftChar(char: string, n: number): string {
+  const code = char.charCodeAt(0);
+  if (code >= 65 && code <= 90) {
+    return String.fromCharCode(((code - 65 + ((n % 26) + 26)) % 26) + 65);
+  }
+  if (code >= 97 && code <= 122) {
+    return String.fromCharCode(((code - 97 + ((n % 26) + 26)) % 26) + 97);
+  }
+  return char;
+}
+
+function caesarShift(text: string, n: number): string {
+  return text
+    .split('')
+    .map((c) => shiftChar(c, n))
+    .join('');
+}
+
+export const CaesarBoxSource = {
+  name: 'Caesar Cipher',
+  description:
+    'Caesar shift cipher. ::caesar=3 to shift by 3; ::caesarcrack to show all 25 shifts.',
+  defaultInput: 'Hello ::caesar=3',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const shiftVal = extractOptionKeys(options, 'caesar');
+    const wantCrack = hasOptionKeys(options, 'caesarcrack', 'caesarbrute');
+
+    if (shiftVal === null && !wantCrack) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (shiftVal !== null) {
+      // parse the shift amount; fall back to 3 when the value is missing or non-numeric
+      const parsedShift =
+        typeof shiftVal === 'boolean' ||
+        Number.isNaN(Number.parseInt(String(shiftVal), 10))
+          ? 3
+          : Number.parseInt(String(shiftVal), 10);
+
+      const shifted = caesarShift(input, parsedShift);
+
+      const box = new BoxBuilder('Caesar Cipher', shifted)
+        .setPriority(Priority)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .build();
+
+      boxes.push(box);
+    }
+
+    if (wantCrack) {
+      // produce all 25 non-zero shifts, one per line
+      const lines = Array.from({ length: 25 }, (_, i) => {
+        const shift = i + 1;
+        return `shift ${shift}: ${caesarShift(input, shift)}`;
+      }).join('\n');
+
+      const box = new BoxBuilder('Caesar Cipher (all shifts)', lines)
+        .setPriority(Priority)
+        .setTemplate(CodeBoxTemplate)
+        .build();
+
+      boxes.push(box);
+    }
+
+    return boxes;
+  },
+};
+
+export default CaesarBoxSource;

--- a/src/modules/boxSources/CaesarBoxSource.ts
+++ b/src/modules/boxSources/CaesarBoxSource.ts
@@ -53,11 +53,9 @@ export const CaesarBoxSource = {
 
     if (shiftVal !== null) {
       // parse the shift amount; fall back to 3 when the value is missing or non-numeric
+      const n = Number.parseInt(String(shiftVal), 10);
       const parsedShift =
-        typeof shiftVal === 'boolean' ||
-        Number.isNaN(Number.parseInt(String(shiftVal), 10))
-          ? 3
-          : Number.parseInt(String(shiftVal), 10);
+        typeof shiftVal === 'boolean' || Number.isNaN(n) ? 3 : n;
 
       const shifted = caesarShift(input, parsedShift);
 

--- a/src/modules/boxSources/CmykBoxSource.ts
+++ b/src/modules/boxSources/CmykBoxSource.ts
@@ -1,0 +1,163 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// parse #RGB or #RRGGBB hex strings into r,g,b integers 0-255
+function parseHex(input: string): RGB | null {
+  const m = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(input);
+  if (!m) return null;
+  const h = m[1];
+  if (h.length === 3) {
+    return {
+      r: Number.parseInt(h[0] + h[0], 16),
+      g: Number.parseInt(h[1] + h[1], 16),
+      b: Number.parseInt(h[2] + h[2], 16),
+    };
+  }
+  return {
+    r: Number.parseInt(h.slice(0, 2), 16),
+    g: Number.parseInt(h.slice(2, 4), 16),
+    b: Number.parseInt(h.slice(4, 6), 16),
+  };
+}
+
+// parse rgb(r, g, b) strings into r,g,b integers 0-255
+function parseRgb(input: string): RGB | null {
+  const m = /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/.exec(
+    input,
+  );
+  if (!m) return null;
+  const r = Number.parseInt(m[1], 10);
+  const g = Number.parseInt(m[2], 10);
+  const b = Number.parseInt(m[3], 10);
+  if (r > 255 || g > 255 || b > 255) return null;
+  return { r, g, b };
+}
+
+interface CMYK {
+  c: number;
+  m: number;
+  y: number;
+  k: number;
+}
+
+// convert r,g,b (0-255) to cmyk percentages (0-100, integer-rounded)
+function rgbToCmyk(r: number, g: number, b: number): CMYK {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+
+  const k = 1 - Math.max(rn, gn, bn);
+  if (k === 1) {
+    return { c: 0, m: 0, y: 0, k: 100 };
+  }
+
+  const c = (1 - rn - k) / (1 - k);
+  const m = (1 - gn - k) / (1 - k);
+  const y = (1 - bn - k) / (1 - k);
+
+  return {
+    c: Math.round(c * 100),
+    m: Math.round(m * 100),
+    y: Math.round(y * 100),
+    k: Math.round(k * 100),
+  };
+}
+
+interface HSV {
+  h: number;
+  s: number;
+  v: number;
+}
+
+// convert r,g,b (0-255) to hsv: h in degrees 0-360, s and v as percentages 0-100
+function rgbToHsv(r: number, g: number, b: number): HSV {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+
+  const v = max;
+  const s = max === 0 ? 0 : delta / max;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rn) {
+      h = 60 * (((gn - bn) / delta) % 6);
+    } else if (max === gn) {
+      h = 60 * ((bn - rn) / delta + 2);
+    } else {
+      h = 60 * ((rn - gn) / delta + 4);
+    }
+  }
+  if (h < 0) h += 360;
+
+  return {
+    h: Math.round(h),
+    s: Math.round(s * 100),
+    v: Math.round(v * 100),
+  };
+}
+
+export const CmykBoxSource = {
+  name: 'CMYK / HSV',
+  description: 'Convert a hex or rgb() color to CMYK and HSV.',
+  defaultInput: '#ff6347 ::cmyk',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cmyk', 'hsv')) return [];
+
+    const raw = trim(input).slice(0, 64);
+    const rgb = parseHex(raw) ?? parseRgb(raw);
+
+    if (!rgb) {
+      const errorText =
+        'A valid hex (#RGB / #RRGGBB) or rgb(r,g,b) color is required.';
+      return [
+        new BoxBuilder('CMYK / HSV', errorText)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ error: errorText })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { r, g, b } = rgb;
+    const { c, m, y, k } = rgbToCmyk(r, g, b);
+    const { h, s, v } = rgbToHsv(r, g, b);
+
+    const rgbStr = `rgb(${r}, ${g}, ${b})`;
+    const cmykStr = `cmyk(${c}%, ${m}%, ${y}%, ${k}%)`;
+    const hsvStr = `hsv(${h}, ${s}%, ${v}%)`;
+
+    const plaintext = `RGB: ${rgbStr}\nCMYK: ${cmykStr}\nHSV: ${hsvStr}`;
+
+    return [
+      new BoxBuilder('CMYK / HSV', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions({ RGB: rgbStr, CMYK: cmykStr, HSV: hsvStr })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CmykBoxSource;

--- a/src/modules/boxSources/JsonToPythonBoxSource.ts
+++ b/src/modules/boxSources/JsonToPythonBoxSource.ts
@@ -6,6 +6,54 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 const Priority = 10;
 const MAX_INPUT = 100_000;
 
+// python reserved words that can't be used as bare field names
+const PY_KEYWORDS = new Set([
+  'False',
+  'None',
+  'True',
+  'and',
+  'as',
+  'assert',
+  'async',
+  'await',
+  'break',
+  'class',
+  'continue',
+  'def',
+  'del',
+  'elif',
+  'else',
+  'except',
+  'finally',
+  'for',
+  'from',
+  'global',
+  'if',
+  'import',
+  'in',
+  'is',
+  'lambda',
+  'nonlocal',
+  'not',
+  'or',
+  'pass',
+  'raise',
+  'return',
+  'try',
+  'while',
+  'with',
+  'yield',
+]);
+
+// maps a json key to a valid python identifier: non-identifier chars → '_',
+// digit-leading names get a prefix, reserved words get a trailing underscore
+function safePyName(key: string): string {
+  const id = key.replace(/[^a-zA-Z0-9_]/g, '_');
+  if (/^\d/.test(id)) return `f_${id}`;
+  if (PY_KEYWORDS.has(id)) return `${id}_`;
+  return id || '_';
+}
+
 // maps a json key to a safe PascalCase class name, de-duplicating against usedNames
 function toPascalCase(key: string): string {
   // replace non-alphanumeric chars with spaces, then capitalise each word
@@ -99,7 +147,7 @@ function buildClass(
   const fields: string[] = [];
   for (const [key, val] of Object.entries(obj)) {
     const pyType = resolveType(val, key, classes, usedNames, imports);
-    fields.push(`    ${key}: ${pyType}`);
+    fields.push(`    ${safePyName(key)}: ${pyType}`);
   }
   // push after nested classes so definitions always appear before their references
   classes.push({ name: className, fields });

--- a/src/modules/boxSources/JsonToPythonBoxSource.ts
+++ b/src/modules/boxSources/JsonToPythonBoxSource.ts
@@ -1,0 +1,209 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// maps a json key to a safe PascalCase class name, de-duplicating against usedNames
+function toPascalCase(key: string): string {
+  // replace non-alphanumeric chars with spaces, then capitalise each word
+  return key
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join('');
+}
+
+function uniqueName(base: string, used: Set<string>): string {
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+  let counter = 2;
+  while (used.has(`${base}${counter}`)) {
+    counter++;
+  }
+  const name = `${base}${counter}`;
+  used.add(name);
+  return name;
+}
+
+interface ClassDef {
+  name: string;
+  fields: string[];
+}
+
+// resolves a json value to a python type string, collecting nested class definitions
+function resolveType(
+  value: unknown,
+  key: string,
+  classes: ClassDef[],
+  usedNames: Set<string>,
+  imports: Set<string>,
+): string {
+  if (value === null) {
+    imports.add('Optional');
+    imports.add('Any');
+    return 'Optional[Any]';
+  }
+  if (typeof value === 'boolean') {
+    return 'bool';
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? 'int' : 'float';
+  }
+  if (typeof value === 'string') {
+    return 'str';
+  }
+  if (Array.isArray(value)) {
+    imports.add('List');
+    if (value.length === 0) {
+      imports.add('Any');
+      return 'List[Any]';
+    }
+    const elemType = resolveType(
+      value[0],
+      `${key}Item`,
+      classes,
+      usedNames,
+      imports,
+    );
+    return `List[${elemType}]`;
+  }
+  if (typeof value === 'object') {
+    const className = uniqueName(toPascalCase(key) || 'Nested', usedNames);
+    buildClass(
+      value as Record<string, unknown>,
+      className,
+      classes,
+      usedNames,
+      imports,
+    );
+    return className;
+  }
+  imports.add('Any');
+  return 'Any';
+}
+
+// builds a ClassDef for an object and pushes nested classes before itself
+function buildClass(
+  obj: Record<string, unknown>,
+  className: string,
+  classes: ClassDef[],
+  usedNames: Set<string>,
+  imports: Set<string>,
+): void {
+  const fields: string[] = [];
+  for (const [key, val] of Object.entries(obj)) {
+    const pyType = resolveType(val, key, classes, usedNames, imports);
+    fields.push(`    ${key}: ${pyType}`);
+  }
+  // push after nested classes so definitions always appear before their references
+  classes.push({ name: className, fields });
+}
+
+function generatePythonDataclasses(json: unknown): string {
+  if (json === null || Array.isArray(json) || typeof json !== 'object') {
+    throw new Error('Root JSON value must be an object');
+  }
+
+  const classes: ClassDef[] = [];
+  const usedNames = new Set<string>();
+  const imports = new Set<string>();
+
+  // reserve 'Root' so nested keys can't collide with it
+  usedNames.add('Root');
+  buildClass(
+    json as Record<string, unknown>,
+    'Root',
+    classes,
+    usedNames,
+    imports,
+  );
+
+  // build import line — only include what was actually used
+  const typingImports: string[] = [];
+  for (const name of ['List', 'Any', 'Optional']) {
+    if (imports.has(name)) typingImports.push(name);
+  }
+
+  const lines: string[] = ['from dataclasses import dataclass'];
+  if (typingImports.length > 0) {
+    lines.push(`from typing import ${typingImports.join(', ')}`);
+  }
+
+  for (const cls of classes) {
+    lines.push('');
+    lines.push('');
+    lines.push('@dataclass');
+    lines.push(`class ${cls.name}:`);
+    if (cls.fields.length === 0) {
+      lines.push('    pass');
+    } else {
+      for (const f of cls.fields) {
+        lines.push(f);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export const JsonToPythonBoxSource = {
+  name: 'JSON to Python',
+  description: 'Generate Python @dataclass definitions from a JSON sample.',
+  defaultInput: '{"id":1,"name":"Bob","tags":["a"]} ::pydataclass',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'pydataclass', 'jsontopython')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      const errorBox = new BoxBuilder(
+        'JSON to Python',
+        'Error: invalid JSON — could not parse input.',
+      )
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'python' })
+        .setPriority(this.priority)
+        .build();
+      return [errorBox];
+    }
+
+    let output: string;
+    try {
+      output = generatePythonDataclasses(parsed);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      const errorBox = new BoxBuilder('JSON to Python', `Error: ${msg}`)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'python' })
+        .setPriority(this.priority)
+        .build();
+      return [errorBox];
+    }
+
+    const box = new BoxBuilder('JSON to Python', output)
+      .setTemplate(CodeBoxTemplate)
+      .setOptions({ language: 'python' })
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default JsonToPythonBoxSource;

--- a/src/modules/boxSources/MarkdownTocBoxSource.ts
+++ b/src/modules/boxSources/MarkdownTocBoxSource.ts
@@ -1,0 +1,123 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// heading pattern: one to six # chars followed by at least one space and text
+const HEADING_RE = /^(#{1,6})\s+(.+)$/;
+
+// fence delimiter pattern: opening ``` or ~~~ (with optional language tag)
+const FENCE_OPEN_RE = /^(`{3,}|~{3,})/;
+
+/** converts heading text to a github-compatible anchor slug */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+interface Heading {
+  level: number;
+  text: string;
+}
+
+/** parses ATX headings from markdown, skipping lines inside fenced code blocks */
+function parseHeadings(input: string): Heading[] {
+  const headings: Heading[] = [];
+  let inFence = false;
+  let fenceChar = '';
+
+  for (const line of input.split('\n')) {
+    if (inFence) {
+      // exit fence when we see the matching closing delimiter
+      if (line.trimStart().startsWith(fenceChar)) {
+        inFence = false;
+        fenceChar = '';
+      }
+      continue;
+    }
+
+    const fenceMatch = FENCE_OPEN_RE.exec(line.trimStart());
+    if (fenceMatch) {
+      inFence = true;
+      fenceChar = fenceMatch[1][0].repeat(3); // normalize to 3 chars of the same type
+      continue;
+    }
+
+    const headingMatch = HEADING_RE.exec(line);
+    if (headingMatch) {
+      const rawText = headingMatch[2];
+      // strip trailing # characters and whitespace (setext-style closers)
+      const text = rawText.replace(/\s+#+\s*$/, '').trim();
+      headings.push({ level: headingMatch[1].length, text });
+    }
+  }
+
+  return headings;
+}
+
+/** builds the nested bullet list string with github-style duplicate slug disambiguation */
+function buildToc(headings: Heading[]): string {
+  const minLevel = Math.min(...headings.map((h) => h.level));
+  const slugCount: Record<string, number> = {};
+  const lines: string[] = [];
+
+  for (const { level, text } of headings) {
+    const baseSlug = slugify(text);
+    const count = slugCount[baseSlug] ?? 0;
+    slugCount[baseSlug] = count + 1;
+
+    // first occurrence uses the base slug; subsequent ones append -1, -2, …
+    const slug = count === 0 ? baseSlug : `${baseSlug}-${count}`;
+    const indent = ' '.repeat((level - minLevel) * 2);
+    lines.push(`${indent}- [${text}](#${slug})`);
+  }
+
+  return lines.join('\n');
+}
+
+export const MarkdownTocBoxSource = {
+  name: 'Markdown TOC',
+  description:
+    'Generate a table of contents (nested bullet list with anchor links) from Markdown headings.',
+  defaultInput: '# Title\n## Section A\n### Sub\n## Section B ::toc',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'toc', 'tableofcontents')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const headings = parseHeadings(input);
+
+    if (headings.length === 0) {
+      return [
+        new BoxBuilder('Markdown TOC', 'No headings found.')
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'markdown' })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const toc = buildToc(headings);
+    return [
+      new BoxBuilder('Markdown TOC', toc)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'markdown' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default MarkdownTocBoxSource;

--- a/src/modules/boxSources/MarkdownTocBoxSource.ts
+++ b/src/modules/boxSources/MarkdownTocBoxSource.ts
@@ -44,7 +44,8 @@ function parseHeadings(input: string): Heading[] {
     const fenceMatch = FENCE_OPEN_RE.exec(line.trimStart());
     if (fenceMatch) {
       inFence = true;
-      fenceChar = fenceMatch[1][0].repeat(3); // normalize to 3 chars of the same type
+      // keep the exact opening run; a closing fence must be at least as long
+      fenceChar = fenceMatch[1];
       continue;
     }
 
@@ -62,7 +63,7 @@ function parseHeadings(input: string): Heading[] {
 
 /** builds the nested bullet list string with github-style duplicate slug disambiguation */
 function buildToc(headings: Heading[]): string {
-  const minLevel = Math.min(...headings.map((h) => h.level));
+  const minLevel = headings.reduce((min, h) => Math.min(min, h.level), 6);
   const slugCount: Record<string, number> = {};
   const lines: string[] = [];
 

--- a/src/modules/boxSources/PrimeFactorBoxSource.ts
+++ b/src/modules/boxSources/PrimeFactorBoxSource.ts
@@ -1,0 +1,149 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// sqrt(10^12) = 1e6 trial-division steps — acceptable worst case
+const MAX_VALUE = 1_000_000_000_000n; // 10^12
+const MAX_DIGITS = 13;
+
+interface FactorMap {
+  [prime: string]: number;
+}
+
+// trial division — returns a map of prime → exponent
+function factorize(n: bigint): FactorMap {
+  const factors: FactorMap = {};
+
+  let remaining = n;
+  while (remaining % 2n === 0n) {
+    factors['2'] = (factors['2'] ?? 0) + 1;
+    remaining /= 2n;
+  }
+
+  for (let i = 3n; i * i <= remaining; i += 2n) {
+    while (remaining % i === 0n) {
+      const key = i.toString();
+      factors[key] = (factors[key] ?? 0) + 1;
+      remaining /= i;
+    }
+  }
+
+  if (remaining > 1n) {
+    const key = remaining.toString();
+    factors[key] = (factors[key] ?? 0) + 1;
+  }
+
+  return factors;
+}
+
+// formats factors as '2^3 × 3^2 × 5' (exponent omitted when 1)
+function formatFactorization(factors: FactorMap): string {
+  return Object.entries(factors)
+    .map(([prime, exp]) => (exp === 1 ? prime : `${prime}^${exp}`))
+    .join(' × ');
+}
+
+// error box explaining valid input range
+function rangeErrorBox(reason: string): Box {
+  return new BoxBuilder(
+    'Prime Factors',
+    `Error: ${reason}\nValid range: integer between 2 and 10^12 (up to 13 digits).`,
+  )
+    .setOptions({
+      Error: reason,
+      'Valid Range': '2 to 10^12 (up to 13 digits)',
+    })
+    .setTemplate(KeyValueBoxTemplate)
+    .setPriority(Priority)
+    .build();
+}
+
+export const PrimeFactorBoxSource = {
+  name: 'Prime Factors',
+  description:
+    'Test primality and show the prime factorization of an integer (up to 10^12).',
+  defaultInput: '360 ::isprime',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'isprime', 'factor', 'primefactors')) return [];
+
+    const raw = trim(input);
+
+    // require purely numeric, capped at MAX_DIGITS characters
+    if (!/^\d+$/.test(raw)) {
+      return [
+        rangeErrorBox(
+          'Input must be a positive integer with no spaces or signs.',
+        ),
+      ];
+    }
+
+    if (raw.length > MAX_DIGITS) {
+      return [
+        rangeErrorBox(
+          `Number too large — maximum is 10^12 (${MAX_DIGITS} digits).`,
+        ),
+      ];
+    }
+
+    const value = BigInt(raw);
+
+    if (value < 2n) {
+      return [
+        rangeErrorBox(
+          'Input must be >= 2 (1 and 0 are not prime by definition).',
+        ),
+      ];
+    }
+
+    if (value > MAX_VALUE) {
+      return [
+        rangeErrorBox(
+          `Number exceeds 10^12 — factorization would be too slow.`,
+        ),
+      ];
+    }
+
+    const factors = factorize(value);
+    const isPrime =
+      Object.keys(factors).length === 1 && Object.values(factors)[0] === 1;
+
+    const factorizationStr = isPrime ? raw : formatFactorization(factors);
+
+    // divisor count = product of (exponent + 1) for each prime factor
+    const divisorCount = Object.values(factors).reduce(
+      (acc, exp) => acc * (exp + 1),
+      1,
+    );
+
+    const kvOptions: Record<string, string> = {
+      Number: raw,
+      Prime: isPrime ? 'true' : 'false',
+      Factorization: factorizationStr,
+      'Divisor Count': divisorCount.toString(),
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Prime Factors', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PrimeFactorBoxSource;

--- a/src/modules/boxSources/SoundexBoxSource.ts
+++ b/src/modules/boxSources/SoundexBoxSource.ts
@@ -1,0 +1,128 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// digit table for consonant groups per American Soundex standard
+const SOUNDEX_TABLE: Record<string, string> = {
+  B: '1',
+  F: '1',
+  P: '1',
+  V: '1',
+  C: '2',
+  G: '2',
+  J: '2',
+  K: '2',
+  Q: '2',
+  S: '2',
+  X: '2',
+  Z: '2',
+  D: '3',
+  T: '3',
+  L: '4',
+  M: '5',
+  N: '5',
+  R: '6',
+};
+
+// vowels that reset adjacency tracking (produce no digit)
+const VOWELS = new Set(['A', 'E', 'I', 'O', 'U', 'Y']);
+
+/** Computes the American Soundex code for a single word. Returns null for words with no leading letter. */
+function soundex(word: string): string | null {
+  const letters = word.toUpperCase().replace(/[^A-Z]/g, '');
+  if (letters.length === 0) {
+    return null;
+  }
+
+  const first = letters[0];
+  const firstDigit = SOUNDEX_TABLE[first] ?? '';
+
+  // initialize prev to firstDigit so the first letter's own code is never
+  // double-counted when the same consonant group appears next
+  let prev = firstDigit;
+  let digits = '';
+
+  for (let i = 1; i < letters.length && digits.length < 3; i++) {
+    const ch = letters[i];
+
+    // H and W are transparent — skip without resetting adjacency
+    if (ch === 'H' || ch === 'W') {
+      continue;
+    }
+
+    if (VOWELS.has(ch)) {
+      // vowels break adjacency so the next same-digit consonant is recorded
+      prev = '';
+      continue;
+    }
+
+    const digit = SOUNDEX_TABLE[ch] ?? '';
+    if (digit !== prev) {
+      digits += digit;
+      prev = digit;
+    }
+  }
+
+  return (first + digits.padEnd(3, '0')).slice(0, 4);
+}
+
+export const SoundexBoxSource = {
+  name: 'Soundex',
+  description:
+    'Compute the American Soundex phonetic code for each word in the input.',
+  defaultInput: 'Robert ::soundex',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'soundex')) {
+      return [];
+    }
+
+    if (!isString(input) || trim(input).length === 0) {
+      return [];
+    }
+
+    if (input.length > MAX_INPUT) {
+      return [];
+    }
+
+    const tokens = input.split(/\s+/).filter((t) => t.length > 0);
+
+    const lines: string[] = [];
+    for (const token of tokens) {
+      // only process tokens that begin with an ASCII letter
+      if (!/^[A-Za-z]/.test(token)) {
+        continue;
+      }
+      const code = soundex(token);
+      if (code !== null) {
+        lines.push(`${token} → ${code}`);
+      }
+    }
+
+    if (lines.length === 0) {
+      return [];
+    }
+
+    const output = lines.join('\n');
+
+    return [
+      new BoxBuilder('Soundex', output)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default SoundexBoxSource;

--- a/src/modules/boxSources/UuidV5BoxSource.ts
+++ b/src/modules/boxSources/UuidV5BoxSource.ts
@@ -1,4 +1,7 @@
-import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
 import { trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
@@ -89,7 +92,7 @@ export const UuidV5BoxSource = {
           'UUID v5',
           'UUID v5 requires a secure context (HTTPS). crypto.subtle is not available.',
         )
-          .setTemplate(KeyValueBoxTemplate)
+          .setTemplate(DefaultBoxTemplate)
           .setShowExpandButton(false)
           .setPriority(this.priority)
           .build(),
@@ -111,7 +114,7 @@ export const UuidV5BoxSource = {
           'UUID v5',
           'A namespace is required. Use ::uuidv5=dns, ::uuidv5=url, ::uuidv5=oid, ::uuidv5=x500, or ::uuidv5=<uuid>.',
         )
-          .setTemplate(KeyValueBoxTemplate)
+          .setTemplate(DefaultBoxTemplate)
           .setShowExpandButton(false)
           .setPriority(this.priority)
           .build(),

--- a/src/modules/boxSources/UuidV5BoxSource.ts
+++ b/src/modules/boxSources/UuidV5BoxSource.ts
@@ -1,0 +1,147 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// uuid regex for validating a custom namespace argument
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// predefined namespaces per RFC 4122 appendix C
+const NAMESPACES: Record<string, string> = {
+  dns: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+  url: '6ba7b811-9dad-11d1-80b4-00c04fd430c8',
+  oid: '6ba7b812-9dad-11d1-80b4-00c04fd430c8',
+  x500: '6ba7b814-9dad-11d1-80b4-00c04fd430c8',
+};
+
+// parse a UUID string (with hyphens) into a 16-byte Uint8Array
+function uuidToBytes(uuid: string): Uint8Array {
+  const hex = uuid.replace(/-/g, '');
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 16; i++) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+// format a 16-byte array as a lowercase 8-4-4-4-12 UUID string
+function bytesToUuid(bytes: Uint8Array): string {
+  const hex = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+// compute a UUID v5 from a namespace UUID string and a name string
+async function computeUuidV5(
+  namespaceUuid: string,
+  name: string,
+): Promise<string> {
+  const namespaceBytes = uuidToBytes(namespaceUuid);
+  const nameBytes = new TextEncoder().encode(name);
+
+  // concatenate namespace bytes and name bytes as the SHA-1 input
+  const input = new Uint8Array(namespaceBytes.length + nameBytes.length);
+  input.set(namespaceBytes, 0);
+  input.set(nameBytes, namespaceBytes.length);
+
+  const hashBuffer = await crypto.subtle.digest('SHA-1', input);
+  const hash = new Uint8Array(hashBuffer);
+
+  // take the first 16 bytes and apply version/variant bits per RFC 4122 §4.3
+  const result = hash.slice(0, 16);
+  result[6] = (result[6] & 0x0f) | 0x50; // version 5
+  result[8] = (result[8] & 0x3f) | 0x80; // RFC 4122 variant
+
+  return bytesToUuid(result);
+}
+
+export const UuidV5BoxSource = {
+  name: 'UUID v5',
+  description:
+    'Generate a deterministic name-based UUID v5 (SHA-1). ::uuidv5=<namespace> where namespace is dns/url/oid/x500 or a UUID; the input is the name.',
+  defaultInput: 'example.com ::uuidv5=dns',
+  tag: '#',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'uuidv5')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // guard for non-secure contexts where crypto.subtle is unavailable
+    if (typeof crypto === 'undefined' || !crypto.subtle) {
+      return [
+        new BoxBuilder(
+          'UUID v5',
+          'UUID v5 requires a secure context (HTTPS). crypto.subtle is not available.',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const nsArg = extractOptionKeys(options, 'uuidv5');
+
+    // bare ::uuidv5 (value is true boolean) or unknown/invalid string → explain required namespace
+    if (
+      nsArg === true ||
+      nsArg === null ||
+      (typeof nsArg === 'string' &&
+        !NAMESPACES[nsArg.toLowerCase()] &&
+        !UUID_REGEX.test(nsArg))
+    ) {
+      return [
+        new BoxBuilder(
+          'UUID v5',
+          'A namespace is required. Use ::uuidv5=dns, ::uuidv5=url, ::uuidv5=oid, ::uuidv5=x500, or ::uuidv5=<uuid>.',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // resolve the namespace uuid from the named alias or use the provided uuid directly
+    const nsKey = (nsArg as string).toLowerCase();
+    const namespaceUuid = NAMESPACES[nsKey] ?? (nsArg as string).toLowerCase();
+    const name = trim(input);
+
+    const uuid = await computeUuidV5(namespaceUuid, name);
+
+    const kvOptions: Record<string, string> = {
+      UUID: uuid,
+      Namespace: namespaceUuid,
+      Name: name,
+    };
+
+    const plaintextOutput = `UUID: ${uuid}\nNamespace: ${namespaceUuid}\nName: ${name}`;
+
+    return [
+      new BoxBuilder('UUID v5', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UuidV5BoxSource;

--- a/src/modules/boxSources/WeekNumberBoxSource.ts
+++ b/src/modules/boxSources/WeekNumberBoxSource.ts
@@ -95,6 +95,9 @@ export const WeekNumberBoxSource = {
     let date: Date;
     if (raw === '' || raw === 'today' || raw === 'now') {
       date = new Date();
+    } else if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+      // pin a date-only string to UTC midnight so the week is timezone-stable
+      date = new Date(`${raw}T00:00:00Z`);
     } else {
       date = new Date(raw);
     }

--- a/src/modules/boxSources/WeekNumberBoxSource.ts
+++ b/src/modules/boxSources/WeekNumberBoxSource.ts
@@ -1,0 +1,142 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// day names indexed by ISO weekday (1=Mon..7=Sun)
+const DAY_NAMES = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+];
+
+// compute ISO 8601 week number, ISO year, and ISO weekday for a given UTC date
+function isoWeekData(d: Date): {
+  isoYear: number;
+  week: number;
+  isoWeekday: number;
+} {
+  // work on a copy at UTC midnight to avoid DST shifts
+  const date = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+
+  // ISO weekday: Mon=0..Sun=6 (shifted from JS Sun=0..Sat=6)
+  const dayNum = (date.getUTCDay() + 6) % 7;
+
+  // move to the Thursday of this week (week is defined by its Thursday)
+  date.setUTCDate(date.getUTCDate() + 3 - dayNum);
+  const isoYear = date.getUTCFullYear();
+
+  // Jan 4 is always in ISO week 1; find the Thursday of that week 1
+  const week1 = new Date(Date.UTC(isoYear, 0, 4));
+  const week1DayNum = (week1.getUTCDay() + 6) % 7;
+  week1.setUTCDate(week1.getUTCDate() + 3 - week1DayNum);
+
+  const week =
+    1 +
+    Math.round((date.getTime() - week1.getTime()) / (7 * 24 * 60 * 60 * 1000));
+
+  // ISO weekday 1=Mon..7=Sun
+  const isoWeekday =
+    ((new Date(
+      Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+    ).getUTCDay() +
+      6) %
+      7) +
+    1;
+
+  return { isoYear, week, isoWeekday };
+}
+
+// compute day-of-year (1-366) using UTC fields
+function dayOfYear(d: Date): number {
+  const start = new Date(Date.UTC(d.getUTCFullYear(), 0, 0));
+  const current = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+  return Math.round(
+    (current.getTime() - start.getTime()) / (24 * 60 * 60 * 1000),
+  );
+}
+
+// format a UTC date as yyyy-MM-dd
+function formatDate(d: Date): string {
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export const WeekNumberBoxSource = {
+  name: 'Week Number',
+  description:
+    'Compute the ISO 8601 week number (and weekday, day-of-year) for a date.',
+  defaultInput: '2024-01-01 ::weeknum',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'weeknum', 'isoweek')) return [];
+
+    const raw = trim(input).slice(0, 64);
+
+    // resolve the target date
+    let date: Date;
+    if (raw === '' || raw === 'today' || raw === 'now') {
+      date = new Date();
+    } else {
+      date = new Date(raw);
+    }
+
+    if (Number.isNaN(date.getTime())) {
+      const errText = `Invalid date: "${raw}"`;
+      return [
+        new BoxBuilder('Week Number', errText)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: errText })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { isoYear, week, isoWeekday } = isoWeekData(date);
+    const doy = dayOfYear(date);
+    const dateStr = formatDate(date);
+    const isoWeekStr = `${isoYear}-W${String(week).padStart(2, '0')}`;
+    const weekdayName = DAY_NAMES[isoWeekday - 1];
+
+    const kvOptions: Record<string, string> = {
+      Date: dateStr,
+      'ISO Week': isoWeekStr,
+      Week: String(week),
+      'ISO Year': String(isoYear),
+      Weekday: weekdayName,
+      'Day of Year': String(doy),
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Week Number', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default WeekNumberBoxSource;

--- a/src/modules/boxSources/__test__/CaesarBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CaesarBoxSource.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { CaesarBoxSource } from '../CaesarBoxSource';
+
+describe('CaesarBoxSource', () => {
+  it('returns [] with no options', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] for empty input', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('', { caesar: '3' });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] for whitespace-only input', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('   ', { caesar: '3' });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('shifts Hello by 3 → Khoor', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', { caesar: '3' });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe('Khoor');
+  });
+
+  it('shifts Khoor by -3 → Hello', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Khoor', {
+      caesar: '-3',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe('Hello');
+  });
+
+  it('wraps around: xyz + 3 → abc', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('xyz', { caesar: '3' });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe('abc');
+  });
+
+  it('preserves case and punctuation: Hello, World! + 1 → Ifmmp, Xpsme!', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello, World!', {
+      caesar: '1',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe('Ifmmp, Xpsme!');
+  });
+
+  it('defaults to shift 3 when ::caesar has no numeric value', async () => {
+    // boolean true simulates ::caesar with no =value
+    const boxes = await CaesarBoxSource.generateBoxes('abc', { caesar: true });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe('def');
+  });
+
+  it('caesarcrack output contains Hello when cracking Khoor', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Khoor', {
+      caesarcrack: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.name).toBe('Caesar Cipher (all shifts)');
+    // shift 23 reverses a +3 shift (26-3=23)
+    expect(boxes[0].props.plaintextOutput).toContain('shift 23: Hello');
+  });
+
+  it('caesarcrack output contains all 25 shift lines', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('A', {
+      caesarcrack: true,
+    });
+    const lines = boxes[0].props.plaintextOutput.split('\n');
+    expect(lines).toHaveLength(25);
+    expect(lines[0]).toMatch(/^shift 1: /);
+    expect(lines[24]).toMatch(/^shift 25: /);
+  });
+
+  it('caesarbrute is accepted as an alias for caesarcrack', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', {
+      caesarbrute: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.name).toBe('Caesar Cipher (all shifts)');
+  });
+
+  it('both ::caesar=3 and ::caesarcrack returns 2 boxes, caesar first', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', {
+      caesar: '3',
+      caesarcrack: true,
+    });
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0].props.name).toBe('Caesar Cipher');
+    expect(boxes[0].props.plaintextOutput).toBe('Khoor');
+    expect(boxes[1].props.name).toBe('Caesar Cipher (all shifts)');
+  });
+
+  it('single-shift box has showExpandButton=false', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', { caesar: '3' });
+    expect(boxes[0].props.showExpandButton).toBe(false);
+  });
+
+  it('priority is set on both box types', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', {
+      caesar: '3',
+      caesarcrack: true,
+    });
+    for (const box of boxes) {
+      expect(box.props.priority).toBe(10);
+    }
+  });
+});

--- a/src/modules/boxSources/__test__/CmykBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CmykBoxSource.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { CmykBoxSource } from '../CmykBoxSource';
+
+describe('CmykBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no cmyk/hsv option is present', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ff6347', null);
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] when unrelated option is present', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ff6347', {
+        color: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('tomato #ff6347 with ::cmyk → correct CMYK and RGB', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ff6347', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // r=255, g=99, b=71; k=0; c=0; m=(255-99)/255≈61%; y=(255-71)/255≈72%
+      expect(opts.CMYK).toBe('cmyk(0%, 61%, 72%, 0%)');
+      expect(opts.RGB).toBe('rgb(255, 99, 71)');
+    });
+
+    it('tomato #ff6347 with ::hsv → correct HSV', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ff6347', { hsv: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // hue ≈ 9°, saturation ≈ 72%, value = 100%
+      expect(opts.HSV).toBe('hsv(9, 72%, 100%)');
+    });
+
+    it('black #000000 → cmyk(0%, 0%, 0%, 100%)', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#000000', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.CMYK).toBe('cmyk(0%, 0%, 0%, 100%)');
+    });
+
+    it('white #ffffff → cmyk(0%, 0%, 0%, 0%)', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ffffff', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.CMYK).toBe('cmyk(0%, 0%, 0%, 0%)');
+    });
+
+    it('rgb(255, 0, 0) → CMYK cmyk(0%, 100%, 100%, 0%) and HSV hsv(0, 100%, 100%)', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('rgb(255, 0, 0)', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.CMYK).toBe('cmyk(0%, 100%, 100%, 0%)');
+      expect(opts.HSV).toBe('hsv(0, 100%, 100%)');
+    });
+
+    it('short hex #f00 expands to red → cmyk(0%, 100%, 100%, 0%)', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#f00', { cmyk: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.CMYK).toBe('cmyk(0%, 100%, 100%, 0%)');
+      expect(opts.RGB).toBe('rgb(255, 0, 0)');
+    });
+
+    it('invalid input returns a box mentioning color required', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('xyz', { cmyk: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // error box should mention that a color is required
+      expect(opts.error).toMatch(/color/i);
+      expect(opts.error).toMatch(/required/i);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JsonToPythonBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonToPythonBoxSource.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonToPythonBoxSource } from '../JsonToPythonBoxSource';
+
+describe('JsonToPythonBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no trigger option is provided', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"id":1}', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"id":1}', {
+        yaml: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should generate a dataclass for a flat object with ::pydataclass', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"id":1,"name":"Bob"}',
+        {
+          pydataclass: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('@dataclass');
+      expect(out).toContain('class Root:');
+      expect(out).toContain('id: int');
+      expect(out).toContain('name: str');
+    });
+
+    it('should trigger with ::jsontopython option', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"id":1}', {
+        jsontopython: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('class Root:');
+    });
+
+    it('should map float numbers to float type', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"price":1.5}', {
+        pydataclass: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('price: float');
+    });
+
+    it('should map boolean values to bool type', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"ok":true}', {
+        pydataclass: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('ok: bool');
+    });
+
+    it('should map arrays of strings to List[str]', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"tags":["a"]}',
+        {
+          pydataclass: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('from typing import');
+      expect(out).toContain('List');
+      expect(out).toContain('tags: List[str]');
+    });
+
+    it('should map empty arrays to List[Any]', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"items":[]}', {
+        pydataclass: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('items: List[Any]');
+    });
+
+    it('should map null values to Optional[Any]', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"value":null}',
+        {
+          pydataclass: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('value: Optional[Any]');
+    });
+
+    it('should generate nested dataclass for nested objects', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"meta":{"ok":true}}',
+        {
+          pydataclass: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      // nested class must appear before Root
+      const metaIdx = out.indexOf('class Meta:');
+      const rootIdx = out.indexOf('class Root:');
+      expect(metaIdx).toBeGreaterThanOrEqual(0);
+      expect(rootIdx).toBeGreaterThan(metaIdx);
+      expect(out).toContain('ok: bool');
+      expect(out).toContain('meta: Meta');
+    });
+
+    it('should de-duplicate class names when two keys normalise to the same PascalCase', async () => {
+      // 'my_data' → MyData, 'myData' → Mydata — both normalise similarly; must produce distinct names
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"my_data":{"x":1},"myData":{"y":2}}',
+        { pydataclass: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      // collect all class names defined in the output
+      const classNames = [...out.matchAll(/^class (\w+):/gm)].map((m) => m[1]);
+      // all class names must be unique
+      const unique = new Set(classNames);
+      expect(unique.size).toBe(classNames.length);
+      // at least 3 classes: two nested + Root
+      expect(classNames.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should return an error box for invalid JSON', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{bad', {
+        pydataclass: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/error/i);
+    });
+
+    it('should include from dataclasses import dataclass in output', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"x":1}', {
+        pydataclass: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain(
+        'from dataclasses import dataclass',
+      );
+    });
+
+    it('should use CodeBoxTemplate with python language option', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"x":1}', {
+        pydataclass: true,
+      });
+      expect(boxes[0].props.options?.language).toBe('python');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JsonToPythonBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonToPythonBoxSource.test.ts
@@ -148,5 +148,16 @@ describe('JsonToPythonBoxSource', () => {
       });
       expect(boxes[0].props.options?.language).toBe('python');
     });
+
+    it('escapes python reserved words and digit-leading keys', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"class":1,"for":2,"1abc":3}',
+        { pydataclass: true },
+      );
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('class_: int');
+      expect(out).toContain('for_: int');
+      expect(out).toContain('f_1abc: int');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/MarkdownTocBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MarkdownTocBoxSource.test.ts
@@ -1,0 +1,140 @@
+import { MarkdownTocBoxSource } from '@modules/boxSources/MarkdownTocBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('MarkdownTocBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes(
+        '# Title\n## Section',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no toc/tableofcontents key', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes(
+        '# Title\n## Section',
+        { foo: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with ::toc option', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('', { toc: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('basic toc generation', () => {
+    it('generates a nested toc from h1/h2/h3 headings', async () => {
+      const input = '# Title\n## Section A\n### Sub\n## Section B';
+      const boxes = await MarkdownTocBoxSource.generateBoxes(input, {
+        toc: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Markdown TOC');
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '- [Title](#title)\n  - [Section A](#section-a)\n    - [Sub](#sub)\n  - [Section B](#section-b)',
+      );
+    });
+
+    it('accepts ::tableofcontents as the trigger option', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('# Hello', {
+        tableofcontents: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('- [Hello](#hello)');
+    });
+
+    it('normalizes indentation so shallowest heading is at indent 0', async () => {
+      // starts at h2, so h2 should be indent 0 and h3 indent 2
+      const input = '## A\n### B';
+      const boxes = await MarkdownTocBoxSource.generateBoxes(input, {
+        toc: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('- [A](#a)\n  - [B](#b)');
+    });
+  });
+
+  describe('duplicate heading disambiguation', () => {
+    it('appends -1 to the second occurrence of a duplicate heading', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('## A\n## A', {
+        toc: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('- [A](#a)\n- [A](#a-1)');
+    });
+
+    it('appends -1, -2 for three identical headings', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes(
+        '## A\n## A\n## A',
+        { toc: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '- [A](#a)\n- [A](#a-1)\n- [A](#a-2)',
+      );
+    });
+  });
+
+  describe('fenced code block exclusion', () => {
+    it('ignores headings inside backtick fences', async () => {
+      const input = '```\n# NotAHeading\n```\n# Real';
+      const boxes = await MarkdownTocBoxSource.generateBoxes(input, {
+        toc: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('- [Real](#real)');
+    });
+
+    it('ignores headings inside tilde fences', async () => {
+      const input = '~~~\n# NotAHeading\n~~~\n# Real';
+      const boxes = await MarkdownTocBoxSource.generateBoxes(input, {
+        toc: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('- [Real](#real)');
+    });
+  });
+
+  describe('slug generation', () => {
+    it('strips special characters from slug', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes(
+        '## Hello, World!',
+        { toc: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '- [Hello, World!](#hello-world)',
+      );
+    });
+
+    it('handles headings with numbers', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('## Step 1', {
+        toc: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('- [Step 1](#step-1)');
+    });
+  });
+
+  describe('no headings found', () => {
+    it('returns a box mentioning no headings when input has no ATX headings', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('just text', {
+        toc: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/no headings/i);
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets priority from source priority field', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('# Hi', {
+        toc: true,
+      });
+      expect(boxes[0].props.priority).toBe(MarkdownTocBoxSource.priority);
+    });
+
+    it('sets language option to markdown for CodeBoxTemplate', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('# Hi', {
+        toc: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ language: 'markdown' });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/MarkdownTocBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MarkdownTocBoxSource.test.ts
@@ -136,5 +136,14 @@ describe('MarkdownTocBoxSource', () => {
       });
       expect(boxes[0].props.options).toMatchObject({ language: 'markdown' });
     });
+
+    it('does not close a 4-backtick fence with a 3-backtick line', async () => {
+      // the inner 3-backtick line must not end the 4-backtick block
+      const md = '````\n# fake\n```\n# still fake\n````\n# real';
+      const boxes = await MarkdownTocBoxSource.generateBoxes(md, { toc: true });
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('[real]');
+      expect(out).not.toContain('fake');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/PrimeFactorBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PrimeFactorBoxSource.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { PrimeFactorBoxSource } from '../PrimeFactorBoxSource';
+
+describe('PrimeFactorBoxSource', () => {
+  it('returns [] when no option keys are present', async () => {
+    const boxes = await PrimeFactorBoxSource.generateBoxes('360', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] when options object has no trigger keys', async () => {
+    const boxes = await PrimeFactorBoxSource.generateBoxes('360', {
+      unrelated: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  describe('360 — composite', () => {
+    it('produces correct factorization, prime=false, divisor count 24', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('360', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Prime).toBe('false');
+      expect(opts.Factorization).toBe('2^3 × 3^2 × 5');
+      expect(opts['Divisor Count']).toBe('24');
+      expect(opts.Number).toBe('360');
+    });
+  });
+
+  describe('97 — prime', () => {
+    it('reports prime=true, factorization is the number itself', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('97', {
+        factor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Prime).toBe('true');
+      expect(opts.Factorization).toBe('97');
+    });
+  });
+
+  describe('2 — smallest prime', () => {
+    it('reports prime=true', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('2', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Prime).toBe('true');
+    });
+  });
+
+  describe('1 — below range', () => {
+    it('returns an error box mentioning valid range', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('1', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // error box uses the same template; check that options signal the problem
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Valid Range']).toBeDefined();
+    });
+  });
+
+  describe('999999999989 — large prime < 10^12', () => {
+    it('reports prime=true', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('999999999989', {
+        primefactors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Prime).toBe('true');
+      expect(opts.Factorization).toBe('999999999989');
+    });
+  });
+
+  describe('10000000000000 — over range (10^13, 14 digits)', () => {
+    it('returns an error box mentioning valid range', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('10000000000000', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Valid Range']).toBeDefined();
+    });
+  });
+
+  describe('non-numeric input', () => {
+    it('returns an error box explaining integer is required', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('abc', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Valid Range']).toBeDefined();
+    });
+  });
+
+  it('triggers on ::factor option key', async () => {
+    const boxes = await PrimeFactorBoxSource.generateBoxes('12', {
+      factor: true,
+    });
+    expect(boxes).toHaveLength(1);
+  });
+
+  it('triggers on ::primefactors option key', async () => {
+    const boxes = await PrimeFactorBoxSource.generateBoxes('12', {
+      primefactors: true,
+    });
+    expect(boxes).toHaveLength(1);
+  });
+});

--- a/src/modules/boxSources/__test__/SoundexBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SoundexBoxSource.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { SoundexBoxSource } from '../SoundexBoxSource';
+
+describe('SoundexBoxSource', () => {
+  describe('generateBoxes - option guard', () => {
+    it('returns empty array when no soundex option is provided', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input with soundex option', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('', { soundex: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('   ', {
+        soundex: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - single word canonical vectors', () => {
+    const cases: [string, string][] = [
+      ['Robert', 'R163'],
+      ['Rupert', 'R163'],
+      ['Rubin', 'R150'],
+      ['Ashcraft', 'A261'],
+      ['Tymczak', 'T522'],
+      ['Pfister', 'P236'],
+      ['Honeyman', 'H555'],
+    ];
+
+    for (const [word, expected] of cases) {
+      it(`${word} → ${expected}`, async () => {
+        const boxes = await SoundexBoxSource.generateBoxes(word, {
+          soundex: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput).toContain(expected);
+      });
+    }
+  });
+
+  describe('generateBoxes - multi-word input', () => {
+    it('formats each word on its own line', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert Rupert', {
+        soundex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'Robert → R163\nRupert → R163',
+      );
+    });
+  });
+
+  describe('generateBoxes - non-letter tokens are skipped', () => {
+    it('skips tokens that do not start with a letter', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('123 Robert', {
+        soundex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Robert → R163');
+    });
+
+    it('returns empty array when all tokens are non-letter', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('123 456', {
+        soundex: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('box props', () => {
+    it('box name is Soundex', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert', {
+        soundex: true,
+      });
+      expect(boxes[0].props.name).toBe('Soundex');
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert', {
+        soundex: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('priority is set', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert', {
+        soundex: true,
+      });
+      expect(typeof boxes[0].props.priority).toBe('number');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(SoundexBoxSource.name).toBe('Soundex');
+      expect(typeof SoundexBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/UuidV5BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UuidV5BoxSource.test.ts
@@ -1,0 +1,193 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { UuidV5BoxSource } from '../UuidV5BoxSource';
+
+describe('UuidV5BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no uuidv5 option is provided', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - RFC 4122 canonical vectors', () => {
+    // canonical uuidv5(DNS, 'example.com') = cfbff0d1-9375-5685-968c-48ce8b15ae17
+    it('produces correct UUID v5 for dns namespace and "example.com"', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'dns',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.UUID).toBe(
+        'cfbff0d1-9375-5685-968c-48ce8b15ae17',
+      );
+    });
+
+    // canonical uuidv5(DNS, 'www.example.com') = 2ed6657d-e927-568b-95e1-2665a8aea6a2
+    it('produces correct UUID v5 for dns namespace and "www.example.com"', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('www.example.com', {
+        uuidv5: 'dns',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.UUID).toBe(
+        '2ed6657d-e927-568b-95e1-2665a8aea6a2',
+      );
+    });
+
+    it('produces the same result when supplying the DNS namespace UUID explicitly', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.UUID).toBe(
+        'cfbff0d1-9375-5685-968c-48ce8b15ae17',
+      );
+    });
+  });
+
+  describe('generateBoxes - namespace aliases (case-insensitive)', () => {
+    it('accepts uppercase DNS alias', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'DNS',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.UUID).toBe(
+        'cfbff0d1-9375-5685-968c-48ce8b15ae17',
+      );
+    });
+
+    it('resolves url namespace alias correctly', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'url',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Namespace).toBe(
+        '6ba7b811-9dad-11d1-80b4-00c04fd430c8',
+      );
+    });
+  });
+
+  describe('generateBoxes - box metadata', () => {
+    it('sets the box name to "UUID v5"', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'dns',
+      });
+      expect(boxes[0].props.name).toBe('UUID v5');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'dns',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets options with UUID, Namespace, and Name keys', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'dns',
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.UUID).toBeDefined();
+      expect(opts.Namespace).toBe('6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+      expect(opts.Name).toBe('example.com');
+    });
+
+    it('emits plaintextOutput as k: v lines', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'dns',
+      });
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('UUID: cfbff0d1-9375-5685-968c-48ce8b15ae17');
+      expect(out).toContain('Namespace: 6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+      expect(out).toContain('Name: example.com');
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'dns',
+      });
+      expect(boxes[0].props.priority).toBe(UuidV5BoxSource.priority);
+    });
+  });
+
+  describe('generateBoxes - version and variant bits', () => {
+    it('has version nibble 5 in the UUID', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'dns',
+      });
+      const uuid = boxes[0].props.options?.UUID as string;
+      // 3rd group, first char is the version nibble
+      expect(uuid.split('-')[2][0]).toBe('5');
+    });
+
+    it('has RFC 4122 variant bits (8, 9, a, or b) in byte 8', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'dns',
+      });
+      const uuid = boxes[0].props.options?.UUID as string;
+      // 4th group, first char encodes the variant nibble
+      const variantChar = uuid.split('-')[3][0];
+      expect(['8', '9', 'a', 'b']).toContain(variantChar);
+    });
+  });
+
+  describe('generateBoxes - bare ::uuidv5 (namespace required)', () => {
+    it('returns a box explaining namespace is required when value is true', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/namespace/i);
+    });
+
+    it('returns an explanatory box for an invalid namespace string', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'notanamespace',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/namespace/i);
+    });
+  });
+
+  describe('generateBoxes - non-secure context fallback', () => {
+    const originalCrypto = globalThis.crypto;
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { subtle: undefined },
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('returns a single informational box when crypto.subtle is unavailable', async () => {
+      const boxes = await UuidV5BoxSource.generateBoxes('example.com', {
+        uuidv5: 'dns',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(UuidV5BoxSource.name).toBe('UUID v5');
+      expect(UuidV5BoxSource.tag).toBe('#');
+      expect(UuidV5BoxSource.kind).toBe('Generate');
+      expect(typeof UuidV5BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/WeekNumberBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/WeekNumberBoxSource.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { WeekNumberBoxSource } from '../WeekNumberBoxSource';
+
+describe('WeekNumberBoxSource', () => {
+  it('returns [] when no matching option is present', async () => {
+    const boxes = await WeekNumberBoxSource.generateBoxes('2024-01-01', null);
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for unrelated options', async () => {
+    const boxes = await WeekNumberBoxSource.generateBoxes('2024-01-01', {
+      base64: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('triggers on ::weeknum option', async () => {
+    const boxes = await WeekNumberBoxSource.generateBoxes('2024-01-01', {
+      weeknum: true,
+    });
+    expect(boxes).toHaveLength(1);
+  });
+
+  it('triggers on ::isoweek option', async () => {
+    const boxes = await WeekNumberBoxSource.generateBoxes('2024-01-01', {
+      isoweek: true,
+    });
+    expect(boxes).toHaveLength(1);
+  });
+
+  describe('2024-01-01 (Monday, ISO week 1 of 2024)', () => {
+    it('returns correct ISO week data', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2024-01-01', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Date).toBe('2024-01-01');
+      expect(opts['ISO Week']).toBe('2024-W01');
+      expect(opts.Week).toBe('1');
+      expect(opts['ISO Year']).toBe('2024');
+      expect(opts.Weekday).toBe('Monday');
+      expect(opts['Day of Year']).toBe('1');
+    });
+  });
+
+  describe('2021-01-01 (Friday) → ISO 2020-W53 (boundary: year starts mid-week)', () => {
+    it('belongs to ISO week 53 of 2020', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2021-01-01', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Week).toBe('53');
+      expect(opts['ISO Year']).toBe('2020');
+      expect(opts['ISO Week']).toBe('2020-W53');
+      expect(opts.Weekday).toBe('Friday');
+    });
+  });
+
+  describe('2020-12-31 → also ISO 2020-W53', () => {
+    it('belongs to ISO week 53 of 2020', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2020-12-31', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Week).toBe('53');
+      expect(opts['ISO Year']).toBe('2020');
+      expect(opts['ISO Week']).toBe('2020-W53');
+    });
+  });
+
+  describe('2016-01-01 (Friday) → ISO 2015-W53', () => {
+    it('belongs to ISO week 53 of 2015', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2016-01-01', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Week).toBe('53');
+      expect(opts['ISO Year']).toBe('2015');
+      expect(opts['ISO Week']).toBe('2015-W53');
+    });
+  });
+
+  describe('2024-12-31 (Tuesday) → ISO 2025-W01 (boundary: week straddles new year)', () => {
+    it('belongs to ISO week 1 of 2025', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2024-12-31', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Week).toBe('1');
+      expect(opts['ISO Year']).toBe('2025');
+      expect(opts['ISO Week']).toBe('2025-W01');
+      expect(opts.Weekday).toBe('Tuesday');
+    });
+  });
+
+  describe('invalid date input', () => {
+    it('returns a box explaining the date is invalid', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('notadate', {
+        weeknum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/invalid date/i);
+    });
+  });
+
+  describe('empty input → today', () => {
+    it('returns a box without error', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('', {
+        weeknum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeUndefined();
+      expect(opts['ISO Week']).toMatch(/^\d{4}-W\d{2}$/);
+    });
+  });
+
+  describe('"today" keyword', () => {
+    it('returns a box without error', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('today', {
+        weeknum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -2,6 +2,8 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import CaesarBoxSource from './CaesarBoxSource';
+import CmykBoxSource from './CmykBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -9,19 +11,25 @@ import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import JsonToPythonBoxSource from './JsonToPythonBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import MarkdownTocBoxSource from './MarkdownTocBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PrimeFactorBoxSource from './PrimeFactorBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SoundexBoxSource from './SoundexBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
+import UuidV5BoxSource from './UuidV5BoxSource';
+import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -29,6 +37,8 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  CmykBoxSource,
+  CaesarBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
@@ -36,18 +46,24 @@ export const boxSources = [
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  JsonToPythonBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  MarkdownTocBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  PrimeFactorBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
+  SoundexBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
+  UuidV5BoxSource,
+  WeekNumberBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,


### PR DESCRIPTION
## Summary

Seventeenth exploration batch — **8 more BoxSource tools** (crypto, phonetics, color, dev utilities).

| Tool | Trigger | What it does |
|------|---------|--------------|
| UUID v5 | `::uuidv5=NS` | deterministic name-based UUID (SHA-1) |
| Soundex | `::soundex` | American Soundex phonetic code |
| Caesar | `::caesar=N` / `::caesarcrack` | shift cipher + brute force |
| CMYK / HSV | `::cmyk` | color-model conversion |
| Markdown TOC | `::toc` | table of contents from headings |
| Prime Factors | `::isprime` | primality + factorization (BigInt, ≤10¹²) |
| JSON to Python | `::pydataclass` | `@dataclass` from JSON |
| Week Number | `::weeknum` | ISO 8601 week of a date |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules — caps, `this.priority`, `BigInt(str)`, KeyValue sources render `k: v` plaintext, generators **dedup type names** (the TS/Go-generator bug from batch 11), crypto secure-context guard, work in UTC for determinism.
- **Verified vectors**: `uuidv5(dns, example.com)`=`cfbff0d1-9375-5685-968c-48ce8b15ae17`; Soundex `Robert`→`R163`, `Ashcraft`→`A261` (H/W rule), `Tymczak`→`T522`, `Pfister`→`P236`; Caesar `Hello`+3→`Khoor`; `#ff6347`→`cmyk(0%, 61%, 72%, 0%)`; `360`=`2^3 × 3^2 × 5`; **ISO `2021-01-01`→`2020-W53`, `2024-12-31`→`2025-W01`** (the classic week-boundary cases).
- Self-review added `tag`/`kind` fields that Soundex was missing — caught by the `BoxSource` type via `tsc` (the source registry now type-checks the full contract).

## Verification

- ✅ `bun run test run` — **440 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#275 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6