### PR TITLE
feat(boxSources): add 8 more tools (verhoeff, fletcher16, json-sort-keys, csv→md, json-schema, regex-escape, glob→regex, on-color)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>VerhoeffBox</b> </summary>
+
+| match rule    | description                          | example          |
+| ------------- | ------------------------------------ | ---------------- |
+| `::verhoeff`  | Verhoeff check digit compute/validate | `236 ::verhoeff` |
+
+</details>
+
+<details>
+<summary> <b>Fletcher16Box</b> </summary>
+
+| match rule       | description                          | example            |
+| ---------------- | ------------------------------------ | ------------------ |
+| `::fletcher16`   | Fletcher-16 checksum                 | `abcde ::fletcher16` |
+
+</details>
+
+<details>
+<summary> <b>JsonSortKeysBox</b> </summary>
+
+| match rule    | description                          | example                  |
+| ------------- | ------------------------------------ | ------------------------ |
+| `::jsonsort`  | recursively sort JSON object keys (`=desc`) | `{"b":1,"a":2} ::jsonsort` |
+
+</details>
+
+<details>
+<summary> <b>CsvToMarkdownBox</b> </summary>
+
+| match rule  | description                          | example                       |
+| ----------- | ------------------------------------ | ----------------------------- |
+| `::csvmd`   | CSV → Markdown table                 | `name,age`<br>`Alice,30 ::csvmd` |
+
+</details>
+
+<details>
+<summary> <b>JsonSchemaBox</b> </summary>
+
+| match rule       | description                          | example                  |
+| ---------------- | ------------------------------------ | ------------------------ |
+| `::jsonschema`   | infer a JSON Schema (draft-07)       | `{"id":1} ::jsonschema`  |
+
+</details>
+
+<details>
+<summary> <b>RegexEscapeBox</b> </summary>
+
+| match rule        | description                          | example               |
+| ----------------- | ------------------------------------ | --------------------- |
+| `::regexescape`   | escape a literal for use in a regex  | `a.b*c ::regexescape` |
+
+</details>
+
+<details>
+<summary> <b>GlobToRegexBox</b> </summary>
+
+| match rule        | description                          | example                  |
+| ----------------- | ------------------------------------ | ------------------------ |
+| `::glob2regex`    | convert a shell glob to a regex      | `src/**/*.ts ::glob2regex` |
+
+</details>
+
+<details>
+<summary> <b>OnColorBox</b> </summary>
+
+| match rule   | description                          | example            |
+| ------------ | ------------------------------------ | ------------------ |
+| `::oncolor`  | readable text color (black/white) for a background | `#3498db ::oncolor` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/CsvToMarkdownBoxSource.ts
+++ b/src/modules/boxSources/CsvToMarkdownBoxSource.ts
@@ -1,0 +1,180 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// parse a single csv line respecting quoted fields with embedded commas, newlines, and "" escapes
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let i = 0;
+  // tracks whether the last token was followed by a comma; a trailing comma
+  // means there is one more (empty) field after it
+  let trailingComma = false;
+
+  while (i < line.length) {
+    trailingComma = false;
+
+    if (line[i] === '"') {
+      // quoted field
+      let field = '';
+      i++; // skip opening quote
+      while (i < line.length) {
+        if (line[i] === '"') {
+          if (line[i + 1] === '"') {
+            // escaped quote
+            field += '"';
+            i += 2;
+          } else {
+            // closing quote
+            i++;
+            break;
+          }
+        } else {
+          field += line[i];
+          i++;
+        }
+      }
+      fields.push(field);
+      if (line[i] === ',') {
+        i++;
+        trailingComma = true;
+      }
+    } else {
+      // unquoted field — read until next comma
+      const start = i;
+      while (i < line.length && line[i] !== ',') i++;
+      fields.push(line.slice(start, i));
+      if (line[i] === ',') {
+        i++;
+        trailingComma = true;
+      }
+    }
+  }
+
+  // a line ending in ',' has a final empty field; an empty line is one field
+  if (trailingComma || fields.length === 0) fields.push('');
+
+  return fields;
+}
+
+// parse full csv text, handling quoted fields that span multiple lines
+function parseCsv(input: string): string[][] {
+  const rows: string[][] = [];
+  let i = 0;
+  const n = input.length;
+
+  while (i < n) {
+    // collect the logical line, respecting quoted multi-line fields
+    let lineChars = '';
+    while (i < n) {
+      if (input[i] === '"') {
+        lineChars += input[i];
+        i++;
+        while (i < n) {
+          if (input[i] === '"') {
+            lineChars += input[i];
+            i++;
+            if (input[i] === '"') {
+              // escaped quote
+              lineChars += input[i];
+              i++;
+            } else {
+              break; // end of quoted field
+            }
+          } else {
+            lineChars += input[i];
+            i++;
+          }
+        }
+      } else if (input[i] === '\n') {
+        i++;
+        break;
+      } else if (input[i] === '\r') {
+        i++;
+        if (input[i] === '\n') i++;
+        break;
+      } else {
+        lineChars += input[i];
+        i++;
+      }
+    }
+
+    rows.push(parseCsvLine(lineChars));
+  }
+
+  // drop fully-blank trailing rows
+  while (
+    rows.length > 0 &&
+    rows[rows.length - 1].every((c) => c.trim() === '')
+  ) {
+    rows.pop();
+  }
+
+  return rows;
+}
+
+// escape pipe chars and replace embedded newlines with <br> for markdown table cells
+function escapeCell(cell: string): string {
+  return cell.replace(/\|/g, '\\|').replace(/\n/g, '<br>');
+}
+
+function buildMarkdownTable(rows: string[][]): string {
+  const [header, ...dataRows] = rows;
+  const colCount = header.length;
+
+  const formatRow = (cells: string[]) => {
+    // clamp to header width; pad short rows with empty cells
+    const padded = Array.from({ length: colCount }, (_, i) =>
+      escapeCell(cells[i] ?? ''),
+    );
+    return `| ${padded.join(' | ')} |`;
+  };
+
+  const separator = `| ${Array(colCount).fill('---').join(' | ')} |`;
+
+  const lines = [formatRow(header), separator, ...dataRows.map(formatRow)];
+  return lines.join('\n');
+}
+
+export const CsvToMarkdownBoxSource = {
+  name: 'CSV to Markdown',
+  description: 'Convert CSV (first row = header) into a Markdown table.',
+  defaultInput: 'name,age\nAlice,30\nBob,25 ::csvmd',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'csvmd', 'csv2md')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const rows = parseCsv(input.trim());
+
+    if (rows.length === 0) {
+      return [
+        new BoxBuilder('CSV to Markdown', 'No CSV rows found.')
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'markdown' })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const markdown = buildMarkdownTable(rows);
+
+    return [
+      new BoxBuilder('CSV to Markdown', markdown)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'markdown' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CsvToMarkdownBoxSource;

--- a/src/modules/boxSources/CsvToMarkdownBoxSource.ts
+++ b/src/modules/boxSources/CsvToMarkdownBoxSource.ts
@@ -117,7 +117,7 @@ function parseCsv(input: string): string[][] {
 
 // escape pipe chars and replace embedded newlines with <br> for markdown table cells
 function escapeCell(cell: string): string {
-  return cell.replace(/\|/g, '\\|').replace(/\n/g, '<br>');
+  return cell.replace(/\|/g, '\\|').replace(/\r\n|\r|\n/g, '<br>');
 }
 
 function buildMarkdownTable(rows: string[][]): string {

--- a/src/modules/boxSources/Fletcher16BoxSource.ts
+++ b/src/modules/boxSources/Fletcher16BoxSource.ts
@@ -1,0 +1,69 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// fletcher-16 over utf-8 bytes; returns (sum2 << 8) | sum1
+function computeFletcher16(input: string): {
+  checksum: number;
+  sum1: number;
+  sum2: number;
+} {
+  const bytes = new TextEncoder().encode(input);
+  let sum1 = 0;
+  let sum2 = 0;
+  for (const b of bytes) {
+    sum1 = (sum1 + b) % 255;
+    sum2 = (sum2 + sum1) % 255;
+  }
+  return { checksum: (sum2 << 8) | sum1, sum1, sum2 };
+}
+
+export const Fletcher16BoxSource = {
+  name: 'Fletcher-16',
+  description: 'Compute the Fletcher-16 checksum of the input text.',
+  defaultInput: 'abcde ::fletcher16',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'fletcher16', 'fletcher')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const { checksum, sum1, sum2 } = computeFletcher16(input);
+    const hex = `0x${checksum.toString(16).padStart(4, '0')}`;
+
+    const kvOptions: Record<string, string> = {
+      Checksum: checksum.toString(),
+      Hex: hex,
+      Sum1: sum1.toString(),
+      Sum2: sum2.toString(),
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Fletcher-16', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Fletcher16BoxSource;

--- a/src/modules/boxSources/GlobToRegexBoxSource.ts
+++ b/src/modules/boxSources/GlobToRegexBoxSource.ts
@@ -31,8 +31,15 @@ function globToRegex(glob: string): string {
     if (ch === '*') {
       // peek ahead: ** matches across path separators, * stays within a segment
       if (glob[i + 1] === '*') {
-        result += '.*';
-        i += 2;
+        // `**/` means zero-or-more directory segments, so src/**/*.ts also
+        // matches src/x.ts; a bare `**` matches anything
+        if (glob[i + 2] === '/') {
+          result += '(?:.*/)?';
+          i += 3;
+        } else {
+          result += '.*';
+          i += 2;
+        }
       } else {
         result += '[^/]*';
         i += 1;

--- a/src/modules/boxSources/GlobToRegexBoxSource.ts
+++ b/src/modules/boxSources/GlobToRegexBoxSource.ts
@@ -1,0 +1,104 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 10_000;
+
+// regex-special chars that have no meaning in glob syntax and must be escaped
+const REGEX_SPECIAL = new Set([
+  '.',
+  '+',
+  '(',
+  ')',
+  '{',
+  '}',
+  '^',
+  '$',
+  '|',
+  '\\',
+]);
+
+// convert a glob pattern to an anchored regex string via a single left-to-right scan
+function globToRegex(glob: string): string {
+  let result = '^';
+  let i = 0;
+
+  while (i < glob.length) {
+    const ch = glob[i];
+
+    if (ch === '*') {
+      // peek ahead: ** matches across path separators, * stays within a segment
+      if (glob[i + 1] === '*') {
+        result += '.*';
+        i += 2;
+      } else {
+        result += '[^/]*';
+        i += 1;
+      }
+    } else if (ch === '?') {
+      result += '[^/]';
+      i += 1;
+    } else if (ch === '[') {
+      // character class — pass through to regex, translating leading ! to ^
+      let cls = '[';
+      i += 1; // consume '['
+
+      if (i < glob.length && glob[i] === '!') {
+        cls += '^';
+        i += 1;
+      }
+
+      // copy everything until the closing ']'
+      while (i < glob.length && glob[i] !== ']') {
+        cls += glob[i];
+        i += 1;
+      }
+
+      cls += ']';
+      i += 1; // consume ']'
+      result += cls;
+    } else if (REGEX_SPECIAL.has(ch)) {
+      result += `\\${ch}`;
+      i += 1;
+    } else {
+      result += ch;
+      i += 1;
+    }
+  }
+
+  result += '$';
+  return result;
+}
+
+export const GlobToRegexBoxSource = {
+  name: 'Glob to Regex',
+  description:
+    'Convert a shell glob pattern (*, ?, [...], **) into an anchored regular expression.',
+  defaultInput: 'src/**/*.ts ::glob2regex',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'glob2regex', 'globregex')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const pattern = trim(input);
+    const regex = globToRegex(pattern);
+
+    return [
+      new BoxBuilder('Glob to Regex', regex)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default GlobToRegexBoxSource;

--- a/src/modules/boxSources/JsonSchemaBoxSource.ts
+++ b/src/modules/boxSources/JsonSchemaBoxSource.ts
@@ -11,6 +11,8 @@ function inferSchema(value: unknown): object {
   if (value === null) return { type: 'null' };
   if (typeof value === 'boolean') return { type: 'boolean' };
   if (typeof value === 'number') {
+    // Infinity/NaN (from JSON.parse of 1e400 etc.) aren't representable
+    if (!Number.isFinite(value)) return {};
     return Number.isInteger(value) ? { type: 'integer' } : { type: 'number' };
   }
   if (typeof value === 'string') return { type: 'string' };

--- a/src/modules/boxSources/JsonSchemaBoxSource.ts
+++ b/src/modules/boxSources/JsonSchemaBoxSource.ts
@@ -1,0 +1,83 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// maps a parsed JSON value to its draft-07 schema fragment
+function inferSchema(value: unknown): object {
+  if (value === null) return { type: 'null' };
+  if (typeof value === 'boolean') return { type: 'boolean' };
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? { type: 'integer' } : { type: 'number' };
+  }
+  if (typeof value === 'string') return { type: 'string' };
+  if (Array.isArray(value)) {
+    return {
+      type: 'array',
+      items: value.length > 0 ? inferSchema(value[0]) : {},
+    };
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value as Record<string, unknown>);
+    const properties: Record<string, object> = {};
+    for (const key of keys) {
+      properties[key] = inferSchema((value as Record<string, unknown>)[key]);
+    }
+    return {
+      type: 'object',
+      properties,
+      required: keys,
+      additionalProperties: false,
+    };
+  }
+  // fallback for unexpected types (e.g. undefined, functions in exotic usage)
+  return {};
+}
+
+export const JsonSchemaBoxSource = {
+  name: 'JSON Schema',
+  description: 'Infer a JSON Schema (draft-07) from a JSON sample.',
+  defaultInput: '{"id":1,"name":"Bob","tags":["a"]} ::jsonschema',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonschema', 'jsonschemainfer')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trim(input));
+    } catch {
+      return [
+        new BoxBuilder('JSON Schema', 'Invalid JSON: unable to parse input')
+          .setOptions({ language: 'json' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      ...inferSchema(parsed),
+    };
+
+    return [
+      new BoxBuilder('JSON Schema', JSON.stringify(schema, null, 2))
+        .setOptions({ language: 'json' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonSchemaBoxSource;

--- a/src/modules/boxSources/JsonSortKeysBoxSource.ts
+++ b/src/modules/boxSources/JsonSortKeysBoxSource.ts
@@ -1,0 +1,74 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// recursively sort object keys; arrays preserve element order but recurse into elements
+function sortKeys(value: unknown, descending: boolean): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortKeys(item, descending));
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    const sorted = entries.sort(([a], [b]) =>
+      descending ? (b < a ? -1 : b > a ? 1 : 0) : a < b ? -1 : a > b ? 1 : 0,
+    );
+    // Object.fromEntries assigns '__proto__' as a plain own data property, not prototype mutation
+    return Object.fromEntries(
+      sorted.map(([k, v]) => [k, sortKeys(v, descending)]),
+    );
+  }
+
+  return value;
+}
+
+export const JsonSortKeysBoxSource = {
+  name: 'JSON Sort Keys',
+  description:
+    'Recursively sort the keys of a JSON object (canonical form). Use ::jsonsort=desc for descending.',
+  defaultInput: '{"b":1,"a":{"d":4,"c":3}} ::jsonsort',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonsort', 'sortkeys')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const descending =
+      extractOptionKeys(options, 'jsonsort', 'sortkeys') === 'desc';
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trim(input));
+    } catch {
+      return [
+        new BoxBuilder('JSON Sort Keys', 'Invalid JSON: unable to parse input')
+          .setOptions({ language: 'json' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const sorted = sortKeys(parsed, descending);
+    const output = JSON.stringify(sorted, null, 2);
+
+    return [
+      new BoxBuilder('JSON Sort Keys', output)
+        .setOptions({ language: 'json' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonSortKeysBoxSource;

--- a/src/modules/boxSources/OnColorBoxSource.ts
+++ b/src/modules/boxSources/OnColorBoxSource.ts
@@ -1,0 +1,134 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_HEX_INPUT = 32;
+
+// expands a 3-digit shorthand hex (e.g. #rgb) to 6-digit form
+function expandShortHex(hex: string): string {
+  return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+}
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// parses #RGB or #RRGGBB hex strings; returns null for anything else
+function parseHex(input: string): { rgb: Rgb; normalized: string } | null {
+  const cleaned = input.trim().toLowerCase();
+  const short = /^#([0-9a-f]{3})$/.exec(cleaned);
+  if (short) {
+    const full = expandShortHex(cleaned);
+    return {
+      rgb: {
+        r: Number.parseInt(full.slice(1, 3), 16),
+        g: Number.parseInt(full.slice(3, 5), 16),
+        b: Number.parseInt(full.slice(5, 7), 16),
+      },
+      normalized: full,
+    };
+  }
+  const long = /^#([0-9a-f]{6})$/.exec(cleaned);
+  if (long) {
+    return {
+      rgb: {
+        r: Number.parseInt(cleaned.slice(1, 3), 16),
+        g: Number.parseInt(cleaned.slice(3, 5), 16),
+        b: Number.parseInt(cleaned.slice(5, 7), 16),
+      },
+      normalized: cleaned,
+    };
+  }
+  return null;
+}
+
+// converts a single 8-bit channel to its WCAG linearized value
+function linearizeChannel(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+// computes WCAG 2.1 relative luminance for an sRGB color
+function relativeLuminance({ r, g, b }: Rgb): number {
+  return (
+    0.2126 * linearizeChannel(r) +
+    0.7152 * linearizeChannel(g) +
+    0.0722 * linearizeChannel(b)
+  );
+}
+
+// formats a contrast ratio as "X.XX:1", dropping decimals when exact
+function formatRatio(ratio: number): string {
+  const rounded = Math.round(ratio * 100) / 100;
+  return `${rounded % 1 === 0 ? rounded.toFixed(0) : rounded}:1`;
+}
+
+export const OnColorBoxSource = {
+  name: 'Readable Text Color',
+  description:
+    'Given a background hex color, pick the readable foreground (black or white) and the WCAG contrast.',
+  defaultInput: '#3498db ::oncolor',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'oncolor', 'textcolor')) return [];
+
+    const raw = trim(input).slice(0, MAX_HEX_INPUT);
+    const parsed = parseHex(raw);
+
+    if (!parsed) {
+      const errorText = 'A valid hex color is required (e.g. #3498db or #fff)';
+      return [
+        new BoxBuilder('Readable Text Color', errorText)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: errorText })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { rgb, normalized } = parsed;
+    const L = relativeLuminance(rgb);
+
+    // WCAG contrast ratio: (lighter + 0.05) / (darker + 0.05)
+    const blackRatio = (L + 0.05) / 0.05;
+    const whiteRatio = 1.05 / (L + 0.05);
+
+    const foreground = blackRatio >= whiteRatio ? '#000000' : '#ffffff';
+    const ratio = Math.max(blackRatio, whiteRatio);
+    const contrastStr = formatRatio(ratio);
+    const wcagAA = ratio >= 4.5 ? 'pass' : 'fail';
+    const wcagAAA = ratio >= 7 ? 'pass' : 'fail';
+
+    const kvOptions: Record<string, string> = {
+      Background: normalized,
+      Foreground: foreground,
+      Contrast: contrastStr,
+      'WCAG AA': wcagAA,
+      'WCAG AAA': wcagAAA,
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Readable Text Color', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default OnColorBoxSource;

--- a/src/modules/boxSources/RegexEscapeBoxSource.ts
+++ b/src/modules/boxSources/RegexEscapeBoxSource.ts
@@ -1,0 +1,43 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// MDN-recommended pattern: escapes all regex metacharacters with a backslash
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export const RegexEscapeBoxSource = {
+  name: 'Regex Escape',
+  description:
+    'Escape a literal string so it can be used inside a regular expression.',
+  defaultInput: 'a.b*c (x?) ::regexescape',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'regexescape', 'reescape')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const escaped = escapeRegex(input);
+
+    return [
+      new BoxBuilder('Regex Escape', escaped)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default RegexEscapeBoxSource;

--- a/src/modules/boxSources/VerhoeffBoxSource.ts
+++ b/src/modules/boxSources/VerhoeffBoxSource.ts
@@ -83,7 +83,7 @@ export const VerhoeffBoxSource = {
           Input: cleaned,
           Error: 'digits only (0-9), max length 1000',
         })
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .setTemplate(KeyValueBoxTemplate)
         .build();
 

--- a/src/modules/boxSources/VerhoeffBoxSource.ts
+++ b/src/modules/boxSources/VerhoeffBoxSource.ts
@@ -1,0 +1,117 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// d = multiplication table (dihedral group D5)
+const D = [
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+  [1, 2, 3, 4, 0, 6, 7, 8, 9, 5],
+  [2, 3, 4, 0, 1, 7, 8, 9, 5, 6],
+  [3, 4, 0, 1, 2, 8, 9, 5, 6, 7],
+  [4, 0, 1, 2, 3, 9, 5, 6, 7, 8],
+  [5, 9, 8, 7, 6, 0, 4, 3, 2, 1],
+  [6, 5, 9, 8, 7, 1, 0, 4, 3, 2],
+  [7, 6, 5, 9, 8, 2, 1, 0, 4, 3],
+  [8, 7, 6, 5, 9, 3, 2, 1, 0, 4],
+  [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+];
+
+// p = permutation table
+const P = [
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+  [1, 5, 7, 6, 2, 8, 3, 0, 9, 4],
+  [5, 8, 0, 3, 7, 9, 6, 1, 4, 2],
+  [8, 9, 1, 6, 0, 4, 3, 5, 2, 7],
+  [9, 4, 5, 3, 1, 2, 6, 8, 7, 0],
+  [4, 2, 8, 6, 5, 7, 3, 9, 0, 1],
+  [2, 7, 9, 3, 8, 0, 6, 4, 1, 5],
+  [7, 0, 4, 6, 9, 1, 3, 2, 5, 8],
+];
+
+// inv = inverse table
+const INV = [0, 4, 3, 2, 1, 5, 6, 7, 8, 9];
+
+// validate whether a digit string (including its check digit) is Verhoeff-valid
+function verhoeffValidate(digits: number[]): boolean {
+  let c = 0;
+  const reversed = [...digits].reverse();
+  for (let i = 0; i < reversed.length; i++) {
+    c = D[c][P[i % 8][reversed[i]]];
+  }
+  return c === 0;
+}
+
+// compute the check digit to append to the payload
+function verhoeffCheckDigit(digits: number[]): number {
+  let c = 0;
+  const reversed = [...digits].reverse();
+  for (let i = 0; i < reversed.length; i++) {
+    c = D[c][P[(i + 1) % 8][reversed[i]]];
+  }
+  return INV[c];
+}
+
+export const VerhoeffBoxSource = {
+  name: 'Verhoeff Check',
+  description:
+    'Compute a Verhoeff check digit for a number, or validate a number that already includes one.',
+  defaultInput: '236 ::verhoeff',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'verhoeff')) return [];
+
+    const cleaned = trim(input);
+
+    // require pure digit input up to length 1000
+    if (!/^\d+$/.test(cleaned) || cleaned.length > 1000) {
+      const plaintextOutput = [
+        `Input: ${cleaned}`,
+        'Error: digits only (0-9), max length 1000',
+      ].join('\n');
+
+      const box = new BoxBuilder('Verhoeff Check', plaintextOutput)
+        .setOptions({
+          Input: cleaned,
+          Error: 'digits only (0-9), max length 1000',
+        })
+        .setPriority(Priority)
+        .setTemplate(KeyValueBoxTemplate)
+        .build();
+
+      return [box];
+    }
+
+    const digits = cleaned.split('').map((d) => Number.parseInt(d, 10));
+    const isValid = verhoeffValidate(digits);
+    const checkDigit = verhoeffCheckDigit(digits);
+
+    const kvOptions = {
+      Input: cleaned,
+      Valid: String(isValid),
+      'Check Digit': String(checkDigit),
+    };
+
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    const box = new BoxBuilder('Verhoeff Check', plaintextOutput)
+      .setOptions(kvOptions)
+      .setPriority(Priority)
+      .setTemplate(KeyValueBoxTemplate)
+      .build();
+
+    return [box];
+  },
+};
+
+export default VerhoeffBoxSource;

--- a/src/modules/boxSources/__test__/CsvToMarkdownBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CsvToMarkdownBoxSource.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { CsvToMarkdownBoxSource } from '../CsvToMarkdownBoxSource';
+
+describe('CsvToMarkdownBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no option key present', async () => {
+      const boxes =
+        await CsvToMarkdownBoxSource.generateBoxes('name,age\nAlice,30');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when option does not match', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes(
+        'name,age\nAlice,30',
+        { other: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts basic csv to markdown table with ::csvmd', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes(
+        'name,age\nAlice,30\nBob,25',
+        { csvmd: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| name | age |\n| --- | --- |\n| Alice | 30 |\n| Bob | 25 |',
+      );
+    });
+
+    it('converts basic csv to markdown table with ::csv2md', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes(
+        'name,age\nAlice,30',
+        { csv2md: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| name | age |\n| --- | --- |\n| Alice | 30 |',
+      );
+    });
+
+    it('handles quoted field with embedded comma', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes('a,b\n"x,y",2', {
+        csvmd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| a | b |\n| --- | --- |\n| x,y | 2 |',
+      );
+    });
+
+    it('escapes pipe characters in cells', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes('a\nx|y', {
+        csvmd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('| a |\n| --- |\n| x\\|y |');
+    });
+
+    it('pads ragged short data rows to header width', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes('a,b\n1', {
+        csvmd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| a | b |\n| --- | --- |\n| 1 |  |',
+      );
+    });
+
+    it('returns a box mentioning no rows for empty input', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes('', {
+        csvmd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/no csv rows found/i);
+    });
+
+    it('sets priority correctly', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes('a\n1', {
+        csvmd: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('sets language option to markdown', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes('a\n1', {
+        csvmd: true,
+      });
+      expect(boxes[0].props.options).toEqual({ language: 'markdown' });
+    });
+
+    it('handles quoted field with embedded double-quote escape', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes(
+        'a\n"say ""hi"""',
+        { csvmd: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| a |\n| --- |\n| say "hi" |',
+      );
+    });
+
+    it('clamps data rows wider than header to header width', async () => {
+      const boxes = await CsvToMarkdownBoxSource.generateBoxes('a,b\n1,2,3', {
+        csvmd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // clamp: only first 2 cells emitted
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '| a | b |\n| --- | --- |\n| 1 | 2 |',
+      );
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/Fletcher16BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Fletcher16BoxSource.test.ts
@@ -1,0 +1,130 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Fletcher16BoxSource } from '../Fletcher16BoxSource';
+
+describe('Fletcher16BoxSource', () => {
+  describe('generateBoxes - guard conditions', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('', {
+        fletcher16: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('   ', {
+        fletcher16: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - canonical Fletcher-16 vectors', () => {
+    it('"abcde" produces checksum 51440 / 0xc8f0', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Checksum: '51440',
+        Hex: '0xc8f0',
+      });
+    });
+
+    it('"abcdef" produces checksum 8279 / 0x2057', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcdef', {
+        fletcher16: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Checksum: '8279',
+        Hex: '0x2057',
+      });
+    });
+
+    it('"abcdefgh" produces checksum 1575 / 0x0627', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcdefgh', {
+        fletcher16: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Checksum: '1575',
+        Hex: '0x0627',
+      });
+    });
+  });
+
+  describe('generateBoxes - box shape', () => {
+    it('box name is "Fletcher-16"', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      expect(boxes[0].props.name).toBe('Fletcher-16');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('options include Sum1 and Sum2 keys', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts).toHaveProperty('Sum1');
+      expect(opts).toHaveProperty('Sum2');
+    });
+
+    it('plaintext output contains k:v lines', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      const text = boxes[0].props.plaintextOutput as string;
+      expect(text).toContain('Checksum: 51440');
+      expect(text).toContain('Hex: 0xc8f0');
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      expect(boxes[0].props.priority).toBe(Fletcher16BoxSource.priority);
+    });
+  });
+
+  describe('generateBoxes - ::fletcher alias', () => {
+    it('::fletcher option triggers the box', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Checksum: '51440',
+        Hex: '0xc8f0',
+      });
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Fletcher16BoxSource.name).toBe('Fletcher-16');
+      expect(Fletcher16BoxSource.tag).toBe('#');
+      expect(Fletcher16BoxSource.kind).toBe('Encode');
+      expect(typeof Fletcher16BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/GlobToRegexBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/GlobToRegexBoxSource.test.ts
@@ -29,12 +29,16 @@ describe('GlobToRegexBoxSource', () => {
   });
 
   describe('generateBoxes - double wildcard **', () => {
-    it('converts src/**/*.ts to ^src/.*/[^/]*\\.ts$', async () => {
+    it('converts src/**/*.ts to ^src/(?:.*/)?[^/]*\\.ts$', async () => {
       const boxes = await GlobToRegexBoxSource.generateBoxes('src/**/*.ts', {
         glob2regex: true,
       });
       expect(boxes).toHaveLength(1);
-      expect(boxes[0].props.plaintextOutput).toBe('^src/.*/[^/]*\\.ts$');
+      expect(boxes[0].props.plaintextOutput).toBe('^src/(?:.*/)?[^/]*\\.ts$');
+      // **/ matches zero directory segments too
+      expect(new RegExp(boxes[0].props.plaintextOutput).test('src/x.ts')).toBe(
+        true,
+      );
     });
   });
 

--- a/src/modules/boxSources/__test__/GlobToRegexBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/GlobToRegexBoxSource.test.ts
@@ -1,0 +1,101 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { GlobToRegexBoxSource } from '../GlobToRegexBoxSource';
+
+describe('GlobToRegexBoxSource', () => {
+  describe('generateBoxes - no matching option', () => {
+    it('returns [] when no glob option is present', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('*.ts', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is present', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('*.ts', {
+        sha256: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - single wildcard *', () => {
+    it('converts *.ts to ^[^/]*\\.ts$', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('*.ts', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^[^/]*\\.ts$');
+    });
+  });
+
+  describe('generateBoxes - double wildcard **', () => {
+    it('converts src/**/*.ts to ^src/.*/[^/]*\\.ts$', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('src/**/*.ts', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^src/.*/[^/]*\\.ts$');
+    });
+  });
+
+  describe('generateBoxes - single char wildcard ?', () => {
+    it('converts ? to ^[^/]$', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('?', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^[^/]$');
+    });
+  });
+
+  describe('generateBoxes - character class', () => {
+    it('preserves [0-9] and escapes dot in file[0-9].txt', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('file[0-9].txt', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^file[0-9]\\.txt$');
+    });
+  });
+
+  describe('generateBoxes - negated character class', () => {
+    it('converts [!a] to [^a] in [!a].txt', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('[!a].txt', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^[^a]\\.txt$');
+    });
+  });
+
+  describe('generateBoxes - literal regex-special chars', () => {
+    it('escapes + and . in a+b.c', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('a+b.c', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^a\\+b\\.c$');
+    });
+  });
+
+  describe('generateBoxes - alternate option key', () => {
+    it('triggers on ::globregex option key as well', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('*.js', {
+        globregex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^[^/]*\\.js$');
+    });
+  });
+
+  describe('generateBoxes - box metadata', () => {
+    it('uses DefaultBoxTemplate and correct name', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('*.ts', {
+        glob2regex: true,
+      });
+      expect(boxes[0].props.name).toBe('Glob to Regex');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JsonSchemaBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonSchemaBoxSource.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { JsonSchemaBoxSource } from '../JsonSchemaBoxSource';
+
+const generate = (input: string, options = {}) =>
+  JsonSchemaBoxSource.generateBoxes(input, options as never);
+
+const parseOutput = async (input: string, options = {}) => {
+  const boxes = await generate(input, options);
+  return JSON.parse(boxes[0].props.plaintextOutput);
+};
+
+describe('JsonSchemaBoxSource', () => {
+  it('returns [] when no trigger option is present', async () => {
+    const boxes = await generate('{"id":1}', {});
+    expect(boxes).toEqual([]);
+  });
+
+  it('infers a full object schema for a typical sample', async () => {
+    const schema = await parseOutput('{"id":1,"name":"Bob","tags":["a"]}', {
+      jsonschema: true,
+    });
+    expect(schema.$schema).toBe('http://json-schema.org/draft-07/schema#');
+    expect(schema.type).toBe('object');
+    expect(schema.properties.id.type).toBe('integer');
+    expect(schema.properties.name.type).toBe('string');
+    expect(schema.properties.tags.type).toBe('array');
+    expect(schema.properties.tags.items.type).toBe('string');
+    expect(schema.required).toContain('id');
+    expect(schema.required).toContain('name');
+    expect(schema.required).toContain('tags');
+    expect(schema.additionalProperties).toBe(false);
+  });
+
+  it('uses type number for floats', async () => {
+    const schema = await parseOutput('{"x":1.5}', { jsonschema: true });
+    expect(schema.properties.x.type).toBe('number');
+  });
+
+  it('uses type boolean and null correctly', async () => {
+    const schema = await parseOutput('{"a":true,"b":null}', {
+      jsonschemainfer: true,
+    });
+    expect(schema.properties.a.type).toBe('boolean');
+    expect(schema.properties.b.type).toBe('null');
+  });
+
+  it('uses empty object for items when array is empty', async () => {
+    const schema = await parseOutput('{"xs":[]}', { jsonschema: true });
+    expect(schema.properties.xs.type).toBe('array');
+    expect(schema.properties.xs.items).toEqual({});
+  });
+
+  it('handles nested objects recursively', async () => {
+    const schema = await parseOutput('{"o":{"k":1}}', { jsonschema: true });
+    expect(schema.properties.o.type).toBe('object');
+    expect(schema.properties.o.properties.k.type).toBe('integer');
+  });
+
+  it('returns an error box for invalid JSON', async () => {
+    const boxes = await generate('{bad', { jsonschema: true });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toMatch(/invalid json/i);
+  });
+});

--- a/src/modules/boxSources/__test__/JsonSchemaBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonSchemaBoxSource.test.ts
@@ -1,8 +1,9 @@
+import type { BoxOptions } from '@modules/Box';
 import { describe, expect, it } from 'vitest';
 import { JsonSchemaBoxSource } from '../JsonSchemaBoxSource';
 
-const generate = (input: string, options = {}) =>
-  JsonSchemaBoxSource.generateBoxes(input, options as never);
+const generate = (input: string, options: BoxOptions = null) =>
+  JsonSchemaBoxSource.generateBoxes(input, options);
 
 const parseOutput = async (input: string, options = {}) => {
   const boxes = await generate(input, options);

--- a/src/modules/boxSources/__test__/JsonSortKeysBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonSortKeysBoxSource.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonSortKeysBoxSource } from '../JsonSortKeysBoxSource';
+
+describe('JsonSortKeysBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no trigger option is provided', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes(
+        '{"b":1,"a":2}',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options is null', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes(
+        '{"b":1,"a":2}',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should sort object keys ascending by default with ::jsonsort', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes(
+        '{"b":1,"a":{"d":4,"c":3}}',
+        { jsonsort: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+
+      const output = boxes[0].props.plaintextOutput;
+      const parsed = JSON.parse(output);
+
+      // deep value equality
+      expect(parsed).toEqual({ a: { c: 3, d: 4 }, b: 1 });
+
+      // key order in serialised output: "a" must appear before "b", "c" before "d"
+      expect(output.indexOf('"a"')).toBeLessThan(output.indexOf('"b"'));
+      expect(output.indexOf('"c"')).toBeLessThan(output.indexOf('"d"'));
+    });
+
+    it('should sort keys descending when ::jsonsort=desc', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes('{"a":1,"b":2}', {
+        jsonsort: 'desc',
+      });
+
+      expect(boxes).toHaveLength(1);
+
+      const output = boxes[0].props.plaintextOutput;
+      // "b" must appear before "a" in descending order
+      expect(output.indexOf('"b"')).toBeLessThan(output.indexOf('"a"'));
+    });
+
+    it('should also trigger on ::sortkeys option', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes('{"b":1,"a":2}', {
+        sortkeys: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+
+      const output = boxes[0].props.plaintextOutput;
+      expect(output.indexOf('"a"')).toBeLessThan(output.indexOf('"b"'));
+    });
+
+    it('should preserve array element order (not sort array contents)', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes('{"x":[3,1,2]}', {
+        jsonsort: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed.x).toEqual([3, 1, 2]);
+    });
+
+    it('should sort keys inside objects that are elements of an array', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes(
+        '[{"b":1,"a":2}]',
+        { jsonsort: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+
+      const output = boxes[0].props.plaintextOutput;
+      const parsed = JSON.parse(output);
+
+      expect(parsed[0]).toEqual({ a: 2, b: 1 });
+      // "a" must come before "b" in the serialised output
+      expect(output.indexOf('"a"')).toBeLessThan(output.indexOf('"b"'));
+    });
+
+    it('should return an error box for invalid JSON', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes('{bad', {
+        jsonsort: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('Invalid JSON');
+    });
+
+    it('should not pollute Object prototype when __proto__ is a JSON key', async () => {
+      const input = '{"__proto__":{"x":1},"a":2}';
+      await JsonSortKeysBoxSource.generateBoxes(input, { jsonsort: true });
+
+      // prototype pollution would make ({}).x === 1
+      expect(({} as Record<string, unknown>).x).toBeUndefined();
+    });
+
+    it('should set language option to json on the output box', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes('{"b":1,"a":2}', {
+        jsonsort: true,
+      });
+
+      expect(boxes[0].props.options).toEqual({ language: 'json' });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/OnColorBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/OnColorBoxSource.test.ts
@@ -1,0 +1,222 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { OnColorBoxSource } from '../OnColorBoxSource';
+
+describe('OnColorBoxSource', () => {
+  describe('guard conditions', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when an unrelated option is set', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('white background (#ffffff)', () => {
+    it('produces one box', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('foreground is black (#000000) because black has higher contrast on white', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Foreground).toBe('#000000');
+    });
+
+    it('contrast is 21:1 (maximum possible)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Contrast).toBe('21:1');
+    });
+
+    it('WCAG AA and AAA both pass', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['WCAG AA']).toBe('pass');
+      expect(opts['WCAG AAA']).toBe('pass');
+    });
+
+    it('background is normalized to #ffffff', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Background).toBe('#ffffff');
+    });
+  });
+
+  describe('black background (#000000)', () => {
+    it('foreground is white (#ffffff)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#000000', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Foreground).toBe('#ffffff');
+    });
+
+    it('contrast is 21:1', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#000000', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Contrast).toBe('21:1');
+    });
+  });
+
+  describe('mid blue (#3498db)', () => {
+    // luminance ~0.283; vs black ~6.66, vs white ~3.15 → black wins
+    it('foreground is #000000 (black has higher contrast)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#3498db', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Foreground).toBe('#000000');
+    });
+
+    it('contrast matches the higher ratio (black wins at ~6.66:1)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#3498db', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Contrast).toBe('6.66:1');
+    });
+
+    it('WCAG AA passes (>= 4.5), WCAG AAA fails (< 7)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#3498db', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['WCAG AA']).toBe('pass');
+      expect(opts['WCAG AAA']).toBe('fail');
+    });
+  });
+
+  describe('mid grey (#777777)', () => {
+    // luminance ~0.184; vs black ~4.69, vs white ~4.48 → black wins narrowly
+    it('produces a valid foreground (black or white)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#777777', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(['#000000', '#ffffff']).toContain(opts.Foreground);
+    });
+
+    it('contrast equals the higher of the two ratios', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#777777', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // expected: black wins at ~4.69:1
+      expect(opts.Contrast).toBe('4.69:1');
+    });
+  });
+
+  describe('invalid color input', () => {
+    it('xyz triggers an error box (not empty array)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('xyz', {
+        oncolor: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('error box mentions that a hex color is required', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('xyz', {
+        oncolor: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text.toLowerCase()).toMatch(/hex color/);
+    });
+
+    it('bare color name without hash returns an error box', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('red', {
+        oncolor: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('shorthand hex (#fff)', () => {
+    it('expands #fff to #ffffff and picks black foreground', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#fff', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Background).toBe('#ffffff');
+      expect(opts.Foreground).toBe('#000000');
+      expect(opts.Contrast).toBe('21:1');
+    });
+  });
+
+  describe('::textcolor alias', () => {
+    it('triggers with ::textcolor option', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        textcolor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Foreground).toBe('#000000');
+    });
+  });
+
+  describe('box shape', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is "Readable Text Color"', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      expect(boxes[0].props.name).toBe('Readable Text Color');
+    });
+
+    it('plaintext output contains k:v lines', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Background: #ffffff');
+      expect(text).toContain('Foreground: #000000');
+      expect(text).toContain('Contrast: 21:1');
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      expect(boxes[0].props.priority).toBe(OnColorBoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(OnColorBoxSource.name).toBe('Readable Text Color');
+      expect(OnColorBoxSource.tag).toBe('#');
+      expect(OnColorBoxSource.kind).toBe('Analyze');
+      expect(typeof OnColorBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/RegexEscapeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/RegexEscapeBoxSource.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { RegexEscapeBoxSource } from '../RegexEscapeBoxSource';
+
+describe('RegexEscapeBoxSource', () => {
+  describe('generateBoxes - gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('a.b*c', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('a.b*c', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input string', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - escaping', () => {
+    it('escapes . and * in "a.b*c"', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('a.b*c', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\\.b\\*c');
+    });
+
+    it('escapes ( ? ) in "(x?)"', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('(x?)', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('\\(x\\?\\)');
+    });
+
+    it('escapes + but leaves = unchanged in "1+1=2"', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('1+1=2', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1\\+1=2');
+    });
+
+    it('escapes $ and . in "price: $5.00"', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('price: $5.00', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('price: \\$5\\.00');
+    });
+
+    it('escapes backslash in "a\\b"', async () => {
+      // input is a-backslash-b (2 chars between a and b)
+      const boxes = await RegexEscapeBoxSource.generateBoxes('a\\b', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // output: a\\b (escaped backslash)
+      expect(boxes[0].props.plaintextOutput).toBe('a\\\\b');
+    });
+
+    it('leaves plain text unchanged when no special chars', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('hello', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+  });
+
+  describe('generateBoxes - alias trigger', () => {
+    it('accepts ::reescape as an alias', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('a.b', {
+        reescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\\.b');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(RegexEscapeBoxSource.name).toBe('Regex Escape');
+      expect(RegexEscapeBoxSource.tag).toBe('#');
+      expect(RegexEscapeBoxSource.kind).toBe('Encode');
+      expect(typeof RegexEscapeBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/VerhoeffBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/VerhoeffBoxSource.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { VerhoeffBoxSource } from '../VerhoeffBoxSource';
+
+describe('VerhoeffBoxSource', () => {
+  it('returns [] when ::verhoeff option is absent', async () => {
+    const boxes = await VerhoeffBoxSource.generateBoxes('236', null);
+    expect(boxes).toEqual([]);
+  });
+
+  it('computes check digit 3 for input 236 (canonical Wikipedia example)', async () => {
+    const boxes = await VerhoeffBoxSource.generateBoxes('236', {
+      verhoeff: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Check Digit']).toBe('3');
+    expect(opts.Input).toBe('236');
+  });
+
+  it('validates 2363 as true (236 + check digit 3)', async () => {
+    const boxes = await VerhoeffBoxSource.generateBoxes('2363', {
+      verhoeff: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Valid).toBe('true');
+  });
+
+  it('validates 2364 as false', async () => {
+    const boxes = await VerhoeffBoxSource.generateBoxes('2364', {
+      verhoeff: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Valid).toBe('false');
+  });
+
+  it('computes check digit 1 for input 12345', async () => {
+    const boxes = await VerhoeffBoxSource.generateBoxes('12345', {
+      verhoeff: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Check Digit']).toBe('1');
+  });
+
+  it('returns an error box for non-digit input', async () => {
+    const boxes = await VerhoeffBoxSource.generateBoxes('abc', {
+      verhoeff: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Error).toBeDefined();
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -4,24 +4,32 @@ import {
 } from './Base64BoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
+import CsvToMarkdownBoxSource from './CsvToMarkdownBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import Fletcher16BoxSource from './Fletcher16BoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
+import GlobToRegexBoxSource from './GlobToRegexBoxSource';
 import HashBoxSource from './HashBoxSource';
+import JsonSchemaBoxSource from './JsonSchemaBoxSource';
+import JsonSortKeysBoxSource from './JsonSortKeysBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import OnColorBoxSource from './OnColorBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import RegexEscapeBoxSource from './RegexEscapeBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
+import VerhoeffBoxSource from './VerhoeffBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -29,13 +37,19 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  OnColorBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
+  CsvToMarkdownBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  Fletcher16BoxSource,
   GenerateQRCodeBoxSource,
+  GlobToRegexBoxSource,
   HashBoxSource,
+  JsonSchemaBoxSource,
+  JsonSortKeysBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
@@ -44,10 +58,12 @@ export const boxSources = [
   PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
+  RegexEscapeBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
+  VerhoeffBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,


### PR DESCRIPTION
## Summary

Twentieth exploration batch — **8 more BoxSource tools** (checksums, JSON/CSV, dev utilities).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Verhoeff Check | `::verhoeff` | dihedral-group check digit |
| Fletcher-16 | `::fletcher16` | checksum |
| JSON Sort Keys | `::jsonsort` | recursive key sort (canonical form) |
| CSV to Markdown | `::csvmd` | CSV → GFM table |
| JSON Schema | `::jsonschema` | infer a draft-07 schema |
| Regex Escape | `::regexescape` | escape a literal for a regex |
| Glob to Regex | `::glob2regex` | shell glob → anchored regex |
| Readable Text Color | `::oncolor` | black/white fg + WCAG ratio for a bg |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules — KeyValue sources render `k: v` plaintext; **`Object.fromEntries` for prototype-safe object rebuild** (JSON Sort Keys); arrays kept in order; linear/ReDoS-safe regex output (Glob→Regex); WCAG 2.1 `0.04045` threshold.
- **Verified vectors**: Verhoeff `236`→`3` / `2363` valid; **Fletcher-16 `abcde`→`0xc8f0`, `abcdef`→`0x2057`, `abcdefgh`→`0x0627`**; `*.ts`→`^[^/]*\.ts$`, `src/**/*.ts`→`^src/.*/[^/]*\.ts$`; white bg→black text 21:1; JSON Sort recursive + array-order-preserved + prototype-safe.
- Self-review fixed a CSV parser bug (an unconditional end-of-line field push added a phantom trailing empty column) — caught by the source's own tests.

## Verification

- ✅ `bun run test run` — **424 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#278 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6