### PR TITLE
feat(boxSources): add 8 more tools (jwt-verify, email-parse, mime-type, ip-in-cidr, entropy, hamming, unicode-normalize, damm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>JwtVerifyBox</b> </summary>
+
+| match rule          | description                          | example                       |
+| ------------------- | ------------------------------------ | ----------------------------- |
+| `::jwtverify=SECRET`| verify an HS256 JWT signature        | `<token> ::jwtverify=secret`  |
+
+</details>
+
+<details>
+<summary> <b>EmailParseBox</b> </summary>
+
+| match rule       | description                          | example                       |
+| ---------------- | ------------------------------------ | ----------------------------- |
+| `::emailparse`   | parse email into local/domain/TLD    | `a+tag@b.example.com ::emailparse` |
+
+</details>
+
+<details>
+<summary> <b>MimeTypeBox</b> </summary>
+
+| match rule     | description                          | example          |
+| -------------- | ------------------------------------ | ---------------- |
+| `::mimetype`   | extension ⇄ MIME type                | `png ::mimetype` |
+
+</details>
+
+<details>
+<summary> <b>IpInCidrBox</b> </summary>
+
+| match rule          | description                          | example                          |
+| ------------------- | ------------------------------------ | -------------------------------- |
+| `::ipincidr=CIDR`   | is an IPv4 address within a CIDR     | `10.0.0.5 ::ipincidr=10.0.0.0/24` |
+
+</details>
+
+<details>
+<summary> <b>ShannonEntropyBox</b> </summary>
+
+| match rule   | description                          | example               |
+| ------------ | ------------------------------------ | --------------------- |
+| `::entropy`  | Shannon entropy (bits/symbol)        | `aaaabbbbcccd ::entropy` |
+
+</details>
+
+<details>
+<summary> <b>HammingDistanceBox</b> </summary>
+
+| match rule   | description                          | example                       |
+| ------------ | ------------------------------------ | ----------------------------- |
+| `::hamming`  | Hamming distance of two equal-length lines | `karolin`<br>`kathrin ::hamming` |
+
+</details>
+
+<details>
+<summary> <b>UnicodeNormalizeBox</b> </summary>
+
+| match rule        | description                          | example                  |
+| ----------------- | ------------------------------------ | ------------------------ |
+| `::normalize=FORM`| Unicode normalize (NFC/NFD/NFKC/NFKD) | `café ::normalize=nfd`  |
+
+</details>
+
+<details>
+<summary> <b>DammBox</b> </summary>
+
+| match rule  | description                          | example         |
+| ----------- | ------------------------------------ | --------------- |
+| `::damm`    | Damm check digit compute/validate    | `572 ::damm`    |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/DammBoxSource.ts
+++ b/src/modules/boxSources/DammBoxSource.ts
@@ -47,7 +47,7 @@ export const DammBoxSource = {
 
     const cleaned = trim(input);
 
-    if (!/^\d+$/.test(cleaned) || cleaned.length === 0) {
+    if (!/^\d+$/.test(cleaned)) {
       const reason = 'Input must contain digits only (0–9).';
       return [
         new BoxBuilder('Damm Check', reason)

--- a/src/modules/boxSources/DammBoxSource.ts
+++ b/src/modules/boxSources/DammBoxSource.ts
@@ -1,0 +1,97 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// the standard Damm operation table (totally anti-symmetric quasigroup, order 10)
+const TABLE: number[][] = [
+  [0, 3, 1, 7, 5, 9, 8, 6, 4, 2],
+  [7, 0, 9, 2, 1, 5, 4, 8, 6, 3],
+  [4, 2, 0, 6, 8, 7, 1, 3, 5, 9],
+  [1, 7, 5, 0, 9, 8, 3, 4, 2, 6],
+  [6, 1, 2, 3, 0, 4, 5, 9, 7, 8],
+  [3, 6, 7, 4, 2, 0, 9, 5, 8, 1],
+  [5, 8, 6, 9, 7, 2, 0, 1, 3, 4],
+  [8, 9, 4, 5, 3, 6, 2, 0, 1, 7],
+  [9, 4, 3, 8, 6, 1, 7, 2, 0, 5],
+  [2, 5, 8, 1, 4, 3, 6, 7, 9, 0],
+];
+
+// runs the Damm algorithm over a digit string and returns the interim value;
+// a final interim of 0 means the input is Damm-valid (already includes a correct check digit)
+function dammInterim(digits: string): number {
+  let interim = 0;
+  for (const ch of digits) {
+    const d = Number.parseInt(ch, 10);
+    interim = TABLE[interim][d];
+  }
+  return interim;
+}
+
+export const DammBoxSource = {
+  name: 'Damm Check',
+  description:
+    'Compute a Damm check digit for a number, or validate a number that already includes one.',
+  defaultInput: '572 ::damm',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'damm')) return [];
+
+    const cleaned = trim(input);
+
+    if (!/^\d+$/.test(cleaned) || cleaned.length === 0) {
+      const reason = 'Input must contain digits only (0–9).';
+      return [
+        new BoxBuilder('Damm Check', reason)
+          .setOptions({ Error: reason })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (cleaned.length > 1000) {
+      const reason = 'Input exceeds maximum length of 1000 digits.';
+      return [
+        new BoxBuilder('Damm Check', reason)
+          .setOptions({ Error: reason })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const interim = dammInterim(cleaned);
+    const isValid = interim === 0;
+    // the interim over the input equals the check digit to append, which drives interim to 0
+    const checkDigit = String(interim);
+
+    const kvOptions: Record<string, string> = {
+      Input: cleaned,
+      Valid: String(isValid),
+      'Check Digit': checkDigit,
+    };
+
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Damm Check', plaintextOutput)
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DammBoxSource;

--- a/src/modules/boxSources/EmailParseBoxSource.ts
+++ b/src/modules/boxSources/EmailParseBoxSource.ts
@@ -1,0 +1,95 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 1000;
+
+// /^[^\s@]+$/ and /^[^\s@]+\.[^\s@]+$/ are linear — no nested quantifiers
+const LOCAL_RE = /^[^\s@]+$/;
+const DOMAIN_RE = /^[^\s@]+\.[^\s@]+$/;
+
+interface ParsedEmail {
+  local: string;
+  domain: string;
+  tld: string;
+  baseLocal: string;
+  tag: string | null;
+  valid: boolean;
+}
+
+function parseEmail(raw: string): ParsedEmail {
+  const at = raw.lastIndexOf('@');
+
+  if (at <= 0 || at === raw.length - 1) {
+    return {
+      local: raw,
+      domain: '',
+      tld: '',
+      baseLocal: raw,
+      tag: null,
+      valid: false,
+    };
+  }
+
+  const local = raw.slice(0, at);
+  const domain = raw.slice(at + 1);
+  const valid = LOCAL_RE.test(local) && DOMAIN_RE.test(domain);
+
+  const dotIdx = domain.lastIndexOf('.');
+  const tld = dotIdx !== -1 ? domain.slice(dotIdx + 1) : domain;
+
+  const plusIdx = local.indexOf('+');
+  const baseLocal = plusIdx !== -1 ? local.slice(0, plusIdx) : local;
+  const tag = plusIdx !== -1 ? local.slice(plusIdx + 1) : null;
+
+  return { local, domain, tld, baseLocal, tag, valid };
+}
+
+export const EmailParseBoxSource = {
+  name: 'Email Parse',
+  description:
+    'Parse an email address into local part, domain, and TLD, with a basic validity check.',
+  defaultInput: 'john.doe+news@mail.example.co.uk ::emailparse',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'emailparse', 'email')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const raw = trim(input);
+    const parsed = parseEmail(raw);
+
+    const kv: Record<string, string> = {
+      Local: parsed.local || raw,
+      Domain: parsed.domain,
+      TLD: parsed.tld,
+      Valid: String(parsed.valid),
+    };
+
+    if (parsed.tag !== null) {
+      kv.Tag = parsed.tag;
+    }
+
+    // plaintext k:v lines mirror the key-value pairs for copy/headless use
+    const plaintext = Object.entries(kv)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Email Parse', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default EmailParseBoxSource;

--- a/src/modules/boxSources/EmailParseBoxSource.ts
+++ b/src/modules/boxSources/EmailParseBoxSource.ts
@@ -74,6 +74,7 @@ export const EmailParseBoxSource = {
     };
 
     if (parsed.tag !== null) {
+      kv.Base = parsed.baseLocal;
       kv.Tag = parsed.tag;
     }
 

--- a/src/modules/boxSources/HammingDistanceBoxSource.ts
+++ b/src/modules/boxSources/HammingDistanceBoxSource.ts
@@ -1,0 +1,95 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 20_000;
+
+export const HammingDistanceBoxSource = {
+  name: 'Hamming Distance',
+  description:
+    'Hamming distance between two equal-length strings (newline-separated).',
+  defaultInput: 'karolin\nkathrin ::hamming',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hamming')) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
+
+    // split on the first newline only
+    const newlineIdx = input.indexOf('\n');
+
+    if (newlineIdx === -1) {
+      return [
+        new BoxBuilder(
+          'Hamming Distance',
+          'Two newline-separated strings are required.',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({
+            Info: 'Two newline-separated strings are required.',
+          })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const a = input.slice(0, newlineIdx);
+    const b = input.slice(newlineIdx + 1);
+
+    if (a.length !== b.length) {
+      return [
+        new BoxBuilder(
+          'Hamming Distance',
+          `Hamming distance requires equal-length strings (got ${a.length} and ${b.length}).`,
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({
+            Info: `Hamming distance requires equal-length strings (got ${a.length} and ${b.length}).`,
+          })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // count positions where code units differ
+    let distance = 0;
+    for (let i = 0; i < a.length; i++) {
+      if (a.charCodeAt(i) !== b.charCodeAt(i)) {
+        distance++;
+      }
+    }
+
+    const length = a.length;
+    const similarity = length === 0 ? 1 : 1 - distance / length;
+
+    const similarityPct = `${(similarity * 100).toFixed(1)}%`;
+
+    const kv: Record<string, string> = {
+      Distance: String(distance),
+      Length: String(length),
+      Similarity: similarityPct,
+    };
+
+    // plaintext k:v lines for copy/headless use
+    const plaintext = Object.entries(kv)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Hamming Distance', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HammingDistanceBoxSource;

--- a/src/modules/boxSources/HammingDistanceBoxSource.ts
+++ b/src/modules/boxSources/HammingDistanceBoxSource.ts
@@ -9,7 +9,7 @@ const MAX_INPUT = 20_000;
 export const HammingDistanceBoxSource = {
   name: 'Hamming Distance',
   description:
-    'Hamming distance between two equal-length strings (newline-separated).',
+    'Hamming distance between two equal-length strings (newline-separated, by UTF-16 code unit).',
   defaultInput: 'karolin\nkathrin ::hamming',
   tag: '#',
   kind: 'Analyze',

--- a/src/modules/boxSources/IpInCidrBoxSource.ts
+++ b/src/modules/boxSources/IpInCidrBoxSource.ts
@@ -112,12 +112,13 @@ export const IpInCidrBoxSource = {
       ];
     }
 
-    const { mask, network, broadcast } = parsed;
+    const { prefix, mask, network, broadcast } = parsed;
     const inRange = (ipInt & mask) >>> 0 === network;
 
     const kvOptions: Record<string, string> = {
       IP: ipStr,
-      CIDR: cidrRaw as string,
+      // show the canonical network/prefix form, not the raw input
+      CIDR: `${uint32ToIp(network)}/${prefix}`,
       Network: uint32ToIp(network),
       Broadcast: uint32ToIp(broadcast),
       'In Range': String(inRange),

--- a/src/modules/boxSources/IpInCidrBoxSource.ts
+++ b/src/modules/boxSources/IpInCidrBoxSource.ts
@@ -1,0 +1,141 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// converts a dotted IPv4 string to an unsigned 32-bit integer, or null if invalid
+function ipToUint32(ip: string): number | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+
+  let result = 0;
+  for (const part of parts) {
+    const octet = Number.parseInt(part, 10);
+    if (
+      Number.isNaN(octet) ||
+      octet < 0 ||
+      octet > 255 ||
+      part.trim() !== String(octet)
+    ) {
+      return null;
+    }
+    result = ((result << 8) | octet) >>> 0;
+  }
+  return result;
+}
+
+// converts an unsigned 32-bit integer to dotted IPv4 notation
+function uint32ToIp(n: number): string {
+  return [
+    (n >>> 24) & 0xff,
+    (n >>> 16) & 0xff,
+    (n >>> 8) & 0xff,
+    n & 0xff,
+  ].join('.');
+}
+
+interface ParsedCidr {
+  cidrInt: number;
+  prefix: number;
+  mask: number;
+  network: number;
+  broadcast: number;
+}
+
+// parses a CIDR string "A.B.C.D/P" and derives mask, network, and broadcast
+function parseCidr(cidr: string): ParsedCidr | null {
+  const slashIdx = cidr.lastIndexOf('/');
+  if (slashIdx === -1) return null;
+
+  const ipPart = cidr.slice(0, slashIdx);
+  const prefixPart = cidr.slice(slashIdx + 1);
+  const prefix = Number.parseInt(prefixPart, 10);
+
+  if (
+    Number.isNaN(prefix) ||
+    prefix < 0 ||
+    prefix > 32 ||
+    prefixPart.trim() !== String(prefix)
+  ) {
+    return null;
+  }
+
+  const cidrInt = ipToUint32(ipPart);
+  if (cidrInt === null) return null;
+
+  // a /0 mask is all zeros; otherwise shift and zero-extend to uint32
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  const network = (cidrInt & mask) >>> 0;
+  const broadcast = (network | (~mask >>> 0)) >>> 0;
+
+  return { cidrInt, prefix, mask, network, broadcast };
+}
+
+export const IpInCidrBoxSource = {
+  name: 'IP in CIDR',
+  description:
+    'Check whether an IPv4 address is within a CIDR range. e.g. 10.0.0.5 ::ipincidr=10.0.0.0/24',
+  defaultInput: '10.0.0.5 ::ipincidr=10.0.0.0/24',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ipincidr', 'incidr')) return [];
+
+    const cidrRaw = extractOptionKeys(options, 'ipincidr', 'incidr');
+    const ipStr = trim(input);
+
+    // validate both ip and cidr before computing
+    const ipInt = ipToUint32(ipStr);
+    const parsed = typeof cidrRaw === 'string' ? parseCidr(cidrRaw) : null;
+
+    if (ipInt === null || parsed === null) {
+      const reason =
+        ipInt === null && parsed === null
+          ? 'Invalid IPv4 address and CIDR.'
+          : ipInt === null
+            ? 'Invalid IPv4 address. Expected format: A.B.C.D (each octet 0-255).'
+            : 'Invalid CIDR. Expected format: A.B.C.D/P (prefix 0-32).';
+
+      return [
+        new BoxBuilder('IP in CIDR', reason)
+          .setOptions({ Error: reason })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { mask, network, broadcast } = parsed;
+    const inRange = (ipInt & mask) >>> 0 === network;
+
+    const kvOptions: Record<string, string> = {
+      IP: ipStr,
+      CIDR: cidrRaw as string,
+      Network: uint32ToIp(network),
+      Broadcast: uint32ToIp(broadcast),
+      'In Range': String(inRange),
+    };
+
+    // plaintext k:v for headless/TUI consumers
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('IP in CIDR', plaintextOutput)
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default IpInCidrBoxSource;

--- a/src/modules/boxSources/JwtVerifyBoxSource.ts
+++ b/src/modules/boxSources/JwtVerifyBoxSource.ts
@@ -171,10 +171,15 @@ export const JwtVerifyBoxSource = {
       expired = payload.exp < Math.floor(Date.now() / 1000) ? 'true' : 'false';
     }
 
+    // keep the k:v value short; long payloads are truncated with an ellipsis
+    const payloadStr = JSON.stringify(payload);
+    const payloadDisplay =
+      payloadStr.length > 200 ? `${payloadStr.slice(0, 197)}...` : payloadStr;
+
     const data: Record<string, string> = {
       Signature: signatureValid ? 'valid' : 'invalid',
       Algorithm: String(header.alg),
-      Payload: JSON.stringify(payload),
+      Payload: payloadDisplay,
       Expired: expired,
     };
 

--- a/src/modules/boxSources/JwtVerifyBoxSource.ts
+++ b/src/modules/boxSources/JwtVerifyBoxSource.ts
@@ -1,0 +1,191 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 20;
+const MAX_INPUT = 100_000;
+
+// converts a base64url string to a regular base64 string, then decodes it
+function base64urlDecode(str: string): string {
+  const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64.padEnd(
+    base64.length + ((4 - (base64.length % 4)) % 4),
+    '=',
+  );
+  return atob(padded);
+}
+
+// encodes an ArrayBuffer as a base64url string (no padding)
+function bufToBase64url(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+// recomputes the HMAC-SHA256 signature over `${header}.${payload}` with the given secret
+async function computeHmacSha256(
+  message: string,
+  secret: string,
+): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(message));
+  return bufToBase64url(sig);
+}
+
+// builds `k: v` plaintext lines from a record, preserving insertion order
+function buildPlaintextLines(data: Record<string, string>): string {
+  return Object.entries(data)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const JwtVerifyBoxSource = {
+  name: 'JWT Verify',
+  description:
+    'Verify an HS256 JWT signature against a secret and decode the payload. token ::jwtverify=secret',
+  defaultInput:
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c ::jwtverify=your-256-bit-secret',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jwtverify')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // guard for non-secure contexts where crypto.subtle is unavailable
+    if (typeof crypto === 'undefined' || !crypto.subtle) {
+      return [
+        new BoxBuilder(
+          'JWT Verify',
+          'JWT verification requires a secure context (HTTPS). crypto.subtle is not available.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const secretValue = extractOptionKeys(options, 'jwtverify');
+    if (
+      !secretValue ||
+      secretValue === true ||
+      String(secretValue).trim() === ''
+    ) {
+      return [
+        new BoxBuilder(
+          'JWT Verify',
+          'A secret is required. Usage: <token> ::jwtverify=<secret>',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+    const secret = String(secretValue);
+
+    const token = trim(input);
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return [
+        new BoxBuilder(
+          'JWT Verify',
+          'Malformed token: expected 3 dot-separated parts (header.payload.signature).',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const [headerB64, payloadB64, signatureB64] = parts;
+
+    // decode and validate header
+    let header: Record<string, unknown>;
+    try {
+      header = JSON.parse(base64urlDecode(headerB64));
+    } catch {
+      return [
+        new BoxBuilder(
+          'JWT Verify',
+          'Malformed token: could not decode header.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (header.alg !== 'HS256') {
+      return [
+        new BoxBuilder(
+          'JWT Verify',
+          `Only HS256 is supported. Token uses: ${String(header.alg ?? 'unknown')}`,
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // recompute HMAC-SHA256 signature and compare
+    const computed = await computeHmacSha256(
+      `${headerB64}.${payloadB64}`,
+      secret,
+    );
+    const signatureValid = computed === signatureB64;
+
+    // decode payload
+    let payload: Record<string, unknown> = {};
+    try {
+      payload = JSON.parse(base64urlDecode(payloadB64));
+    } catch {
+      // payload is not valid JSON; treat as empty
+    }
+
+    // check token expiry if exp claim is present
+    let expired: 'true' | 'false' | 'n/a' = 'n/a';
+    if (typeof payload.exp === 'number') {
+      expired = payload.exp < Math.floor(Date.now() / 1000) ? 'true' : 'false';
+    }
+
+    const data: Record<string, string> = {
+      Signature: signatureValid ? 'valid' : 'invalid',
+      Algorithm: String(header.alg),
+      Payload: JSON.stringify(payload),
+      Expired: expired,
+    };
+
+    return [
+      new BoxBuilder('JWT Verify', buildPlaintextLines(data))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(data)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JwtVerifyBoxSource;

--- a/src/modules/boxSources/MimeTypeBoxSource.ts
+++ b/src/modules/boxSources/MimeTypeBoxSource.ts
@@ -1,0 +1,201 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// extension (no dot, lowercase) -> mime type
+const EXT_TO_MIME: Record<string, string> = {
+  // text
+  txt: 'text/plain',
+  html: 'text/html',
+  htm: 'text/html',
+  css: 'text/css',
+  csv: 'text/csv',
+  md: 'text/markdown',
+  rtf: 'text/rtf',
+  ics: 'text/calendar',
+  vcf: 'text/vcard',
+  xml: 'text/xml',
+  // javascript / json / data
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  ts: 'text/typescript',
+  tsx: 'text/typescript',
+  jsx: 'text/jsx',
+  json: 'application/json',
+  yaml: 'application/yaml',
+  yml: 'application/yaml',
+  toml: 'application/toml',
+  sql: 'application/sql',
+  // documents
+  pdf: 'application/pdf',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  odt: 'application/vnd.oasis.opendocument.text',
+  ods: 'application/vnd.oasis.opendocument.spreadsheet',
+  odp: 'application/vnd.oasis.opendocument.presentation',
+  epub: 'application/epub+zip',
+  mobi: 'application/x-mobipocket-ebook',
+  // images
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  ico: 'image/x-icon',
+  bmp: 'image/bmp',
+  tiff: 'image/tiff',
+  avif: 'image/avif',
+  heic: 'image/heic',
+  // audio
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  flac: 'audio/flac',
+  aac: 'audio/aac',
+  // video
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  mkv: 'video/x-matroska',
+  // archives
+  zip: 'application/zip',
+  gz: 'application/gzip',
+  tar: 'application/x-tar',
+  rar: 'application/vnd.rar',
+  '7z': 'application/x-7z-compressed',
+  bz2: 'application/x-bzip2',
+  // fonts
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  ttf: 'font/ttf',
+  otf: 'font/otf',
+  eot: 'application/vnd.ms-fontobject',
+  // binaries / executables
+  bin: 'application/octet-stream',
+  exe: 'application/x-msdownload',
+  apk: 'application/vnd.android.package-archive',
+  deb: 'application/vnd.debian.binary-package',
+  dmg: 'application/x-apple-diskimage',
+  iso: 'application/x-iso9660-image',
+  wasm: 'application/wasm',
+  // scripts / source
+  sh: 'application/x-sh',
+  py: 'text/x-python',
+  rb: 'application/x-ruby',
+  go: 'text/x-go',
+  rs: 'text/x-rust',
+  c: 'text/x-c',
+  cpp: 'text/x-c++',
+  java: 'text/x-java-source',
+  php: 'application/x-httpd-php',
+};
+
+// build reverse map once at module load
+const MIME_TO_EXTS: Map<string, string[]> = new Map();
+for (const [ext, mime] of Object.entries(EXT_TO_MIME)) {
+  const existing = MIME_TO_EXTS.get(mime);
+  if (existing) {
+    existing.push(ext);
+  } else {
+    MIME_TO_EXTS.set(mime, [ext]);
+  }
+}
+
+// extract the extension from a raw input string (filename, path, or bare extension)
+function extractExtension(raw: string): string {
+  const base = raw.includes('.') ? raw.slice(raw.lastIndexOf('.') + 1) : raw;
+  return base.toLowerCase();
+}
+
+// derive the broad category from a mime type string (e.g. 'image' from 'image/png')
+function mimeCategory(mime: string): string {
+  return mime.split('/')[0] ?? 'unknown';
+}
+
+export const MimeTypeBoxSource = {
+  name: 'MIME Type',
+  description:
+    'Look up the MIME type for a file extension, or extensions for a MIME type.',
+  defaultInput: 'png ::mimetype',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'mimetype', 'mime')) return [];
+
+    const normalized = trim(input);
+    if (!normalized) return [];
+
+    // if input contains '/' treat it as a mime type -> reverse lookup
+    if (normalized.includes('/')) {
+      const mime = normalized.toLowerCase();
+      const exts = MIME_TO_EXTS.get(mime);
+      const extensionsValue = exts ? exts.join(', ') : 'none known';
+
+      const kv: Record<string, string> = {
+        'MIME Type': mime,
+        Extensions: extensionsValue,
+      };
+      const plaintext = `MIME Type: ${mime}\nExtensions: ${extensionsValue}`;
+
+      return [
+        new BoxBuilder('MIME Type', plaintext)
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // forward lookup: extension -> mime type
+    const ext = extractExtension(normalized);
+    const mime = EXT_TO_MIME[ext];
+
+    if (!mime) {
+      const kv: Record<string, string> = {
+        Extension: ext,
+        'MIME Type': 'unknown',
+        Category: 'unknown',
+      };
+      const plaintext = `Extension: ${ext}\nMIME Type: unknown\nCategory: unknown`;
+
+      return [
+        new BoxBuilder('MIME Type', plaintext)
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const kv: Record<string, string> = {
+      Extension: ext,
+      'MIME Type': mime,
+      Category: mimeCategory(mime),
+    };
+    const plaintext = `Extension: ${ext}\nMIME Type: ${mime}\nCategory: ${mimeCategory(mime)}`;
+
+    return [
+      new BoxBuilder('MIME Type', plaintext)
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default MimeTypeBoxSource;

--- a/src/modules/boxSources/ShannonEntropyBoxSource.ts
+++ b/src/modules/boxSources/ShannonEntropyBoxSource.ts
@@ -1,0 +1,84 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// compute Shannon entropy (bits per symbol) by iterating code points
+function computeEntropy(input: string): {
+  entropy: number;
+  length: number;
+  uniqueSymbols: number;
+  totalBits: number;
+} {
+  const freq = new Map<string, number>();
+  let n = 0;
+  for (const cp of input) {
+    freq.set(cp, (freq.get(cp) ?? 0) + 1);
+    n++;
+  }
+
+  let h = 0;
+  for (const count of freq.values()) {
+    const p = count / n;
+    h -= p * Math.log2(p);
+  }
+
+  return {
+    entropy: h,
+    length: n,
+    uniqueSymbols: freq.size,
+    totalBits: Math.round(h * n),
+  };
+}
+
+export const ShannonEntropyBoxSource = {
+  name: 'Shannon Entropy',
+  description:
+    'Compute the Shannon entropy (bits per symbol) of the input text.',
+  defaultInput: 'aaaabbbbcccd ::entropy',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'entropy', 'shannon')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const { entropy, length, uniqueSymbols, totalBits } = computeEntropy(input);
+
+    const entropyStr = `${entropy.toFixed(3)} bits/symbol`;
+    const lengthStr = `${length} symbols`;
+    const uniqueStr = `${uniqueSymbols}`;
+    const totalBitsStr = `${totalBits}`;
+
+    // plaintext k:v lines for the box content
+    const content = `Entropy: ${entropyStr}
+Length: ${lengthStr}
+Unique Symbols: ${uniqueStr}
+Total Bits: ${totalBitsStr}`;
+
+    const output: Record<string, string> = {
+      Entropy: entropyStr,
+      Length: lengthStr,
+      'Unique Symbols': uniqueStr,
+      'Total Bits': totalBitsStr,
+    };
+
+    return [
+      new BoxBuilder('Shannon Entropy', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ShannonEntropyBoxSource;

--- a/src/modules/boxSources/UnicodeNormalizeBoxSource.ts
+++ b/src/modules/boxSources/UnicodeNormalizeBoxSource.ts
@@ -1,0 +1,67 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// supported Unicode normalization forms
+const FORMS = ['NFC', 'NFD', 'NFKC', 'NFKD'] as const;
+type NormalizationForm = (typeof FORMS)[number];
+
+function resolveForm(raw: string | boolean | null): NormalizationForm {
+  if (
+    typeof raw === 'string' &&
+    (FORMS as readonly string[]).includes(raw.toUpperCase())
+  ) {
+    return raw.toUpperCase() as NormalizationForm;
+  }
+  return 'NFC';
+}
+
+export const UnicodeNormalizeBoxSource = {
+  name: 'Unicode Normalize',
+  description:
+    'Normalize text to a Unicode form (NFC/NFD/NFKC/NFKD). ::normalize=nfc (default NFC).',
+  defaultInput: 'café ::normalize=nfd',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'normalize', 'unicodenormalize')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const raw = extractOptionKeys(options, 'normalize', 'unicodenormalize');
+    const form = resolveForm(raw);
+    const normalized = input.normalize(form);
+
+    const kvOptions: Record<string, string> = {
+      Form: form,
+      Normalized: normalized,
+      'Input Length': String(input.length),
+      'Output Length': String(normalized.length),
+      Changed: String(normalized !== input),
+    };
+
+    // plaintext k:v lines for headless/TUI consumers
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Unicode Normalize', plaintextOutput)
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UnicodeNormalizeBoxSource;

--- a/src/modules/boxSources/__test__/DammBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DammBoxSource.test.ts
@@ -1,0 +1,96 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DammBoxSource } from '../DammBoxSource';
+
+describe('DammBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no trigger option is present', async () => {
+      const boxes = await DammBoxSource.generateBoxes('572', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options exist but no damm key', async () => {
+      const boxes = await DammBoxSource.generateBoxes('572', { hash: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('check digit computation', () => {
+      // canonical Wikipedia Damm example: 572 → check digit 4, so 5724 is Damm-valid
+      it('572 produces check digit 4', async () => {
+        const boxes = await DammBoxSource.generateBoxes('572', { damm: true });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['Check Digit']).toBe('4');
+        expect(boxes[0].props.options?.Valid).toBe('false');
+        expect(boxes[0].props.options?.Input).toBe('572');
+      });
+
+      it('5724 is Damm-valid (interim reduces to 0)', async () => {
+        const boxes = await DammBoxSource.generateBoxes('5724', { damm: true });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Valid).toBe('true');
+        expect(boxes[0].props.options?.['Check Digit']).toBe('0');
+      });
+
+      it('5720 is NOT Damm-valid (wrong check digit)', async () => {
+        const boxes = await DammBoxSource.generateBoxes('5720', { damm: true });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Valid).toBe('false');
+      });
+    });
+
+    describe('single digit edge cases', () => {
+      it('single digit 0: TABLE[0][0]=0 → check digit 0, valid true', async () => {
+        const boxes = await DammBoxSource.generateBoxes('0', { damm: true });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['Check Digit']).toBe('0');
+        expect(boxes[0].props.options?.Valid).toBe('true');
+      });
+
+      it('single digit 5: TABLE[0][5]=9 → check digit 9, not valid', async () => {
+        const boxes = await DammBoxSource.generateBoxes('5', { damm: true });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['Check Digit']).toBe('9');
+        expect(boxes[0].props.options?.Valid).toBe('false');
+      });
+    });
+
+    describe('invalid input', () => {
+      it('non-digit input returns a box explaining digits required', async () => {
+        const boxes = await DammBoxSource.generateBoxes('abc', { damm: true });
+        expect(boxes).toHaveLength(1);
+        const errMsg = boxes[0].props.options?.Error as string;
+        expect(errMsg).toBeTruthy();
+        expect(errMsg.toLowerCase()).toContain('digit');
+      });
+
+      it('mixed alphanumeric input returns an error box', async () => {
+        const boxes = await DammBoxSource.generateBoxes('12a3', { damm: true });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Error).toBeTruthy();
+      });
+    });
+
+    describe('template and priority', () => {
+      it('uses KeyValueBoxTemplate', async () => {
+        const boxes = await DammBoxSource.generateBoxes('572', { damm: true });
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      });
+
+      it('sets priority to 10', async () => {
+        const boxes = await DammBoxSource.generateBoxes('572', { damm: true });
+        expect(boxes[0].props.priority).toBe(10);
+      });
+    });
+
+    describe('plaintext output', () => {
+      it('contains k:v lines for Input, Valid, and Check Digit', async () => {
+        const boxes = await DammBoxSource.generateBoxes('572', { damm: true });
+        const output = boxes[0].props.plaintextOutput;
+        expect(output).toContain('Input: 572');
+        expect(output).toContain('Valid: false');
+        expect(output).toContain('Check Digit: 4');
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/EmailParseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/EmailParseBoxSource.test.ts
@@ -1,0 +1,120 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { EmailParseBoxSource } from '../EmailParseBoxSource';
+
+describe('EmailParseBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(EmailParseBoxSource.name).toBe('Email Parse');
+      expect(EmailParseBoxSource.tag).toBe('#');
+      expect(EmailParseBoxSource.kind).toBe('Analyze');
+      expect(typeof EmailParseBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - option guard', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes(
+        'john.doe@example.com',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes(
+        'john.doe@example.com',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - full address with plus-tag (::emailparse)', () => {
+    it('parses john.doe+news@mail.example.co.uk correctly', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes(
+        'john.doe+news@mail.example.co.uk',
+        { emailparse: true },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Local).toBe('john.doe+news');
+      expect(options?.Domain).toBe('mail.example.co.uk');
+      expect(options?.TLD).toBe('uk');
+      expect(options?.Tag).toBe('news');
+      expect(options?.Valid).toBe('true');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+
+  describe('generateBoxes - simple valid address', () => {
+    it('parses a@b.com with no Tag key', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('a@b.com', {
+        emailparse: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Local).toBe('a');
+      expect(options?.Domain).toBe('b.com');
+      expect(options?.TLD).toBe('com');
+      expect(options?.Valid).toBe('true');
+      // no plus-tag in local part — Tag key must be absent
+      expect(options).not.toHaveProperty('Tag');
+    });
+  });
+
+  describe('generateBoxes - invalid address (no @)', () => {
+    it('marks not-an-email as invalid', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('not-an-email', {
+        emailparse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Valid).toBe('false');
+    });
+  });
+
+  describe('generateBoxes - invalid address (no dot in domain)', () => {
+    it('marks a@b (domain without dot) as invalid', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('a@b', {
+        emailparse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Valid).toBe('false');
+    });
+  });
+
+  describe('generateBoxes - ::email alias', () => {
+    it('triggers on ::email option key', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('a@b.com', {
+        email: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Valid).toBe('true');
+    });
+  });
+
+  describe('generateBoxes - input length guard', () => {
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('a'.repeat(1001), {
+        emailparse: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - plaintext output', () => {
+    it('contains k:v lines matching options', async () => {
+      const boxes = await EmailParseBoxSource.generateBoxes('a@b.com', {
+        emailparse: true,
+      });
+      const { plaintextOutput } = boxes[0].props;
+      expect(plaintextOutput).toContain('Local: a');
+      expect(plaintextOutput).toContain('Domain: b.com');
+      expect(plaintextOutput).toContain('TLD: com');
+      expect(plaintextOutput).toContain('Valid: true');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HammingDistanceBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HammingDistanceBoxSource.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { HammingDistanceBoxSource } from '../HammingDistanceBoxSource';
+
+describe('HammingDistanceBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no hamming option is provided', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin\nkathrin',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin\nkathrin',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - classic string example', () => {
+    it('karolin vs kathrin → Distance 3, Length 7', async () => {
+      // k=k, a=a, r≠t, o≠h, l≠r, i=i, n=n → 3 differences
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin\nkathrin',
+        { hamming: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('3');
+      expect(opts.Length).toBe('7');
+    });
+  });
+
+  describe('generateBoxes - identical strings', () => {
+    it('abc vs abc → Distance 0, Similarity 100.0%', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('abc\nabc', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('0');
+      expect(opts.Similarity).toBe('100.0%');
+    });
+  });
+
+  describe('generateBoxes - classic binary example', () => {
+    it('1011101 vs 1001001 → Distance 2', async () => {
+      // 1=1, 0=0, 1≠0, 1=1, 1≠0, 0=0, 1=1 → 2 differences
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        '1011101\n1001001',
+        { hamming: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('2');
+    });
+  });
+
+  describe('generateBoxes - error cases', () => {
+    it('different-length strings → box mentioning equal-length required', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('ab\nabc', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Info).toMatch(/equal-length/i);
+    });
+
+    it('no newline → box mentioning two strings are required', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('abc', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Info).toMatch(/two newline-separated strings are required/i);
+    });
+  });
+
+  describe('generateBoxes - plaintext output', () => {
+    it('plaintextOutput contains k:v lines', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin\nkathrin',
+        { hamming: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toContain('Distance: 3');
+      expect(boxes[0].props.plaintextOutput).toContain('Length: 7');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HammingDistanceBoxSource.name).toBe('Hamming Distance');
+      expect(HammingDistanceBoxSource.tag).toBe('#');
+      expect(HammingDistanceBoxSource.kind).toBe('Analyze');
+      expect(typeof HammingDistanceBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/IpInCidrBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/IpInCidrBoxSource.test.ts
@@ -1,0 +1,150 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { IpInCidrBoxSource } from '../IpInCidrBoxSource';
+
+describe('IpInCidrBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no trigger option is present', async () => {
+      const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.5', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options exist but neither ipincidr nor incidr key', async () => {
+      const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.5', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('/24 network', () => {
+      it('10.0.0.5 is in 10.0.0.0/24', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.5', {
+          ipincidr: '10.0.0.0/24',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('true');
+        expect(boxes[0].props.options?.Network).toBe('10.0.0.0');
+        expect(boxes[0].props.options?.Broadcast).toBe('10.0.0.255');
+        expect(boxes[0].props.options?.IP).toBe('10.0.0.5');
+        expect(boxes[0].props.options?.CIDR).toBe('10.0.0.0/24');
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      });
+
+      it('10.0.1.5 is NOT in 10.0.0.0/24', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.1.5', {
+          ipincidr: '10.0.0.0/24',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('false');
+        expect(boxes[0].props.options?.Network).toBe('10.0.0.0');
+        expect(boxes[0].props.options?.Broadcast).toBe('10.0.0.255');
+      });
+    });
+
+    describe('/25 network boundary', () => {
+      it('192.168.1.130 is in 192.168.1.128/25 (upper half)', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('192.168.1.130', {
+          ipincidr: '192.168.1.128/25',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('true');
+        expect(boxes[0].props.options?.Network).toBe('192.168.1.128');
+        expect(boxes[0].props.options?.Broadcast).toBe('192.168.1.255');
+      });
+
+      it('192.168.1.100 is NOT in 192.168.1.128/25 (lower half)', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('192.168.1.100', {
+          ipincidr: '192.168.1.128/25',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('false');
+      });
+    });
+
+    describe('/32 exact host match', () => {
+      it('1.2.3.4 is in 1.2.3.4/32', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('1.2.3.4', {
+          ipincidr: '1.2.3.4/32',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('true');
+        expect(boxes[0].props.options?.Network).toBe('1.2.3.4');
+        expect(boxes[0].props.options?.Broadcast).toBe('1.2.3.4');
+      });
+
+      it('1.2.3.5 is NOT in 1.2.3.4/32', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('1.2.3.5', {
+          ipincidr: '1.2.3.4/32',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('false');
+      });
+    });
+
+    describe('incidr alias', () => {
+      it('accepts ::incidr option key as an alias', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.1', {
+          incidr: '10.0.0.0/24',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('true');
+      });
+    });
+
+    describe('invalid inputs', () => {
+      it('invalid IP 999.1.1.1 produces an error box', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('999.1.1.1', {
+          ipincidr: '10.0.0.0/24',
+        });
+        expect(boxes).toHaveLength(1);
+        const errMsg = boxes[0].props.options?.Error as string;
+        expect(errMsg).toBeTruthy();
+        expect(errMsg.toLowerCase()).toContain('invalid');
+      });
+
+      it('invalid CIDR produces an error box', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.1', {
+          ipincidr: 'notacidr',
+        });
+        expect(boxes).toHaveLength(1);
+        const errMsg = boxes[0].props.options?.Error as string;
+        expect(errMsg).toBeTruthy();
+        expect(errMsg.toLowerCase()).toContain('invalid');
+      });
+
+      it('CIDR prefix out of range (> 32) produces an error box', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.1', {
+          ipincidr: '10.0.0.0/33',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Error).toBeTruthy();
+      });
+
+      it('both IP and CIDR invalid produces an error box mentioning both', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('bad', {
+          ipincidr: 'also-bad',
+        });
+        expect(boxes).toHaveLength(1);
+        const errMsg = boxes[0].props.options?.Error as string;
+        expect(errMsg.toLowerCase()).toContain('invalid');
+      });
+    });
+
+    describe('priority and template', () => {
+      it('sets priority to 10', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.1', {
+          ipincidr: '10.0.0.0/24',
+        });
+        expect(boxes[0].props.priority).toBe(10);
+      });
+
+      it('uses KeyValueBoxTemplate', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.1', {
+          ipincidr: '10.0.0.0/24',
+        });
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JwtVerifyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JwtVerifyBoxSource.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { JwtVerifyBoxSource } from '../JwtVerifyBoxSource';
+
+// canonical jwt.io HS256 example token and secret
+const CANONICAL_TOKEN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+const CANONICAL_SECRET = 'your-256-bit-secret';
+
+describe('JwtVerifyBoxSource', () => {
+  describe('trigger guard', () => {
+    it('returns [] when ::jwtverify option is absent', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes(
+        CANONICAL_TOKEN,
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no jwtverify key', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes(CANONICAL_TOKEN, {
+        hash: 'sha256',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('secret validation', () => {
+    it('returns an explanatory box when ::jwtverify is bare (boolean true)', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes(CANONICAL_TOKEN, {
+        jwtverify: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(/secret/);
+    });
+
+    it('returns an explanatory box when secret is an empty string', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes(CANONICAL_TOKEN, {
+        jwtverify: '',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(/secret/);
+    });
+  });
+
+  describe('token format validation', () => {
+    it('returns a malformed-token box for non-JWT input', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes('abc', {
+        jwtverify: 'x',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(/malformed/);
+    });
+
+    it('returns a malformed-token box for a two-part dotted string', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes('a.b', {
+        jwtverify: 'x',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(/malformed/);
+    });
+  });
+
+  describe('algorithm guard', () => {
+    it('returns an unsupported-alg box for a non-HS256 token', async () => {
+      // manually constructed RS256 header (alg changed; signature won't verify, but alg check comes first)
+      const rs256Header = btoa(JSON.stringify({ alg: 'RS256', typ: 'JWT' }))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '');
+      const payloadB64 = 'eyJzdWIiOiJ0ZXN0In0';
+      const fakeToken = `${rs256Header}.${payloadB64}.fakesig`;
+      const boxes = await JwtVerifyBoxSource.generateBoxes(fakeToken, {
+        jwtverify: 'secret',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(
+        /hs256|unsupported|only/,
+      );
+    });
+  });
+
+  describe('signature verification', () => {
+    it('reports Signature=valid for the canonical jwt.io token with correct secret', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes(CANONICAL_TOKEN, {
+        jwtverify: CANONICAL_SECRET,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Signature).toBe('valid');
+      expect(opts.Algorithm).toBe('HS256');
+    });
+
+    it('reports Signature=invalid when a wrong secret is used', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes(CANONICAL_TOKEN, {
+        jwtverify: 'wrong',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Signature).toBe('invalid');
+    });
+
+    it('does not include the secret value anywhere in the output', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes(CANONICAL_TOKEN, {
+        jwtverify: CANONICAL_SECRET,
+      });
+      const box = boxes[0];
+      expect(box.props.plaintextOutput).not.toContain(CANONICAL_SECRET);
+      const optsStr = JSON.stringify(box.props.options);
+      expect(optsStr).not.toContain(CANONICAL_SECRET);
+    });
+  });
+
+  describe('payload decoding', () => {
+    it('includes the decoded payload as compact JSON in options', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes(CANONICAL_TOKEN, {
+        jwtverify: CANONICAL_SECRET,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      const payload = JSON.parse(opts.Payload);
+      expect(payload.sub).toBe('1234567890');
+      expect(payload.name).toBe('John Doe');
+      expect(payload.iat).toBe(1516239022);
+    });
+
+    it('reports Expired=n/a when no exp claim is present', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes(CANONICAL_TOKEN, {
+        jwtverify: CANONICAL_SECRET,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // canonical token has no exp claim
+      expect(opts.Expired).toBe('n/a');
+    });
+  });
+
+  describe('plaintextOutput format', () => {
+    it('builds k: v lines that include all four keys', async () => {
+      const boxes = await JwtVerifyBoxSource.generateBoxes(CANONICAL_TOKEN, {
+        jwtverify: CANONICAL_SECRET,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toMatch(/Signature: (valid|invalid)/);
+      expect(text).toMatch(/Algorithm: HS256/);
+      expect(text).toMatch(/Payload: /);
+      expect(text).toMatch(/Expired: /);
+    });
+  });
+
+  describe('secure context guard', () => {
+    it('returns an explanatory box when crypto.subtle is unavailable', async () => {
+      // temporarily hide crypto.subtle to simulate a non-secure context
+      const originalSubtle = crypto.subtle;
+      vi.spyOn(crypto, 'subtle', 'get').mockReturnValue(
+        undefined as unknown as SubtleCrypto,
+      );
+
+      try {
+        const boxes = await JwtVerifyBoxSource.generateBoxes(CANONICAL_TOKEN, {
+          jwtverify: CANONICAL_SECRET,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(
+          /secure context|crypto\.subtle/,
+        );
+      } finally {
+        vi.spyOn(crypto, 'subtle', 'get').mockReturnValue(originalSubtle);
+      }
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/MimeTypeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MimeTypeBoxSource.test.ts
@@ -1,0 +1,143 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { MimeTypeBoxSource } from '../MimeTypeBoxSource';
+
+describe('MimeTypeBoxSource', () => {
+  describe('no trigger option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is provided', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('forward lookup (extension -> mime)', () => {
+    it('resolves bare extension png to image/png with correct category', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'MIME Type': 'image/png',
+        Category: 'image',
+        Extension: 'png',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('resolves extension with leading dot (.json)', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('.json', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'MIME Type': 'application/json',
+        Extension: 'json',
+      });
+    });
+
+    it('extracts extension from a compound filename (archive.tar.gz)', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('archive.tar.gz', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'MIME Type': 'application/gzip',
+        Extension: 'gz',
+      });
+    });
+
+    it('is case-insensitive for extension input (PNG uppercase)', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('PNG', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'MIME Type': 'image/png',
+      });
+    });
+
+    it('returns unknown box for unrecognised extension xyzzy', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('xyzzy', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Extension: 'xyzzy',
+        'MIME Type': 'unknown',
+        Category: 'unknown',
+      });
+    });
+  });
+
+  describe('reverse lookup (mime -> extensions)', () => {
+    it('returns extensions for a known mime type (image/png)', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('image/png', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const exts: string = boxes[0].props.options?.Extensions as string;
+      expect(exts).toContain('png');
+    });
+
+    it('lists multiple extensions for text/html', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('text/html', {
+        mimetype: true,
+      });
+      const exts: string = boxes[0].props.options?.Extensions as string;
+      expect(exts).toContain('html');
+      expect(exts).toContain('htm');
+    });
+
+    it('returns "none known" for an unrecognised mime type', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes(
+        'application/x-unknown-format',
+        { mimetype: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Extensions).toBe('none known');
+    });
+  });
+
+  describe('::mime alias', () => {
+    it('triggers on ::mime option key', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        mime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'MIME Type': 'image/png',
+      });
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets priority to 10', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        mimetype: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('sets box name to "MIME Type"', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        mimetype: true,
+      });
+      expect(boxes[0].props.name).toBe('MIME Type');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        mimetype: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ShannonEntropyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ShannonEntropyBoxSource.test.ts
@@ -1,0 +1,96 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ShannonEntropyBoxSource } from '../ShannonEntropyBoxSource';
+
+describe('ShannonEntropyBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no matching option key', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('', {
+        entropy: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('single distinct symbol → 0.000 bits/symbol', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('aaaa', {
+        entropy: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Entropy).toBe('0.000 bits/symbol');
+      expect(opts['Unique Symbols']).toBe('1');
+    });
+
+    it("'ab' → 1.000 bits/symbol, 2 unique symbols", async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('ab', {
+        entropy: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Entropy).toBe('1.000 bits/symbol');
+      expect(opts['Unique Symbols']).toBe('2');
+      expect(opts.Length).toBe('2 symbols');
+      expect(opts['Total Bits']).toBe('2');
+    });
+
+    // a=4, b=4, c=3, d=1, N=12 → H ≈ 1.855 bits/symbol, total bits = round(1.855*12) = 22
+    it("'aaaabbbbcccd' → 1.855 bits/symbol", async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes(
+        'aaaabbbbcccd',
+        { entropy: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Entropy).toBe('1.855 bits/symbol');
+      expect(opts['Unique Symbols']).toBe('4');
+      expect(opts.Length).toBe('12 symbols');
+      expect(opts['Total Bits']).toBe('22');
+    });
+
+    it("'abcd' (4 equal) → 2.000 bits/symbol", async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('abcd', {
+        entropy: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Entropy).toBe('2.000 bits/symbol');
+      expect(opts['Unique Symbols']).toBe('4');
+    });
+
+    it('::shannon alias triggers the box', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('ab', {
+        shannon: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Entropy).toBe('1.000 bits/symbol');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('ab', {
+        entropy: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('ab', {
+        entropy: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('box name is Shannon Entropy', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('ab', {
+        entropy: true,
+      });
+      expect(boxes[0].props.name).toBe('Shannon Entropy');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/UnicodeNormalizeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UnicodeNormalizeBoxSource.test.ts
@@ -1,0 +1,117 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { UnicodeNormalizeBoxSource } from '../UnicodeNormalizeBoxSource';
+
+describe('UnicodeNormalizeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no trigger option is present', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('café', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options exist but no normalize key', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('café', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('', {
+        normalize: 'nfc',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('NFD decomposition', () => {
+      // 'café' with precomposed é (U+00E9) has length 4.
+      // NFD decomposes é → e + U+0301 (combining acute accent), giving length 5.
+      it('decomposes precomposed é under NFD', async () => {
+        const input = 'café'; // café, length 4 (NFC form)
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes(input, {
+          normalize: 'nfd',
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options;
+        expect(opts?.Form).toBe('NFD');
+        expect(opts?.['Input Length']).toBe('4');
+        expect(opts?.['Output Length']).toBe('5');
+        expect(opts?.Changed).toBe('true');
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      });
+    });
+
+    describe('NFC recomposition', () => {
+      // 'café' with decomposed é (e + U+0301) has length 5.
+      // NFC recomposes back to é (U+00E9), giving length 4.
+      it('recomposes decomposed é under NFC', async () => {
+        const input = 'café'; // e + combining acute, length 5 (NFD form)
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes(input, {
+          normalize: 'nfc',
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options;
+        expect(opts?.Form).toBe('NFC');
+        expect(opts?.Normalized).toBe('café');
+        expect(opts?.['Input Length']).toBe('5');
+        expect(opts?.['Output Length']).toBe('4');
+        expect(opts?.Changed).toBe('true');
+      });
+    });
+
+    describe('already-normalized input', () => {
+      it('ASCII hello under NFC is unchanged', async () => {
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes('hello', {
+          normalize: 'nfc',
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options;
+        expect(opts?.Changed).toBe('false');
+        expect(opts?.['Input Length']).toBe(opts?.['Output Length']);
+      });
+    });
+
+    describe('NFKC compatibility normalization', () => {
+      // fullwidth Latin capital A (U+FF21) normalizes to ASCII A (U+0041) under NFKC
+      it('converts fullwidth A to ASCII A', async () => {
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes('Ａ', {
+          normalize: 'nfkc',
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options;
+        expect(opts?.Form).toBe('NFKC');
+        expect(opts?.Normalized).toBe('A');
+        expect(opts?.Changed).toBe('true');
+      });
+    });
+
+    describe('default form fallback', () => {
+      it('uses NFC when option value is a bare flag (true)', async () => {
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes('x', {
+          normalize: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Form).toBe('NFC');
+      });
+
+      it('uses NFC for unrecognized form string', async () => {
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes('x', {
+          normalize: 'xyz',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Form).toBe('NFC');
+      });
+    });
+
+    describe('unicodenormalize alias', () => {
+      it('triggers on ::unicodenormalize option key', async () => {
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes('hello', {
+          unicodenormalize: 'nfd',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Form).toBe('NFD');
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -4,22 +4,30 @@ import {
 } from './Base64BoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
+import DammBoxSource from './DammBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import EmailParseBoxSource from './EmailParseBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
+import HammingDistanceBoxSource from './HammingDistanceBoxSource';
 import HashBoxSource from './HashBoxSource';
+import IpInCidrBoxSource from './IpInCidrBoxSource';
 import JWTBoxSource from './JWTBoxSource';
+import JwtVerifyBoxSource from './JwtVerifyBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
+import MimeTypeBoxSource from './MimeTypeBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import ShannonEntropyBoxSource from './ShannonEntropyBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
@@ -32,20 +40,28 @@ export const boxSources = [
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
+  DammBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  EmailParseBoxSource,
   GenerateQRCodeBoxSource,
+  HammingDistanceBoxSource,
   HashBoxSource,
+  IpInCidrBoxSource,
+  JwtVerifyBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
+  MimeTypeBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
+  ShannonEntropyBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
+  UnicodeNormalizeBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
   TimestampBoxSource,


### PR DESCRIPTION
## Summary

Nineteenth exploration batch — **8 more BoxSource tools** (crypto, networking, text analysis, validation).

| Tool | Trigger | What it does |
|------|---------|--------------|
| JWT Verify | `::jwtverify=SECRET` | verify an HS256 signature + decode |
| Email Parse | `::emailparse` | local / domain / TLD / +tag + validity |
| MIME Type | `::mimetype` | extension ⇄ MIME type (~80 types) |
| IP in CIDR | `::ipincidr=CIDR` | IPv4 membership check |
| Shannon Entropy | `::entropy` | bits/symbol over code points |
| Hamming Distance | `::hamming` | between two equal-length lines |
| Unicode Normalize | `::normalize=FORM` | NFC/NFD/NFKC/NFKD |
| Damm Check | `::damm` | single-digit check (anti-symmetric quasigroup) |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules — KeyValue sources render `k: v` plaintext (the recurring blank-TUI-box class), **JWT secret never echoed**, linear/ReDoS-safe regexes, `>>> 0` unsigned IP math, code-point iteration for entropy/normalize, input caps.
- **Verified vectors**: canonical jwt.io HS256 token verifies valid (wrong secret → invalid); `png`→`image/png`; `10.0.0.5` ∈ `10.0.0.0/24`; entropy `ab`→`1.000`, `abcd`→`2.000`, `aaaabbbbcccd`→`1.855`; `karolin`/`kathrin`→`3`; **Damm `572`→`4`, `5724` valid**; NFD/NFC é round-trip + fullwidth-A→A under NFKC.

## Verification

- ✅ `bun run test run` — **423 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#277 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6