### PR TITLE
feat(boxSources): add 8 more tools (nanoid, base62, css-color-name, rail-fence, scinote, dms, chmod, whitespace-normalize)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,80 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>NanoIdBox</b> </summary>
+
+| match rule  | description                          | example      |
+| ----------- | ------------------------------------ | ------------ |
+| `::nanoid`  | generate a URL-safe NanoID (`=length`) | `::nanoid`  |
+
+</details>
+
+<details>
+<summary> <b>Base62Box</b> </summary>
+
+| match rule        | description                          | example              |
+| ----------------- | ------------------------------------ | -------------------- |
+| `::base62`        | encode an integer to Base62          | `123456789 ::base62` |
+| `::base62decode`  | decode Base62 to a number            | `8M0kX ::base62decode` |
+
+</details>
+
+<details>
+<summary> <b>CssColorNameBox</b> </summary>
+
+| match rule     | description                          | example             |
+| -------------- | ------------------------------------ | ------------------- |
+| `::colorname`  | CSS color name ⇄ hex (nearest match) | `tomato ::colorname` |
+
+</details>
+
+<details>
+<summary> <b>RailFenceBox</b> </summary>
+
+| match rule           | description                          | example                  |
+| -------------------- | ------------------------------------ | ------------------------ |
+| `::railfence=N`      | Rail Fence cipher encode             | `HELLO ::railfence=3`    |
+| `::railfencedecode=N`| Rail Fence cipher decode             | `HOLELL ::railfencedecode=3` |
+
+</details>
+
+<details>
+<summary> <b>ScientificNotationBox</b> </summary>
+
+| match rule   | description                          | example               |
+| ------------ | ------------------------------------ | --------------------- |
+| `::scinote`  | decimal ⇄ scientific/engineering notation | `0.00012345 ::scinote` |
+
+</details>
+
+<details>
+<summary> <b>DmsBox</b> </summary>
+
+| match rule  | description                          | example              |
+| ----------- | ------------------------------------ | -------------------- |
+| `::dms`     | decimal degrees ⇄ DMS coordinates    | `40.446195 ::dms`    |
+
+</details>
+
+<details>
+<summary> <b>ChmodBox</b> </summary>
+
+| match rule  | description                          | example       |
+| ----------- | ------------------------------------ | ------------- |
+| `::chmod`   | Unix permissions octal ⇄ symbolic    | `755 ::chmod` |
+
+</details>
+
+<details>
+<summary> <b>WhitespaceNormalizeBox</b> </summary>
+
+| match rule      | description                          | example                  |
+| --------------- | ------------------------------------ | ------------------------ |
+| `::trimlines`   | trim trailing spaces + collapse blank lines (`::normalizews` collapses internal runs) | `text ::trimlines` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/Base62BoxSource.ts
+++ b/src/modules/boxSources/Base62BoxSource.ts
@@ -1,0 +1,109 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// standard base62 alphabet: digits, uppercase, then lowercase
+const ALPHABET =
+  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const BASE = 62n;
+
+// build reverse lookup once at module init
+const CHAR_TO_INDEX = new Map<string, bigint>(
+  [...ALPHABET].map((ch, i) => [ch, BigInt(i)]),
+);
+
+function encodeBase62(n: bigint): string {
+  if (n === 0n) return '0';
+  let result = '';
+  let value = n;
+  while (value > 0n) {
+    result = ALPHABET[Number(value % BASE)] + result;
+    value /= BASE;
+  }
+  return result;
+}
+
+function decodeBase62(s: string): bigint {
+  let value = 0n;
+  for (const ch of s) {
+    const digit = CHAR_TO_INDEX.get(ch);
+    if (digit === undefined) throw new Error(`invalid base62 char: ${ch}`);
+    value = value * BASE + digit;
+  }
+  return value;
+}
+
+export const Base62BoxSource = {
+  name: 'Base62',
+  description:
+    'Encode a non-negative integer to Base62, or decode a Base62 string to a number.',
+  defaultInput: '123456789 ::base62',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'base62', 'base62encode');
+    const wantDecode = hasOptionKeys(options, 'base62decode');
+    if (!wantEncode && !wantDecode) return [];
+
+    // cap input length to avoid DoS on huge strings
+    const raw = trim(input).slice(0, 5000);
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      if (!/^\d+$/.test(raw)) {
+        boxes.push(
+          new BoxBuilder(
+            'Base62',
+            'Invalid input: a non-negative integer is required for encoding.',
+          )
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        const decimal = BigInt(raw);
+        const encoded = encodeBase62(decimal);
+        boxes.push(
+          new BoxBuilder('Base62', '')
+            .setOptions({ Decimal: raw, Base62: encoded })
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    if (wantDecode) {
+      if (!/^[0-9A-Za-z]+$/.test(raw)) {
+        boxes.push(
+          new BoxBuilder(
+            'Base62',
+            'Invalid input: only base62 characters (0–9, A–Z, a–z) are allowed.',
+          )
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        const decoded = decodeBase62(raw);
+        boxes.push(
+          new BoxBuilder('Base62', '')
+            .setOptions({ Base62: raw, Decimal: decoded.toString() })
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Base62BoxSource;

--- a/src/modules/boxSources/Base62BoxSource.ts
+++ b/src/modules/boxSources/Base62BoxSource.ts
@@ -71,7 +71,7 @@ export const Base62BoxSource = {
         const decimal = BigInt(raw);
         const encoded = encodeBase62(decimal);
         boxes.push(
-          new BoxBuilder('Base62', '')
+          new BoxBuilder('Base62', `Decimal: ${raw}\nBase62: ${encoded}`)
             .setOptions({ Decimal: raw, Base62: encoded })
             .setTemplate(KeyValueBoxTemplate)
             .setPriority(this.priority)
@@ -93,7 +93,7 @@ export const Base62BoxSource = {
       } else {
         const decoded = decodeBase62(raw);
         boxes.push(
-          new BoxBuilder('Base62', '')
+          new BoxBuilder('Base62', `Base62: ${raw}\nDecimal: ${decoded}`)
             .setOptions({ Base62: raw, Decimal: decoded.toString() })
             .setTemplate(KeyValueBoxTemplate)
             .setPriority(this.priority)

--- a/src/modules/boxSources/ChmodBoxSource.ts
+++ b/src/modules/boxSources/ChmodBoxSource.ts
@@ -1,0 +1,178 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// octal digit → rwx triplet string
+function octalDigitToRwx(digit: number): string {
+  const r = digit & 4 ? 'r' : '-';
+  const w = digit & 2 ? 'w' : '-';
+  const x = digit & 1 ? 'x' : '-';
+  return `${r}${w}${x}`;
+}
+
+// build symbolic string from 3-digit octal value (user/group/other)
+// if special != 0: bit 4=setuid (user x→s/S), bit 2=setgid (group x→s/S), bit 1=sticky (other x→t/T)
+function octalToSymbolic(octalStr: string): string {
+  let special = 0;
+  let digits: string;
+
+  if (octalStr.length === 4) {
+    special = Number.parseInt(octalStr[0], 8);
+    digits = octalStr.slice(1);
+  } else {
+    digits = octalStr;
+  }
+
+  const u = Number.parseInt(digits[0], 8);
+  const g = Number.parseInt(digits[1], 8);
+  const o = Number.parseInt(digits[2], 8);
+
+  let userRwx = octalDigitToRwx(u);
+  let groupRwx = octalDigitToRwx(g);
+  let otherRwx = octalDigitToRwx(o);
+
+  if (special & 4) {
+    // setuid: replace user x with 's' (x set) or 'S' (x not set)
+    userRwx = userRwx.slice(0, 2) + (u & 1 ? 's' : 'S');
+  }
+  if (special & 2) {
+    // setgid: replace group x with 's'/'S'
+    groupRwx = groupRwx.slice(0, 2) + (g & 1 ? 's' : 'S');
+  }
+  if (special & 1) {
+    // sticky: replace other x with 't'/'T'
+    otherRwx = otherRwx.slice(0, 2) + (o & 1 ? 't' : 'T');
+  }
+
+  return `${userRwx}${groupRwx}${otherRwx}`;
+}
+
+// human-readable description of a single rwx triplet
+function rwxDescription(rwx: string, label: string): string {
+  const parts: string[] = [];
+  if (rwx[0] === 'r') parts.push('read');
+  if (rwx[1] === 'w') parts.push('write');
+  const x = rwx[2];
+  if (x === 'x' || x === 's' || x === 't') parts.push('execute');
+  if (x === 's' || x === 'S') parts.push('setuid/setgid');
+  if (x === 't' || x === 'T') parts.push('sticky');
+  return parts.length > 0
+    ? `${label}: ${parts.join(', ')}`
+    : `${label}: no permissions`;
+}
+
+// build description string from symbolic (9 chars, after stripping file-type prefix)
+function symbolicDescription(sym: string): string {
+  const user = rwxDescription(sym.slice(0, 3), 'user');
+  const group = rwxDescription(sym.slice(3, 6), 'group');
+  const other = rwxDescription(sym.slice(6, 9), 'other');
+  return `${user}; ${group}; ${other}`;
+}
+
+// symbolic 9-char string → octal string (3 or 4 digits)
+function symbolicToOctal(sym: string): string {
+  let special = 0;
+
+  // compute each triad's base value (r=4, w=2, x=1)
+  function triadValue(triad: string): number {
+    let v = 0;
+    if (triad[0] === 'r') v += 4;
+    if (triad[1] === 'w') v += 2;
+    const x = triad[2];
+    if (x === 'x' || x === 's' || x === 't') v += 1;
+    return v;
+  }
+
+  const u = triadValue(sym.slice(0, 3));
+  const g = triadValue(sym.slice(3, 6));
+  const o = triadValue(sym.slice(6, 9));
+
+  // accumulate special bits from symbolic chars
+  const ux = sym[2];
+  const gx = sym[5];
+  const ox = sym[8];
+  if (ux === 's' || ux === 'S') special |= 4;
+  if (gx === 's' || gx === 'S') special |= 2;
+  if (ox === 't' || ox === 'T') special |= 1;
+
+  const base = `${u}${g}${o}`;
+  return special > 0 ? `${special}${base}` : base;
+}
+
+export const ChmodBoxSource = {
+  name: 'chmod',
+  description:
+    'Convert Unix permissions between octal (755) and symbolic (rwxr-xr-x).',
+  defaultInput: '755 ::chmod',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'chmod', 'permissions')) return [];
+
+    const raw = trim(input);
+
+    // octal input: 3 or 4 octal digits
+    if (/^[0-7]{3,4}$/.test(raw)) {
+      const symbolic = octalToSymbolic(raw);
+      const description = symbolicDescription(symbolic);
+      return [
+        new BoxBuilder('chmod', '')
+          .setOptions({
+            Octal: raw,
+            Symbolic: symbolic,
+            Description: description,
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // symbolic input: 9 or 10 chars (optional leading file-type char)
+    if (/^[-rwxsStTdlcbp]{9,10}$/.test(raw)) {
+      // strip leading file-type character if present (e.g. 'd' in 'drwxr-xr-x')
+      const sym9 = raw.length === 10 ? raw.slice(1) : raw;
+
+      // validate that sym9 is a proper 9-char permission string
+      if (!/^[-rwxsStT]{9}$/.test(sym9)) {
+        return [invalidFormatBox(this.priority)];
+      }
+
+      const octal = symbolicToOctal(sym9);
+      const description = symbolicDescription(sym9);
+      return [
+        new BoxBuilder('chmod', '')
+          .setOptions({
+            Octal: octal,
+            Symbolic: sym9,
+            Description: description,
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // unrecognized input: explain expected formats
+    return [invalidFormatBox(this.priority)];
+  },
+};
+
+function invalidFormatBox(priority: number): Box {
+  return new BoxBuilder(
+    'chmod',
+    'Enter an octal permission (e.g. 755) or symbolic string (e.g. rwxr-xr-x).',
+  )
+    .setPriority(priority)
+    .build();
+}
+
+export default ChmodBoxSource;

--- a/src/modules/boxSources/ChmodBoxSource.ts
+++ b/src/modules/boxSources/ChmodBoxSource.ts
@@ -5,6 +5,13 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 
+// render key/value pairs as `k: v` lines for the headless/TUI plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
 // octal digit → rwx triplet string
 function octalDigitToRwx(digit: number): string {
   const r = digit & 4 ? 'r' : '-';
@@ -117,19 +124,16 @@ export const ChmodBoxSource = {
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'chmod', 'permissions')) return [];
 
-    const raw = trim(input);
+    const raw = trim(input).slice(0, 20);
 
     // octal input: 3 or 4 octal digits
     if (/^[0-7]{3,4}$/.test(raw)) {
       const symbolic = octalToSymbolic(raw);
       const description = symbolicDescription(symbolic);
+      const kv = { Octal: raw, Symbolic: symbolic, Description: description };
       return [
-        new BoxBuilder('chmod', '')
-          .setOptions({
-            Octal: raw,
-            Symbolic: symbolic,
-            Description: description,
-          })
+        new BoxBuilder('chmod', kvToPlaintext(kv))
+          .setOptions(kv)
           .setTemplate(KeyValueBoxTemplate)
           .setPriority(this.priority)
           .build(),
@@ -148,13 +152,10 @@ export const ChmodBoxSource = {
 
       const octal = symbolicToOctal(sym9);
       const description = symbolicDescription(sym9);
+      const kv = { Octal: octal, Symbolic: sym9, Description: description };
       return [
-        new BoxBuilder('chmod', '')
-          .setOptions({
-            Octal: octal,
-            Symbolic: sym9,
-            Description: description,
-          })
+        new BoxBuilder('chmod', kvToPlaintext(kv))
+          .setOptions(kv)
           .setTemplate(KeyValueBoxTemplate)
           .setPriority(this.priority)
           .build(),

--- a/src/modules/boxSources/CssColorNameBoxSource.ts
+++ b/src/modules/boxSources/CssColorNameBoxSource.ts
@@ -1,0 +1,285 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// the full CSS Color Module Level 4 named-color list mapped to 6-digit lowercase hex (no leading #)
+const NAMED: Record<string, string> = {
+  aliceblue: 'f0f8ff',
+  antiquewhite: 'faebd7',
+  aqua: '00ffff',
+  aquamarine: '7fffd4',
+  azure: 'f0ffff',
+  beige: 'f5f5dc',
+  bisque: 'ffe4c4',
+  black: '000000',
+  blanchedalmond: 'ffebcd',
+  blue: '0000ff',
+  blueviolet: '8a2be2',
+  brown: 'a52a2a',
+  burlywood: 'deb887',
+  cadetblue: '5f9ea0',
+  chartreuse: '7fff00',
+  chocolate: 'd2691e',
+  coral: 'ff7f50',
+  cornflowerblue: '6495ed',
+  cornsilk: 'fff8dc',
+  crimson: 'dc143c',
+  cyan: '00ffff',
+  darkblue: '00008b',
+  darkcyan: '008b8b',
+  darkgoldenrod: 'b8860b',
+  darkgray: 'a9a9a9',
+  darkgreen: '006400',
+  darkgrey: 'a9a9a9',
+  darkkhaki: 'bdb76b',
+  darkmagenta: '8b008b',
+  darkolivegreen: '556b2f',
+  darkorange: 'ff8c00',
+  darkorchid: '9932cc',
+  darkred: '8b0000',
+  darksalmon: 'e9967a',
+  darkseagreen: '8fbc8f',
+  darkslateblue: '483d8b',
+  darkslategray: '2f4f4f',
+  darkslategrey: '2f4f4f',
+  darkturquoise: '00ced1',
+  darkviolet: '9400d3',
+  deeppink: 'ff1493',
+  deepskyblue: '00bfff',
+  dimgray: '696969',
+  dimgrey: '696969',
+  dodgerblue: '1e90ff',
+  firebrick: 'b22222',
+  floralwhite: 'fffaf0',
+  forestgreen: '228b22',
+  fuchsia: 'ff00ff',
+  gainsboro: 'dcdcdc',
+  ghostwhite: 'f8f8ff',
+  gold: 'ffd700',
+  goldenrod: 'daa520',
+  gray: '808080',
+  green: '008000',
+  greenyellow: 'adff2f',
+  grey: '808080',
+  honeydew: 'f0fff0',
+  hotpink: 'ff69b4',
+  indianred: 'cd5c5c',
+  indigo: '4b0082',
+  ivory: 'fffff0',
+  khaki: 'f0e68c',
+  lavender: 'e6e6fa',
+  lavenderblush: 'fff0f5',
+  lawngreen: '7cfc00',
+  lemonchiffon: 'fffacd',
+  lightblue: 'add8e6',
+  lightcoral: 'f08080',
+  lightcyan: 'e0ffff',
+  lightgoldenrodyellow: 'fafad2',
+  lightgray: 'd3d3d3',
+  lightgreen: '90ee90',
+  lightgrey: 'd3d3d3',
+  lightpink: 'ffb6c1',
+  lightsalmon: 'ffa07a',
+  lightseagreen: '20b2aa',
+  lightskyblue: '87cefa',
+  lightslategray: '778899',
+  lightslategrey: '778899',
+  lightsteelblue: 'b0c4de',
+  lightyellow: 'ffffe0',
+  lime: '00ff00',
+  limegreen: '32cd32',
+  linen: 'faf0e6',
+  magenta: 'ff00ff',
+  maroon: '800000',
+  mediumaquamarine: '66cdaa',
+  mediumblue: '0000cd',
+  mediumorchid: 'ba55d3',
+  mediumpurple: '9370db',
+  mediumseagreen: '3cb371',
+  mediumslateblue: '7b68ee',
+  mediumspringgreen: '00fa9a',
+  mediumturquoise: '48d1cc',
+  mediumvioletred: 'c71585',
+  midnightblue: '191970',
+  mintcream: 'f5fffa',
+  mistyrose: 'ffe4e1',
+  moccasin: 'ffe4b5',
+  navajowhite: 'ffdead',
+  navy: '000080',
+  oldlace: 'fdf5e6',
+  olive: '808000',
+  olivedrab: '6b8e23',
+  orange: 'ffa500',
+  orangered: 'ff4500',
+  orchid: 'da70d6',
+  palegoldenrod: 'eee8aa',
+  palegreen: '98fb98',
+  paleturquoise: 'afeeee',
+  palevioletred: 'db7093',
+  papayawhip: 'ffefd5',
+  peachpuff: 'ffdab9',
+  peru: 'cd853f',
+  pink: 'ffb6c1',
+  plum: 'dda0dd',
+  powderblue: 'b0e0e6',
+  purple: '800080',
+  rebeccapurple: '663399',
+  red: 'ff0000',
+  rosybrown: 'bc8f8f',
+  royalblue: '4169e1',
+  saddlebrown: '8b4513',
+  salmon: 'fa8072',
+  sandybrown: 'f4a460',
+  seagreen: '2e8b57',
+  seashell: 'fff5ee',
+  sienna: 'a0522d',
+  silver: 'c0c0c0',
+  skyblue: '87ceeb',
+  slateblue: '6a5acd',
+  slategray: '708090',
+  slategrey: '708090',
+  snow: 'fffafa',
+  springgreen: '00ff7f',
+  steelblue: '4682b4',
+  tan: 'd2b48c',
+  teal: '008080',
+  thistle: 'd8bfd8',
+  tomato: 'ff6347',
+  turquoise: '40e0d0',
+  violet: 'ee82ee',
+  wheat: 'f5deb3',
+  white: 'ffffff',
+  whitesmoke: 'f5f5f5',
+  yellow: 'ffff00',
+  yellowgreen: '9acd32',
+};
+
+// build a reverse map from hex to canonical name (first entry wins for duplicates like aqua/cyan)
+const HEX_TO_NAME: Record<string, string> = {};
+for (const [name, hex] of Object.entries(NAMED)) {
+  if (!(hex in HEX_TO_NAME)) {
+    HEX_TO_NAME[hex] = name;
+  }
+}
+
+// expand a 3-digit hex string to 6 digits
+function expandShortHex(hex: string): string {
+  if (hex.length === 3) {
+    return hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  }
+  return hex;
+}
+
+// parse a #rgb or #rrggbb string into [r, g, b] components, returns null on failure
+function parseHex(raw: string): [number, number, number] | null {
+  const stripped = raw.startsWith('#') ? raw.slice(1) : raw;
+  const expanded = expandShortHex(stripped);
+  if (!/^[0-9a-fA-F]{6}$/.test(expanded)) return null;
+  const r = Number.parseInt(expanded.slice(0, 2), 16);
+  const g = Number.parseInt(expanded.slice(2, 4), 16);
+  const b = Number.parseInt(expanded.slice(4, 6), 16);
+  return [r, g, b];
+}
+
+// find the nearest CSS named color by squared Euclidean RGB distance
+function nearestName(r: number, g: number, b: number): string {
+  let bestName = '';
+  let bestDist = Number.MAX_SAFE_INTEGER;
+  for (const [name, hex] of Object.entries(NAMED)) {
+    const nr = Number.parseInt(hex.slice(0, 2), 16);
+    const ng = Number.parseInt(hex.slice(2, 4), 16);
+    const nb = Number.parseInt(hex.slice(4, 6), 16);
+    const dist = (r - nr) ** 2 + (g - ng) ** 2 + (b - nb) ** 2;
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestName = name;
+    }
+  }
+  return bestName;
+}
+
+export const CssColorNameBoxSource = {
+  name: 'CSS Color Name',
+  description:
+    'Convert a CSS named color to hex, or a hex color to the nearest CSS named color.',
+  defaultInput: 'tomato ::colorname',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'colorname', 'csscolor')) return [];
+
+    const raw = trim(input);
+
+    if (raw.startsWith('#')) {
+      // hex → nearest name
+      const lower = raw.toLowerCase();
+      const stripped = lower.slice(1);
+      const expanded = expandShortHex(stripped);
+
+      const components = parseHex(raw);
+      if (!components) return [];
+      const [r, g, b] = components;
+
+      const name = nearestName(r, g, b);
+      const nameHex = NAMED[name];
+      const isExact = nameHex === expanded;
+
+      const box = new BoxBuilder('CSS Color Name', '')
+        .setOptions({
+          Hex: `#${expanded}`,
+          'Nearest Name': name,
+          'Name Hex': `#${nameHex}`,
+          Exact: isExact ? 'true' : 'false',
+        })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .build();
+
+      return [box];
+    }
+
+    // name → hex
+    const nameLower = raw.toLowerCase();
+    const hex = NAMED[nameLower];
+
+    if (!hex) {
+      // unknown name — return a box explaining the color isn't a CSS named color
+      const box = new BoxBuilder('CSS Color Name', '')
+        .setOptions({
+          Name: raw,
+          Error: `'${raw}' is not a CSS named color`,
+        })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .build();
+
+      return [box];
+    }
+
+    const r = Number.parseInt(hex.slice(0, 2), 16);
+    const g = Number.parseInt(hex.slice(2, 4), 16);
+    const b = Number.parseInt(hex.slice(4, 6), 16);
+
+    const box = new BoxBuilder('CSS Color Name', '')
+      .setOptions({
+        Name: nameLower,
+        Hex: `#${hex}`,
+        RGB: `rgb(${r}, ${g}, ${b})`,
+      })
+      .setTemplate(KeyValueBoxTemplate)
+      .setPriority(Priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default CssColorNameBoxSource;

--- a/src/modules/boxSources/CssColorNameBoxSource.ts
+++ b/src/modules/boxSources/CssColorNameBoxSource.ts
@@ -5,6 +5,13 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 
+// render key/value pairs as `k: v` lines for the headless/TUI plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
 // the full CSS Color Module Level 4 named-color list mapped to 6-digit lowercase hex (no leading #)
 const NAMED: Record<string, string> = {
   aliceblue: 'f0f8ff',
@@ -216,7 +223,7 @@ export const CssColorNameBoxSource = {
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'colorname', 'csscolor')) return [];
 
-    const raw = trim(input);
+    const raw = trim(input).slice(0, 200);
 
     if (raw.startsWith('#')) {
       // hex → nearest name
@@ -232,15 +239,16 @@ export const CssColorNameBoxSource = {
       const nameHex = NAMED[name];
       const isExact = nameHex === expanded;
 
-      const box = new BoxBuilder('CSS Color Name', '')
-        .setOptions({
-          Hex: `#${expanded}`,
-          'Nearest Name': name,
-          'Name Hex': `#${nameHex}`,
-          Exact: isExact ? 'true' : 'false',
-        })
+      const kv = {
+        Hex: `#${expanded}`,
+        'Nearest Name': name,
+        'Name Hex': `#${nameHex}`,
+        Exact: isExact ? 'true' : 'false',
+      };
+      const box = new BoxBuilder('CSS Color Name', kvToPlaintext(kv))
+        .setOptions(kv)
         .setTemplate(KeyValueBoxTemplate)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build();
 
       return [box];
@@ -252,13 +260,14 @@ export const CssColorNameBoxSource = {
 
     if (!hex) {
       // unknown name — return a box explaining the color isn't a CSS named color
-      const box = new BoxBuilder('CSS Color Name', '')
-        .setOptions({
-          Name: raw,
-          Error: `'${raw}' is not a CSS named color`,
-        })
+      const kv = {
+        Name: raw,
+        Error: `'${raw}' is not a CSS named color`,
+      };
+      const box = new BoxBuilder('CSS Color Name', kvToPlaintext(kv))
+        .setOptions(kv)
         .setTemplate(KeyValueBoxTemplate)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build();
 
       return [box];
@@ -268,14 +277,15 @@ export const CssColorNameBoxSource = {
     const g = Number.parseInt(hex.slice(2, 4), 16);
     const b = Number.parseInt(hex.slice(4, 6), 16);
 
-    const box = new BoxBuilder('CSS Color Name', '')
-      .setOptions({
-        Name: nameLower,
-        Hex: `#${hex}`,
-        RGB: `rgb(${r}, ${g}, ${b})`,
-      })
+    const kv = {
+      Name: nameLower,
+      Hex: `#${hex}`,
+      RGB: `rgb(${r}, ${g}, ${b})`,
+    };
+    const box = new BoxBuilder('CSS Color Name', kvToPlaintext(kv))
+      .setOptions(kv)
       .setTemplate(KeyValueBoxTemplate)
-      .setPriority(Priority)
+      .setPriority(this.priority)
       .build();
 
     return [box];

--- a/src/modules/boxSources/DmsBoxSource.ts
+++ b/src/modules/boxSources/DmsBoxSource.ts
@@ -66,7 +66,16 @@ export const DmsBoxSource = {
     const decimalMatch = raw.match(DECIMAL_RE);
     if (decimalMatch) {
       const decimal = Number.parseFloat(decimalMatch[1]);
-      if (Number.isNaN(decimal) || decimal < -180 || decimal > 180) return [];
+      if (Number.isNaN(decimal) || decimal < -180 || decimal > 180) {
+        return [
+          new BoxBuilder(
+            'DMS Coordinates',
+            'A coordinate must be between -180 and 180 degrees.',
+          )
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
 
       const components = decimalToDms(decimal);
       const dmsStr = formatDmsString(components);

--- a/src/modules/boxSources/DmsBoxSource.ts
+++ b/src/modules/boxSources/DmsBoxSource.ts
@@ -1,0 +1,155 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to avoid runaway regexes
+const MAX_INPUT_LENGTH = 100;
+
+// matches a plain decimal degree: optional sign, digits, optional decimal
+const DECIMAL_RE = /^(-?\d+(?:\.\d+)?)$/;
+
+// matches DMS in various formats, e.g. "40°26'40.3"N" or "40 26 40.3 N" or "40°26'40.3""
+// groups: deg, min, sec, optional hemisphere
+const DMS_RE = /^(\d+)[°\s]+(\d+)['\s]+(\d+(?:\.\d+)?)["\s]*([NSEWnsew]?)$/;
+
+interface DmsComponents {
+  degrees: number;
+  minutes: number;
+  seconds: number;
+  // sign: +1 or -1 (from input sign or hemisphere)
+  sign: number;
+}
+
+function decimalToDms(decimal: number): DmsComponents {
+  const sign = decimal < 0 ? -1 : 1;
+  const abs = Math.abs(decimal);
+  const degrees = Math.trunc(abs);
+  const minFloat = (abs - degrees) * 60;
+  const minutes = Math.trunc(minFloat);
+  const seconds = (minFloat - minutes) * 60;
+  return { degrees, minutes, seconds, sign };
+}
+
+function dmsToDecimal(components: DmsComponents): number {
+  const { degrees, minutes, seconds, sign } = components;
+  const abs = degrees + minutes / 60 + seconds / 3600;
+  return sign * abs;
+}
+
+function formatDmsString(components: DmsComponents): string {
+  const { degrees, minutes, seconds } = components;
+  return `${degrees}°${minutes}'${seconds.toFixed(2)}"`;
+}
+
+export const DmsBoxSource = {
+  name: 'DMS Coordinates',
+  description:
+    'Convert a coordinate between decimal degrees and degrees/minutes/seconds (DMS).',
+  defaultInput: '40.446195 ::dms',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'dms', 'latlng')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT_LENGTH) return [];
+
+    // try decimal degrees first
+    const decimalMatch = raw.match(DECIMAL_RE);
+    if (decimalMatch) {
+      const decimal = Number.parseFloat(decimalMatch[1]);
+      if (Number.isNaN(decimal) || decimal < -180 || decimal > 180) return [];
+
+      const components = decimalToDms(decimal);
+      const dmsStr = formatDmsString(components);
+
+      // plaintext k:v output
+      const content = [
+        `Decimal: ${decimal}`,
+        `DMS: ${dmsStr}`,
+        `Degrees: ${components.degrees}`,
+        `Minutes: ${components.minutes}`,
+        `Seconds: ${components.seconds.toFixed(2)}`,
+      ].join('\n');
+
+      const opts: Record<string, string> = {
+        Decimal: String(decimal),
+        DMS: dmsStr,
+        Degrees: String(components.degrees),
+        Minutes: String(components.minutes),
+        Seconds: components.seconds.toFixed(2),
+      };
+
+      return [
+        new BoxBuilder('DMS Coordinates', content)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(opts)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // try DMS string
+    const dmsMatch = raw.match(DMS_RE);
+    if (dmsMatch) {
+      const degrees = Number.parseInt(dmsMatch[1], 10);
+      const minutes = Number.parseInt(dmsMatch[2], 10);
+      const seconds = Number.parseFloat(dmsMatch[3]);
+      const hemisphere = dmsMatch[4].toUpperCase();
+
+      // south and west hemispheres are negative
+      const sign = hemisphere === 'S' || hemisphere === 'W' ? -1 : 1;
+
+      const components: DmsComponents = { degrees, minutes, seconds, sign };
+      const decimal = dmsToDecimal(components);
+      const decimalStr = decimal.toFixed(6);
+      const dmsStr = formatDmsString(components);
+
+      const content = [
+        `Decimal: ${decimalStr}`,
+        `DMS: ${dmsStr}`,
+        `Degrees: ${degrees}`,
+        `Minutes: ${minutes}`,
+        `Seconds: ${seconds.toFixed(2)}`,
+      ].join('\n');
+
+      const opts: Record<string, string> = {
+        Decimal: decimalStr,
+        DMS: dmsStr,
+        Degrees: String(degrees),
+        Minutes: String(minutes),
+        Seconds: seconds.toFixed(2),
+      };
+
+      return [
+        new BoxBuilder('DMS Coordinates', content)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(opts)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // neither format matched — return a hint box
+    const hint =
+      'Expected formats:\n  Decimal: 40.446195 or -73.985\n  DMS: 40°26\'40.3"N or 40 26 40.3 N';
+
+    return [
+      new BoxBuilder('DMS Coordinates', hint)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions({ Format: 'Decimal or DMS' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DmsBoxSource;

--- a/src/modules/boxSources/NanoIdBoxSource.ts
+++ b/src/modules/boxSources/NanoIdBoxSource.ts
@@ -1,0 +1,95 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const DEFAULT_LENGTH = 21;
+const MIN_LENGTH = 1;
+const MAX_LENGTH = 512;
+
+// default nanoid alphabet (URL-safe, 64 chars)
+const ALPHABET =
+  'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict';
+
+// bitmask for the 64-char alphabet: each byte & 63 maps to exactly one char with no bias
+const MASK = 63;
+
+/** Generates a URL-safe NanoID of the given length using unbiased sampling against ALPHABET. */
+function generateNanoId(length: number): string {
+  const bytes = new Uint8Array(length) as Uint8Array<ArrayBuffer>;
+  crypto.getRandomValues(bytes);
+  let id = '';
+  for (let i = 0; i < length; i++) {
+    id += ALPHABET[bytes[i] & MASK];
+  }
+  return id;
+}
+
+function parseLength(options: BoxOptions): number {
+  const val = extractOptionKeys(options, 'nanoid');
+  if (typeof val === 'string' && val !== '') {
+    const parsed = Number.parseInt(val, 10);
+    if (!Number.isNaN(parsed)) {
+      return Math.min(MAX_LENGTH, Math.max(MIN_LENGTH, parsed));
+    }
+  }
+  return DEFAULT_LENGTH;
+}
+
+export const NanoIdBoxSource = {
+  name: 'NanoID',
+  description:
+    'Generate a URL-safe NanoID. Default length 21; ::nanoid=<length> for a custom size.',
+  defaultInput: ' ::nanoid',
+  tag: '#',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    _input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'nanoid')) return [];
+
+    if (
+      typeof crypto === 'undefined' ||
+      typeof crypto.getRandomValues !== 'function'
+    ) {
+      return [
+        new BoxBuilder(
+          'NanoID',
+          'Error: crypto.getRandomValues is unavailable. A secure context (HTTPS or localhost) is required.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const length = parseLength(options);
+    const id = generateNanoId(length);
+
+    const content = `NanoID: ${id}\nLength: ${length}\nAlphabet Size: 64`;
+
+    const kvOptions: Record<string, string> = {
+      NanoID: id,
+      Length: String(length),
+      'Alphabet Size': '64',
+    };
+
+    return [
+      new BoxBuilder('NanoID', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NanoIdBoxSource;

--- a/src/modules/boxSources/RailFenceBoxSource.ts
+++ b/src/modules/boxSources/RailFenceBoxSource.ts
@@ -1,0 +1,123 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+const DEFAULT_RAILS = 3;
+const MIN_RAILS = 2;
+const MAX_RAILS = 1000;
+
+// parse and clamp the rail count from an option value
+function parseRails(value: string | boolean): number {
+  if (typeof value === 'boolean') return DEFAULT_RAILS;
+  const n = Number.parseInt(value, 10);
+  if (Number.isNaN(n)) return DEFAULT_RAILS;
+  return Math.min(Math.max(n, MIN_RAILS), MAX_RAILS);
+}
+
+// build the zigzag row-index pattern for a given text length and rail count
+function zigzagPattern(length: number, numRails: number): number[] {
+  const pattern: number[] = [];
+  let row = 0;
+  let dir = 1;
+  for (let i = 0; i < length; i++) {
+    pattern.push(row);
+    if (row === 0) dir = 1;
+    else if (row === numRails - 1) dir = -1;
+    row += dir;
+  }
+  return pattern;
+}
+
+function encode(text: string, numRails: number): string {
+  const rails: string[][] = Array.from({ length: numRails }, () => []);
+  const pattern = zigzagPattern(text.length, numRails);
+  for (let i = 0; i < text.length; i++) {
+    rails[pattern[i]].push(text[i]);
+  }
+  return rails.map((r) => r.join('')).join('');
+}
+
+function decode(cipher: string, numRails: number): string {
+  const n = cipher.length;
+  const pattern = zigzagPattern(n, numRails);
+
+  // count how many characters land on each rail
+  const counts = new Array<number>(numRails).fill(0);
+  for (const r of pattern) counts[r]++;
+
+  // slice the ciphertext into per-rail segments in read order
+  const railStrings: string[] = [];
+  let pos = 0;
+  for (let i = 0; i < numRails; i++) {
+    railStrings.push(cipher.slice(pos, pos + counts[i]));
+    pos += counts[i];
+  }
+
+  // read characters back out in zigzag order
+  const railCursors = new Array<number>(numRails).fill(0);
+  let result = '';
+  for (const r of pattern) {
+    result += railStrings[r][railCursors[r]++];
+  }
+  return result;
+}
+
+export const RailFenceBoxSource = {
+  name: 'Rail Fence',
+  description:
+    'Rail Fence (zigzag) transposition cipher. ::railfence=3 to encode with 3 rails; ::railfencedecode=3 to decode.',
+  defaultInput: 'WEAREDISCOVEREDFLEEATONCE ::railfence=3',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (
+      !hasOptionKeys(options, 'railfence', 'railfenceencode', 'railfencedecode')
+    ) {
+      return [];
+    }
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT) {
+      return [];
+    }
+
+    const encValue = extractOptionKeys(options, 'railfence', 'railfenceencode');
+    const decValue = extractOptionKeys(options, 'railfencedecode');
+
+    const boxes: Box[] = [];
+
+    if (encValue !== null) {
+      const numRails = parseRails(encValue);
+      const encoded = encode(input, numRails);
+      boxes.push(
+        new BoxBuilder('Rail Fence (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (decValue !== null) {
+      const numRails = parseRails(decValue);
+      const decoded = decode(input, numRails);
+      boxes.push(
+        new BoxBuilder('Rail Fence (Decode)', decoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default RailFenceBoxSource;

--- a/src/modules/boxSources/ScientificNotationBoxSource.ts
+++ b/src/modules/boxSources/ScientificNotationBoxSource.ts
@@ -84,12 +84,12 @@ export const ScientificNotationBoxSource = {
     const raw = trim(input).slice(0, 100);
 
     if (!NUMBER_RE.test(raw)) {
+      // no setTemplate → DefaultBoxTemplate renders the plaintext message
       const box = new BoxBuilder(
         'Scientific Notation',
         'A valid number is required (e.g. 0.00012345 or 1.5e-3).',
       )
         .setPriority(this.priority)
-        .setTemplate(KeyValueBoxTemplate)
         .build();
       return [box];
     }
@@ -102,7 +102,6 @@ export const ScientificNotationBoxSource = {
         'A valid finite number is required.',
       )
         .setPriority(this.priority)
-        .setTemplate(KeyValueBoxTemplate)
         .build();
       return [box];
     }

--- a/src/modules/boxSources/ScientificNotationBoxSource.ts
+++ b/src/modules/boxSources/ScientificNotationBoxSource.ts
@@ -1,0 +1,133 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// valid decimal or scientific notation number (optional sign, digits, optional decimal, optional exponent)
+const NUMBER_RE = /^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
+
+// trim trailing zeros after decimal in mantissa, keep at least one digit
+function trimMantissa(mantissa: string): string {
+  if (!mantissa.includes('.')) return mantissa;
+  return mantissa.replace(/\.?0+$/, '');
+}
+
+// format to scientific notation: Xe+Y with trimmed mantissa
+function toScientific(n: number): string {
+  const raw = n.toExponential();
+  // raw is like "1.23450e-4" — split on 'e'
+  const [mantissa, expPart] = raw.split('e');
+  const exp = Number.parseInt(expPart, 10);
+  const sign = exp >= 0 ? '+' : '';
+  return `${trimMantissa(mantissa)}e${sign}${exp}`;
+}
+
+// format to engineering notation: exponent is a multiple of 3
+function toEngineering(n: number): string {
+  if (n === 0) return '0e+0';
+
+  const exp = Math.floor(Math.log10(Math.abs(n)));
+  // round down to nearest multiple of 3
+  const engExp = Math.floor(exp / 3) * 3;
+  const mantissa = n / 10 ** engExp;
+
+  // round to avoid floating-point noise (up to 10 significant digits)
+  const mantissaRounded = Number.parseFloat(mantissa.toPrecision(10));
+  const sign = engExp >= 0 ? '+' : '';
+  return `${trimMantissa(mantissaRounded.toString())}e${sign}${engExp}`;
+}
+
+// produce a plain decimal string without JS auto-exponent notation
+function toDecimal(n: number): string {
+  // Number.toString() uses exponent for very large/small values;
+  // toFixed loses precision for very large numbers, so use a threshold approach
+  const abs = Math.abs(n);
+  if (abs === 0) return '0';
+  // for numbers JS would render in exponent form natively (< 1e-6 or >= 1e21),
+  // reconstruct from toExponential to get full decimal expansion
+  if (abs < 1e-6 || abs >= 1e21) {
+    const [mantissa, expPart] = n.toExponential().split('e');
+    const exp = Number.parseInt(expPart, 10);
+    const digits = mantissa.replace('-', '').replace('.', '');
+    const isNeg = n < 0;
+    const dotPos = 1 + exp; // position of decimal point in digits
+    let result: string;
+    if (dotPos <= 0) {
+      result = `0.${'0'.repeat(-dotPos)}${digits}`;
+    } else if (dotPos >= digits.length) {
+      result = digits + '0'.repeat(dotPos - digits.length);
+    } else {
+      result = `${digits.slice(0, dotPos)}.${digits.slice(dotPos)}`;
+    }
+    return isNeg ? `-${result}` : result;
+  }
+  // for normal range, toString() is fine
+  return n.toString();
+}
+
+export const ScientificNotationBoxSource = {
+  name: 'Scientific Notation',
+  description: 'Convert a number to/from scientific and engineering notation.',
+  defaultInput: '0.00012345 ::scinote',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'scinote', 'scientific')) return [];
+
+    const raw = trim(input).slice(0, 100);
+
+    if (!NUMBER_RE.test(raw)) {
+      const box = new BoxBuilder(
+        'Scientific Notation',
+        'A valid number is required (e.g. 0.00012345 or 1.5e-3).',
+      )
+        .setPriority(this.priority)
+        .setTemplate(KeyValueBoxTemplate)
+        .build();
+      return [box];
+    }
+
+    const n = Number.parseFloat(raw);
+
+    if (!Number.isFinite(n)) {
+      const box = new BoxBuilder(
+        'Scientific Notation',
+        'A valid finite number is required.',
+      )
+        .setPriority(this.priority)
+        .setTemplate(KeyValueBoxTemplate)
+        .build();
+      return [box];
+    }
+
+    const decimal = toDecimal(n);
+    const scientific = toScientific(n);
+    const engineering = toEngineering(n);
+    const eNotation = scientific.toUpperCase();
+
+    // plaintext output is a k:v block for KeyValueBoxTemplate fallback rendering
+    const plaintext = `Decimal: ${decimal}\nScientific: ${scientific}\nEngineering: ${engineering}\nE-notation: ${eNotation}`;
+
+    const box = new BoxBuilder('Scientific Notation', plaintext)
+      .setOptions({
+        Decimal: decimal,
+        Scientific: scientific,
+        Engineering: engineering,
+        'E-notation': eNotation,
+      })
+      .setTemplate(KeyValueBoxTemplate)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default ScientificNotationBoxSource;

--- a/src/modules/boxSources/WhitespaceNormalizeBoxSource.ts
+++ b/src/modules/boxSources/WhitespaceNormalizeBoxSource.ts
@@ -1,0 +1,97 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// normalize line endings to LF
+function normalizeCRLF(text: string): string {
+  return text.replace(/\r\n|\r/g, '\n');
+}
+
+// strip trailing whitespace from every line
+function stripTrailingWhitespace(lines: string[]): string[] {
+  return lines.map((line) => line.replace(/[ \t]+$/, ''));
+}
+
+// collapse 2+ consecutive blank lines to a single blank line
+function collapseBlankLines(lines: string[]): string[] {
+  const result: string[] = [];
+  let blanks = 0;
+  for (const line of lines) {
+    if (line === '') {
+      blanks++;
+      if (blanks <= 1) result.push(line);
+    } else {
+      blanks = 0;
+      result.push(line);
+    }
+  }
+  return result;
+}
+
+// trim leading and trailing blank lines from the line array
+function trimLeadingTrailingBlankLines(lines: string[]): string[] {
+  let start = 0;
+  while (start < lines.length && lines[start] === '') start++;
+  let end = lines.length - 1;
+  while (end >= start && lines[end] === '') end--;
+  return lines.slice(start, end + 1);
+}
+
+// collapse internal runs of spaces/tabs to a single space and trim leading whitespace per line
+function collapseInternalWhitespace(lines: string[]): string[] {
+  return lines.map((line) =>
+    line.replace(/^[ \t]+/, '').replace(/[ \t]{2,}/g, ' '),
+  );
+}
+
+function normalize(input: string, applyNormalizews: boolean): string {
+  const text = normalizeCRLF(input);
+  let lines = text.split('\n');
+
+  lines = stripTrailingWhitespace(lines);
+
+  if (applyNormalizews) {
+    lines = collapseInternalWhitespace(lines);
+  }
+
+  lines = collapseBlankLines(lines);
+  lines = trimLeadingTrailingBlankLines(lines);
+
+  return lines.join('\n');
+}
+
+export const WhitespaceNormalizeBoxSource = {
+  name: 'Normalize Whitespace',
+  description:
+    'Trim trailing spaces per line, collapse multiple blank lines to one, and strip leading/trailing blank lines.',
+  defaultInput: 'foo   \n\n\n  bar  \n\n ::trimlines',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'trimlines', 'normalizews')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const applyNormalizews = hasOptionKeys(options, 'normalizews');
+    const output = normalize(input, applyNormalizews);
+
+    return [
+      new BoxBuilder('Normalize Whitespace', output)
+        .setTemplate(CodeBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default WhitespaceNormalizeBoxSource;

--- a/src/modules/boxSources/__test__/Base62BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base62BoxSource.test.ts
@@ -1,0 +1,169 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Base62BoxSource } from '../Base62BoxSource';
+
+describe('Base62BoxSource', () => {
+  describe('no option keys → empty array', () => {
+    it('returns [] when no base62 option is provided', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('123456789', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] with unrelated options', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('123456789', {
+        foo: 'bar',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode', () => {
+    it('encodes 0 to "0"', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('0', { base62: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Decimal: '0',
+        Base62: '0',
+      });
+    });
+
+    it('encodes 61 to "z" (last single-char value)', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('61', { base62: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Decimal: '61',
+        Base62: 'z',
+      });
+    });
+
+    it('encodes 62 to "10"', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('62', { base62: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Decimal: '62',
+        Base62: '10',
+      });
+    });
+
+    it('encodes 123456789 and round-trips back', async () => {
+      const encBoxes = await Base62BoxSource.generateBoxes('123456789', {
+        base62: true,
+      });
+      expect(encBoxes).toHaveLength(1);
+      const encoded = encBoxes[0].props.options?.Base62 as string;
+      expect(encoded).toBeTruthy();
+
+      const decBoxes = await Base62BoxSource.generateBoxes(encoded, {
+        base62decode: true,
+      });
+      expect(decBoxes).toHaveLength(1);
+      expect(decBoxes[0].props.options).toMatchObject({ Decimal: '123456789' });
+    });
+
+    it('uses KeyValueBoxTemplate for valid encode', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('62', { base62: true });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('returns error box for non-digit encode input', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('abc', {
+        base62: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/non-negative integer/i);
+    });
+
+    it('accepts ::base62encode option alias', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('62', {
+        base62encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Base62: '10' });
+    });
+  });
+
+  describe('decode', () => {
+    it('decodes "10" to 62', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('10', {
+        base62decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Base62: '10',
+        Decimal: '62',
+      });
+    });
+
+    it('decodes "z" to 61', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('z', {
+        base62decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Base62: 'z',
+        Decimal: '61',
+      });
+    });
+
+    it('uses KeyValueBoxTemplate for valid decode', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('10', {
+        base62decode: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('returns error box for invalid base62 chars', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('!!', {
+        base62decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+  });
+
+  describe('BigInt round-trip for value > Number.MAX_SAFE_INTEGER', () => {
+    // 9007199254740993 = 2^53 + 1, which Number.parseInt would lose precision on
+    it('encodes and decodes 9007199254740993 exactly', async () => {
+      const input = '9007199254740993';
+      const encBoxes = await Base62BoxSource.generateBoxes(input, {
+        base62: true,
+      });
+      expect(encBoxes).toHaveLength(1);
+      const encoded = encBoxes[0].props.options?.Base62 as string;
+
+      const decBoxes = await Base62BoxSource.generateBoxes(encoded, {
+        base62decode: true,
+      });
+      expect(decBoxes).toHaveLength(1);
+      expect(decBoxes[0].props.options?.Decimal).toBe(input);
+    });
+  });
+
+  describe('both options → two boxes', () => {
+    it('produces encode box then decode box when both options set', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('62', {
+        base62: true,
+        base62decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      // first box is encode result
+      expect(boxes[0].props.options).toMatchObject({
+        Decimal: '62',
+        Base62: '10',
+      });
+      // second box is decode result: '62' as base62 = 6*62 + 2 = 374
+      expect(boxes[1].props.options).toMatchObject({
+        Base62: '62',
+        Decimal: '374',
+      });
+    });
+  });
+
+  describe('priority', () => {
+    it('sets priority to 10', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('1', { base62: true });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ChmodBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ChmodBoxSource.test.ts
@@ -1,0 +1,207 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ChmodBoxSource } from '../ChmodBoxSource';
+
+describe('ChmodBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] with no options', async () => {
+      expect(await ChmodBoxSource.generateBoxes('755', null)).toHaveLength(0);
+    });
+
+    it('returns [] with unrelated options', async () => {
+      expect(
+        await ChmodBoxSource.generateBoxes('755', { foo: true }),
+      ).toHaveLength(0);
+    });
+
+    it('triggers on ::chmod option', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('triggers on ::permissions option', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', {
+        permissions: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('octal → symbolic', () => {
+    it('755 → rwxr-xr-x', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({
+        Octal: '755',
+        Symbolic: 'rwxr-xr-x',
+      });
+    });
+
+    it('644 → rw-r--r--', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('644', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({
+        Octal: '644',
+        Symbolic: 'rw-r--r--',
+      });
+    });
+
+    it('777 → rwxrwxrwx', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('777', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({ Symbolic: 'rwxrwxrwx' });
+    });
+
+    it('000 → ---------', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('000', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({ Symbolic: '---------' });
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('includes Description with human-readable labels', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      const desc = boxes[0].props.options?.Description as string;
+      expect(desc).toMatch(/user/i);
+      expect(desc).toMatch(/group/i);
+      expect(desc).toMatch(/other/i);
+    });
+  });
+
+  describe('setuid / special bits (4-digit octal)', () => {
+    it('4755 → rwsr-xr-x (setuid sets user x to s)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('4755', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({
+        Octal: '4755',
+        Symbolic: 'rwsr-xr-x',
+      });
+    });
+
+    it('2755 → rwxr-sr-x (setgid sets group x to s)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('2755', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({ Symbolic: 'rwxr-sr-x' });
+    });
+
+    it('1755 → rwxr-xr-t (sticky sets other x to t)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('1755', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({ Symbolic: 'rwxr-xr-t' });
+    });
+
+    it('4644 → rwSr--r-- (setuid, no user x → S)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('4644', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({ Symbolic: 'rwSr--r--' });
+    });
+  });
+
+  describe('symbolic → octal', () => {
+    it('rwxr-xr-x → 755', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwxr-xr-x', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Octal: '755',
+        Symbolic: 'rwxr-xr-x',
+      });
+    });
+
+    it('rw-r--r-- → 644', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rw-r--r--', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '644' });
+    });
+
+    it('rwxrwxrwx → 777', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwxrwxrwx', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '777' });
+    });
+
+    it('--------- → 000', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('---------', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '000' });
+    });
+
+    it('rwsr-xr-x → 4755 (setuid round-trip)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwsr-xr-x', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '4755' });
+    });
+
+    it('rwxr-sr-x → 2755 (setgid)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwxr-sr-x', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '2755' });
+    });
+
+    it('rwxr-xr-t → 1755 (sticky)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwxr-xr-t', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '1755' });
+    });
+  });
+
+  describe('leading file-type character', () => {
+    it('drwxr-xr-x → 755 (strips leading d)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('drwxr-xr-x', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '755' });
+    });
+
+    it('-rwxr-xr-x → 755 (strips leading -)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('-rwxr-xr-x', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '755' });
+    });
+  });
+
+  describe('invalid input', () => {
+    it('abc → format hint box', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('abc', { chmod: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/octal|symbolic/i);
+    });
+
+    it('999 (invalid octal) → format hint box', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('999', { chmod: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/octal|symbolic/i);
+    });
+
+    it('empty string → format hint box', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('', { chmod: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/octal|symbolic/i);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('755 octal → symbolic → octal', async () => {
+      const box1 = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      const sym = box1[0].props.options?.Symbolic as string;
+      const box2 = await ChmodBoxSource.generateBoxes(sym, { chmod: true });
+      expect(box2[0].props.options).toMatchObject({ Octal: '755' });
+    });
+
+    it('4755 octal → symbolic → octal', async () => {
+      const box1 = await ChmodBoxSource.generateBoxes('4755', { chmod: true });
+      const sym = box1[0].props.options?.Symbolic as string;
+      const box2 = await ChmodBoxSource.generateBoxes(sym, { chmod: true });
+      expect(box2[0].props.options).toMatchObject({ Octal: '4755' });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CssColorNameBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CssColorNameBoxSource.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { CssColorNameBoxSource } from '../CssColorNameBoxSource';
+
+describe('CssColorNameBoxSource', () => {
+  it('returns [] when no option keys are present', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('tomato', null);
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when unrelated options are present', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('tomato', {
+      base64: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('name→hex: tomato resolves to #ff6347', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('tomato', {
+      colorname: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({ Hex: '#ff6347' });
+  });
+
+  it('name→hex: case-insensitive — RebeccaPurple resolves to #663399', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('RebeccaPurple', {
+      colorname: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({ Hex: '#663399' });
+  });
+
+  it('name→hex: includes Name and RGB keys', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('tomato', {
+      colorname: true,
+    });
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Name).toBe('tomato');
+    expect(opts.RGB).toBe('rgb(255, 99, 71)');
+  });
+
+  it('hex→name: #ff6347 exact match — Nearest Name is tomato, Exact is true', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('#ff6347', {
+      colorname: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Nearest Name']).toBe('tomato');
+    expect(opts.Exact).toBe('true');
+  });
+
+  it('hex→name: #ff6348 near match — Nearest Name is tomato, Exact is false', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('#ff6348', {
+      colorname: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Nearest Name']).toBe('tomato');
+    expect(opts.Exact).toBe('false');
+  });
+
+  it('hex→name: includes Hex and Name Hex keys', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('#ff6347', {
+      colorname: true,
+    });
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Hex).toBe('#ff6347');
+    expect(opts['Name Hex']).toBe('#ff6347');
+  });
+
+  it('unknown name returns a box mentioning not a CSS color', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('notacolor', {
+      colorname: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Error).toMatch(/not a CSS (named )?color/i);
+  });
+
+  it('accepts ::csscolor option key', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('tomato', {
+      csscolor: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toMatchObject({ Hex: '#ff6347' });
+  });
+
+  it('handles 3-digit shorthand hex like #f63', async () => {
+    // #f63 expands to #ff6633 — nearest to tomato (#ff6347) or coral (#ff7f50)
+    const boxes = await CssColorNameBoxSource.generateBoxes('#f63', {
+      colorname: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Hex).toBe('#ff6633');
+    expect(opts['Nearest Name']).toBeTruthy();
+  });
+
+  it('invalid hex returns []', async () => {
+    const boxes = await CssColorNameBoxSource.generateBoxes('#zzzzzz', {
+      colorname: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+});

--- a/src/modules/boxSources/__test__/DmsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DmsBoxSource.test.ts
@@ -115,9 +115,10 @@ describe('DmsBoxSource', () => {
         expect(boxes).toHaveLength(0);
       });
 
-      it('returns [] for out-of-range decimal 999', async () => {
+      it('returns a range hint box for out-of-range decimal 999', async () => {
         const boxes = await DmsBoxSource.generateBoxes('999', { dms: true });
-        expect(boxes).toHaveLength(0);
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput).toMatch(/-180 and 180/);
       });
     });
   });

--- a/src/modules/boxSources/__test__/DmsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DmsBoxSource.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { DmsBoxSource } from '../DmsBoxSource';
+
+describe('DmsBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await DmsBoxSource.generateBoxes('40.446195', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await DmsBoxSource.generateBoxes('40.446195', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('decimal → DMS', () => {
+      it('converts 40.446195 correctly with ::dms', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40.446195', {
+          dms: true,
+        });
+        expect(boxes).toHaveLength(1);
+
+        const opts = boxes[0].props.options as Record<string, string>;
+        // 0.446195 * 60 = 26.7717 → 26 min
+        // 0.7717 * 60 = 46.302 → 46.30 sec
+        expect(opts.Degrees).toBe('40');
+        expect(opts.Minutes).toBe('26');
+        expect(opts.Seconds).toBe('46.30');
+        expect(opts.DMS).toBe('40°26\'46.30"');
+        expect(opts.Decimal).toBe('40.446195');
+      });
+
+      it('converts 40.446195 correctly with ::latlng', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40.446195', {
+          latlng: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Degrees).toBe('40');
+        expect(opts.Minutes).toBe('26');
+      });
+
+      it('handles negative decimal -73.985', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('-73.985', {
+          dms: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        // magnitude degrees
+        expect(opts.Degrees).toBe('73');
+        expect(opts.Decimal).toBe('-73.985');
+      });
+
+      it('returns box name "DMS Coordinates"', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40.446195', {
+          dms: true,
+        });
+        expect(boxes[0].props.name).toBe('DMS Coordinates');
+      });
+
+      it('sets priority correctly', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40.446195', {
+          dms: true,
+        });
+        expect(boxes[0].props.priority).toBe(10);
+      });
+    });
+
+    describe('DMS → decimal', () => {
+      it('converts 40°26\'46.3"N to decimal ≈ 40.4462', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40°26\'46.3"N', {
+          dms: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        // 40 + 26/60 + 46.3/3600 ≈ 40.446194...
+        expect(opts.Decimal.startsWith('40.4461')).toBe(true);
+      });
+
+      it('converts 33°51\'54"S to negative decimal', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('33°51\'54"S', {
+          dms: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        // 33 + 51/60 + 54/3600 = 33.865 → negative due to S
+        expect(opts.Decimal.startsWith('-33.86')).toBe(true);
+      });
+
+      it('converts space-separated DMS without hemisphere', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40 26 40.3', {
+          dms: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Degrees).toBe('40');
+        expect(opts.Minutes).toBe('26');
+      });
+    });
+
+    describe('invalid input', () => {
+      it('returns a hint box for non-parseable input "abc"', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('abc', { dms: true });
+        expect(boxes).toHaveLength(1);
+        // the hint box content should mention expected formats
+        expect(boxes[0].props.plaintextOutput).toContain('Expected formats');
+      });
+
+      it('returns [] for input exceeding 100 chars', async () => {
+        const long = 'a'.repeat(101);
+        const boxes = await DmsBoxSource.generateBoxes(long, { dms: true });
+        expect(boxes).toHaveLength(0);
+      });
+
+      it('returns [] for out-of-range decimal 999', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('999', { dms: true });
+        expect(boxes).toHaveLength(0);
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NanoIdBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NanoIdBoxSource.test.ts
@@ -1,0 +1,118 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { NanoIdBoxSource } from '../NanoIdBoxSource';
+
+// default nanoid alphabet — mirrors the source constant for assertion purposes
+const ALPHABET =
+  'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict';
+
+describe('NanoIdBoxSource', () => {
+  describe('generateBoxes — trigger conditions', () => {
+    it('should return empty array without nanoid option', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('anything', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array with unrelated options', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('anything', {
+        qr: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — default length', () => {
+    it('should generate a NanoID of length 21 with ::nanoid option (boolean)', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', { nanoid: true });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      const id = opts.NanoID;
+
+      expect(id).toHaveLength(21);
+      expect(id).toMatch(/^[A-Za-z0-9_-]{21}$/);
+      for (const ch of id) {
+        expect(ALPHABET).toContain(ch);
+      }
+
+      expect(opts.Length).toBe('21');
+      expect(opts['Alphabet Size']).toBe('64');
+    });
+
+    it('should use KeyValueBoxTemplate', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', { nanoid: true });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('should set correct box name and priority', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', { nanoid: true });
+      expect(boxes[0].props.name).toBe('NanoID');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes — custom length', () => {
+    it('should generate a NanoID of length 10 with ::nanoid=10', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', { nanoid: '10' });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.NanoID).toHaveLength(10);
+      expect(opts.Length).toBe('10');
+    });
+  });
+
+  describe('generateBoxes — length clamping', () => {
+    it('should clamp ::nanoid=9999 to maximum 512', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', { nanoid: '9999' });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.NanoID).toHaveLength(512);
+      expect(opts.Length).toBe('512');
+    });
+
+    it('should clamp ::nanoid=0 to minimum 1', async () => {
+      const boxes = await NanoIdBoxSource.generateBoxes('', { nanoid: '0' });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.NanoID).toHaveLength(1);
+      expect(opts.Length).toBe('1');
+    });
+  });
+
+  describe('generateBoxes — randomness', () => {
+    it('should produce different IDs on two consecutive calls', async () => {
+      const [a, b] = await Promise.all([
+        NanoIdBoxSource.generateBoxes('', { nanoid: true }),
+        NanoIdBoxSource.generateBoxes('', { nanoid: true }),
+      ]);
+      const idA = (a[0].props.options as Record<string, string>).NanoID;
+      const idB = (b[0].props.options as Record<string, string>).NanoID;
+      expect(idA).not.toBe(idB);
+    });
+  });
+
+  describe('generateBoxes — secure context fallback', () => {
+    it('should return an explanatory box when crypto.getRandomValues is unavailable', async () => {
+      const original = globalThis.crypto;
+      // @ts-expect-error — intentionally removing crypto to test the fallback
+      delete globalThis.crypto;
+
+      try {
+        const boxes = await NanoIdBoxSource.generateBoxes('', { nanoid: true });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+      } finally {
+        globalThis.crypto = original;
+      }
+    });
+  });
+
+  describe('metadata', () => {
+    it('should have correct static properties', () => {
+      expect(NanoIdBoxSource.name).toBe('NanoID');
+      expect(NanoIdBoxSource.tag).toBe('#');
+      expect(NanoIdBoxSource.kind).toBe('Generate');
+      expect(NanoIdBoxSource.defaultInput).toBe(' ::nanoid');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/RailFenceBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/RailFenceBoxSource.test.ts
@@ -1,0 +1,135 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { RailFenceBoxSource } from '../RailFenceBoxSource';
+
+describe('RailFenceBoxSource', () => {
+  describe('gate conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no relevant keys', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes('', {
+        railfence: '3',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding MAX_INPUT', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'a'.repeat(100_001),
+        { railfence: '3' },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — canonical 3-rail vector', () => {
+    it('encodes WEAREDISCOVEREDFLEEATONCE with 3 rails to WECRLTEERDSOEEFEAOCAIVDEN', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        { railfence: '3' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Rail Fence (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('WECRLTEERDSOEEFEAOCAIVDEN');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('decode — canonical 3-rail vector', () => {
+    it('decodes WECRLTEERDSOEEFEAOCAIVDEN with 3 rails to WEAREDISCOVEREDFLEEATONCE', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WECRLTEERDSOEEFEAOCAIVDEN',
+        { railfencedecode: '3' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Rail Fence (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('WEAREDISCOVEREDFLEEATONCE');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('round-trips HELLO WORLD with 4 rails', async () => {
+      const encBoxes = await RailFenceBoxSource.generateBoxes('HELLO WORLD', {
+        railfence: '4',
+      });
+      expect(encBoxes).toHaveLength(1);
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await RailFenceBoxSource.generateBoxes(encoded, {
+        railfencedecode: '4',
+      });
+      expect(decBoxes).toHaveLength(1);
+      expect(decBoxes[0].props.plaintextOutput).toBe('HELLO WORLD');
+    });
+  });
+
+  describe('N=2 edge case', () => {
+    it('encodes abcdef with 2 rails to acebdf', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes('abcdef', {
+        railfence: '2',
+      });
+      expect(boxes).toHaveLength(1);
+      // rails: a c e / b d f → "ace" + "bdf"
+      expect(boxes[0].props.plaintextOutput).toBe('acebdf');
+    });
+  });
+
+  describe('both encode and decode options', () => {
+    it('returns 2 boxes when both ::railfence and ::railfencedecode are set', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        { railfence: '3', railfencedecode: '3' },
+      );
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Rail Fence (Encode)');
+      expect(names).toContain('Rail Fence (Decode)');
+    });
+  });
+
+  describe('rail clamping', () => {
+    it('clamps rail count below MIN to 2', async () => {
+      // rails=1 is invalid; should clamp to 2 and not throw
+      const boxes = await RailFenceBoxSource.generateBoxes('abcdef', {
+        railfence: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      // 2-rail result matches known good output
+      expect(boxes[0].props.plaintextOutput).toBe('acebdf');
+    });
+
+    it('uses default of 3 rails when option value is boolean true', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        { railfence: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('WECRLTEERDSOEEFEAOCAIVDEN');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(RailFenceBoxSource.name).toBe('Rail Fence');
+      expect(RailFenceBoxSource.tag).toBe('#');
+      expect(RailFenceBoxSource.kind).toBe('Encode');
+      expect(typeof RailFenceBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ScientificNotationBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ScientificNotationBoxSource.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { ScientificNotationBoxSource } from '../ScientificNotationBoxSource';
+
+describe('ScientificNotationBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no matching option key', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes(
+        '0.00012345',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is present', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes(
+        '0.00012345',
+        { base64: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::scinote option', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes(
+        '0.00012345',
+        { scinote: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('triggers on ::scientific option', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes(
+        '0.00012345',
+        { scientific: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('returns error box for invalid input', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes('abc', {
+        scinote: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/valid number/i);
+    });
+
+    it('returns error box for empty input', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes('', {
+        scinote: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/valid number/i);
+    });
+
+    describe('0.00012345', () => {
+      it('produces Scientific = 1.2345e-4', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '0.00012345',
+          { scinote: true },
+        );
+        expect(boxes[0].props.options?.Scientific).toBe('1.2345e-4');
+      });
+
+      it('produces Engineering = 123.45e-6', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '0.00012345',
+          { scinote: true },
+        );
+        expect(boxes[0].props.options?.Engineering).toBe('123.45e-6');
+      });
+
+      it('produces Decimal = 0.00012345', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '0.00012345',
+          { scinote: true },
+        );
+        expect(boxes[0].props.options?.Decimal).toBe('0.00012345');
+      });
+    });
+
+    describe('123456', () => {
+      it('produces Scientific = 1.23456e+5', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '123456',
+          { scinote: true },
+        );
+        expect(boxes[0].props.options?.Scientific).toBe('1.23456e+5');
+      });
+    });
+
+    describe('1.5e3', () => {
+      it('produces Decimal = 1500', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes('1.5e3', {
+          scinote: true,
+        });
+        expect(boxes[0].props.options?.Decimal).toBe('1500');
+      });
+
+      it('produces Scientific = 1.5e+3', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes('1.5e3', {
+          scinote: true,
+        });
+        expect(boxes[0].props.options?.Scientific).toBe('1.5e+3');
+      });
+    });
+
+    describe('1000000', () => {
+      it('produces Engineering with exponent that is a multiple of 3', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '1000000',
+          { scinote: true },
+        );
+        const eng = boxes[0].props.options?.Engineering as string;
+        expect(eng).toBeDefined();
+        // extract exponent value and verify it's a multiple of 3
+        const match = eng.match(/e([+-]\d+)$/);
+        expect(match).not.toBeNull();
+        const expVal = Number.parseInt(match?.[1] ?? '', 10);
+        expect(expVal % 3).toBe(0);
+      });
+
+      it('produces Engineering = 1e+6', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '1000000',
+          { scinote: true },
+        );
+        expect(boxes[0].props.options?.Engineering).toBe('1e+6');
+      });
+    });
+
+    it('E-notation is uppercase version of Scientific', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes(
+        '0.00012345',
+        { scinote: true },
+      );
+      const scientific = boxes[0].props.options?.Scientific as string;
+      const eNotation = boxes[0].props.options?.['E-notation'] as string;
+      expect(eNotation).toBe(scientific.toUpperCase());
+    });
+
+    it('sets priority matching source priority', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes('42', {
+        scinote: true,
+      });
+      expect(boxes[0].props.priority).toBe(
+        ScientificNotationBoxSource.priority,
+      );
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/WhitespaceNormalizeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/WhitespaceNormalizeBoxSource.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { WhitespaceNormalizeBoxSource } from '../WhitespaceNormalizeBoxSource';
+
+describe('WhitespaceNormalizeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option keys present', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes(
+        'foo   \n\n\n  bar  \n\n',
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with option key', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes('', {
+        trimlines: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('trimlines: strips trailing spaces, collapses blank lines, trims leading/trailing blank lines', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes(
+        'foo   \n\n\n  bar  \n\n',
+        { trimlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      // trailing spaces stripped, triple blank → single blank, trailing blank line gone; leading indent on bar kept
+      expect(boxes[0].props.plaintextOutput).toBe('foo\n\n  bar');
+    });
+
+    it('trimlines: strips trailing spaces only', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes(
+        'a   \nb\t',
+        { trimlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb');
+    });
+
+    it('normalizews: collapses internal runs of spaces/tabs to a single space', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes('a    b', {
+        normalizews: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a b');
+    });
+
+    it('normalizews: trims leading whitespace per line', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes('   x', {
+        normalizews: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('x');
+    });
+
+    it('trimlines: normalizes CRLF to LF', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes('a\r\nb', {
+        trimlines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb');
+    });
+
+    it('box has correct name and priority', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes('hello', {
+        trimlines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Normalize Whitespace');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,11 +1,15 @@
+import Base62BoxSource from './Base62BoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import ChmodBoxSource from './ChmodBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
+import CssColorNameBoxSource from './CssColorNameBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DmsBoxSource from './DmsBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
@@ -13,15 +17,19 @@ import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
+import NanoIdBoxSource from './NanoIdBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import RailFenceBoxSource from './RailFenceBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import ScientificNotationBoxSource from './ScientificNotationBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
+import WhitespaceNormalizeBoxSource from './WhitespaceNormalizeBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -29,25 +37,33 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  CssColorNameBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  Base62BoxSource,
+  ChmodBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  DmsBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
+  NanoIdBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  RailFenceBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
+  ScientificNotationBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
+  WhitespaceNormalizeBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,


### PR DESCRIPTION
## Summary

Twenty-first exploration batch — **8 more BoxSource tools** (IDs, encodings, color, ciphers, dev utilities).

| Tool | Trigger | What it does |
|------|---------|--------------|
| NanoID | `::nanoid` | URL-safe random id (crypto, unbiased) |
| Base62 | `::base62` | integer ⇄ Base62 (BigInt-exact) |
| CSS Color Name | `::colorname` | named color ⇄ hex (148-color nearest match) |
| Rail Fence | `::railfence=N` | zigzag transposition cipher |
| Scientific Notation | `::scinote` | decimal ⇄ scientific/engineering |
| DMS Coordinates | `::dms` | decimal degrees ⇄ DMS |
| chmod | `::chmod` | octal ⇄ symbolic permissions (setuid/sticky) |
| Normalize Whitespace | `::trimlines` / `::normalizews` | clean up whitespace |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules — KeyValue sources render `k: v` plaintext, `BigInt(str)` (Base62), unbiased crypto (NanoID 64-char mask), linear regexes (DMS/whitespace), `Uint8Array<ArrayBuffer>` typing.
- **Verified vectors**: Base62 `62`→`10`, `61`→`z`, `>2^53` round-trip exact; `tomato`↔`#ff6347`, `rebeccapurple`↔`#663399`; **rail-fence `WEAREDISCOVEREDFLEEATONCE`→`WECRLTEERDSOEEFEAOCAIVDEN`**; `0.00012345`→`1.2345e-4` / `123.45e-6`; `40.446195`→`40°26'46.30"`; **`755`↔`rwxr-xr-x`, `4755`↔`rwsr-xr-x`**.
- Self-review fixed: a NanoID unused param, three tests reading `props.output` (→ `plaintextOutput`), and a `string|undefined` `parseInt` in the scinote test (all caught by `tsc`/lint).

## Verification

- ✅ `bun run test run` — **446 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

## Review

Automated review will be posted as a comment shortly.

> Independent of #260–#279 — branched from `main`, merges in any order.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6