### PR TITLE
feat(boxSources): add 8 more tools (crc16, affine, polybius, words→number, frontmatter, percent-encode, kelvin→rgb, pig-latin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,80 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>Crc16Box</b> </summary>
+
+| match rule  | description                          | example              |
+| ----------- | ------------------------------------ | -------------------- |
+| `::crc16`   | CRC-16 (CCITT-FALSE + Modbus)        | `123456789 ::crc16`  |
+
+</details>
+
+<details>
+<summary> <b>AffineCipherBox</b> </summary>
+
+| match rule          | description                          | example                  |
+| ------------------- | ------------------------------------ | ------------------------ |
+| `::affine=a,b`      | affine cipher encrypt (a coprime 26) | `AFFINE ::affine=5,8`    |
+| `::affinedecode=a,b`| affine cipher decrypt                | `IHHWVC ::affinedecode=5,8` |
+
+</details>
+
+<details>
+<summary> <b>PolybiusBox</b> </summary>
+
+| match rule          | description                          | example            |
+| ------------------- | ------------------------------------ | ------------------ |
+| `::polybius`        | Polybius square encode (5×5, I/J)    | `HELLO ::polybius` |
+| `::polybiusdecode`  | Polybius square decode               | `23 15 ::polybiusdecode` |
+
+</details>
+
+<details>
+<summary> <b>WordsToNumberBox</b> </summary>
+
+| match rule       | description                          | example                  |
+| ---------------- | ------------------------------------ | ------------------------ |
+| `::wordstonum`   | English number words → integer       | `one thousand ::wordstonum` |
+
+</details>
+
+<details>
+<summary> <b>FrontmatterBox</b> </summary>
+
+| match rule        | description                          | example                       |
+| ----------------- | ------------------------------------ | ----------------------------- |
+| `::frontmatter`   | extract YAML frontmatter as JSON     | `---`<br>`title: Hi`<br>`---` `::frontmatter` |
+
+</details>
+
+<details>
+<summary> <b>PercentEncodeBox</b> </summary>
+
+| match rule          | description                          | example                  |
+| ------------------- | ------------------------------------ | ------------------------ |
+| `::percentencode`   | RFC 3986 percent-encode (`::percentdecode` to decode) | `a b&c ::percentencode` |
+
+</details>
+
+<details>
+<summary> <b>KelvinToRgbBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::kelvin`  | color temperature (K) → RGB/hex      | `6500 ::kelvin`  |
+
+</details>
+
+<details>
+<summary> <b>PigLatinBox</b> </summary>
+
+| match rule    | description                          | example                |
+| ------------- | ------------------------------------ | ---------------------- |
+| `::piglatin`  | convert English text to Pig Latin    | `hello world ::piglatin` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/AffineCipherBoxSource.ts
+++ b/src/modules/boxSources/AffineCipherBoxSource.ts
@@ -1,0 +1,154 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// valid multipliers coprime with 26
+const COPRIME_26 = new Set([1, 3, 5, 7, 9, 11, 15, 17, 19, 21, 23, 25]);
+
+// returns aInv such that (a * aInv) mod 26 === 1, or null if none exists
+function modInverse(a: number): number | null {
+  const normalized = ((a % 26) + 26) % 26;
+  for (let i = 1; i < 26; i++) {
+    if ((normalized * i) % 26 === 1) return i;
+  }
+  return null;
+}
+
+function affineEncrypt(text: string, a: number, b: number): string {
+  return text
+    .split('')
+    .map((ch) => {
+      const code = ch.charCodeAt(0);
+      if (code >= 65 && code <= 90) {
+        // uppercase
+        return String.fromCharCode(((a * (code - 65) + b) % 26) + 65);
+      }
+      if (code >= 97 && code <= 122) {
+        // lowercase
+        return String.fromCharCode(((a * (code - 97) + b) % 26) + 97);
+      }
+      return ch;
+    })
+    .join('');
+}
+
+function affineDecrypt(text: string, a: number, b: number): string {
+  const aInv = modInverse(a);
+  if (aInv === null) return text;
+  return text
+    .split('')
+    .map((ch) => {
+      const code = ch.charCodeAt(0);
+      if (code >= 65 && code <= 90) {
+        return String.fromCharCode(
+          ((((aInv * (code - 65 - b)) % 26) + 26) % 26) + 65,
+        );
+      }
+      if (code >= 97 && code <= 122) {
+        return String.fromCharCode(
+          ((((aInv * (code - 97 - b)) % 26) + 26) % 26) + 97,
+        );
+      }
+      return ch;
+    })
+    .join('');
+}
+
+// parses "a,b" from an option value; returns {a, b} or an error string
+function parseAB(
+  raw: string | boolean,
+): { a: number; b: number } | { error: string } {
+  if (typeof raw !== 'string') {
+    return { error: 'Option value must be in the format a,b (e.g. 5,8).' };
+  }
+  const match = raw.match(/^(\d+),(\d+)$/);
+  if (!match) {
+    return { error: `Invalid format "${raw}". Expected a,b (e.g. 5,8).` };
+  }
+  return { a: Number.parseInt(match[1], 10), b: Number.parseInt(match[2], 10) };
+}
+
+function errorBox(message: string, priority: number): Box {
+  return new BoxBuilder('Affine Cipher', message)
+    .setTemplate(DefaultBoxTemplate)
+    .setShowExpandButton(false)
+    .setPriority(priority)
+    .build();
+}
+
+export const AffineCipherBoxSource = {
+  name: 'Affine Cipher',
+  description:
+    'Affine cipher E(x)=(a*x+b) mod 26. ::affine=a,b to encrypt; ::affinedecode=a,b to decrypt. a must be coprime with 26.',
+  defaultInput: 'AFFINE ::affine=5,8',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const encKey = extractOptionKeys(options, 'affine', 'affineencode');
+    const decKey = extractOptionKeys(options, 'affinedecode');
+    if (encKey === null && decKey === null) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (encKey !== null) {
+      const parsed = parseAB(encKey);
+      if ('error' in parsed) {
+        boxes.push(errorBox(parsed.error, this.priority));
+      } else if (!COPRIME_26.has(parsed.a % 26)) {
+        boxes.push(
+          errorBox(
+            `a=${parsed.a} is not coprime with 26. a must be one of: ${[...COPRIME_26].sort((x, y) => x - y).join(', ')}.`,
+            this.priority,
+          ),
+        );
+      } else {
+        const result = affineEncrypt(input, parsed.a, parsed.b);
+        boxes.push(
+          new BoxBuilder('Affine Cipher (Encrypt)', result)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    if (decKey !== null) {
+      const parsed = parseAB(decKey);
+      if ('error' in parsed) {
+        boxes.push(errorBox(parsed.error, this.priority));
+      } else if (!COPRIME_26.has(parsed.a % 26)) {
+        boxes.push(
+          errorBox(
+            `a=${parsed.a} is not coprime with 26. a must be one of: ${[...COPRIME_26].sort((x, y) => x - y).join(', ')}.`,
+            this.priority,
+          ),
+        );
+      } else {
+        const result = affineDecrypt(input, parsed.a, parsed.b);
+        boxes.push(
+          new BoxBuilder('Affine Cipher (Decrypt)', result)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default AffineCipherBoxSource;

--- a/src/modules/boxSources/Crc16BoxSource.ts
+++ b/src/modules/boxSources/Crc16BoxSource.ts
@@ -1,0 +1,83 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// CRC-16/CCITT-FALSE: init=0xFFFF, poly=0x1021, no input/output reflection
+function crc16CcittFalse(bytes: Uint8Array): number {
+  let crc = 0xffff;
+  for (const byte of bytes) {
+    crc ^= byte << 8;
+    for (let i = 0; i < 8; i++) {
+      crc =
+        (crc & 0x8000) !== 0
+          ? ((crc << 1) ^ 0x1021) & 0xffff
+          : (crc << 1) & 0xffff;
+    }
+  }
+  return crc & 0xffff;
+}
+
+// CRC-16/MODBUS: init=0xFFFF, poly=0xA001 (reflected 0x8005)
+function crc16Modbus(bytes: Uint8Array): number {
+  let crc = 0xffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i++) {
+      crc = (crc & 1) !== 0 ? (crc >> 1) ^ 0xa001 : crc >> 1;
+    }
+  }
+  return crc & 0xffff;
+}
+
+function toHex4(value: number): string {
+  return `0x${value.toString(16).padStart(4, '0')}`;
+}
+
+export const Crc16BoxSource = {
+  name: 'CRC-16',
+  description:
+    'Compute CRC-16 (CCITT-FALSE and Modbus) checksums of the input text.',
+  defaultInput: '123456789 ::crc16',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'crc16')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const bytes = new TextEncoder().encode(input);
+
+    const ccittFalse = toHex4(crc16CcittFalse(bytes));
+    const modbus = toHex4(crc16Modbus(bytes));
+
+    const plaintextOutput = `CCITT-FALSE: ${ccittFalse}\nModbus: ${modbus}`;
+
+    const outputOptions: Record<string, string> = {
+      'CCITT-FALSE': ccittFalse,
+      Modbus: modbus,
+    };
+
+    return [
+      new BoxBuilder('CRC-16', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(outputOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Crc16BoxSource;

--- a/src/modules/boxSources/FrontmatterBoxSource.ts
+++ b/src/modules/boxSources/FrontmatterBoxSource.ts
@@ -1,0 +1,68 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+import { parse } from 'yaml';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// matches a leading YAML frontmatter block delimited by --- lines
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+export const FrontmatterBoxSource = {
+  name: 'Frontmatter',
+  description:
+    'Extract YAML frontmatter (--- delimited) from a Markdown document as JSON.',
+  defaultInput: '---\ntitle: Hello\ntags: [a, b]\n---\n# Body ::frontmatter',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'frontmatter', 'fm')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // strip a leading BOM or blank lines before the opening ---
+    const normalized = input.replace(/^﻿/, '').replace(/^\n+/, '');
+
+    const match = FRONTMATTER_RE.exec(normalized);
+    if (!match) {
+      return [
+        new BoxBuilder('Frontmatter', 'No frontmatter found in the document.')
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const yamlBlock = match[1];
+    let parsed: unknown;
+    try {
+      parsed = parse(yamlBlock);
+    } catch {
+      return [
+        new BoxBuilder(
+          'Frontmatter',
+          'Invalid YAML frontmatter: could not be parsed.',
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const json = JSON.stringify(parsed, null, 2);
+    return [
+      new BoxBuilder('Frontmatter', json)
+        .setOptions({ language: 'json' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FrontmatterBoxSource;

--- a/src/modules/boxSources/FrontmatterBoxSource.ts
+++ b/src/modules/boxSources/FrontmatterBoxSource.ts
@@ -1,4 +1,5 @@
 import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 import { parse } from 'yaml';
@@ -23,7 +24,7 @@ export const FrontmatterBoxSource = {
     options: BoxOptions = null,
   ): Promise<Box[]> {
     if (!hasOptionKeys(options, 'frontmatter', 'fm')) return [];
-    if (input.length > MAX_INPUT) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
 
     // strip a leading BOM or blank lines before the opening ---
     const normalized = input.replace(/^﻿/, '').replace(/^\n+/, '');

--- a/src/modules/boxSources/KelvinToRgbBoxSource.ts
+++ b/src/modules/boxSources/KelvinToRgbBoxSource.ts
@@ -89,19 +89,24 @@ export const KelvinToRgbBoxSource = {
       ];
     }
 
-    const raw_k = Number.parseInt(raw, 10);
-    const kelvin = Math.min(MAX_KELVIN, Math.max(MIN_KELVIN, raw_k));
+    const rawK = Number.parseInt(raw, 10);
+    const kelvin = Math.min(MAX_KELVIN, Math.max(MIN_KELVIN, rawK));
 
     const { r, g, b } = kelvinToRgb(kelvin);
     const hex = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
 
+    const kv = {
+      Kelvin: `${kelvin}K`,
+      RGB: `rgb(${r}, ${g}, ${b})`,
+      Hex: hex,
+    };
+    const plaintext = Object.entries(kv)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
     return [
-      new BoxBuilder('Color Temperature', '')
-        .setOptions({
-          Kelvin: `${kelvin}K`,
-          RGB: `rgb(${r}, ${g}, ${b})`,
-          Hex: hex,
-        })
+      new BoxBuilder('Color Temperature', plaintext)
+        .setOptions(kv)
         .setTemplate(KeyValueBoxTemplate)
         .setPriority(this.priority)
         .build(),

--- a/src/modules/boxSources/KelvinToRgbBoxSource.ts
+++ b/src/modules/boxSources/KelvinToRgbBoxSource.ts
@@ -1,0 +1,112 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// min/max valid kelvin range per the Tanner Helland approximation
+const MIN_KELVIN = 1000;
+const MAX_KELVIN = 40000;
+
+interface RgbColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// clamp a float to [0, 255] and round to integer
+function clampChannel(value: number): number {
+  return Math.round(Math.min(255, Math.max(0, value)));
+}
+
+// Tanner Helland algorithm: convert a Kelvin temperature to approximate RGB
+// https://tannerhelland.com/2012/09/18/convert-temperature-rgb-algorithm-code.html
+function kelvinToRgb(kelvin: number): RgbColor {
+  const temp = kelvin / 100;
+
+  let r: number;
+  if (temp <= 66) {
+    r = 255;
+  } else {
+    r = 329.698727446 * (temp - 60) ** -0.1332047592;
+  }
+
+  let g: number;
+  if (temp <= 66) {
+    g = 99.4708025861 * Math.log(temp) - 161.1195681661;
+  } else {
+    g = 288.1221695283 * (temp - 60) ** -0.0755148492;
+  }
+
+  let b: number;
+  if (temp >= 66) {
+    b = 255;
+  } else if (temp <= 19) {
+    b = 0;
+  } else {
+    b = 138.5177312231 * Math.log(temp - 10) - 305.0447927307;
+  }
+
+  return { r: clampChannel(r), g: clampChannel(g), b: clampChannel(b) };
+}
+
+// format a channel byte as a two-digit hex string
+function toHex(channel: number): string {
+  return channel.toString(16).padStart(2, '0');
+}
+
+export const KelvinToRgbBoxSource = {
+  name: 'Color Temperature',
+  description:
+    'Convert a color temperature in Kelvin (1000–40000) to an approximate RGB/hex color.',
+  defaultInput: '6500 ::kelvin',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'kelvin', 'colortemp')) return [];
+
+    const raw = trim(input).replace(/[Kk]$/, '').trim();
+
+    // input too long or not a plain integer
+    if (raw.length > 8 || !/^\d+$/.test(raw)) {
+      return [
+        new BoxBuilder(
+          'Color Temperature',
+          'Please provide a valid Kelvin value (e.g. 6500 ::kelvin)',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({
+            Error: 'A numeric Kelvin value is required (1000–40000)',
+          })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const raw_k = Number.parseInt(raw, 10);
+    const kelvin = Math.min(MAX_KELVIN, Math.max(MIN_KELVIN, raw_k));
+
+    const { r, g, b } = kelvinToRgb(kelvin);
+    const hex = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+
+    return [
+      new BoxBuilder('Color Temperature', '')
+        .setOptions({
+          Kelvin: `${kelvin}K`,
+          RGB: `rgb(${r}, ${g}, ${b})`,
+          Hex: hex,
+        })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default KelvinToRgbBoxSource;

--- a/src/modules/boxSources/PercentEncodeBoxSource.ts
+++ b/src/modules/boxSources/PercentEncodeBoxSource.ts
@@ -1,0 +1,75 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// RFC 3986 sub-delimiters that encodeURIComponent leaves unescaped
+const escapeRfc3986Extras = (s: string): string =>
+  s.replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+
+export const PercentEncodeBoxSource = {
+  name: 'Percent Encode',
+  description:
+    'Percent-encode a string for use in a URL (or decode it). ::percentencode / ::percentdecode.',
+  defaultInput: 'a b&c=日本 ::percentencode',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'percentencode', 'urlencode');
+    const wantDecode = hasOptionKeys(options, 'percentdecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    if (wantEncode) {
+      // encode as a URI component, then additionally escape RFC 3986 sub-delims
+      const encoded = escapeRfc3986Extras(encodeURIComponent(input));
+      return [
+        new BoxBuilder('Percent Encode', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    // decode path: propagate URIError as a descriptive box
+    try {
+      const decoded = decodeURIComponent(input);
+      return [
+        new BoxBuilder('Percent Decode', decoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(Priority)
+          .build(),
+      ];
+    } catch (e) {
+      if (e instanceof URIError) {
+        return [
+          new BoxBuilder(
+            'Percent Decode',
+            'Invalid percent-encoding: the input contains malformed sequences.',
+          )
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(Priority)
+            .build(),
+        ];
+      }
+      throw e;
+    }
+  },
+};
+
+export default PercentEncodeBoxSource;

--- a/src/modules/boxSources/PigLatinBoxSource.ts
+++ b/src/modules/boxSources/PigLatinBoxSource.ts
@@ -1,0 +1,86 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+const VOWELS = /[aeiou]/i;
+// matches a contiguous run of ASCII letters (a word token to transform)
+const WORD_RE = /[a-zA-Z]+/g;
+
+// moves the leading consonant cluster to the end and appends 'ay'.
+// 'y' is treated as a vowel only when it is not the first letter.
+function convertWord(word: string): string {
+  // words starting with a vowel get 'way' appended
+  if (VOWELS.test(word[0])) {
+    return `${word}way`;
+  }
+
+  // find the split index: first vowel, treating y as vowel after position 0
+  let splitAt = word.length; // fallback: all consonants (e.g. "rhythm" has y)
+  for (let i = 0; i < word.length; i++) {
+    const ch = word[i].toLowerCase();
+    if (VOWELS.test(ch) || (i > 0 && ch === 'y')) {
+      splitAt = i;
+      break;
+    }
+  }
+
+  const cluster = word.slice(0, splitAt);
+  const remainder = word.slice(splitAt);
+  return `${remainder}${cluster}ay`;
+}
+
+// preserves title-case: if the original started with an uppercase letter, capitalize
+// the result's first letter and lowercase the rest.
+function applyCase(original: string, converted: string): string {
+  if (original.length === 0 || converted.length === 0) return converted;
+  const firstOriginal = original[0];
+  if (firstOriginal >= 'A' && firstOriginal <= 'Z') {
+    return converted[0].toUpperCase() + converted.slice(1).toLowerCase();
+  }
+  return converted;
+}
+
+function toPigLatin(input: string): string {
+  return input.replace(WORD_RE, (word) => {
+    const converted = convertWord(word.toLowerCase());
+    return applyCase(word, converted);
+  });
+}
+
+export const PigLatinBoxSource = {
+  name: 'Pig Latin',
+  description: 'Convert English text to Pig Latin.',
+  defaultInput: 'hello world ::piglatin',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'piglatin', 'piglatinencode')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const result = toPigLatin(input);
+
+    return [
+      new BoxBuilder('Pig Latin', result)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PigLatinBoxSource;

--- a/src/modules/boxSources/PolybiusBoxSource.ts
+++ b/src/modules/boxSources/PolybiusBoxSource.ts
@@ -1,0 +1,109 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// 5x5 grid, row-major; I and J share cell — J is excluded, mapped to I before lookup
+const SQUARE = 'ABCDEFGHIKLMNOPQRSTUVWXYZ'; // 25 chars, no 'J'
+
+/** encodes a single letter to its two-digit Polybius coordinate string */
+function encodeChar(ch: string): string {
+  const normalized = ch === 'J' ? 'I' : ch;
+  const idx = SQUARE.indexOf(normalized);
+  if (idx === -1) return '';
+  const row = Math.floor(idx / 5) + 1;
+  const col = (idx % 5) + 1;
+  return `${row}${col}`;
+}
+
+/** encodes plaintext to space-separated Polybius pairs, dropping non-letters */
+function encode(input: string): string {
+  const pairs: string[] = [];
+  for (const ch of input.toUpperCase()) {
+    const pair = encodeChar(ch);
+    if (pair !== '') {
+      pairs.push(pair);
+    }
+  }
+  return pairs.join(' ');
+}
+
+/** decodes space-separated Polybius pairs back to uppercase letters; invalid pair → '?' */
+function decode(input: string): string {
+  const tokens = input.trim().split(/\s+/);
+  return tokens
+    .map((token) => {
+      if (token.length !== 2) return '?';
+      const row = Number.parseInt(token[0], 10);
+      const col = Number.parseInt(token[1], 10);
+      if (
+        Number.isNaN(row) ||
+        Number.isNaN(col) ||
+        row < 1 ||
+        row > 5 ||
+        col < 1 ||
+        col > 5
+      ) {
+        return '?';
+      }
+      const idx = (row - 1) * 5 + (col - 1);
+      return SQUARE[idx] ?? '?';
+    })
+    .join('');
+}
+
+export const PolybiusBoxSource = {
+  name: 'Polybius Square',
+  description:
+    'Polybius square cipher (5x5, I/J combined). ::polybius to encode; ::polybiusdecode to decode.',
+  defaultInput: 'HELLO ::polybius',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'polybius', 'polybiusencode');
+    const wantDecode = hasOptionKeys(options, 'polybiusdecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = encode(input);
+      boxes.push(
+        new BoxBuilder('Polybius Square (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decode(input);
+      boxes.push(
+        new BoxBuilder('Polybius Square (Decode)', decoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default PolybiusBoxSource;

--- a/src/modules/boxSources/WordsToNumberBoxSource.ts
+++ b/src/modules/boxSources/WordsToNumberBoxSource.ts
@@ -42,9 +42,9 @@ const TENS: Record<string, number> = {
   ninety: 90,
 };
 
-// scales that multiply the current accumulator and flush into the result
+// scales that flush the accumulator into the result; 'hundred' is handled
+// separately (it multiplies the accumulator) so it's intentionally not here
 const SCALES: Record<string, number> = {
-  hundred: 100,
   thousand: 1_000,
   million: 1_000_000,
   billion: 1_000_000_000,

--- a/src/modules/boxSources/WordsToNumberBoxSource.ts
+++ b/src/modules/boxSources/WordsToNumberBoxSource.ts
@@ -1,0 +1,147 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 1000;
+
+// maps unit words (zero–nineteen) to their numeric values
+const UNITS: Record<string, number> = {
+  zero: 0,
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+  thirteen: 13,
+  fourteen: 14,
+  fifteen: 15,
+  sixteen: 16,
+  seventeen: 17,
+  eighteen: 18,
+  nineteen: 19,
+};
+
+// maps tens words to their numeric values
+const TENS: Record<string, number> = {
+  twenty: 20,
+  thirty: 30,
+  forty: 40,
+  fifty: 50,
+  sixty: 60,
+  seventy: 70,
+  eighty: 80,
+  ninety: 90,
+};
+
+// scales that multiply the current accumulator and flush into the result
+const SCALES: Record<string, number> = {
+  hundred: 100,
+  thousand: 1_000,
+  million: 1_000_000,
+  billion: 1_000_000_000,
+  trillion: 1_000_000_000_000,
+};
+
+type ParseResult =
+  | { ok: true; value: number }
+  | { ok: false; unrecognized: string };
+
+/** Converts a list of normalised word tokens into an integer using standard accumulation. */
+function parseWords(words: string[]): ParseResult {
+  let result = 0;
+  let current = 0;
+  let negative = false;
+
+  for (const word of words) {
+    if (word === 'negative' || word === 'minus') {
+      negative = true;
+      continue;
+    }
+    if (word === 'and') {
+      continue;
+    }
+
+    if (Object.hasOwn(UNITS, word)) {
+      current += UNITS[word];
+    } else if (Object.hasOwn(TENS, word)) {
+      current += TENS[word];
+    } else if (word === 'hundred') {
+      // hundred multiplies only the sub-hundred accumulator, not the full result
+      current = current === 0 ? 100 : current * 100;
+    } else if (Object.hasOwn(SCALES, word)) {
+      // thousand and above: flush current into result scaled up, then reset current
+      result += current * SCALES[word];
+      current = 0;
+    } else {
+      return { ok: false, unrecognized: word };
+    }
+  }
+
+  result += current;
+  return { ok: true, value: negative ? -result : result };
+}
+
+export const WordsToNumberBoxSource = {
+  name: 'Words to Number',
+  description:
+    'Parse English number words into an integer (e.g. "one thousand two hundred" → 1200).',
+  defaultInput: 'one million two hundred thirty-four thousand ::wordstonum',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'wordstonum', 'wordstonumber')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    // normalise: lowercase, replace hyphens with spaces, split on whitespace
+    const words = input
+      .toLowerCase()
+      .replace(/-/g, ' ')
+      .trim()
+      .split(/\s+/)
+      .filter((w) => w.length > 0);
+
+    const result = parseWords(words);
+
+    if (!result.ok) {
+      return [
+        new BoxBuilder(
+          'Words to Number',
+          `couldn't parse '${result.unrecognized}'`,
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    return [
+      new BoxBuilder('Words to Number', String(result.value))
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default WordsToNumberBoxSource;

--- a/src/modules/boxSources/__test__/AffineCipherBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AffineCipherBoxSource.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { AffineCipherBoxSource } from '../AffineCipherBoxSource';
+
+describe('AffineCipherBoxSource', () => {
+  describe('no option → empty', () => {
+    it('returns [] when no affine option is provided', async () => {
+      const boxes = await AffineCipherBoxSource.generateBoxes('HELLO', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await AffineCipherBoxSource.generateBoxes('HELLO', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty input → empty', () => {
+    it('returns [] when input is empty string', async () => {
+      const boxes = await AffineCipherBoxSource.generateBoxes('', {
+        affine: '5,8',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encrypt — canonical Wikipedia vector (a=5, b=8)', () => {
+    it('encrypts AFFINECIPHER to IHHWVCSWFRCP', async () => {
+      // wikipedia affine cipher example: a=5 b=8
+      const boxes = await AffineCipherBoxSource.generateBoxes('AFFINECIPHER', {
+        affine: '5,8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('IHHWVCSWFRCP');
+      expect(boxes[0].props.name).toBe('Affine Cipher (Encrypt)');
+    });
+  });
+
+  describe('decrypt — canonical Wikipedia vector (a=5, b=8)', () => {
+    it('decrypts IHHWVCSWFRCP back to AFFINECIPHER', async () => {
+      const boxes = await AffineCipherBoxSource.generateBoxes('IHHWVCSWFRCP', {
+        affinedecode: '5,8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('AFFINECIPHER');
+      expect(boxes[0].props.name).toBe('Affine Cipher (Decrypt)');
+    });
+  });
+
+  describe('case and punctuation preservation', () => {
+    it('round-trips mixed-case text with punctuation', async () => {
+      const plain = 'Hi, There!';
+      const encrypted = await AffineCipherBoxSource.generateBoxes(plain, {
+        affine: '5,8',
+      });
+      expect(encrypted).toHaveLength(1);
+      const ciphertext = encrypted[0].props.plaintextOutput;
+
+      // comma, space, and exclamation must pass through unchanged
+      expect(ciphertext[2]).toBe(',');
+      expect(ciphertext[3]).toBe(' ');
+      expect(ciphertext[ciphertext.length - 1]).toBe('!');
+
+      const decrypted = await AffineCipherBoxSource.generateBoxes(ciphertext, {
+        affinedecode: '5,8',
+      });
+      expect(decrypted).toHaveLength(1);
+      expect(decrypted[0].props.plaintextOutput).toBe(plain);
+    });
+  });
+
+  describe('invalid a (not coprime with 26)', () => {
+    it('returns an error box mentioning coprime when a=2', async () => {
+      const boxes = await AffineCipherBoxSource.generateBoxes('HELLO', {
+        affine: '2,3',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(/coprime/);
+    });
+  });
+
+  describe('malformed option value', () => {
+    it('returns an error box mentioning format a,b for non-numeric input', async () => {
+      const boxes = await AffineCipherBoxSource.generateBoxes('HELLO', {
+        affine: 'abc',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toMatch(/a,b/);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(AffineCipherBoxSource.name).toBe('Affine Cipher');
+      expect(AffineCipherBoxSource.kind).toBe('Encode');
+      expect(typeof AffineCipherBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/Crc16BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Crc16BoxSource.test.ts
@@ -1,0 +1,116 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Crc16BoxSource } from '../Crc16BoxSource';
+
+describe('Crc16BoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Crc16BoxSource.name).toBe('CRC-16');
+      expect(Crc16BoxSource.tag).toBe('#');
+      expect(Crc16BoxSource.kind).toBe('Encode');
+      expect(typeof Crc16BoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - gate', () => {
+    it('returns empty array when crc16 option is absent', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options object has no crc16 key', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input with crc16 option', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('', { crc16: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('   ', { crc16: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - canonical check values for "123456789"', () => {
+    it('returns exactly one box', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('box uses KeyValueBoxTemplate', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box is named CRC-16', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes[0].props.name).toBe('CRC-16');
+    });
+
+    // canonical CRC-16/CCITT-FALSE check value for "123456789"
+    it('CCITT-FALSE option value is 0x29b1', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes[0].props.options?.['CCITT-FALSE']).toBe('0x29b1');
+    });
+
+    // canonical CRC-16/MODBUS check value for "123456789"
+    it('Modbus option value is 0x4b37', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes[0].props.options?.Modbus).toBe('0x4b37');
+    });
+
+    it('plaintextOutput is non-empty and contains CCITT-FALSE result', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toBeTruthy();
+      expect(text).toContain('CCITT-FALSE: 0x29b1');
+    });
+
+    it('plaintextOutput contains Modbus result', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('Modbus: 0x4b37');
+    });
+  });
+
+  describe('generateBoxes - priority', () => {
+    it('box carries the source priority', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('hello', {
+        crc16: true,
+      });
+      expect(boxes[0].props.priority).toBe(Crc16BoxSource.priority);
+    });
+  });
+
+  describe('generateBoxes - UTF-8 input', () => {
+    it('processes non-ASCII input without throwing', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('héllo wörld', {
+        crc16: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['CCITT-FALSE']).toMatch(
+        /^0x[0-9a-f]{4}$/,
+      );
+      expect(boxes[0].props.options?.Modbus).toMatch(/^0x[0-9a-f]{4}$/);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/FrontmatterBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FrontmatterBoxSource.test.ts
@@ -1,0 +1,107 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { FrontmatterBoxSource } from '../FrontmatterBoxSource';
+
+describe('FrontmatterBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is given', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\ntitle: Hi\n---\nbody',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is given', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\ntitle: Hi\n---\nbody',
+        { qrcode: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const big = `---\ntitle: x\n---\n${'x'.repeat(100_001)}`;
+      const boxes = await FrontmatterBoxSource.generateBoxes(big, {
+        frontmatter: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('parses frontmatter with ::frontmatter option', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\ntitle: Hello\ntags: [a, b]\n---\n# Body',
+        { frontmatter: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Frontmatter');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.options).toEqual({ language: 'json' });
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ title: 'Hello', tags: ['a', 'b'] });
+    });
+
+    it('parses frontmatter with ::fm alias', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\ntitle: Hello\ntags: [a, b]\n---\n# Body',
+        { fm: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ title: 'Hello', tags: ['a', 'b'] });
+    });
+
+    it('handles numeric and boolean values', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\nn: 42\nok: true\n---\nx',
+        { frontmatter: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ n: 42, ok: true });
+    });
+
+    it('returns a box noting no frontmatter for plain text', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes('just text', {
+        frontmatter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/no frontmatter/i);
+    });
+
+    it('returns a box noting invalid YAML when frontmatter cannot be parsed', async () => {
+      // yaml package may parse this leniently; if it throws we get the error box,
+      // if it parses we accept whatever it returns as valid
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\n: : bad\n---\n',
+        { frontmatter: true },
+      );
+      expect(boxes).toHaveLength(1);
+      // either an invalid-YAML message or a valid parse is acceptable
+      const output = boxes[0].props.plaintextOutput;
+      const isErrorMessage = /invalid/i.test(output);
+      const isValidJson = (() => {
+        try {
+          JSON.parse(output);
+          return true;
+        } catch {
+          return false;
+        }
+      })();
+      expect(isErrorMessage || isValidJson).toBe(true);
+    });
+
+    it('strips a leading BOM before the frontmatter', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '﻿---\ntitle: BOM\n---\nbody',
+        { frontmatter: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ title: 'BOM' });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/KelvinToRgbBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/KelvinToRgbBoxSource.test.ts
@@ -1,0 +1,172 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { KelvinToRgbBoxSource } from '../KelvinToRgbBoxSource';
+
+// Tanner Helland formula replicated to compute expected channel values in tests
+function clamp(v: number): number {
+  return Math.round(Math.min(255, Math.max(0, v)));
+}
+
+function kelvinToRgb(kelvin: number): { r: number; g: number; b: number } {
+  const temp = kelvin / 100;
+
+  const r =
+    temp <= 66 ? 255 : clamp(329.698727446 * (temp - 60) ** -0.1332047592);
+
+  const g =
+    temp <= 66
+      ? clamp(99.4708025861 * Math.log(temp) - 161.1195681661)
+      : clamp(288.1221695283 * (temp - 60) ** -0.0755148492);
+
+  const b =
+    temp >= 66
+      ? 255
+      : temp <= 19
+        ? 0
+        : clamp(138.5177312231 * Math.log(temp - 10) - 305.0447927307);
+
+  return { r, g, b };
+}
+
+describe('KelvinToRgbBoxSource', () => {
+  describe('generateBoxes — option guard', () => {
+    it('returns [] when no matching option key is present', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('6500', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option keys are present', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('6500', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — valid input via ::kelvin', () => {
+    it('6500K — near white: R===255 and Hex starts with #ff', async () => {
+      const { r, g, b } = kelvinToRgb(6500);
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('6500', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('6500K');
+      expect(opts.RGB).toBe(`rgb(${r}, ${g}, ${b})`);
+      // R channel must be 255 for 6500K (temp<=66)
+      expect(r).toBe(255);
+      // G and B are high for daylight white
+      expect(g).toBeGreaterThanOrEqual(240);
+      expect(b).toBeGreaterThanOrEqual(240);
+      expect(opts.Hex).toMatch(/^#ff/);
+    });
+
+    it('1000K — very warm: R===255, B===0', async () => {
+      const { r, b } = kelvinToRgb(1000);
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('1000', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('1000K');
+      // 1000K: temp=10, <=66 → R=255; temp<=19 → B=0
+      expect(r).toBe(255);
+      expect(b).toBe(0);
+      expect(opts.RGB).toMatch(/^rgb\(255,/);
+      expect(opts.RGB).toMatch(/, 0\)$/);
+    });
+
+    it('40000K — cool: B===255, R<255', async () => {
+      const { r, b } = kelvinToRgb(40000);
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('40000', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('40000K');
+      // 40000K: temp=400 >66 → B=255; R is reduced
+      expect(b).toBe(255);
+      expect(r).toBeLessThan(255);
+      expect(opts.Hex).toMatch(/ff$/); // ends with ff for blue channel
+    });
+
+    it('2700K — incandescent: R===255, G and B lower than R', async () => {
+      const { r, g, b } = kelvinToRgb(2700);
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('2700', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(r).toBe(255);
+      expect(g).toBeLessThan(r);
+      expect(b).toBeLessThan(r);
+    });
+
+    it('trailing K suffix "5000K" is parsed as 5000', async () => {
+      const { r, g, b } = kelvinToRgb(5000);
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('5000K', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('5000K');
+      expect(opts.RGB).toBe(`rgb(${r}, ${g}, ${b})`);
+    });
+  });
+
+  describe('generateBoxes — ::colortemp alias', () => {
+    it('accepts ::colortemp option key', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('6500', {
+        colortemp: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('6500K');
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('non-numeric input returns an error box mentioning Kelvin', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('abc', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // error box should mention Kelvin in its message
+      const combined = JSON.stringify(opts).toLowerCase();
+      expect(combined).toContain('kelvin');
+    });
+
+    it('empty string returns an error box mentioning Kelvin', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      const combined = JSON.stringify(opts).toLowerCase();
+      expect(combined).toContain('kelvin');
+    });
+  });
+
+  describe('generateBoxes — clamping', () => {
+    it('value below 1000 is clamped to 1000', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('500', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('1000K');
+    });
+
+    it('value above 40000 is clamped to 40000', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('99999', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('40000K');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PercentEncodeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PercentEncodeBoxSource.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import { PercentEncodeBoxSource } from '../PercentEncodeBoxSource';
+
+describe('PercentEncodeBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a b&c=', null);
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a b&c=', {
+        sha256: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] for empty input even with option', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('', {
+        percentencode: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+  });
+
+  describe('encode — ::percentencode', () => {
+    it('encodes spaces and special chars', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a b&c=', {
+        percentencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a%20b%26c%3D');
+    });
+
+    it('strictly escapes RFC 3986 sub-delims: ! ( ) * that encodeURIComponent misses', async () => {
+      // encodeURIComponent leaves ! ' ( ) * unescaped; we must escape them too
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a(b)*c!', {
+        percentencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a%28b%29%2Ac%21');
+    });
+
+    it("strictly escapes single-quote '", async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes("it's", {
+        percentencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('it%27s');
+    });
+
+    it('encodes unicode characters', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('日本', {
+        percentencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('%E6%97%A5%E6%9C%AC');
+    });
+
+    it('accepts ::urlencode alias', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a b', {
+        urlencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a%20b');
+    });
+
+    it('box name is "Percent Encode"', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('x', {
+        percentencode: true,
+      });
+      expect(boxes[0].props.name).toBe('Percent Encode');
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('x', {
+        percentencode: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('decode — ::percentdecode', () => {
+    it('decodes a percent-encoded string', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a%20b%26c%3D', {
+        percentdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a b&c=');
+    });
+
+    it('returns a descriptive box on malformed input', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('%ZZ', {
+        percentdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(
+        /invalid percent-encoding/i,
+      );
+    });
+
+    it('box name is "Percent Decode"', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('hello', {
+        percentdecode: true,
+      });
+      expect(boxes[0].props.name).toBe('Percent Decode');
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('hello', {
+        percentdecode: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encodes then decodes back to the original', async () => {
+      const original = 'hello world! (test)';
+      const encoded = await PercentEncodeBoxSource.generateBoxes(original, {
+        percentencode: true,
+      });
+      const encodedStr = encoded[0].props.plaintextOutput;
+
+      const decoded = await PercentEncodeBoxSource.generateBoxes(encodedStr, {
+        percentdecode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe(original);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PigLatinBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PigLatinBoxSource.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { PigLatinBoxSource } from '../PigLatinBoxSource';
+
+describe('PigLatinBoxSource', () => {
+  describe('no option → empty', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty input → empty', () => {
+    it('returns [] when input is empty string', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is whitespace only', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('   ', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('consonant-start words', () => {
+    it("converts 'hello' → 'ellohay'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ellohay');
+    });
+
+    it("converts 'world' → 'orldway'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('world', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('orldway');
+    });
+  });
+
+  describe('vowel-start words', () => {
+    it("converts 'apple' → 'appleway'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('apple', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('appleway');
+    });
+  });
+
+  describe('sentence', () => {
+    it("converts 'hello world' → 'ellohay orldway'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello world', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ellohay orldway');
+    });
+  });
+
+  describe('capitalization', () => {
+    it("converts 'Hello' → 'Ellohay'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('Hello', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Ellohay');
+    });
+  });
+
+  describe('punctuation', () => {
+    it("keeps trailing punctuation in place: 'hello!' → 'ellohay!'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello!', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ellohay!');
+    });
+  });
+
+  describe('y as vowel', () => {
+    it("converts 'rhythm' → 'ythmrhay' (y treated as vowel after position 0)", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('rhythm', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ythmrhay');
+    });
+  });
+
+  describe('piglatinencode alias', () => {
+    it('also triggers on ::piglatinencode option', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello', {
+        piglatinencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ellohay');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('box has correct name', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello world', {
+        piglatin: true,
+      });
+      expect(boxes[0].props.name).toBe('Pig Latin');
+    });
+  });
+
+  describe('static properties', () => {
+    it('has expected metadata', () => {
+      expect(PigLatinBoxSource.name).toBe('Pig Latin');
+      expect(PigLatinBoxSource.kind).toBe('Transform');
+      expect(typeof PigLatinBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PolybiusBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PolybiusBoxSource.test.ts
@@ -40,7 +40,7 @@ describe('PolybiusBoxSource', () => {
 
   describe('generateBoxes — encode', () => {
     it('encodes HELLO correctly via ::polybius', async () => {
-      // H=idx7→23, E=idx4→15, L=idx10→31, L→31, O=idx13→35
+      // H=idx7→23, E=idx4→15, L=idx10→31, L→31, O=idx13→34 (J removed)
       const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {
         polybius: true,
       });

--- a/src/modules/boxSources/__test__/PolybiusBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PolybiusBoxSource.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import { PolybiusBoxSource } from '../PolybiusBoxSource';
+
+describe('PolybiusBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(PolybiusBoxSource.name).toBe('Polybius Square');
+      expect(PolybiusBoxSource.tag).toBe('#');
+      expect(PolybiusBoxSource.kind).toBe('Encode');
+      expect(typeof PolybiusBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes — option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::polybius', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('   ', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — encode', () => {
+    it('encodes HELLO correctly via ::polybius', async () => {
+      // H=idx7→23, E=idx4→15, L=idx10→31, L→31, O=idx13→35
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Polybius Square (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('23 15 31 31 34');
+    });
+
+    it('encodes HELLO correctly via ::polybiusencode', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {
+        polybiusencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('23 15 31 31 34');
+    });
+
+    it('maps J to I before encoding (JUMP)', async () => {
+      // J→I=idx8→24, U=idx19→45, M=idx11→32, P=idx14→35
+      const boxes = await PolybiusBoxSource.generateBoxes('JUMP', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('24 45 32 35');
+    });
+
+    it('handles lowercase input by uppercasing', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('hello', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('23 15 31 31 34');
+    });
+
+    it('drops non-letter characters', async () => {
+      // only letters are encoded; spaces and punctuation are dropped
+      const boxes = await PolybiusBoxSource.generateBoxes('HI!', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // H=23, I=24
+      expect(boxes[0].props.plaintextOutput).toBe('23 24');
+    });
+  });
+
+  describe('generateBoxes — decode', () => {
+    it('decodes "23 15 31 31 34" back to HELLO', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('23 15 31 31 34', {
+        polybiusdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Polybius Square (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('HELLO');
+    });
+
+    it('returns ? for invalid pairs', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('99 00', {
+        polybiusdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('??');
+    });
+  });
+
+  describe('generateBoxes — round-trip', () => {
+    it('round-trips POLYBIUS through encode then decode', async () => {
+      const [encBox] = await PolybiusBoxSource.generateBoxes('POLYBIUS', {
+        polybius: true,
+      });
+      const encoded = encBox.props.plaintextOutput;
+
+      const [decBox] = await PolybiusBoxSource.generateBoxes(encoded, {
+        polybiusdecode: true,
+      });
+      // note: B→I path: no J in POLYBIUS, so round-trip is lossless
+      expect(decBox.props.plaintextOutput).toBe('POLYBIUS');
+    });
+  });
+
+  describe('generateBoxes — both options produce two boxes', () => {
+    it('returns 2 boxes when both ::polybius and ::polybiusdecode are set', async () => {
+      // input is valid for encode; decode of "HELLO" treats each char as a token → '?????'
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {
+        polybius: true,
+        polybiusdecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Polybius Square (Encode)');
+      expect(boxes[1].props.name).toBe('Polybius Square (Decode)');
+    });
+  });
+
+  describe('generateBoxes — showExpandButton', () => {
+    it('sets showExpandButton to false on encode box', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {
+        polybius: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('sets showExpandButton to false on decode box', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('23 15 31 31 34', {
+        polybiusdecode: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/WordsToNumberBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/WordsToNumberBoxSource.test.ts
@@ -1,0 +1,140 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { WordsToNumberBoxSource } from '../WordsToNumberBoxSource';
+
+describe('WordsToNumberBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'forty-two',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('forty-two', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with option', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('   ', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('basic parsing with ::wordstonum', () => {
+    it('parses "forty-two" → 42', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('forty-two', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('42');
+    });
+
+    it('parses "one hundred" → 100', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('one hundred', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('100');
+    });
+
+    it('parses "one hundred one" → 101', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'one hundred one',
+        {
+          wordstonum: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('101');
+    });
+
+    it('parses "one thousand two hundred thirty-four" → 1234', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'one thousand two hundred thirty-four',
+        { wordstonum: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1234');
+    });
+
+    it('parses "one million two hundred thirty-four thousand five hundred sixty-seven" → 1234567', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'one million two hundred thirty-four thousand five hundred sixty-seven',
+        { wordstonum: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1234567');
+    });
+
+    it('parses "negative five" → -5', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'negative five',
+        {
+          wordstonum: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('-5');
+    });
+
+    it('parses "zero" → 0', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('zero', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('0');
+    });
+  });
+
+  describe('alias option ::wordstonumber', () => {
+    it('also triggers on ::wordstonumber', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('five', {
+        wordstonumber: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('5');
+    });
+  });
+
+  describe('unrecognized word', () => {
+    it('returns a box mentioning the unrecognized word for "one bazillion"', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'one bazillion',
+        {
+          wordstonum: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain("couldn't parse");
+      expect(boxes[0].props.plaintextOutput).toContain('bazillion');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets correct name, priority, template, and showExpandButton', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('ten', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Words to Number');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,20 +1,27 @@
+import AffineCipherBoxSource from './AffineCipherBoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import Crc16BoxSource from './Crc16BoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FrontmatterBoxSource from './FrontmatterBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import KelvinToRgbBoxSource from './KelvinToRgbBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PercentEncodeBoxSource from './PercentEncodeBoxSource';
+import PigLatinBoxSource from './PigLatinBoxSource';
+import PolybiusBoxSource from './PolybiusBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
@@ -23,31 +30,40 @@ import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
 // catch-all encoders (Base64 Encode, Word Count) sit at the bottom so they
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  AffineCipherBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  Crc16BoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  FrontmatterBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  KelvinToRgbBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  PercentEncodeBoxSource,
+  PigLatinBoxSource,
+  PolybiusBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
+  WordsToNumberBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,


### PR DESCRIPTION
## Summary

Twenty-third exploration batch — **8 more BoxSource tools** (checksums, ciphers, conversions).

| Tool | Trigger | What it does |
|------|---------|--------------|
| CRC-16 | `::crc16` | CCITT-FALSE + Modbus checksums |
| Affine Cipher | `::affine=a,b` | `E(x)=(ax+b) mod 26` (coprime-a checked) |
| Polybius Square | `::polybius` | 5×5 I/J-merged cipher |
| Words to Number | `::wordstonum` | English words → integer (inverse of `::spell`) |
| Frontmatter | `::frontmatter` | extract YAML frontmatter as JSON |
| Percent Encode | `::percentencode` | strict RFC 3986 encode/decode |
| Color Temperature | `::kelvin` | Kelvin → RGB/hex (Tanner Helland) |
| Pig Latin | `::piglatin` | English → Pig Latin |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Prompts pre-loaded the accumulated hardening rules — KeyValue sources render `k: v` plaintext (manual, since #281's `keyValueBox()` helper isn't on `main` yet), input caps, coprime-`a` validation, linear regexes, `& 0xffff` masking.
- **Verified vectors**: CRC-16 `"123456789"`→CCITT `0x29b1` / Modbus `0x4b37`; **affine `AFFINECIPHER`+5,8→`IHHWVCSWFRCP`**; polybius `HELLO`→`23 15 31 31 34` (I/J-merged square, `O` at index 13); words `"one million two hundred thirty-four thousand five hundred sixty-seven"`→`1234567`; percent `a(b)*c!`→`a%28b%29%2Ac%21`; kelvin `1000K`→blue 0, `40000K`→blue 255.
- Self-review fixed a wrong Polybius test vector (with `J` removed from the square, `O` encodes to `34`, not `35`).

## Verification

- ✅ `bun run test run` — **432 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Once the `keyValueBox()`/`errorBox()` helper PR (#281) merges, the KeyValue sources here can adopt it. Independent of #260–#281 — branched from `main`.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6