### PR TITLE
feat(boxSources): add 8 more tools (http-status, ieee754, uuid-parse, css→js, md→html, json→sql, dice, twos-complement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>HttpStatusBox</b> </summary>
+
+| match rule       | description                          | example          |
+| ---------------- | ------------------------------------ | ---------------- |
+| `::httpstatus`   | look up an HTTP status code          | `404 ::httpstatus` |
+
+</details>
+
+<details>
+<summary> <b>Ieee754Box</b> </summary>
+
+| match rule    | description                          | example          |
+| ------------- | ------------------------------------ | ---------------- |
+| `::ieee754`   | IEEE-754 bits of a float / decode hex | `3.14 ::ieee754` |
+
+</details>
+
+<details>
+<summary> <b>UuidParseBox</b> </summary>
+
+| match rule      | description                          | example                       |
+| --------------- | ------------------------------------ | ----------------------------- |
+| `::uuidparse`   | version/variant/timestamp of a UUID  | `550e8400-e29b-41d4-a716-446655440000 ::uuidparse` |
+
+</details>
+
+<details>
+<summary> <b>CssToJsBox</b> </summary>
+
+| match rule  | description                          | example                       |
+| ----------- | ------------------------------------ | ----------------------------- |
+| `::cssjs`   | CSS declarations ⇄ JS style object   | `color: red; ::cssjs`         |
+
+</details>
+
+<details>
+<summary> <b>MarkdownToHtmlBox</b> </summary>
+
+| match rule   | description                          | example            |
+| ------------ | ------------------------------------ | ------------------ |
+| `::md2html`  | convert Markdown to HTML             | `# Title ::md2html` |
+
+</details>
+
+<details>
+<summary> <b>SqlCreateTableBox</b> </summary>
+
+| match rule       | description                          | example                       |
+| ---------------- | ------------------------------------ | ----------------------------- |
+| `::sqltable=NAME`| infer CREATE TABLE from JSON         | `{"id":1} ::sqltable=users`   |
+
+</details>
+
+<details>
+<summary> <b>DiceRollBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::roll`    | roll dice notation (e.g. 2d6+3)      | `2d6+3 ::roll`   |
+
+</details>
+
+<details>
+<summary> <b>TwosComplementBox</b> </summary>
+
+| match rule              | description                          | example                       |
+| ----------------------- | ------------------------------------ | ----------------------------- |
+| `::twoscomplement=BITS` | two's-complement binary/hex of an int | `-42 ::twoscomplement=8`     |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/CssToJsBoxSource.ts
+++ b/src/modules/boxSources/CssToJsBoxSource.ts
@@ -40,11 +40,30 @@ function camelToKebab(prop: string): string {
   return prop.replace(/([A-Z])/g, '-$1').toLowerCase();
 }
 
+// split declarations on ';' that are outside parentheses, so values like
+// url(data:image/png;base64,...) aren't truncated
+function splitDeclarations(css: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < css.length; i++) {
+    const ch = css[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') depth = Math.max(0, depth - 1);
+    else if (ch === ';' && depth === 0) {
+      parts.push(css.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(css.slice(start));
+  return parts;
+}
+
 // convert CSS declaration block to a JS object literal string
 function cssToJs(css: string): string {
   const pairs: string[] = [];
 
-  for (const decl of css.split(';')) {
+  for (const decl of splitDeclarations(css)) {
     const colonIdx = decl.indexOf(':');
     if (colonIdx === -1) continue;
 

--- a/src/modules/boxSources/CssToJsBoxSource.ts
+++ b/src/modules/boxSources/CssToJsBoxSource.ts
@@ -1,0 +1,132 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// convert kebab-case CSS property to camelCase JS property
+// vendor prefixes like -webkit-x become WebkitX (capital first letter per React convention)
+function kebabToCamel(prop: string): string {
+  const trimmed = prop.trim();
+
+  // vendor prefix: leading hyphen, e.g. -webkit-box-shadow → WebkitBoxShadow
+  if (trimmed.startsWith('-')) {
+    return trimmed
+      .slice(1)
+      .split('-')
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join('');
+  }
+
+  // standard kebab-case → camelCase
+  return trimmed.replace(/-([a-z])/g, (_, ch) => ch.toUpperCase());
+}
+
+// convert camelCase JS property back to kebab-case CSS property
+// React vendor prefix convention: leading uppercase segment → hyphen prefix
+// e.g. WebkitBoxShadow → -webkit-box-shadow
+function camelToKebab(prop: string): string {
+  // detect leading capital-only segment as vendor prefix (e.g. Webkit, Moz, Ms, O)
+  const vendorMatch = prop.match(/^([A-Z][a-z]*)(.+)/);
+  if (vendorMatch) {
+    const vendor = vendorMatch[1].toLowerCase();
+    const rest = vendorMatch[2];
+    const restKebab = rest.replace(/([A-Z])/g, '-$1').toLowerCase();
+    return `-${vendor}${restKebab}`;
+  }
+
+  return prop.replace(/([A-Z])/g, '-$1').toLowerCase();
+}
+
+// convert CSS declaration block to a JS object literal string
+function cssToJs(css: string): string {
+  const pairs: string[] = [];
+
+  for (const decl of css.split(';')) {
+    const colonIdx = decl.indexOf(':');
+    if (colonIdx === -1) continue;
+
+    const prop = decl.slice(0, colonIdx).trim();
+    const value = decl.slice(colonIdx + 1).trim();
+
+    if (!prop || !value) continue;
+
+    const jsProp = kebabToCamel(prop);
+    pairs.push(`  ${jsProp}: "${value}"`);
+  }
+
+  return `{\n${pairs.join(',\n')}\n}`;
+}
+
+// convert a JS style object literal to CSS declarations
+function jsToCss(js: string): string {
+  const lines: string[] = [];
+
+  // lenient extraction: match key: "value" or key: value pairs
+  const pairRegex = /([a-zA-Z][a-zA-Z0-9]*):\s*["']?([^"',}\n]+)["']?/g;
+  let match: RegExpExecArray | null;
+
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex loop pattern
+  while ((match = pairRegex.exec(js)) !== null) {
+    const jsProp = match[1].trim();
+    const value = match[2].trim();
+    if (!jsProp || !value) continue;
+
+    const cssProp = camelToKebab(jsProp);
+    lines.push(`${cssProp}: ${value};`);
+  }
+
+  return lines.join('\n');
+}
+
+export const CssToJsBoxSource = {
+  name: 'CSS to JS',
+  description:
+    'Convert CSS declarations to a React/JS style object, or a JS style object back to CSS.',
+  defaultInput: 'background-color: red;\nfont-size: 14px; ::cssjs',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cssjs', 'csstojs')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    if (!trimmed) return [];
+
+    // detect direction: if input starts with '{' it is a JS object → convert to CSS
+    const isJsInput = trimmed.startsWith('{');
+
+    if (isJsInput) {
+      const cssOutput = jsToCss(trimmed);
+      if (!cssOutput) return [];
+
+      return [
+        new BoxBuilder('JS to CSS', cssOutput)
+          .setOptions({ language: 'css' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const jsOutput = cssToJs(trimmed);
+    if (!jsOutput || jsOutput === '{\n\n}') return [];
+
+    return [
+      new BoxBuilder('CSS to JS', jsOutput)
+        .setOptions({ language: 'javascript' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CssToJsBoxSource;

--- a/src/modules/boxSources/DiceRollBoxSource.ts
+++ b/src/modules/boxSources/DiceRollBoxSource.ts
@@ -27,7 +27,7 @@ function parseNotation(raw: string): ParsedNotation | null {
   const sides = Number.parseInt(match[2], 10);
   const modifier = match[3] ? Number.parseInt(match[3], 10) : 0;
 
-  if (sides < 1) return null;
+  if (sides < 1 || count < 1) return null;
 
   return {
     count: Math.min(count, MAX_COUNT),
@@ -135,8 +135,11 @@ export const DiceRollBoxSource = {
     const total = sum + parsed.modifier;
     const modifierStr = formatModifier(parsed.modifier);
 
+    // reconstruct from capped values so the label matches what was rolled
+    const effectiveNotation = `${parsed.count}d${parsed.sides}${modifierStr === '0' ? '' : modifierStr}`;
+
     const kvOptions: Record<string, string> = {
-      Notation: parsed.raw,
+      Notation: effectiveNotation,
       Rolls: `[${rolls.join(', ')}]`,
       Sum: String(sum),
       Modifier: modifierStr,

--- a/src/modules/boxSources/DiceRollBoxSource.ts
+++ b/src/modules/boxSources/DiceRollBoxSource.ts
@@ -1,0 +1,160 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max caps prevent pathological inputs from blocking the event loop
+const MAX_COUNT = 1000;
+const MAX_SIDES = 1_000_000;
+
+const NOTATION_RE = /^(\d*)d(\d+)([+-]\d+)?$/i;
+
+interface ParsedNotation {
+  count: number;
+  sides: number;
+  modifier: number;
+  raw: string;
+}
+
+/** Parses XdY+Z dice notation. Returns null when the string is not valid notation. */
+function parseNotation(raw: string): ParsedNotation | null {
+  const match = NOTATION_RE.exec(raw.trim());
+  if (!match) return null;
+
+  const count = match[1] === '' ? 1 : Number.parseInt(match[1], 10);
+  const sides = Number.parseInt(match[2], 10);
+  const modifier = match[3] ? Number.parseInt(match[3], 10) : 0;
+
+  if (sides < 1) return null;
+
+  return {
+    count: Math.min(count, MAX_COUNT),
+    sides: Math.min(sides, MAX_SIDES),
+    modifier,
+    raw,
+  };
+}
+
+/** Returns a cryptographically unbiased integer in [1, sides] via rejection sampling. */
+function rollOne(
+  sides: number,
+  buf: Uint32Array<ArrayBuffer>,
+  cursor: { i: number },
+): number {
+  // largest multiple of `sides` that fits in a uint32 to avoid modulo bias
+  const limit = Math.floor(0x1_0000_0000 / sides) * sides;
+  for (;;) {
+    if (cursor.i >= buf.length) {
+      crypto.getRandomValues(buf);
+      cursor.i = 0;
+    }
+    const val = buf[cursor.i++];
+    if (val < limit) {
+      return (val % sides) + 1;
+    }
+    // rejected — try next value
+  }
+}
+
+/** Rolls `count` fair dice each with `sides` faces. Falls back to Math.random when crypto is unavailable. */
+function rollDice(count: number, sides: number): number[] {
+  const results: number[] = [];
+
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.getRandomValues === 'function'
+  ) {
+    // over-allocate by a small factor to reduce refill frequency from rejection sampling
+    const buf = new Uint32Array(Math.min(count + 16, 4096));
+    crypto.getRandomValues(buf);
+    const cursor = { i: 0 };
+    for (let i = 0; i < count; i++) {
+      results.push(rollOne(sides, buf, cursor));
+    }
+  } else {
+    // fallback for environments without a secure context (e.g. some jest setups)
+    for (let i = 0; i < count; i++) {
+      results.push(Math.floor(Math.random() * sides) + 1);
+    }
+  }
+
+  return results;
+}
+
+/** Formats a modifier as a signed string, or '0' if zero. */
+function formatModifier(modifier: number): string {
+  if (modifier === 0) return '0';
+  return modifier > 0 ? `+${modifier}` : `${modifier}`;
+}
+
+const INVALID_BOX_OUTPUT =
+  'Dice Roll requires valid dice notation, e.g. 2d6+3 or 1d20.';
+
+export const DiceRollBoxSource = {
+  name: 'Dice Roll',
+  description:
+    'Roll dice with standard notation, e.g. 2d6+3 or 1d20. ::roll or ::roll=3d8.',
+  defaultInput: '2d6+3 ::roll',
+  tag: '#',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'roll', 'dice')) return [];
+
+    // prefer explicit notation from the option value; fall back to the input string
+    const optionValue = extractOptionKeys(options, 'roll', 'dice');
+    const notationRaw =
+      typeof optionValue === 'string' && optionValue.trim() !== ''
+        ? optionValue.trim()
+        : trim(input);
+
+    const parsed = parseNotation(notationRaw);
+
+    if (!parsed) {
+      const kvOptions: Record<string, string> = {
+        Info: INVALID_BOX_OUTPUT,
+      };
+      const plaintext = `Info: ${INVALID_BOX_OUTPUT}`;
+      return [
+        new BoxBuilder('Dice Roll', plaintext)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kvOptions)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const rolls = rollDice(parsed.count, parsed.sides);
+    const sum = rolls.reduce((a, b) => a + b, 0);
+    const total = sum + parsed.modifier;
+    const modifierStr = formatModifier(parsed.modifier);
+
+    const kvOptions: Record<string, string> = {
+      Notation: parsed.raw,
+      Rolls: `[${rolls.join(', ')}]`,
+      Sum: String(sum),
+      Modifier: modifierStr,
+      Total: String(total),
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Dice Roll', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DiceRollBoxSource;

--- a/src/modules/boxSources/HttpStatusBoxSource.ts
+++ b/src/modules/boxSources/HttpStatusBoxSource.ts
@@ -1,0 +1,386 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// standard IANA HTTP status codes with official reason phrases and one-line descriptions.
+const STATUS: Record<number, { name: string; description: string }> = {
+  // 1xx Informational
+  100: {
+    name: 'Continue',
+    description:
+      'The server has received the request headers; client should proceed.',
+  },
+  101: {
+    name: 'Switching Protocols',
+    description: 'The server agrees to switch protocols as requested.',
+  },
+  102: {
+    name: 'Processing',
+    description:
+      'The server has received and is processing the request, no response yet.',
+  },
+  103: {
+    name: 'Early Hints',
+    description:
+      'Used to return some response headers before the final HTTP message.',
+  },
+
+  // 2xx Success
+  200: { name: 'OK', description: 'The request succeeded.' },
+  201: {
+    name: 'Created',
+    description: 'The request succeeded and a new resource was created.',
+  },
+  202: {
+    name: 'Accepted',
+    description:
+      'The request was accepted for processing, but processing is not complete.',
+  },
+  203: {
+    name: 'Non-Authoritative Information',
+    description:
+      'The returned metadata is from a local or third-party copy, not the origin server.',
+  },
+  204: {
+    name: 'No Content',
+    description: 'The request succeeded but there is no content to return.',
+  },
+  205: {
+    name: 'Reset Content',
+    description:
+      'The request succeeded; the client should reset the document view.',
+  },
+  206: {
+    name: 'Partial Content',
+    description:
+      'The server is delivering only part of the resource due to a range header.',
+  },
+  207: {
+    name: 'Multi-Status',
+    description:
+      'The response body contains multiple separate response codes (WebDAV).',
+  },
+  208: {
+    name: 'Already Reported',
+    description: 'The members of a DAV binding have already been enumerated.',
+  },
+  226: {
+    name: 'IM Used',
+    description:
+      'The server fulfilled a GET request using instance manipulations.',
+  },
+
+  // 3xx Redirection
+  300: {
+    name: 'Multiple Choices',
+    description:
+      'The request has more than one possible response; the user should choose one.',
+  },
+  301: {
+    name: 'Moved Permanently',
+    description:
+      'The requested resource has been permanently moved to a new URL.',
+  },
+  302: {
+    name: 'Found',
+    description: 'The requested resource is temporarily at a different URL.',
+  },
+  303: {
+    name: 'See Other',
+    description:
+      'The response to the request can be found at a different URL using GET.',
+  },
+  304: {
+    name: 'Not Modified',
+    description:
+      'The resource has not been modified since the last request; use the cached version.',
+  },
+  305: {
+    name: 'Use Proxy',
+    description:
+      'The requested resource must be accessed through the specified proxy.',
+  },
+  307: {
+    name: 'Temporary Redirect',
+    description:
+      'The resource is temporarily at a different URL; method and body must not change.',
+  },
+  308: {
+    name: 'Permanent Redirect',
+    description:
+      'The resource is permanently at a different URL; method and body must not change.',
+  },
+
+  // 4xx Client Error
+  400: {
+    name: 'Bad Request',
+    description: 'The server cannot process the request due to a client error.',
+  },
+  401: {
+    name: 'Unauthorized',
+    description:
+      'Authentication is required and has failed or not been provided.',
+  },
+  402: {
+    name: 'Payment Required',
+    description:
+      'Reserved for future use; sometimes used for digital payment requirements.',
+  },
+  403: {
+    name: 'Forbidden',
+    description:
+      'The server understood the request but refuses to authorize it.',
+  },
+  404: {
+    name: 'Not Found',
+    description: 'The server cannot find the requested resource.',
+  },
+  405: {
+    name: 'Method Not Allowed',
+    description: 'The HTTP method is not allowed for the requested resource.',
+  },
+  406: {
+    name: 'Not Acceptable',
+    description:
+      'The resource does not match the acceptable content types in the request.',
+  },
+  407: {
+    name: 'Proxy Authentication Required',
+    description:
+      'Authentication with the proxy is required before the request can be served.',
+  },
+  408: {
+    name: 'Request Timeout',
+    description: 'The server timed out waiting for the request.',
+  },
+  409: {
+    name: 'Conflict',
+    description:
+      'The request conflicts with the current state of the resource.',
+  },
+  410: {
+    name: 'Gone',
+    description:
+      'The resource is permanently deleted and will not be available again.',
+  },
+  411: {
+    name: 'Length Required',
+    description: 'The request did not include a Content-Length header.',
+  },
+  412: {
+    name: 'Precondition Failed',
+    description:
+      'The server does not meet one of the preconditions set by the client.',
+  },
+  413: {
+    name: 'Content Too Large',
+    description:
+      'The request body is larger than the server is willing to process.',
+  },
+  414: {
+    name: 'URI Too Long',
+    description:
+      'The URI requested by the client is longer than the server will interpret.',
+  },
+  415: {
+    name: 'Unsupported Media Type',
+    description:
+      'The media format of the request is not supported by the server.',
+  },
+  416: {
+    name: 'Range Not Satisfiable',
+    description: 'The range specified in the Range header cannot be fulfilled.',
+  },
+  417: {
+    name: 'Expectation Failed',
+    description:
+      'The server cannot meet the requirements of the Expect request header.',
+  },
+  418: {
+    name: "I'm a Teapot",
+    description:
+      'The server refuses to brew coffee because it is a teapot (RFC 2324).',
+  },
+  421: {
+    name: 'Misdirected Request',
+    description:
+      'The request was directed at a server unable to produce a response.',
+  },
+  422: {
+    name: 'Unprocessable Content',
+    description: 'The request was well-formed but contains semantic errors.',
+  },
+  423: {
+    name: 'Locked',
+    description: 'The resource being accessed is locked (WebDAV).',
+  },
+  424: {
+    name: 'Failed Dependency',
+    description:
+      'The request failed because it depended on another request that failed.',
+  },
+  425: {
+    name: 'Too Early',
+    description:
+      'The server is unwilling to process a request that might be replayed.',
+  },
+  426: {
+    name: 'Upgrade Required',
+    description: 'The client should switch to a different protocol.',
+  },
+  428: {
+    name: 'Precondition Required',
+    description: 'The origin server requires the request to be conditional.',
+  },
+  429: {
+    name: 'Too Many Requests',
+    description:
+      'The client has sent too many requests in a given amount of time.',
+  },
+  431: {
+    name: 'Request Header Fields Too Large',
+    description:
+      'The server is unwilling to process the request because header fields are too large.',
+  },
+  451: {
+    name: 'Unavailable For Legal Reasons',
+    description:
+      'The server is denying access to the resource as a consequence of a legal demand.',
+  },
+
+  // 5xx Server Error
+  500: {
+    name: 'Internal Server Error',
+    description:
+      'The server encountered an unexpected condition that prevented it from fulfilling the request.',
+  },
+  501: {
+    name: 'Not Implemented',
+    description:
+      'The server does not support the functionality required to fulfill the request.',
+  },
+  502: {
+    name: 'Bad Gateway',
+    description:
+      'The server received an invalid response from an upstream server.',
+  },
+  503: {
+    name: 'Service Unavailable',
+    description:
+      'The server is not ready to handle the request, usually due to maintenance or overload.',
+  },
+  504: {
+    name: 'Gateway Timeout',
+    description:
+      'The server did not receive a timely response from an upstream server.',
+  },
+  505: {
+    name: 'HTTP Version Not Supported',
+    description:
+      'The server does not support the HTTP version used in the request.',
+  },
+  506: {
+    name: 'Variant Also Negotiates',
+    description:
+      'The server has a configuration error in transparent content negotiation.',
+  },
+  507: {
+    name: 'Insufficient Storage',
+    description:
+      'The server cannot store the representation needed to complete the request.',
+  },
+  508: {
+    name: 'Loop Detected',
+    description:
+      'The server detected an infinite loop while processing the request (WebDAV).',
+  },
+  510: {
+    name: 'Not Extended',
+    description:
+      'Further extensions to the request are required for the server to fulfill it.',
+  },
+  511: {
+    name: 'Network Authentication Required',
+    description: 'The client needs to authenticate to gain network access.',
+  },
+};
+
+// maps the first digit of an HTTP status code to its category name.
+const CATEGORIES: Record<number, string> = {
+  1: 'Informational',
+  2: 'Success',
+  3: 'Redirection',
+  4: 'Client Error',
+  5: 'Server Error',
+};
+
+const VALID_CODE_RE = /^[1-5]\d{2}$/;
+
+export const HttpStatusBoxSource = {
+  name: 'HTTP Status',
+  description: 'Look up an HTTP status code (name, category, description).',
+  defaultInput: '404 ::httpstatus',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'httpstatus', 'httpcode')) return [];
+
+    // prefer an explicit numeric option value; fall back to parsing the input string.
+    const optionValue = extractOptionKeys(options, 'httpstatus', 'httpcode');
+    const rawCode =
+      typeof optionValue === 'string' && optionValue.trim() !== ''
+        ? optionValue.trim()
+        : trim(input);
+
+    if (!VALID_CODE_RE.test(rawCode)) {
+      const plaintextOutput = `Code: ${rawCode}\nInfo: A valid HTTP status code must be a 3-digit number between 100 and 599.`;
+      const kvOptions: Record<string, string> = {
+        Code: rawCode,
+        Info: 'A valid HTTP status code must be a 3-digit number between 100 and 599.',
+      };
+      return [
+        new BoxBuilder('HTTP Status', plaintextOutput)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kvOptions)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const code = Number.parseInt(rawCode, 10);
+    const entry = STATUS[code] ?? null;
+    const category = CATEGORIES[Math.floor(code / 100)] ?? 'Unknown';
+    const name = entry?.name ?? 'Unassigned/Unknown';
+    const description = entry?.description ?? '';
+
+    const kvOptions: Record<string, string> = {
+      Code: rawCode,
+      Name: name,
+      Category: category,
+      ...(description !== '' ? { Description: description } : {}),
+    };
+
+    // k: v plaintext format for the headless TUI consumer.
+    const lines = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('HTTP Status', lines)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HttpStatusBoxSource;

--- a/src/modules/boxSources/Ieee754BoxSource.ts
+++ b/src/modules/boxSources/Ieee754BoxSource.ts
@@ -1,0 +1,179 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// regex for a valid decimal float literal, including scientific notation and special values
+const FLOAT_LITERAL_RE =
+  /^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$|^-?Infinity$|^NaN$/;
+
+// regex for a hex bit-pattern (8 digits = single, 16 digits = double)
+const HEX_PATTERN_RE = /^0x([0-9a-fA-F]+)$/;
+
+// convert an ArrayBuffer to a zero-padded hex string without the 0x prefix
+function bufToHex(buf: ArrayBuffer, byteLength: number): string {
+  return Array.from(new Uint8Array(buf, 0, byteLength))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// extract the full bit string from the first `byteLength` bytes of a DataView
+function toBitString(dv: DataView, byteLength: number): string {
+  return Array.from({ length: byteLength }, (_, i) =>
+    dv.getUint8(i).toString(2).padStart(8, '0'),
+  ).join('');
+}
+
+interface DoubleRepr {
+  hex: string;
+  sign: string;
+  exponent: string;
+  mantissa: string;
+}
+
+interface SingleRepr {
+  hex: string;
+  sign: string;
+  exponent: string;
+  mantissa: string;
+  /** value after the double→single→double round-trip */
+  roundTrip: number;
+}
+
+function encodeDouble(value: number): DoubleRepr {
+  const buf = new ArrayBuffer(8);
+  const dv = new DataView(buf);
+  dv.setFloat64(0, value, false);
+  const bits = toBitString(dv, 8);
+  return {
+    hex: `0x${bufToHex(buf, 8)}`,
+    sign: bits[0],
+    exponent: bits.slice(1, 12),
+    mantissa: bits.slice(12),
+  };
+}
+
+function encodeSingle(value: number): SingleRepr {
+  const buf = new ArrayBuffer(4);
+  const dv = new DataView(buf);
+  dv.setFloat32(0, value, false);
+  const bits = toBitString(dv, 4);
+  const roundTrip = dv.getFloat32(0, false);
+  return {
+    hex: `0x${bufToHex(buf, 4)}`,
+    sign: bits[0],
+    exponent: bits.slice(1, 9),
+    mantissa: bits.slice(9),
+    roundTrip,
+  };
+}
+
+function decodeHex(
+  hexDigits: string,
+): { value: number; type: 'double' | 'single' } | null {
+  const len = hexDigits.length;
+  if (len === 16) {
+    const buf = new ArrayBuffer(8);
+    const dv = new DataView(buf);
+    for (let i = 0; i < 8; i++) {
+      dv.setUint8(i, Number.parseInt(hexDigits.slice(i * 2, i * 2 + 2), 16));
+    }
+    return { value: dv.getFloat64(0, false), type: 'double' };
+  }
+  if (len === 8) {
+    const buf = new ArrayBuffer(4);
+    const dv = new DataView(buf);
+    for (let i = 0; i < 4; i++) {
+      dv.setUint8(i, Number.parseInt(hexDigits.slice(i * 2, i * 2 + 2), 16));
+    }
+    return { value: dv.getFloat32(0, false), type: 'single' };
+  }
+  return null;
+}
+
+export const Ieee754BoxSource = {
+  name: 'IEEE 754',
+  description:
+    'Show the IEEE-754 (double + single) bit representation of a number, or decode a hex pattern back to a float.',
+  defaultInput: '3.14 ::ieee754',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ieee754', 'floatbits')) return [];
+
+    const raw = trim(input).slice(0, 64);
+    if (!raw) return [];
+
+    // check for hex bit-pattern decode (must come before float parse to avoid
+    // misidentifying '0x...' as a numeric literal in some environments)
+    const hexMatch = HEX_PATTERN_RE.exec(raw);
+    if (hexMatch) {
+      const hexDigits = hexMatch[1];
+      const decoded = decodeHex(hexDigits);
+      if (!decoded) return [];
+
+      const kvOptions: Record<string, string> = {
+        Hex: `0x${hexDigits}`,
+        Value: String(decoded.value),
+        Type: decoded.type,
+      };
+
+      const plaintext = Object.entries(kvOptions)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('\n');
+
+      return [
+        new BoxBuilder('IEEE 754', plaintext)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kvOptions)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // check for a decimal float literal or special values
+    if (!FLOAT_LITERAL_RE.test(raw)) return [];
+
+    const value = Number.parseFloat(raw);
+    if (
+      !Number.isFinite(value) &&
+      !Number.isNaN(value) &&
+      raw !== 'Infinity' &&
+      raw !== '-Infinity'
+    ) {
+      return [];
+    }
+
+    const dbl = encodeDouble(value);
+    const sgl = encodeSingle(value);
+
+    const kvOptions: Record<string, string> = {
+      Value: String(value),
+      'Double (hex)': dbl.hex,
+      'Double (bits)': `${dbl.sign} ${dbl.exponent} ${dbl.mantissa}`,
+      'Single (hex)': sgl.hex,
+      'Single (value)': String(sgl.roundTrip),
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('IEEE 754', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Ieee754BoxSource;

--- a/src/modules/boxSources/MarkdownToHtmlBoxSource.ts
+++ b/src/modules/boxSources/MarkdownToHtmlBoxSource.ts
@@ -26,9 +26,27 @@ function applyInline(text: string): string {
   text = text.replace(/_([^_]+)_/g, '<em>$1</em>');
   // inline code: `x`
   text = text.replace(/`([^`]+)`/g, '<code>$1</code>');
-  // links: [text](url) — url attr is also escaped (already done by escapeHtml on &/</>)
-  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  // links: [text](url) — drop dangerous url schemes so the generated HTML
+  // (which the user will paste elsewhere) can't carry a script payload
+  text = text.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    (_m, label: string, url: string) =>
+      `<a href="${safeHref(url)}">${label}</a>`,
+  );
   return text;
+}
+
+// neutralize javascript:/vbscript:/data: hrefs (text is already html-escaped)
+function safeHref(url: string): string {
+  const scheme = url.trim().toLowerCase();
+  if (
+    scheme.startsWith('javascript:') ||
+    scheme.startsWith('vbscript:') ||
+    scheme.startsWith('data:')
+  ) {
+    return '#unsafe-url-removed';
+  }
+  return url;
 }
 
 // converts a subset of markdown to html source text
@@ -45,7 +63,7 @@ function convertMarkdownToHtml(markdown: string): string {
       const fence = '```';
       i++;
       const codeLines: string[] = [];
-      while (i < lines.length && lines[i].trim() !== fence) {
+      while (i < lines.length && !lines[i].trim().startsWith(fence)) {
         codeLines.push(escapeHtml(lines[i]));
         i++;
       }

--- a/src/modules/boxSources/MarkdownToHtmlBoxSource.ts
+++ b/src/modules/boxSources/MarkdownToHtmlBoxSource.ts
@@ -1,0 +1,153 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// escapes html special chars in a raw text fragment so the output markup is valid
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// applies inline markdown rules to an already-html-escaped string.
+// all regexes use negated character classes ([^...]) to stay linear — no nested quantifiers.
+function applyInline(text: string): string {
+  // bold: **x** or __x__
+  text = text.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  text = text.replace(/__([^_]+)__/g, '<strong>$1</strong>');
+  // italic: *x* or _x_ (after bold so ** is consumed first)
+  text = text.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+  text = text.replace(/_([^_]+)_/g, '<em>$1</em>');
+  // inline code: `x`
+  text = text.replace(/`([^`]+)`/g, '<code>$1</code>');
+  // links: [text](url) — url attr is also escaped (already done by escapeHtml on &/</>)
+  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  return text;
+}
+
+// converts a subset of markdown to html source text
+function convertMarkdownToHtml(markdown: string): string {
+  const lines = markdown.split('\n');
+  const output: string[] = [];
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // fenced code block: ``` ... ```
+    if (line.trim() === '```' || line.trim().startsWith('```')) {
+      const fence = '```';
+      i++;
+      const codeLines: string[] = [];
+      while (i < lines.length && lines[i].trim() !== fence) {
+        codeLines.push(escapeHtml(lines[i]));
+        i++;
+      }
+      i++; // skip closing fence
+      output.push(`<pre><code>${codeLines.join('\n')}</code></pre>`);
+      continue;
+    }
+
+    // atx headings: # through ######
+    const headingMatch = line.match(/^(#{1,6}) (.+)/);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const content = applyInline(escapeHtml(headingMatch[2]));
+      output.push(`<h${level}>${content}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    // unordered list block: lines starting with "- " or "* "
+    if (/^[*-] /.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^[*-] /.test(lines[i])) {
+        const itemText = applyInline(
+          escapeHtml(lines[i].replace(/^[*-] /, '')),
+        );
+        items.push(`<li>${itemText}</li>`);
+        i++;
+      }
+      output.push(`<ul>${items.join('')}</ul>`);
+      continue;
+    }
+
+    // ordered list block: lines starting with "N. "
+    if (/^\d+\. /.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\d+\. /.test(lines[i])) {
+        const itemText = applyInline(
+          escapeHtml(lines[i].replace(/^\d+\. /, '')),
+        );
+        items.push(`<li>${itemText}</li>`);
+        i++;
+      }
+      output.push(`<ol>${items.join('')}</ol>`);
+      continue;
+    }
+
+    // blank line: separator — skip
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    // paragraph: collect consecutive non-blank, non-special lines
+    const paraLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== '' &&
+      !/^#{1,6} /.test(lines[i]) &&
+      !/^[*-] /.test(lines[i]) &&
+      !/^\d+\. /.test(lines[i]) &&
+      lines[i].trim() !== '```' &&
+      !lines[i].trim().startsWith('```')
+    ) {
+      paraLines.push(applyInline(escapeHtml(lines[i])));
+      i++;
+    }
+    if (paraLines.length > 0) {
+      output.push(`<p>${paraLines.join('\n')}</p>`);
+    }
+  }
+
+  return output.join('\n');
+}
+
+export const MarkdownToHtmlBoxSource = {
+  name: 'Markdown to HTML',
+  description:
+    'Convert a subset of Markdown (headings, bold, italic, code, links, lists) to HTML.',
+  defaultInput: '# Title\n\nSome **bold** and *italic* and `code`. ::md2html',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'md2html', 'markdownhtml')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const html = convertMarkdownToHtml(input);
+
+    return [
+      new BoxBuilder('Markdown to HTML', html)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'html' })
+        .setShowExpandButton(true)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default MarkdownToHtmlBoxSource;

--- a/src/modules/boxSources/SqlCreateTableBoxSource.ts
+++ b/src/modules/boxSources/SqlCreateTableBoxSource.ts
@@ -69,11 +69,11 @@ function buildCreateTable(
   return `CREATE TABLE ${quoteIdent(tableName)} (\n${lines.join(',\n')}\n);`;
 }
 
-function errorBox(message: string): Box {
+function errorBox(message: string, priority: number): Box {
   return new BoxBuilder('JSON to SQL Table', message)
     .setTemplate(CodeBoxTemplate)
     .setOptions({ language: 'sql' })
-    .setPriority(Priority)
+    .setPriority(priority)
     .build();
 }
 
@@ -101,7 +101,7 @@ export const SqlCreateTableBoxSource = {
     try {
       parsed = JSON.parse(trim(input));
     } catch {
-      return [errorBox('Error: invalid JSON input')];
+      return [errorBox('Error: invalid JSON input', this.priority)];
     }
 
     const rows: Record<string, unknown>[] = Array.isArray(parsed)
@@ -111,7 +111,12 @@ export const SqlCreateTableBoxSource = {
     const cols = collectColumns(rows);
 
     if (cols.size === 0) {
-      return [errorBox('Error: no columns could be inferred from the input')];
+      return [
+        errorBox(
+          'Error: no columns could be inferred from the input',
+          this.priority,
+        ),
+      ];
     }
 
     const sql = buildCreateTable(tableName, cols);
@@ -120,7 +125,7 @@ export const SqlCreateTableBoxSource = {
       new BoxBuilder('JSON to SQL Table', sql)
         .setTemplate(CodeBoxTemplate)
         .setOptions({ language: 'sql' })
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build(),
     ];
   },

--- a/src/modules/boxSources/SqlCreateTableBoxSource.ts
+++ b/src/modules/boxSources/SqlCreateTableBoxSource.ts
@@ -1,0 +1,129 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// reserved prototype-chain keys — safe to read Object.keys, but guard defensively
+const BANNED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function sanitizeTableName(raw: string | boolean | undefined): string {
+  if (!raw || raw === true) return 'my_table';
+  const cleaned = String(raw).replace(/[^A-Za-z0-9_]/g, '');
+  return cleaned.length > 0 ? cleaned : 'my_table';
+}
+
+// wrap a column/table name in double-quotes, escaping embedded double-quotes
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+type SqlType =
+  | 'BOOLEAN'
+  | 'INTEGER'
+  | 'INTEGER PRIMARY KEY'
+  | 'DOUBLE PRECISION'
+  | 'TEXT';
+
+function inferType(value: unknown, colName: string): SqlType {
+  if (value === null || value === undefined) return 'TEXT';
+  if (typeof value === 'boolean') return 'BOOLEAN';
+  if (typeof value === 'number') {
+    if (Number.isInteger(value) && colName === 'id')
+      return 'INTEGER PRIMARY KEY';
+    if (Number.isInteger(value)) return 'INTEGER';
+    return 'DOUBLE PRECISION';
+  }
+  if (typeof value === 'object') return 'TEXT'; // nested object/array → serialised TEXT
+  return 'TEXT';
+}
+
+// build a map of column name → first non-null sample value seen across all rows
+function collectColumns(rows: Record<string, unknown>[]): Map<string, unknown> {
+  const cols = new Map<string, unknown>();
+  for (const row of rows) {
+    if (row === null || typeof row !== 'object' || Array.isArray(row)) continue;
+    for (const key of Object.keys(row)) {
+      if (BANNED_KEYS.has(key)) continue;
+      if (!cols.has(key)) {
+        cols.set(key, row[key] ?? null);
+      } else if (cols.get(key) === null && row[key] != null) {
+        // upgrade null placeholder to a concrete value for better type inference
+        cols.set(key, row[key]);
+      }
+    }
+  }
+  return cols;
+}
+
+function buildCreateTable(
+  tableName: string,
+  cols: Map<string, unknown>,
+): string {
+  const lines: string[] = [];
+  for (const [col, sample] of cols) {
+    lines.push(`  ${quoteIdent(col)} ${inferType(sample, col)}`);
+  }
+  return `CREATE TABLE ${quoteIdent(tableName)} (\n${lines.join(',\n')}\n);`;
+}
+
+function errorBox(message: string): Box {
+  return new BoxBuilder('JSON to SQL Table', message)
+    .setTemplate(CodeBoxTemplate)
+    .setOptions({ language: 'sql' })
+    .setPriority(Priority)
+    .build();
+}
+
+export const SqlCreateTableBoxSource = {
+  name: 'JSON to SQL Table',
+  description:
+    'Infer a CREATE TABLE statement from a JSON object or array of objects. ::sqltable=<tablename>.',
+  defaultInput: '{"id":1,"name":"Bob","active":true} ::sqltable=users',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'sqltable', 'createtable')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const rawTableName =
+      options?.sqltable !== undefined ? options.sqltable : options?.createtable;
+    const tableName = sanitizeTableName(rawTableName);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trim(input));
+    } catch {
+      return [errorBox('Error: invalid JSON input')];
+    }
+
+    const rows: Record<string, unknown>[] = Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>[])
+      : [parsed as Record<string, unknown>];
+
+    const cols = collectColumns(rows);
+
+    if (cols.size === 0) {
+      return [errorBox('Error: no columns could be inferred from the input')];
+    }
+
+    const sql = buildCreateTable(tableName, cols);
+
+    return [
+      new BoxBuilder('JSON to SQL Table', sql)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'sql' })
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default SqlCreateTableBoxSource;

--- a/src/modules/boxSources/TwosComplementBoxSource.ts
+++ b/src/modules/boxSources/TwosComplementBoxSource.ts
@@ -1,0 +1,98 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// matches a signed decimal integer with optional leading/trailing whitespace
+const INTEGER_RE = /^-?\d+$/;
+
+// parse the bit width from the option value, clamped to [1, 64]
+function parseBitWidth(raw: BoxOptions): number {
+  const val = extractOptionKeys(raw, 'twoscomplement', 'twos');
+  if (typeof val === 'string' && /^\d+$/.test(val)) {
+    const n = Number.parseInt(val, 10);
+    return Math.min(64, Math.max(1, n));
+  }
+  return 8;
+}
+
+export const TwosComplementBoxSource = {
+  name: "Two's Complement",
+  description:
+    "Show the two's-complement binary/hex of a signed integer at a bit width. ::twoscomplement=8 (default 8).",
+  defaultInput: '-42 ::twoscomplement=8',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'twoscomplement', 'twos')) return [];
+
+    const raw = trim(input).slice(0, 25);
+    if (!INTEGER_RE.test(raw)) return [];
+
+    const width = parseBitWidth(options);
+    const widthN = BigInt(width);
+
+    // use BigInt directly on the trimmed string — never go through Number
+    const value = BigInt(raw);
+
+    const minVal = -(1n << (widthN - 1n));
+    const maxVal = (1n << (widthN - 1n)) - 1n;
+
+    if (value < minVal || value > maxVal) {
+      const msg = `${raw} does not fit in a signed ${width}-bit integer (range ${minVal} to ${maxVal}).`;
+      const kvOptions: Record<string, string> = {
+        Value: raw,
+        'Bit Width': String(width),
+        Error: msg,
+      };
+      const plaintext = Object.entries(kvOptions)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('\n');
+      return [
+        new BoxBuilder("Two's Complement", plaintext)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kvOptions)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // mask to the low `width` bits — for negative BigInt this yields the two's complement pattern
+    const mask = (1n << widthN) - 1n;
+    const pattern = value & mask;
+
+    const binary = pattern.toString(2).padStart(width, '0');
+    const hexLen = Math.ceil(width / 4);
+    const hex = `0x${pattern.toString(16).padStart(hexLen, '0')}`;
+    const unsigned = pattern.toString(10);
+
+    const kvOptions: Record<string, string> = {
+      Value: raw,
+      'Bit Width': String(width),
+      Binary: binary,
+      Hex: hex,
+      Unsigned: unsigned,
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder("Two's Complement", plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default TwosComplementBoxSource;

--- a/src/modules/boxSources/UuidParseBoxSource.ts
+++ b/src/modules/boxSources/UuidParseBoxSource.ts
@@ -1,0 +1,90 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// gregorian epoch offset in 100-ns intervals: from 1582-10-15 to 1970-01-01
+const GREGORIAN_OFFSET_100NS = BigInt('122192928000000000');
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function parseVariant(hexChar: string): string {
+  const nibble = Number.parseInt(hexChar, 16);
+  // check top bits to determine variant
+  if ((nibble & 0b1000) === 0) return 'NCS (0)';
+  if ((nibble & 0b1100) === 0b1000) return 'RFC 4122 (variant 1)';
+  if ((nibble & 0b1110) === 0b1100) return 'Microsoft (variant 2)';
+  return 'Reserved';
+}
+
+// extracts the embedded 60-bit timestamp from a v1 UUID and returns an ISO string
+function v1Timestamp(uuid: string): string {
+  // layout: tttttttt-tttt-1ttt-... where t = time fields
+  const timeLow = BigInt(`0x${uuid.slice(0, 8)}`);
+  const timeMid = BigInt(`0x${uuid.slice(9, 13)}`);
+  // strip the version nibble (top 4 bits of third group)
+  const timeHi = BigInt(`0x${uuid.slice(15, 18)}`);
+
+  const ts100ns = (timeHi << BigInt(48)) | (timeMid << BigInt(32)) | timeLow;
+
+  const unixMs = Number((ts100ns - GREGORIAN_OFFSET_100NS) / BigInt(10000));
+  return new Date(unixMs).toISOString();
+}
+
+export const UuidParseBoxSource = {
+  name: 'UUID Parse',
+  description:
+    'Parse a UUID: show its version, variant, and (for v1) the embedded timestamp.',
+  defaultInput: '550e8400-e29b-41d4-a716-446655440000 ::uuidparse',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'uuidparse', 'uuidinfo')) return [];
+
+    const uuid = trim(input).toLowerCase();
+
+    if (!UUID_RE.test(uuid)) {
+      return [
+        new BoxBuilder('UUID Parse', 'A valid UUID is required.')
+          .setOptions({ Error: 'A valid UUID is required.' })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const isNil = uuid === '00000000-0000-0000-0000-000000000000';
+    const versionDigit = uuid[14];
+    const version = isNil ? '0 (nil)' : versionDigit;
+    const variant = parseVariant(uuid[19]);
+
+    const kvOptions: Record<string, string> = {
+      UUID: uuid,
+      Version: version,
+      Variant: variant,
+    };
+
+    // include timestamp only for version 1 (time-based)
+    if (!isNil && versionDigit === '1') {
+      kvOptions.Timestamp = v1Timestamp(uuid);
+    }
+
+    return [
+      new BoxBuilder('UUID Parse', '')
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UuidParseBoxSource;

--- a/src/modules/boxSources/UuidParseBoxSource.ts
+++ b/src/modules/boxSources/UuidParseBoxSource.ts
@@ -77,8 +77,13 @@ export const UuidParseBoxSource = {
       kvOptions.Timestamp = v1Timestamp(uuid);
     }
 
+    // render k:v lines so the headless TUI shows the fields (not a blank box)
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
     return [
-      new BoxBuilder('UUID Parse', '')
+      new BoxBuilder('UUID Parse', plaintext)
         .setOptions(kvOptions)
         .setTemplate(KeyValueBoxTemplate)
         .setPriority(this.priority)

--- a/src/modules/boxSources/__test__/CssToJsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CssToJsBoxSource.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { CssToJsBoxSource } from '../CssToJsBoxSource';
+
+describe('CssToJsBoxSource', () => {
+  describe('generateBoxes — option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('color: red;', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are provided', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('color: red;', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('CSS → JS conversion', () => {
+    it('converts basic CSS declarations to a JS object', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes(
+        'background-color: red; font-size: 14px;',
+        { cssjs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('CSS to JS');
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('backgroundColor: "red"');
+      expect(out).toContain('fontSize: "14px"');
+    });
+
+    it('handles vendor prefix -webkit-box-shadow → WebkitBoxShadow', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes(
+        '-webkit-box-shadow: none;',
+        { csstojs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('WebkitBoxShadow: "none"');
+    });
+
+    it('skips empty declarations gracefully', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes(';;;', {
+        cssjs: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('color: blue;', {
+        cssjs: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('JS → CSS conversion', () => {
+    it('converts a JS object literal to CSS declarations', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes(
+        '{ backgroundColor: "red", fontSize: "14px" }',
+        { cssjs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JS to CSS');
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('background-color: red;');
+      expect(out).toContain('font-size: 14px;');
+    });
+
+    it('converts vendor prefix WebkitBoxShadow → -webkit-box-shadow', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes(
+        '{ WebkitBoxShadow: "0 0 5px rgba(0,0,0,0.5)" }',
+        { cssjs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('-webkit-box-shadow:');
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('{ color: "blue" }', {
+        cssjs: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty string without crashing', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('', { cssjs: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('handles whitespace-only input without crashing', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('   ', {
+        cssjs: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('handles garbage input without crashing', async () => {
+      // no valid declarations → empty object output → returns []
+      const boxes = await CssToJsBoxSource.generateBoxes(
+        'this is not css at all!!!',
+        { cssjs: true },
+      );
+      // may return [] or a box with empty output — must not throw
+      expect(Array.isArray(boxes)).toBe(true);
+    });
+
+    it('respects MAX_INPUT cap', async () => {
+      const huge = 'a'.repeat(100_001);
+      const boxes = await CssToJsBoxSource.generateBoxes(huge, { cssjs: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/DiceRollBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DiceRollBoxSource.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import { DiceRollBoxSource } from '../DiceRollBoxSource';
+
+describe('DiceRollBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no roll/dice option is present', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('2d6');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when options is null', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('2d6', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated option is present', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('2d6', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should roll 2d6 and return values within range', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('2d6', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Notation).toBe('2d6');
+
+      const rollsRaw = options?.Rolls as string;
+      // parse "[4, 2]" style string
+      const rolls = JSON.parse(rollsRaw) as number[];
+      expect(rolls).toHaveLength(2);
+      for (const r of rolls) {
+        expect(r).toBeGreaterThanOrEqual(1);
+        expect(r).toBeLessThanOrEqual(6);
+      }
+
+      const total = Number(options?.Total);
+      expect(total).toBeGreaterThanOrEqual(2);
+      expect(total).toBeLessThanOrEqual(12);
+      expect(options?.Modifier).toBe('0');
+    });
+
+    it('should handle 1d20+5 with modifier applied to total', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('1d20+5', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Notation).toBe('1d20+5');
+      expect(options?.Modifier).toBe('+5');
+
+      const total = Number(options?.Total);
+      expect(total).toBeGreaterThanOrEqual(6);
+      expect(total).toBeLessThanOrEqual(25);
+    });
+
+    it('should use the option value as notation when ::roll=4d4', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('', {
+        roll: '4d4',
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Notation).toBe('4d4');
+
+      const rolls = JSON.parse(options?.Rolls as string) as number[];
+      expect(rolls).toHaveLength(4);
+      for (const r of rolls) {
+        expect(r).toBeGreaterThanOrEqual(1);
+        expect(r).toBeLessThanOrEqual(4);
+      }
+    });
+
+    it('should default count to 1 when notation omits the count (d6)', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('d6', { roll: true });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      const rolls = JSON.parse(options?.Rolls as string) as number[];
+      expect(rolls).toHaveLength(1);
+      expect(rolls[0]).toBeGreaterThanOrEqual(1);
+      expect(rolls[0]).toBeLessThanOrEqual(6);
+    });
+
+    it('should accept ::dice option as an alias', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('1d6', {
+        dice: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Notation).toBe('1d6');
+    });
+
+    it('should return an error box for invalid notation "abc"', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('abc', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      // no Notation/Rolls — only an Info key explaining the required format
+      expect(options?.Notation).toBeUndefined();
+      expect(options?.Info).toBeTruthy();
+      const info = options?.Info as string;
+      expect(info.toLowerCase()).toContain('notation');
+    });
+
+    it('should roll 10d10 and all results should be within [1, 10]', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('10d10', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      const rolls = JSON.parse(options?.Rolls as string) as number[];
+      expect(rolls).toHaveLength(10);
+      for (const r of rolls) {
+        expect(r).toBeGreaterThanOrEqual(1);
+        expect(r).toBeLessThanOrEqual(10);
+      }
+
+      const total = Number(options?.Total);
+      expect(total).toBeGreaterThanOrEqual(10);
+      expect(total).toBeLessThanOrEqual(100);
+    });
+
+    it('should include k: v plaintext lines in plaintextOutput for headless TUI', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('1d6', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { plaintextOutput } = boxes[0].props;
+      expect(plaintextOutput).toContain('Notation: 1d6');
+      expect(plaintextOutput).toContain('Rolls:');
+      expect(plaintextOutput).toContain('Sum:');
+      expect(plaintextOutput).toContain('Modifier:');
+      expect(plaintextOutput).toContain('Total:');
+    });
+
+    it('should set priority from source priority', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('1d6', {
+        roll: true,
+      });
+      expect(boxes[0].props.priority).toBe(DiceRollBoxSource.priority);
+    });
+
+    it('should handle negative modifier (1d6-2) and apply it to total', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('1d6-2', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Modifier).toBe('-2');
+
+      const total = Number(options?.Total);
+      // 1d6-2 range: [1-2, 6-2] = [-1, 4]
+      expect(total).toBeGreaterThanOrEqual(-1);
+      expect(total).toBeLessThanOrEqual(4);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HttpStatusBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HttpStatusBoxSource.test.ts
@@ -1,0 +1,129 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { HttpStatusBoxSource } from '../HttpStatusBoxSource';
+
+describe('HttpStatusBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no httpstatus/httpcode option is present', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('404');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when options is null', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('404', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should look up 404 from input with ::httpstatus option', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('404', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Code).toBe('404');
+      expect(options?.Name).toBe('Not Found');
+      expect(options?.Category).toBe('Client Error');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('should prefer ::httpstatus=500 option value over input', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('', {
+        httpstatus: '500',
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Code).toBe('500');
+      expect(options?.Name).toBe('Internal Server Error');
+      expect(options?.Category).toBe('Server Error');
+    });
+
+    it('should look up 200 OK', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('200', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Name).toBe('OK');
+      expect(options?.Category).toBe('Success');
+    });
+
+    it('should look up 301 Moved Permanently', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('301', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Name).toBe('Moved Permanently');
+      expect(options?.Category).toBe('Redirection');
+    });
+
+    it("should look up 418 I'm a Teapot", async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('418', {
+        httpcode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Name).toMatch(/teapot/i);
+      expect(options?.Category).toBe('Client Error');
+    });
+
+    it('should handle valid-but-unassigned code 299 as Unknown', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('299', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Category).toBe('Success');
+      expect(options?.Name).toMatch(/unknown|unassigned/i);
+    });
+
+    it('should return an error box for invalid code 999 (out of 1xx-5xx range)', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('999', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Code).toBe('999');
+      // should mention the valid range, not resolve as a real status
+      expect(options?.Name).toBeUndefined();
+      expect(options?.Info).toBeTruthy();
+    });
+
+    it('should return an error box for non-numeric input "abc"', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('abc', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Code).toBe('abc');
+      expect(options?.Info).toBeTruthy();
+    });
+
+    it('should use ::httpcode option key as an alias', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('200', {
+        httpcode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Name).toBe('OK');
+    });
+
+    it('should include k: v plaintext lines in plaintextOutput for headless TUI', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('404', {
+        httpstatus: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { plaintextOutput } = boxes[0].props;
+      expect(plaintextOutput).toContain('Code: 404');
+      expect(plaintextOutput).toContain('Name: Not Found');
+      expect(plaintextOutput).toContain('Category: Client Error');
+    });
+
+    it('should set priority from source priority', async () => {
+      const boxes = await HttpStatusBoxSource.generateBoxes('200', {
+        httpstatus: true,
+      });
+      expect(boxes[0].props.priority).toBe(HttpStatusBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/Ieee754BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Ieee754BoxSource.test.ts
@@ -1,0 +1,217 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Ieee754BoxSource } from '../Ieee754BoxSource';
+
+describe('Ieee754BoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Ieee754BoxSource.name).toBe('IEEE 754');
+      expect(Ieee754BoxSource.priority).toBe(10);
+    });
+  });
+
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('3.14', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('3.14', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for unrelated options', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('3.14', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns [] for non-numeric string', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('xyz', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty string', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('', { ieee754: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for partial hex (not 8 or 16 digits)', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0xdeadbeef00', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('float encoding — double (64-bit)', () => {
+    it('3.14 → Double (hex) 0x40091eb851eb851f', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('3.14', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0x40091eb851eb851f',
+      );
+    });
+
+    it('1.0 → Double (hex) 0x3ff0000000000000', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0x3ff0000000000000',
+      );
+    });
+
+    it('0.5 → Double (hex) 0x3fe0000000000000', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0.5', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0x3fe0000000000000',
+      );
+    });
+
+    it('-2 → Double (hex) 0xc000000000000000', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('-2', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0xc000000000000000',
+      );
+    });
+
+    it('NaN → Double (hex) 0x7ff8000000000000', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('NaN', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0x7ff8000000000000',
+      );
+    });
+  });
+
+  describe('float encoding — single (32-bit)', () => {
+    it('0.5 → Single (hex) 0x3f000000', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0.5', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.options?.['Single (hex)']).toBe('0x3f000000');
+    });
+
+    it('includes Single (value) round-trip for 0.5', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0.5', {
+        ieee754: true,
+      });
+      // 0.5 is exactly representable in both precisions
+      expect(boxes[0].props.options?.['Single (value)']).toBe('0.5');
+    });
+  });
+
+  describe('float encoding — output shape', () => {
+    it('box uses KeyValueBoxTemplate', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        ieee754: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is "IEEE 754"', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.name).toBe('IEEE 754');
+    });
+
+    it('options include all five expected keys', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        ieee754: true,
+      });
+      const opts = boxes[0].props.options ?? {};
+      expect(opts).toHaveProperty('Value');
+      expect(opts).toHaveProperty('Double (hex)');
+      expect(opts).toHaveProperty('Double (bits)');
+      expect(opts).toHaveProperty('Single (hex)');
+      expect(opts).toHaveProperty('Single (value)');
+    });
+
+    it('Double (bits) has sign + exponent + mantissa separated by spaces', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        ieee754: true,
+      });
+      const bits = boxes[0].props.options?.['Double (bits)'] as string;
+      const parts = bits.split(' ');
+      expect(parts).toHaveLength(3);
+      expect(parts[0]).toHaveLength(1); // sign: 1 bit
+      expect(parts[1]).toHaveLength(11); // exponent: 11 bits
+      expect(parts[2]).toHaveLength(52); // mantissa: 52 bits
+    });
+
+    it('triggers on ::floatbits option as well', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        floatbits: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0x3ff0000000000000',
+      );
+    });
+  });
+
+  describe('hex decode — double (16 hex digits)', () => {
+    it('0x40091eb851eb851f → Value 3.14', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0x40091eb851eb851f', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Value).toBe('3.14');
+      expect(boxes[0].props.options?.Type).toBe('double');
+    });
+
+    it('0x3ff0000000000000 → Value 1', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0x3ff0000000000000', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.options?.Value).toBe('1');
+    });
+  });
+
+  describe('hex decode — single (8 hex digits)', () => {
+    it('0x3f000000 → Value 0.5, Type single', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0x3f000000', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Value).toBe('0.5');
+      expect(boxes[0].props.options?.Type).toBe('single');
+    });
+  });
+
+  describe('hex decode — output shape', () => {
+    it('box uses KeyValueBoxTemplate', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0x3f000000', {
+        ieee754: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('options include Hex, Value, Type keys', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0x3f000000', {
+        ieee754: true,
+      });
+      const opts = boxes[0].props.options ?? {};
+      expect(opts).toHaveProperty('Hex');
+      expect(opts).toHaveProperty('Value');
+      expect(opts).toHaveProperty('Type');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/MarkdownToHtmlBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MarkdownToHtmlBoxSource.test.ts
@@ -177,5 +177,21 @@ describe('MarkdownToHtmlBoxSource', () => {
         );
       }
     });
+
+    it('a language-tagged closing fence still closes the code block', async () => {
+      const md = '```python\ncode\n```python\n# real';
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes(md, {
+        md2html: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('<h1>real</h1>');
+    });
+
+    it('strips a javascript: href from a link', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes(
+        '[x](javascript:alert(1))',
+        { md2html: true },
+      );
+      expect(boxes[0].props.plaintextOutput).not.toContain('javascript:');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/MarkdownToHtmlBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MarkdownToHtmlBoxSource.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import { MarkdownToHtmlBoxSource } from '../MarkdownToHtmlBoxSource';
+
+describe('MarkdownToHtmlBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes(
+        '# Title',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is provided', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('# Title', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('', {
+        md2html: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts atx heading with ::md2html option', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('# Title', {
+        md2html: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('<h1>Title</h1>');
+    });
+
+    it('converts atx heading with ::markdownhtml option', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('## Section', {
+        markdownhtml: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('<h2>Section</h2>');
+    });
+
+    it('converts bold with **', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('**bold**', {
+        md2html: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('<strong>bold</strong>');
+    });
+
+    it('converts bold with __', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('__bold__', {
+        md2html: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('<strong>bold</strong>');
+    });
+
+    it('converts italic with *', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('*italic*', {
+        md2html: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('<em>italic</em>');
+    });
+
+    it('converts italic with _', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('_italic_', {
+        md2html: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('<em>italic</em>');
+    });
+
+    it('converts inline code', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes(
+        'inline `code` here',
+        { md2html: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toContain('<code>code</code>');
+    });
+
+    it('converts links', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes(
+        '[link](https://x.com)',
+        { md2html: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toContain(
+        '<a href="https://x.com">link</a>',
+      );
+    });
+
+    it('html-escapes text content (& and <)', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('a < b & c', {
+        md2html: true,
+      });
+      const html = boxes[0].props.plaintextOutput;
+      expect(html).toContain('&lt;');
+      expect(html).toContain('&amp;');
+      expect(html).not.toContain('<b');
+    });
+
+    it('wraps unordered list items in <ul>', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes(
+        '- one\n- two',
+        { md2html: true },
+      );
+      const html = boxes[0].props.plaintextOutput;
+      expect(html).toContain('<ul>');
+      const liMatches = html.match(/<li>/g);
+      expect(liMatches).toHaveLength(2);
+      expect(html).toContain('<li>one</li>');
+      expect(html).toContain('<li>two</li>');
+    });
+
+    it('wraps ordered list items in <ol>', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes(
+        '1. first\n2. second',
+        { md2html: true },
+      );
+      const html = boxes[0].props.plaintextOutput;
+      expect(html).toContain('<ol>');
+      expect(html).toContain('<li>first</li>');
+      expect(html).toContain('<li>second</li>');
+    });
+
+    it('escapes fenced code block content and does not apply inline rules inside', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes(
+        '```\n<x>\n```',
+        { md2html: true },
+      );
+      const html = boxes[0].props.plaintextOutput;
+      expect(html).toContain('<pre><code>');
+      expect(html).toContain('&lt;x&gt;');
+      // the raw tag must not appear in output
+      expect(html).not.toContain('<x>');
+    });
+
+    it('sets CodeBoxTemplate on the returned box', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('# H', {
+        md2html: true,
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+
+    it('sets priority on the returned box', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('# H', {
+        md2html: true,
+      });
+      expect(boxes[0].props.priority).toBe(MarkdownToHtmlBoxSource.priority);
+    });
+
+    it('wraps plain text in a paragraph', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes('Hello world', {
+        md2html: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('<p>Hello world</p>');
+    });
+
+    it('handles multiple blocks separated by blank lines', async () => {
+      const boxes = await MarkdownToHtmlBoxSource.generateBoxes(
+        '# Title\n\nSome text.',
+        { md2html: true },
+      );
+      const html = boxes[0].props.plaintextOutput;
+      expect(html).toContain('<h1>Title</h1>');
+      expect(html).toContain('<p>Some text.</p>');
+    });
+
+    it('handles all heading levels h1–h6', async () => {
+      for (let level = 1; level <= 6; level++) {
+        const hashes = '#'.repeat(level);
+        const boxes = await MarkdownToHtmlBoxSource.generateBoxes(
+          `${hashes} Heading`,
+          { md2html: true },
+        );
+        expect(boxes[0].props.plaintextOutput).toBe(
+          `<h${level}>Heading</h${level}>`,
+        );
+      }
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/SqlCreateTableBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SqlCreateTableBoxSource.test.ts
@@ -1,0 +1,116 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { SqlCreateTableBoxSource } from '../SqlCreateTableBoxSource';
+
+describe('SqlCreateTableBoxSource', () => {
+  it('returns [] when no trigger option is present', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{"id":1}', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] when unrelated option is present', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{"id":1}', {
+      base64: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('infers types from a simple object with ::sqltable', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes(
+      '{"id":1,"name":"Bob","active":true}',
+      { sqltable: 'users' },
+    );
+    expect(boxes).toHaveLength(1);
+    const sql = boxes[0].props.plaintextOutput;
+    expect(sql).toContain('CREATE TABLE "users"');
+    expect(sql).toContain('"id" INTEGER PRIMARY KEY');
+    expect(sql).toContain('"name" TEXT');
+    expect(sql).toContain('"active" BOOLEAN');
+  });
+
+  it('infers DOUBLE PRECISION for a float column', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{"price":1.5}', {
+      sqltable: 'p',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toContain(
+      '"price" DOUBLE PRECISION',
+    );
+  });
+
+  it('unions columns from an array of objects', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes(
+      '[{"a":1},{"b":"x"}]',
+      { sqltable: 't' },
+    );
+    expect(boxes).toHaveLength(1);
+    const sql = boxes[0].props.plaintextOutput;
+    expect(sql).toContain('"a" INTEGER');
+    expect(sql).toContain('"b" TEXT');
+  });
+
+  it('uses "my_table" when ::sqltable has no value', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{"x":1}', {
+      sqltable: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toContain('CREATE TABLE "my_table"');
+  });
+
+  it('uses "my_table" when ::sqltable value contains only invalid characters', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{"x":1}', {
+      sqltable: '!!!',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toContain('CREATE TABLE "my_table"');
+  });
+
+  it('returns an error box for invalid JSON', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{bad', {
+      sqltable: 'x',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toContain(
+      'Error: invalid JSON input',
+    );
+  });
+
+  it('triggers on ::createtable as an alias', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{"id":1}', {
+      createtable: 'things',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toContain('CREATE TABLE "things"');
+  });
+
+  it('uses CodeBoxTemplate', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{"id":1}', {
+      sqltable: 'users',
+    });
+    expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+  });
+
+  it('sets sql language option', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{"id":1}', {
+      sqltable: 'users',
+    });
+    expect(boxes[0].props.options).toEqual({ language: 'sql' });
+  });
+
+  it('sets priority', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{"id":1}', {
+      sqltable: 'users',
+    });
+    expect(boxes[0].props.priority).toBe(10);
+  });
+
+  it('strips invalid characters from table name', async () => {
+    const boxes = await SqlCreateTableBoxSource.generateBoxes('{"x":1}', {
+      sqltable: 'my-table!',
+    });
+    expect(boxes).toHaveLength(1);
+    // hyphens and ! stripped → "mytable"
+    expect(boxes[0].props.plaintextOutput).toContain('CREATE TABLE "mytable"');
+  });
+});

--- a/src/modules/boxSources/__test__/TwosComplementBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TwosComplementBoxSource.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import { TwosComplementBoxSource } from '../TwosComplementBoxSource';
+
+describe('TwosComplementBoxSource', () => {
+  describe('no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe("-42 @ 8-bit — known two's complement vector", () => {
+    it('produces correct Binary, Hex, Unsigned for -42 with ::twoscomplement=8', async () => {
+      // -42 in 8-bit two's complement: (-42) & 0xFF = 214 = 0b11010110 = 0xd6
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {
+        twoscomplement: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Binary).toBe('11010110');
+      expect(opts.Hex).toBe('0xd6');
+      expect(opts.Unsigned).toBe('214');
+      expect(opts['Bit Width']).toBe('8');
+      expect(opts.Value).toBe('-42');
+    });
+  });
+
+  describe('42 @ 8-bit with ::twos alias', () => {
+    it('produces correct Binary and Unsigned for positive 42', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('42', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Binary).toBe('00101010');
+      expect(opts.Unsigned).toBe('42');
+    });
+  });
+
+  describe('-1 @ 8-bit', () => {
+    it('all bits set: Binary 11111111, Hex 0xff, Unsigned 255', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-1', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Binary).toBe('11111111');
+      expect(opts.Hex).toBe('0xff');
+      expect(opts.Unsigned).toBe('255');
+    });
+  });
+
+  describe('-1 @ 16-bit', () => {
+    it('all 16 bits set, Unsigned 65535', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-1', {
+        twos: '16',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Binary).toBe('1111111111111111');
+      expect(opts.Unsigned).toBe('65535');
+    });
+  });
+
+  describe('default width 8', () => {
+    it('uses 8 bits when option has no numeric value', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('5', {
+        twoscomplement: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Binary).toBe('00000101');
+      expect(opts['Bit Width']).toBe('8');
+    });
+  });
+
+  describe('out of range', () => {
+    it('returns an error box for 200 in 8-bit (max signed = 127)', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('200', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+      // error message should mention "fit" or the word "8"
+      expect(opts.Error).toMatch(/fit|8/i);
+    });
+
+    it('returns an error box for -200 in 8-bit (min signed = -128)', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-200', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+      expect(opts.Error).toMatch(/fit|8/i);
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns empty array for non-integer input', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('abc', {
+        twoscomplement: '8',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for float input', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('3.14', {
+        twoscomplement: '8',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(TwosComplementBoxSource.name).toBe("Two's Complement");
+      expect(TwosComplementBoxSource.tag).toBe('#');
+      expect(TwosComplementBoxSource.kind).toBe('Convert');
+      expect(typeof TwosComplementBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/UuidParseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UuidParseBoxSource.test.ts
@@ -1,0 +1,178 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { UuidParseBoxSource } from '../UuidParseBoxSource';
+
+describe('UuidParseBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no option is present', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is present', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        { base64: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns an error box for a non-UUID string', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes('not-a-uuid', {
+        uuidparse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/valid UUID/i);
+    });
+
+    it('returns an error box for empty input', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes('', {
+        uuidparse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/valid UUID/i);
+    });
+  });
+
+  describe('generateBoxes — v4 UUID', () => {
+    const v4 = '550e8400-e29b-41d4-a716-446655440000';
+
+    it('detects version 4', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(v4, {
+        uuidparse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Version).toBe('4');
+    });
+
+    it('detects RFC 4122 variant (char "a" at index 19 → bits 1010)', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(v4, {
+        uuidparse: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Variant).toContain('RFC 4122');
+    });
+
+    it('does not include a Timestamp key for v4', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(v4, {
+        uuidparse: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Timestamp).toBeUndefined();
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(v4, {
+        uuidparse: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('also triggers on ::uuidinfo option key', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(v4, {
+        uuidinfo: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes — v1 UUID (6ba7b810-9dad-11d1-80b4-00c04fd430c8)', () => {
+    // RFC namespace DNS UUID — a real v1 UUID generated circa 1998-02
+    const v1 = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
+    it('detects version 1', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(v1, {
+        uuidparse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Version).toBe('1');
+    });
+
+    it('includes a Timestamp key for v1', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(v1, {
+        uuidparse: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Timestamp).toBeDefined();
+    });
+
+    it('decodes the timestamp to ~1998 (RFC namespace UUIDs were generated 1998-02)', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(v1, {
+        uuidparse: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Timestamp).toMatch(/^1998-/);
+    });
+  });
+
+  describe('generateBoxes — minimal v1 UUID', () => {
+    // all-zero except version nibble = 1; variant nibble = 8 (RFC 4122)
+    const minV1 = '00000000-0000-1000-8000-000000000000';
+
+    it('detects version 1', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(minV1, {
+        uuidparse: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Version).toBe('1');
+    });
+
+    it('includes a Timestamp key', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(minV1, {
+        uuidparse: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Timestamp).toBeDefined();
+    });
+  });
+
+  describe('generateBoxes — nil UUID', () => {
+    const nil = '00000000-0000-0000-0000-000000000000';
+
+    it('reports version as "0 (nil)"', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(nil, {
+        uuidparse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Version).toContain('0');
+      expect(opts.Version).toContain('nil');
+    });
+
+    it('does not include a Timestamp key for nil UUID', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(nil, {
+        uuidparse: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Timestamp).toBeUndefined();
+    });
+  });
+
+  describe('generateBoxes — priority and box name', () => {
+    it('sets priority to 10', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        { uuidparse: true },
+      );
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('names the box "UUID Parse"', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        { uuidparse: true },
+      );
+      expect(boxes[0].props.name).toBe('UUID Parse');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/UuidParseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UuidParseBoxSource.test.ts
@@ -174,5 +174,13 @@ describe('UuidParseBoxSource', () => {
       );
       expect(boxes[0].props.name).toBe('UUID Parse');
     });
+
+    it('renders k:v lines into plaintextOutput (not blank) for the TUI', async () => {
+      const boxes = await UuidParseBoxSource.generateBoxes(
+        '550e8400-e29b-41d4-a716-446655440000',
+        { uuidparse: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toContain('Version: 4');
+    });
   });
 });

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -4,13 +4,18 @@ import {
 } from './Base64BoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
+import CssToJsBoxSource from './CssToJsBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DiceRollBoxSource from './DiceRollBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HttpStatusBoxSource from './HttpStatusBoxSource';
+import Ieee754BoxSource from './Ieee754BoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import MarkdownToHtmlBoxSource from './MarkdownToHtmlBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
@@ -18,10 +23,13 @@ import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SqlCreateTableBoxSource from './SqlCreateTableBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import TwosComplementBoxSource from './TwosComplementBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
+import UuidParseBoxSource from './UuidParseBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -29,15 +37,20 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  CssToJsBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  DiceRollBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HttpStatusBoxSource,
+  Ieee754BoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  MarkdownToHtmlBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
@@ -45,9 +58,12 @@ export const boxSources = [
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
+  SqlCreateTableBoxSource,
   TimeFormatBoxSource,
+  TwosComplementBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
+  UuidParseBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,


### PR DESCRIPTION
## Summary

Eighteenth exploration batch — **8 more BoxSource tools** (web, numerics, dev utilities).

| Tool | Trigger | What it does |
|------|---------|--------------|
| HTTP Status | `::httpstatus` | code → name / category / description |
| IEEE 754 | `::ieee754` | float → bit pattern, or hex → float |
| UUID Parse | `::uuidparse` | version / variant / v1 timestamp |
| CSS to JS | `::cssjs` | CSS declarations ⇄ React style object |
| Markdown to HTML | `::md2html` | MD subset → HTML |
| JSON to SQL Table | `::sqltable=NAME` | infer `CREATE TABLE` |
| Dice Roll | `::roll` | dice notation (e.g. `2d6+3`) |
| Two's Complement | `::twoscomplement=BITS` | signed int → N-bit pattern |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules — KeyValue sources render `k: v` plaintext (not JSON), `BigInt(str)` not `BigInt(parseInt)`, **linear regexes only** (md→html avoids ReDoS), **HTML-escape generated markup**, **quote SQL identifiers**, **unbiased dice** (crypto rejection sampling), prototype-key defensiveness on the SQL generator.
- **Verified vectors**: `404`→Not Found; **`3.14`→`0x40091eb851eb851f`, `1.0`→`0x3ff0000000000000`** (exact IEEE-754); `6ba7b810-9dad-11d1-…`→v1, 1998 timestamp; **`-42`@8-bit→`11010110`/`0xd6`/`214`**, `-1`@8→`11111111`.
- Self-review fixed a `Uint32Array<ArrayBuffer>` annotation so `crypto.getRandomValues` type-checks (TS 5.7 typed-array generics).

## Verification

- ✅ `bun run test run` — **456 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#276 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6