### PR TITLE
refactor(Box): add keyValueBox()/errorBox() helpers; fix K8sSecret blank TUI box

### DIFF
--- a/src/modules/Box.ts
+++ b/src/modules/Box.ts
@@ -123,3 +123,40 @@ export class BoxBuilder {
     };
   }
 }
+
+// builds a key/value box: renders the pairs as `k: v` lines for the headless
+// plaintextOutput (TUI/clipboard) AND stores them as structured options for the
+// web template. the template is passed in so this module stays framework-agnostic.
+// using this avoids the recurring bug where a KeyValue box ships an empty
+// plaintextOutput and renders blank in the headless TUI.
+export function keyValueBox(
+  template: BoxTemplate | undefined,
+  name: string,
+  kv: Record<string, string>,
+  opts: { priority?: number; showExpandButton?: boolean } = {},
+): Box {
+  const plaintext = Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  const builder = new BoxBuilder(name, plaintext)
+    .setOptions(kv)
+    .setTemplate(template);
+  if (opts.priority !== undefined) builder.setPriority(opts.priority);
+  if (opts.showExpandButton !== undefined) {
+    builder.setShowExpandButton(opts.showExpandButton);
+  }
+  return builder.build();
+}
+
+// builds a plain message box for error/empty states. it leaves the template
+// undefined so the web layer falls back to DefaultBoxTemplate and the headless
+// layer renders the message — never a blank KeyValue grid.
+export function errorBox(
+  name: string,
+  message: string,
+  opts: { priority?: number } = {},
+): Box {
+  const builder = new BoxBuilder(name, message).setShowExpandButton(false);
+  if (opts.priority !== undefined) builder.setPriority(opts.priority);
+  return builder.build();
+}

--- a/src/modules/__test__/Box.test.ts
+++ b/src/modules/__test__/Box.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import type { BoxTemplate } from '../Box';
 import { errorBox, keyValueBox } from '../Box';
 
 // a stand-in template; keyValueBox only stores it on the box, never invokes it
-const FakeTemplate = (() => null) as never;
+const FakeTemplate = (() => null) as unknown as BoxTemplate;
 
 describe('keyValueBox', () => {
   it('renders the pairs as k: v lines in plaintextOutput', () => {
@@ -39,6 +40,16 @@ describe('keyValueBox', () => {
   it('handles an empty kv as an empty string (no entries)', () => {
     const box = keyValueBox(FakeTemplate, 'Demo', {});
     expect(box.props.plaintextOutput).toBe('');
+  });
+
+  it('defaults showExpandButton to true when not provided', () => {
+    const box = keyValueBox(FakeTemplate, 'Demo', { A: '1' });
+    expect(box.props.showExpandButton).toBe(true);
+  });
+
+  it('passes through an undefined template (web fallback)', () => {
+    const box = keyValueBox(undefined, 'Demo', { A: '1' });
+    expect(box.boxTemplate).toBeUndefined();
   });
 });
 

--- a/src/modules/__test__/Box.test.ts
+++ b/src/modules/__test__/Box.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { errorBox, keyValueBox } from '../Box';
+
+// a stand-in template; keyValueBox only stores it on the box, never invokes it
+const FakeTemplate = (() => null) as never;
+
+describe('keyValueBox', () => {
+  it('renders the pairs as k: v lines in plaintextOutput', () => {
+    const box = keyValueBox(FakeTemplate, 'Demo', { A: '1', B: '2' });
+    expect(box.props.plaintextOutput).toBe('A: 1\nB: 2');
+  });
+
+  it('stores the same pairs as structured options', () => {
+    const box = keyValueBox(FakeTemplate, 'Demo', { A: '1', B: '2' });
+    expect(box.props.options).toEqual({ A: '1', B: '2' });
+  });
+
+  it('never produces an empty plaintextOutput for non-empty kv (the TUI bug)', () => {
+    const box = keyValueBox(FakeTemplate, 'Demo', { Only: 'x' });
+    expect(box.props.plaintextOutput).not.toBe('');
+    expect(box.props.plaintextOutput).toBe('Only: x');
+  });
+
+  it('attaches the given template and applies priority/showExpandButton', () => {
+    const box = keyValueBox(
+      FakeTemplate,
+      'Demo',
+      { A: '1' },
+      {
+        priority: 7,
+        showExpandButton: false,
+      },
+    );
+    expect(box.boxTemplate).toBe(FakeTemplate);
+    expect(box.props.priority).toBe(7);
+    expect(box.props.showExpandButton).toBe(false);
+  });
+
+  it('handles an empty kv as an empty string (no entries)', () => {
+    const box = keyValueBox(FakeTemplate, 'Demo', {});
+    expect(box.props.plaintextOutput).toBe('');
+  });
+});
+
+describe('errorBox', () => {
+  it('renders the message as plaintextOutput and sets no template', () => {
+    const box = errorBox('Demo', 'something went wrong');
+    expect(box.props.plaintextOutput).toBe('something went wrong');
+    // no template → the web layer falls back to DefaultBoxTemplate; the
+    // headless layer renders plaintextOutput (never a blank KeyValue grid)
+    expect(box.boxTemplate).toBeUndefined();
+  });
+
+  it('hides the expand button and applies priority', () => {
+    const box = errorBox('Demo', 'oops', { priority: 3 });
+    expect(box.props.showExpandButton).toBe(false);
+    expect(box.props.priority).toBe(3);
+  });
+});

--- a/src/modules/boxSources/K8sSecretBoxSource.ts
+++ b/src/modules/boxSources/K8sSecretBoxSource.ts
@@ -2,7 +2,7 @@ import { KeyValueBoxTemplate } from '@components/BoxTemplate';
 import { decodeBase64 } from '@functions/base64';
 import { isString, trim } from '@functions/helper';
 import type { Box } from '@modules/Box';
-import { BoxBuilder } from '@modules/Box';
+import { keyValueBox } from '@modules/Box';
 import { parse } from 'yaml';
 
 const PriorityK8sSecret = 10;
@@ -73,11 +73,9 @@ data:
     }
 
     return [
-      new BoxBuilder('Kubernetes Secret', '')
-        .setOptions(match.data)
-        .setTemplate(KeyValueBoxTemplate)
-        .setPriority(this.priority)
-        .build(),
+      keyValueBox(KeyValueBoxTemplate, 'Kubernetes Secret', match.data, {
+        priority: this.priority,
+      }),
     ];
   },
 };

--- a/src/modules/boxSources/WordCountBoxSource.ts
+++ b/src/modules/boxSources/WordCountBoxSource.ts
@@ -1,7 +1,7 @@
 import { KeyValueBoxTemplate } from '@components/BoxTemplate';
 import { isString, trim } from '@functions/helper';
 import type { Box } from '@modules/Box';
-import { BoxBuilder } from '@modules/Box';
+import { keyValueBox } from '@modules/Box';
 
 const Priority = 0;
 
@@ -56,10 +56,6 @@ i'mdifficult
     const words = countWords(match.text);
     const characters = match.text.length;
 
-    const content = `lines: ${lines}
-words: ${words}
-characters: ${characters}`;
-
     const output: Record<string, string> = {
       lines: lines.toString(),
       words: words.toString(),
@@ -67,11 +63,9 @@ characters: ${characters}`;
     };
 
     return [
-      new BoxBuilder('Word Count', content)
-        .setTemplate(KeyValueBoxTemplate)
-        .setOptions(output)
-        .setPriority(this.priority)
-        .build(),
+      keyValueBox(KeyValueBoxTemplate, 'Word Count', output, {
+        priority: this.priority,
+      }),
     ];
   },
 };


### PR DESCRIPTION
## Summary

This is the **root-cause fix** for a bug class that recurred in **5 of the last ~10 batches** (#271 Snowflake, #273 Subnet, #276 NumberBases, #277 UuidParse, #280 Base62/CssColorName/chmod): a KeyValue source ships an **empty `plaintextOutput`**, so it renders correctly on the web (from `options`) but **blank in the headless TUI**, which reads `props.plaintextOutput`. The sibling bug: error boxes wired to `KeyValueBoxTemplate` with no `options` also render blank. Each was caught in review, but the real problem was a missing abstraction.

## What this adds

Two framework-agnostic helpers in `@modules/Box` (the template is passed in, so `Box.ts` stays free of any React/MUI import and remains headless-safe):

- **`keyValueBox(template, name, kv, opts?)`** — renders `kv` as `k: v` lines into `plaintextOutput` **and** stores it as structured `options`, so the TUI and web views can't diverge. Optional `priority` / `showExpandButton`.
- **`errorBox(name, message, opts?)`** — a plain message box that leaves the template undefined (web → `DefaultBoxTemplate`, headless → the message), never a blank KeyValue grid.

## Live bug fixed

`K8sSecretBoxSource` passed `''` as `plaintextOutput` on **main** — a decoded secret renders blank in the TUI today. Refactored it (and `WordCount`) onto `keyValueBox`.

## Why it matters going forward

Future BoxSource batches can call `keyValueBox(...)` instead of hand-rolling the builder chain, making both recurring classes **structurally impossible** rather than relying on per-tool review vigilance.

## Verification

- ✅ `bun run test run` — **336 passing** (incl. new `src/modules/__test__/Box.test.ts` covering the exact rendering invariant)
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of the #260–#280 tool PRs — branched from `main`, merges cleanly alongside them.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6