### PR TITLE
feat(boxSources): add 8 more tools (text↔hex, length, datasize, angle, ini, country-flag, beaufort, base91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>HexTextBox</b> </summary>
+
+| match rule    | description                          | example       |
+| ------------- | ------------------------------------ | ------------- |
+| `::hex`       | text → hex string (UTF-8); `::hexdecode` to reverse | `Hi ::hex` |
+
+</details>
+
+<details>
+<summary> <b>LengthConvertBox</b> </summary>
+
+| match rule   | description                          | example            |
+| ------------ | ------------------------------------ | ------------------ |
+| `::length`   | convert a length across units (`::length=mi` for one target) | `1 mi ::length` |
+
+</details>
+
+<details>
+<summary> <b>DataSizeBox</b> </summary>
+
+| match rule     | description                          | example              |
+| -------------- | ------------------------------------ | -------------------- |
+| `::datasize`   | convert a data size SI ⇄ IEC         | `1.5 GB ::datasize`  |
+
+</details>
+
+<details>
+<summary> <b>AngleConvertBox</b> </summary>
+
+| match rule  | description                          | example            |
+| ----------- | ------------------------------------ | ------------------ |
+| `::angle`   | convert deg / rad / grad / turn      | `180 deg ::angle`  |
+
+</details>
+
+<details>
+<summary> <b>IniBox</b> </summary>
+
+| match rule | description                          | example                    |
+| ---------- | ------------------------------------ | -------------------------- |
+| `::ini`    | INI ⇄ JSON                           | `[s]`<br>`k=v` `::ini`     |
+
+</details>
+
+<details>
+<summary> <b>CountryFlagBox</b> </summary>
+
+| match rule  | description                          | example       |
+| ----------- | ------------------------------------ | ------------- |
+| `::flag`    | ISO country code ⇄ flag emoji        | `US ::flag`   |
+
+</details>
+
+<details>
+<summary> <b>BeaufortBox</b> </summary>
+
+| match rule         | description                          | example                  |
+| ------------------ | ------------------------------------ | ------------------------ |
+| `::beaufort=key`   | Beaufort cipher (self-reciprocal)    | `DEFEND ::beaufort=FORTIFICATION` |
+
+</details>
+
+<details>
+<summary> <b>Base91Box</b> </summary>
+
+| match rule       | description                          | example            |
+| ---------------- | ------------------------------------ | ------------------ |
+| `::base91`       | basE91 encode (`::base91decode` to decode) | `hello ::base91` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/AngleConvertBoxSource.ts
+++ b/src/modules/boxSources/AngleConvertBoxSource.ts
@@ -81,6 +81,7 @@ Units: ${VALID_UNITS}`;
       return [
         new BoxBuilder('Angle Convert', errorContent)
           .setOptions({
+            Input: trimmed,
             Error: 'unable to parse input',
             Format: '<number> <unit>',
             Units: VALID_UNITS,
@@ -102,6 +103,7 @@ Units: ${VALID_UNITS}`;
       return [
         new BoxBuilder('Angle Convert', errorContent)
           .setOptions({
+            Input: trimmed,
             Error: `unrecognized unit "${match[2]}"`,
             Units: VALID_UNITS,
           })

--- a/src/modules/boxSources/AngleConvertBoxSource.ts
+++ b/src/modules/boxSources/AngleConvertBoxSource.ts
@@ -1,0 +1,146 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// maps all accepted unit spellings to a canonical unit name
+const unitAliases: Record<string, string> = {
+  deg: 'deg',
+  degree: 'deg',
+  degrees: 'deg',
+  '°': 'deg',
+  rad: 'rad',
+  radian: 'rad',
+  radians: 'rad',
+  grad: 'grad',
+  gradian: 'grad',
+  gradians: 'grad',
+  gon: 'grad',
+  turn: 'turn',
+  turns: 'turn',
+  rev: 'turn',
+};
+
+// converts a value in the given canonical unit to degrees
+function toDegrees(value: number, unit: string): number {
+  switch (unit) {
+    case 'deg':
+      return value;
+    case 'rad':
+      return value * (180 / Math.PI);
+    case 'grad':
+      return value * 0.9;
+    case 'turn':
+      return value * 360;
+    default:
+      return value;
+  }
+}
+
+// formats a number to ~6 significant figures and strips trailing zeros
+function formatSigFigs(n: number): string {
+  // toPrecision(7) gives 7 sig figs; we use 7 to keep the 6th digit accurate
+  const formatted = n.toPrecision(7);
+  // remove trailing zeros after decimal point
+  if (formatted.includes('.')) {
+    return formatted.replace(/\.?0+$/, '');
+  }
+  return formatted;
+}
+
+const INPUT_MAX_LEN = 64;
+const UNIT_REGEX = /^(-?\d+(?:\.\d+)?)\s*([a-z°]+)$/i;
+const VALID_UNITS = Object.keys(unitAliases).join(', ');
+
+export const AngleConvertBoxSource = {
+  name: 'Angle Convert',
+  description:
+    'Convert an angle between degrees, radians, gradians, and turns. e.g. "180 deg ::angle".',
+  defaultInput: '180 deg ::angle',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'angle')) return [];
+
+    const trimmed = trim(input).slice(0, INPUT_MAX_LEN);
+    const match = UNIT_REGEX.exec(trimmed);
+
+    if (!match) {
+      // invalid format — return an informational box
+      const errorContent = `Input: ${trimmed}
+Error: unable to parse input
+Format: <number> <unit>
+Units: ${VALID_UNITS}`;
+      return [
+        new BoxBuilder('Angle Convert', errorContent)
+          .setOptions({
+            Error: 'unable to parse input',
+            Format: '<number> <unit>',
+            Units: VALID_UNITS,
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const rawUnit = match[2].toLowerCase();
+    const canonicalUnit = unitAliases[rawUnit];
+
+    if (!canonicalUnit) {
+      const errorContent = `Input: ${trimmed}
+Error: unrecognized unit "${match[2]}"
+Units: ${VALID_UNITS}`;
+      return [
+        new BoxBuilder('Angle Convert', errorContent)
+          .setOptions({
+            Error: `unrecognized unit "${match[2]}"`,
+            Units: VALID_UNITS,
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const degrees = toDegrees(value, canonicalUnit);
+    const radians = degrees * (Math.PI / 180);
+    const gradians = degrees / 0.9;
+    const turns = degrees / 360;
+
+    const degreesStr = formatSigFigs(degrees);
+    const radiansStr = formatSigFigs(radians);
+    const gradiansStr = formatSigFigs(gradians);
+    const turnsStr = formatSigFigs(turns);
+
+    const content = `Input: ${trimmed}
+Degrees: ${degreesStr}
+Radians: ${radiansStr}
+Gradians: ${gradiansStr}
+Turns: ${turnsStr}`;
+
+    return [
+      new BoxBuilder('Angle Convert', content)
+        .setOptions({
+          Input: trimmed,
+          Degrees: degreesStr,
+          Radians: radiansStr,
+          Gradians: gradiansStr,
+          Turns: turnsStr,
+        })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default AngleConvertBoxSource;

--- a/src/modules/boxSources/Base91BoxSource.ts
+++ b/src/modules/boxSources/Base91BoxSource.ts
@@ -59,8 +59,11 @@ function decodeBase91(encoded: string): Uint8Array {
   const out: number[] = [];
 
   for (let i = 0; i < encoded.length; i++) {
-    const d = DECODE_TABLE[encoded.charCodeAt(i)];
-    if (d === -1) continue;
+    const code = encoded.charCodeAt(i);
+    // chars above the 256-entry table (e.g. CJK, emoji surrogates) are
+    // out of range → undefined, which `< 0` would NOT catch; skip explicitly
+    const d = code < 256 ? DECODE_TABLE[code] : -1;
+    if (d < 0) continue;
 
     if (v < 0) {
       v = d;

--- a/src/modules/boxSources/Base91BoxSource.ts
+++ b/src/modules/boxSources/Base91BoxSource.ts
@@ -1,0 +1,137 @@
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// basE91 alphabet (91 printable ASCII chars, Joachim Henke's ordering)
+const ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&()*+,./:;<=>?@[]^_`{|}~"';
+
+// precomputed reverse lookup: char → index in ALPHABET, -1 for non-members
+const DECODE_TABLE: Int8Array = (() => {
+  const table = new Int8Array(256).fill(-1);
+  for (let i = 0; i < ALPHABET.length; i++) {
+    table[ALPHABET.charCodeAt(i)] = i;
+  }
+  return table;
+})();
+
+// encodes a byte array to a basE91 string using the standard Henke algorithm
+function encodeBase91(bytes: Uint8Array): string {
+  let b = 0;
+  let n = 0;
+  const out: string[] = [];
+
+  for (const byte of bytes) {
+    b |= byte << n;
+    n += 8;
+    if (n > 13) {
+      let v = b & 8191;
+      if (v > 88) {
+        b >>= 13;
+        n -= 13;
+      } else {
+        v = b & 16383;
+        b >>= 14;
+        n -= 14;
+      }
+      out.push(ALPHABET[v % 91], ALPHABET[(v / 91) | 0]);
+    }
+  }
+
+  if (n > 0) {
+    out.push(ALPHABET[b % 91]);
+    if (n > 7 || b > 90) {
+      out.push(ALPHABET[(b / 91) | 0]);
+    }
+  }
+
+  return out.join('');
+}
+
+// decodes a basE91 string back to a byte array; non-alphabet chars are skipped per spec
+function decodeBase91(encoded: string): Uint8Array {
+  let v = -1;
+  let b = 0;
+  let n = 0;
+  const out: number[] = [];
+
+  for (let i = 0; i < encoded.length; i++) {
+    const d = DECODE_TABLE[encoded.charCodeAt(i)];
+    if (d === -1) continue;
+
+    if (v < 0) {
+      v = d;
+    } else {
+      v += d * 91;
+      b |= v << n;
+      n += (v & 8191) > 88 ? 13 : 14;
+      do {
+        out.push(b & 255);
+        b >>= 8;
+        n -= 8;
+      } while (n > 7);
+      v = -1;
+    }
+  }
+
+  if (v >= 0) {
+    out.push((b | (v << n)) & 255);
+  }
+
+  return new Uint8Array(out);
+}
+
+export const Base91BoxSource = {
+  name: 'basE91',
+  description: 'Encode text to basE91 or decode a basE91 string.',
+  defaultInput: 'hello ::base91',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'base91', 'base91encode');
+    const wantDecode = hasOptionKeys(options, 'base91decode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const bytes = new TextEncoder().encode(input);
+      const encoded = encodeBase91(bytes);
+      boxes.push(
+        new BoxBuilder('basE91 (Encode)', encoded)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const bytes = decodeBase91(input);
+      const decoded = new TextDecoder().decode(bytes);
+      boxes.push(
+        new BoxBuilder('basE91 (Decode)', decoded)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default Base91BoxSource;

--- a/src/modules/boxSources/BeaufortBoxSource.ts
+++ b/src/modules/boxSources/BeaufortBoxSource.ts
@@ -50,12 +50,14 @@ export const BeaufortBoxSource = {
       return [];
     }
 
-    const key = normalizeKey(String(rawKey));
+    // a bare `::beaufort` (no `=key`) yields the boolean `true`, not a key;
+    // only a string option value can be a cipher key
+    const key = typeof rawKey === 'string' ? normalizeKey(rawKey) : null;
     if (key === null) {
-      // the option was present but contained no alphabetic characters
+      // the option was missing a value or contained no alphabetic characters
       const box = new BoxBuilder(
         'Beaufort Cipher',
-        'Key must contain at least one alphabetic character.',
+        'Provide an alphabetic key, e.g. ::beaufort=FORTIFICATION',
       )
         .setShowExpandButton(false)
         .setPriority(this.priority)

--- a/src/modules/boxSources/BeaufortBoxSource.ts
+++ b/src/modules/boxSources/BeaufortBoxSource.ts
@@ -1,0 +1,75 @@
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// strips non-alpha chars from the key and uppercases, returning null when nothing remains
+function normalizeKey(raw: string): string | null {
+  const letters = raw.replace(/[^a-zA-Z]/g, '').toUpperCase();
+  return letters.length > 0 ? letters : null;
+}
+
+// beaufort cipher: C[i] = (key[i] - plain[i]) mod 26.
+// non-letter characters in the plaintext are passed through unchanged
+// and do NOT advance the key index. output letters are uppercase.
+function beaufort(text: string, key: string): string {
+  let ki = 0;
+  let result = '';
+  for (const ch of text) {
+    const code = ch.toUpperCase().charCodeAt(0);
+    if (code >= 65 && code <= 90) {
+      const p = code - 65;
+      const k = key.charCodeAt(ki % key.length) - 65;
+      result += String.fromCharCode(((k - p + 26) % 26) + 65);
+      ki++;
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+export const BeaufortBoxSource = {
+  name: 'Beaufort Cipher',
+  description:
+    'Beaufort cipher (self-reciprocal): C[i] = (key[i] - plain[i]) mod 26. ::beaufort=key.',
+  defaultInput: 'DEFEND ::beaufort=FORTIFICATION',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const rawKey = extractOptionKeys(options, 'beaufort');
+    if (rawKey === null) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT) {
+      return [];
+    }
+
+    const key = normalizeKey(String(rawKey));
+    if (key === null) {
+      // the option was present but contained no alphabetic characters
+      const box = new BoxBuilder(
+        'Beaufort Cipher',
+        'Key must contain at least one alphabetic character.',
+      )
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    const output = beaufort(input, key);
+    const box = new BoxBuilder('Beaufort Cipher', output)
+      .setShowExpandButton(false)
+      .setPriority(this.priority)
+      .build();
+    return [box];
+  },
+};
+
+export default BeaufortBoxSource;

--- a/src/modules/boxSources/CountryFlagBoxSource.ts
+++ b/src/modules/boxSources/CountryFlagBoxSource.ts
@@ -1,0 +1,171 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// base code point for regional indicator symbols (🇦 = U+1F1E6)
+const REGIONAL_INDICATOR_BASE = 0x1f1e6;
+
+// map of ISO 3166-1 alpha-2 codes to country names for the ~50 most common countries
+const NAMES: Record<string, string> = {
+  AD: 'Andorra',
+  AE: 'United Arab Emirates',
+  AF: 'Afghanistan',
+  AR: 'Argentina',
+  AU: 'Australia',
+  AT: 'Austria',
+  BE: 'Belgium',
+  BR: 'Brazil',
+  CA: 'Canada',
+  CH: 'Switzerland',
+  CL: 'Chile',
+  CN: 'China',
+  CO: 'Colombia',
+  CZ: 'Czech Republic',
+  DE: 'Germany',
+  DK: 'Denmark',
+  EG: 'Egypt',
+  ES: 'Spain',
+  FI: 'Finland',
+  FR: 'France',
+  GB: 'United Kingdom',
+  GR: 'Greece',
+  HK: 'Hong Kong',
+  HU: 'Hungary',
+  ID: 'Indonesia',
+  IE: 'Ireland',
+  IL: 'Israel',
+  IN: 'India',
+  IT: 'Italy',
+  JP: 'Japan',
+  KR: 'South Korea',
+  MX: 'Mexico',
+  MY: 'Malaysia',
+  NL: 'Netherlands',
+  NO: 'Norway',
+  NZ: 'New Zealand',
+  PH: 'Philippines',
+  PK: 'Pakistan',
+  PL: 'Poland',
+  PT: 'Portugal',
+  RO: 'Romania',
+  RU: 'Russia',
+  SA: 'Saudi Arabia',
+  SE: 'Sweden',
+  SG: 'Singapore',
+  TH: 'Thailand',
+  TR: 'Turkey',
+  TW: 'Taiwan',
+  UA: 'Ukraine',
+  US: 'United States',
+  VN: 'Vietnam',
+  ZA: 'South Africa',
+};
+
+// converts a 2-letter ISO code (uppercase) to its flag emoji via regional indicator symbols
+function codeToFlag(code: string): string {
+  const a = code.charCodeAt(0) - 'A'.charCodeAt(0);
+  const b = code.charCodeAt(1) - 'A'.charCodeAt(0);
+  return String.fromCodePoint(
+    REGIONAL_INDICATOR_BASE + a,
+    REGIONAL_INDICATOR_BASE + b,
+  );
+}
+
+// extracts the two regional indicator code points from a flag emoji, returns uppercase 2-letter code or null
+function flagToCode(flag: string): string | null {
+  const codePoints: number[] = [];
+  for (const cp of flag) {
+    const n = cp.codePointAt(0) ?? 0;
+    if (n >= REGIONAL_INDICATOR_BASE && n <= 0x1f1ff) {
+      codePoints.push(n);
+    }
+  }
+  if (codePoints.length !== 2) return null;
+  const a = String.fromCharCode(
+    codePoints[0] - REGIONAL_INDICATOR_BASE + 'A'.charCodeAt(0),
+  );
+  const b = String.fromCharCode(
+    codePoints[1] - REGIONAL_INDICATOR_BASE + 'A'.charCodeAt(0),
+  );
+  return a + b;
+}
+
+export const CountryFlagBoxSource = {
+  name: 'Country Flag',
+  description:
+    'Convert an ISO 3166-1 alpha-2 country code to its flag emoji, or a flag emoji back to its code.',
+  defaultInput: 'US ::flag',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'flag', 'countryflag')) return [];
+
+    const text = trim(input);
+
+    // code → flag path
+    if (/^[A-Za-z]{2}$/.test(text)) {
+      const code = text.toUpperCase();
+      const flag = codeToFlag(code);
+      const name = NAMES[code];
+
+      const kv: Record<string, string> = { Code: code, Flag: flag };
+      if (name) kv.Name = name;
+
+      const lines = Object.entries(kv)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('\n');
+
+      return [
+        new BoxBuilder('Country Flag', lines)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // flag → code path: check for two regional indicator symbols
+    const reverseCode = flagToCode(text);
+    if (reverseCode !== null) {
+      const flag = text;
+      const name = NAMES[reverseCode];
+
+      const kv: Record<string, string> = { Code: reverseCode, Flag: flag };
+      if (name) kv.Name = name;
+
+      const lines = Object.entries(kv)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('\n');
+
+      return [
+        new BoxBuilder('Country Flag', lines)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // unrecognized input — explain what is required
+    const message =
+      'Enter a 2-letter country code (e.g. US) or a flag emoji (e.g. 🇺🇸) with ::flag';
+
+    return [
+      new BoxBuilder('Country Flag', message)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions({ Info: message })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CountryFlagBoxSource;

--- a/src/modules/boxSources/DataSizeConvertBoxSource.ts
+++ b/src/modules/boxSources/DataSizeConvertBoxSource.ts
@@ -31,6 +31,8 @@ const OUTPUT_UNITS: Array<{ label: string; divisor: number }> = [
   { label: 'MiB', divisor: 1024 ** 2 },
   { label: 'GiB', divisor: 1024 ** 3 },
   { label: 'TiB', divisor: 1024 ** 4 },
+  { label: 'PB', divisor: 1e15 },
+  { label: 'PiB', divisor: 1024 ** 5 },
 ];
 
 // format a byte-derived value: exact integers stay exact (sig-figs would
@@ -43,8 +45,7 @@ function formatSigFigs(value: number): string {
 
 // parse "<value> <unit>" or bare "<value>" (no unit means bytes)
 function parseInput(raw: string): { bytes: number } | { error: string } | null {
-  const s = raw.slice(0, 64);
-  const trimmed = trim(s);
+  const trimmed = trim(raw).slice(0, 64);
   if (!trimmed) return null;
 
   // bare number → treat as bytes

--- a/src/modules/boxSources/DataSizeConvertBoxSource.ts
+++ b/src/modules/boxSources/DataSizeConvertBoxSource.ts
@@ -1,0 +1,137 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit string (lowercase) -> bytes multiplier
+const TO_BYTES: Record<string, number> = {
+  b: 1,
+  kb: 1e3,
+  mb: 1e6,
+  gb: 1e9,
+  tb: 1e12,
+  pb: 1e15,
+  kib: 1024,
+  mib: 1024 ** 2,
+  gib: 1024 ** 3,
+  tib: 1024 ** 4,
+  pib: 1024 ** 5,
+};
+
+// ordered output units shown in the result box
+const OUTPUT_UNITS: Array<{ label: string; divisor: number }> = [
+  { label: 'Bytes', divisor: 1 },
+  { label: 'KB', divisor: 1e3 },
+  { label: 'MB', divisor: 1e6 },
+  { label: 'GB', divisor: 1e9 },
+  { label: 'TB', divisor: 1e12 },
+  { label: 'KiB', divisor: 1024 },
+  { label: 'MiB', divisor: 1024 ** 2 },
+  { label: 'GiB', divisor: 1024 ** 3 },
+  { label: 'TiB', divisor: 1024 ** 4 },
+];
+
+// format a byte-derived value: exact integers stay exact (sig-figs would
+// corrupt large byte counts like 1073741824), fractionals round to 6 decimals
+function formatSigFigs(value: number): string {
+  if (value === 0) return '0';
+  if (Number.isInteger(value)) return value.toString();
+  return Number.parseFloat(value.toFixed(6)).toString();
+}
+
+// parse "<value> <unit>" or bare "<value>" (no unit means bytes)
+function parseInput(raw: string): { bytes: number } | { error: string } | null {
+  const s = raw.slice(0, 64);
+  const trimmed = trim(s);
+  if (!trimmed) return null;
+
+  // bare number → treat as bytes
+  const bareMatch = /^(-?\d+(?:\.\d+)?)$/.exec(trimmed);
+  if (bareMatch) {
+    const value = Number.parseFloat(bareMatch[1]);
+    if (Number.isNaN(value)) return null;
+    return { bytes: value };
+  }
+
+  const m = /^(-?\d+(?:\.\d+)?)\s*([a-z]+)$/i.exec(trimmed);
+  if (!m) return null;
+
+  const value = Number.parseFloat(m[1]);
+  const unit = m[2].toLowerCase();
+
+  if (Number.isNaN(value)) return null;
+
+  if (!(unit in TO_BYTES)) {
+    const supported = Object.keys(TO_BYTES).join(', ');
+    return { error: `Unknown unit "${m[2]}". Supported units: ${supported}` };
+  }
+
+  return { bytes: value * TO_BYTES[unit] };
+}
+
+export const DataSizeConvertBoxSource = {
+  name: 'Data Size',
+  description:
+    'Convert a data size between SI (KB, MB, GB) and IEC (KiB, MiB, GiB) units.',
+  defaultInput: '1.5 GB ::datasize',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'datasize', 'bytesize')) return [];
+
+    const parsed = parseInput(input);
+    if (!parsed) return [];
+
+    // error result: show a box explaining the problem
+    if ('error' in parsed) {
+      const kv: Record<string, string> = { Error: parsed.error };
+      const plaintext = `Error: ${parsed.error}`;
+      return [
+        new BoxBuilder('Data Size', plaintext)
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { bytes } = parsed;
+    const kv: Record<string, string> = {};
+
+    for (const { label, divisor } of OUTPUT_UNITS) {
+      kv[label] = formatSigFigs(bytes / divisor);
+    }
+
+    // if a target unit is specified (e.g. ::datasize=mib), add a Result entry
+    const targetRaw = extractOptionKeys(options, 'datasize', 'bytesize');
+    if (typeof targetRaw === 'string' && targetRaw.length > 0) {
+      const targetUnit = targetRaw.toLowerCase();
+      if (targetUnit in TO_BYTES) {
+        const resultValue = bytes / TO_BYTES[targetUnit];
+        kv.Result = `${formatSigFigs(resultValue)} ${targetRaw.toUpperCase()}`;
+      }
+    }
+
+    // build plaintext as "Key: value" lines for headless consumers
+    const plaintext = Object.entries(kv)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Data Size', plaintext)
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DataSizeConvertBoxSource;

--- a/src/modules/boxSources/HexTextBoxSource.ts
+++ b/src/modules/boxSources/HexTextBoxSource.ts
@@ -1,0 +1,112 @@
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// converts text to a compact lowercase hex string (no separators)
+function encodeTextToHex(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+interface DecodeResult {
+  ok: true;
+  text: string;
+}
+
+interface DecodeError {
+  ok: false;
+  message: string;
+}
+
+// parses a hex string (optional leading 0x, optional whitespace) into text
+function decodeHexToText(hex: string): DecodeResult | DecodeError {
+  const cleaned = hex.replace(/\s+/g, '').replace(/^0x/i, '').toLowerCase();
+
+  if (!/^[0-9a-f]*$/.test(cleaned)) {
+    return {
+      ok: false,
+      message: `Invalid hex input: contains non-hex characters`,
+    };
+  }
+  if (cleaned.length % 2 !== 0) {
+    return {
+      ok: false,
+      message: `Invalid hex input: odd number of characters`,
+    };
+  }
+
+  const bytes = new Uint8Array(cleaned.length / 2);
+  for (let i = 0; i < cleaned.length; i += 2) {
+    bytes[i / 2] = Number.parseInt(cleaned.slice(i, i + 2), 16);
+  }
+
+  return { ok: true, text: new TextDecoder().decode(bytes) };
+}
+
+export const HexTextBoxSource = {
+  name: 'Text to Hex',
+  description:
+    'Convert text to a hex string (UTF-8) or decode a hex string back to text.',
+  defaultInput: 'Hi ::hex',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'hex', 'tohex');
+    const wantDecode = hasOptionKeys(options, 'hexdecode', 'fromhex');
+    if (!wantEncode && !wantDecode) {
+      return [];
+    }
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    ) {
+      return [];
+    }
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const hexOutput = encodeTextToHex(input);
+      boxes.push(
+        new BoxBuilder('Text to Hex', hexOutput)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const result = decodeHexToText(input);
+      if (result.ok) {
+        boxes.push(
+          new BoxBuilder('Hex to Text', result.text)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        boxes.push(
+          new BoxBuilder('Hex to Text', result.message)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default HexTextBoxSource;

--- a/src/modules/boxSources/IniBoxSource.ts
+++ b/src/modules/boxSources/IniBoxSource.ts
@@ -1,0 +1,148 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// keys that must never be set on parsed objects to prevent prototype pollution
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** parses an INI string into a plain object with optional top-level and section keys */
+function parseIni(input: string): Record<string, unknown> {
+  const root = Object.create(null) as Record<string, unknown>;
+  let current: Record<string, unknown> = root;
+
+  for (const rawLine of input.split('\n')) {
+    const line = rawLine.trim();
+
+    // skip blank lines and comments
+    if (!line || line.startsWith(';') || line.startsWith('#')) continue;
+
+    // section header
+    if (line.startsWith('[') && line.endsWith(']')) {
+      const section = line.slice(1, -1).trim();
+      if (FORBIDDEN_KEYS.has(section)) continue;
+      const sectionObj = Object.create(null) as Record<string, unknown>;
+      root[section] = sectionObj;
+      current = sectionObj;
+      continue;
+    }
+
+    // key = value
+    const eqIdx = line.indexOf('=');
+    if (eqIdx === -1) continue;
+
+    const key = line.slice(0, eqIdx).trim();
+    if (FORBIDDEN_KEYS.has(key)) continue;
+
+    let value = line.slice(eqIdx + 1).trim();
+    // strip one layer of surrounding quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    current[key] = value;
+  }
+
+  return root;
+}
+
+/** serialises a plain JSON object to INI format (one level of nesting supported) */
+function stringifyIni(obj: Record<string, unknown>): string {
+  const lines: string[] = [];
+
+  // top-level scalar values first
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== null && typeof value !== 'object') {
+      lines.push(`${key}=${value}`);
+    }
+  }
+
+  // nested sections
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      lines.push(`[${key}]`);
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        const serialised =
+          v !== null && typeof v === 'object' ? JSON.stringify(v) : String(v);
+        lines.push(`${k}=${serialised}`);
+      }
+    } else if (value !== null && typeof value === 'object') {
+      // arrays or deeper nesting — JSON-stringify the value as a scalar
+      lines.push(`${key}=${JSON.stringify(value)}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export const IniBoxSource = {
+  name: 'INI / JSON',
+  description:
+    'Convert INI config to JSON, or a flat/sectioned JSON object to INI.',
+  defaultInput: '[server]\nhost = localhost\nport = 8080 ::ini',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ini', 'inijson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    // direction: JSON string → INI, otherwise INI → JSON
+    if (trimmed.startsWith('{')) {
+      try {
+        const obj = JSON.parse(trimmed) as Record<string, unknown>;
+        const output = stringifyIni(obj);
+        return [
+          new BoxBuilder('JSON → INI', output)
+            .setOptions({ language: 'ini' })
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      } catch {
+        return [
+          new BoxBuilder('JSON → INI', 'Error: invalid JSON input')
+            .setOptions({ language: 'ini' })
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // INI → JSON
+    try {
+      const obj = parseIni(trimmed);
+      const output = JSON.stringify(obj, null, 2);
+      return [
+        new BoxBuilder('INI → JSON', output)
+          .setOptions({ language: 'json' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    } catch {
+      return [
+        new BoxBuilder('INI → JSON', 'Error: failed to parse INI input')
+          .setOptions({ language: 'json' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+  },
+};
+
+export default IniBoxSource;

--- a/src/modules/boxSources/IniBoxSource.ts
+++ b/src/modules/boxSources/IniBoxSource.ts
@@ -98,6 +98,7 @@ export const IniBoxSource = {
     if (input.length > MAX_INPUT) return [];
 
     const trimmed = trim(input);
+    if (!trimmed) return [];
 
     // direction: JSON string → INI, otherwise INI → JSON
     if (trimmed.startsWith('{')) {

--- a/src/modules/boxSources/LengthConvertBoxSource.ts
+++ b/src/modules/boxSources/LengthConvertBoxSource.ts
@@ -1,0 +1,126 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit -> meters conversion factor
+const TO_M: Record<string, number> = {
+  mm: 0.001,
+  cm: 0.01,
+  m: 1,
+  km: 1000,
+  in: 0.0254,
+  ft: 0.3048,
+  yd: 0.9144,
+  mi: 1609.344,
+  nmi: 1852,
+};
+
+// display order for output keys
+const UNIT_ORDER = ['mm', 'cm', 'm', 'km', 'in', 'ft', 'yd', 'mi', 'nmi'];
+
+const PARSE_RE = /^(-?\d+(?:\.\d+)?)\s*([a-z]+)$/i;
+
+// format a number to up to 6 significant figures, stripping trailing zeros
+function formatValue(n: number): string {
+  // handle exact integers cleanly (sig-figs would corrupt large exact values)
+  if (Number.isInteger(n)) return String(n);
+
+  // round to 6 decimal places, then strip trailing zeros
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// render key/value pairs as `k: v` lines for the headless/TUI plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const LengthConvertBoxSource = {
+  name: 'Length Convert',
+  description:
+    'Convert a length between units. e.g. "1 mi ::length" or "5 km ::length=mi".',
+  defaultInput: '1 mi ::length',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'length')) return [];
+
+    const raw = trim(input).slice(0, 64);
+    const match = PARSE_RE.exec(raw);
+
+    if (!match) {
+      // invalid format — return an explanatory box
+      const kv: Record<string, string> = {
+        Error: 'Invalid format. Expected: <number> <unit>',
+        'Supported Units': UNIT_ORDER.join(', '),
+        Example: '1 mi, 5.5 km, -2.5 ft',
+      };
+      return [
+        new BoxBuilder('Length Convert', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitRaw = match[2].toLowerCase();
+
+    if (!(unitRaw in TO_M)) {
+      // unknown unit — return an explanatory box
+      const kv: Record<string, string> = {
+        Error: `Unknown unit: "${unitRaw}"`,
+        'Supported Units': UNIT_ORDER.join(', '),
+        Example: '1 mi, 5.5 km, -2.5 ft',
+      };
+      return [
+        new BoxBuilder('Length Convert', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const meters = value * TO_M[unitRaw];
+
+    // optional target unit from option value, e.g. ::length=km
+    const targetRaw = extractOptionKeys(options, 'length');
+    const target =
+      typeof targetRaw === 'string' && targetRaw.toLowerCase() in TO_M
+        ? targetRaw.toLowerCase()
+        : null;
+
+    const kv: Record<string, string> = {
+      Input: `${formatValue(value)} ${unitRaw}`,
+    };
+
+    for (const unit of UNIT_ORDER) {
+      kv[unit] = formatValue(meters / TO_M[unit]);
+    }
+
+    if (target !== null) {
+      kv.Result = `${formatValue(meters / TO_M[target])} ${target}`;
+    }
+
+    return [
+      new BoxBuilder('Length Convert', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LengthConvertBoxSource;

--- a/src/modules/boxSources/__test__/AngleConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AngleConvertBoxSource.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { AngleConvertBoxSource } from '../AngleConvertBoxSource';
+
+describe('AngleConvertBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when ::angle option is not present', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('180 deg', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options object has no angle key', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('180 deg', {
+        foo: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert 180 deg → π rad, 200 grad, 0.5 turn', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('180 deg', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('180');
+      expect(opts.Radians).toBe('3.141593');
+      expect(opts.Gradians).toBe('200');
+      expect(opts.Turns).toBe('0.5');
+    });
+
+    it('should convert 1 turn → 360 deg, ~6.283185 rad, 400 grad', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('1 turn', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('360');
+      expect(opts.Radians).toBe('6.283185');
+      expect(opts.Gradians).toBe('400');
+      expect(opts.Turns).toBe('1');
+    });
+
+    it('should convert 100 grad → 90 deg', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('100 grad', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('90');
+    });
+
+    it('should convert 1.5708 rad → ~90 deg', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('1.5708 rad', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1.5708 rad is approximately 90 degrees (within floating-point tolerance)
+      expect(Number.parseFloat(opts.Degrees)).toBeCloseTo(90, 3);
+    });
+
+    it('should handle the ° symbol: 90° → ~1.570796 rad', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('90°', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('90');
+      expect(opts.Radians).toBe('1.570796');
+    });
+
+    it('should return an error box for non-numeric input "abc"', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('abc', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // error box must mention valid units
+      expect(opts.Units).toBeDefined();
+      expect(opts.Units.length).toBeGreaterThan(0);
+    });
+
+    it('should return an error box for unrecognized unit "5 parsecs"', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('5 parsecs', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Units).toBeDefined();
+      expect(opts.Units.length).toBeGreaterThan(0);
+    });
+
+    it('should accept unit alias "degrees"', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('360 degrees', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('360');
+      expect(opts.Turns).toBe('1');
+    });
+
+    it('should accept unit alias "radians"', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('1 radians', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(opts.Degrees)).toBeCloseTo(57.29578, 3);
+    });
+
+    it('should handle negative angles', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('-90 deg', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('-90');
+      expect(opts.Turns).toBe('-0.25');
+    });
+
+    it('should set box name to "Angle Convert"', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('180 deg', {
+        angle: true,
+      });
+
+      expect(boxes[0].props.name).toBe('Angle Convert');
+    });
+
+    it('should set priority to the module priority', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('180 deg', {
+        angle: true,
+      });
+
+      expect(boxes[0].props.priority).toBe(AngleConvertBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/Base91BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base91BoxSource.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import { Base91BoxSource } from '../Base91BoxSource';
+
+// basE91 alphabet used by the encoder — used to validate output chars
+const ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&()*+,./:;<=>?@[]^_`{|}~"';
+const ALPHABET_SET = new Set(ALPHABET);
+
+describe('Base91BoxSource', () => {
+  describe('generateBoxes — no match', () => {
+    it('should return [] when no option keys are given', async () => {
+      const boxes = await Base91BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] for empty input with ::base91', async () => {
+      const boxes = await Base91BoxSource.generateBoxes('', { base91: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] for whitespace-only input', async () => {
+      const boxes = await Base91BoxSource.generateBoxes('   ', {
+        base91: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode (::base91 / ::base91encode)', () => {
+    it('should produce a non-empty string of valid alphabet chars for "hello"', async () => {
+      const boxes = await Base91BoxSource.generateBoxes('hello', {
+        base91: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('basE91 (Encode)');
+      expect(boxes[0].props.priority).toBe(10);
+
+      const out = boxes[0].props.plaintextOutput;
+      expect(out.length).toBeGreaterThan(0);
+      for (const ch of out) {
+        expect(ALPHABET_SET.has(ch)).toBe(true);
+      }
+    });
+
+    it('should produce valid alphabet chars using ::base91encode alias', async () => {
+      const boxes = await Base91BoxSource.generateBoxes('hello', {
+        base91encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out.length).toBeGreaterThan(0);
+      for (const ch of out) {
+        expect(ALPHABET_SET.has(ch)).toBe(true);
+      }
+    });
+  });
+
+  describe('decode (::base91decode)', () => {
+    it('should decode an encoded value back to original', async () => {
+      const encBoxes = await Base91BoxSource.generateBoxes('hello', {
+        base91: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Base91BoxSource.generateBoxes(encoded, {
+        base91decode: true,
+      });
+      expect(decBoxes).toHaveLength(1);
+      expect(decBoxes[0].props.name).toBe('basE91 (Decode)');
+      expect(decBoxes[0].props.plaintextOutput).toBe('hello');
+    });
+  });
+
+  describe('round-trip — ASCII', () => {
+    it('should round-trip "hello world"', async () => {
+      const input = 'hello world';
+      const enc = await Base91BoxSource.generateBoxes(input, { base91: true });
+      const encoded = enc[0].props.plaintextOutput;
+      const dec = await Base91BoxSource.generateBoxes(encoded, {
+        base91decode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe(input);
+    });
+
+    it('should round-trip the quick brown fox sentence', async () => {
+      const input = 'The quick brown fox jumps over the lazy dog';
+      const enc = await Base91BoxSource.generateBoxes(input, { base91: true });
+      const encoded = enc[0].props.plaintextOutput;
+      const dec = await Base91BoxSource.generateBoxes(encoded, {
+        base91decode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe(input);
+    });
+  });
+
+  describe('round-trip — unicode', () => {
+    it('should round-trip "café 日本 😀"', async () => {
+      const input = 'café 日本 😀';
+      const enc = await Base91BoxSource.generateBoxes(input, { base91: true });
+      expect(enc).toHaveLength(1);
+      const encoded = enc[0].props.plaintextOutput;
+
+      // all output chars must be in the basE91 alphabet
+      for (const ch of encoded) {
+        expect(ALPHABET_SET.has(ch)).toBe(true);
+      }
+
+      const dec = await Base91BoxSource.generateBoxes(encoded, {
+        base91decode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe(input);
+    });
+  });
+
+  describe('both options', () => {
+    it('should return 2 boxes when both ::base91 and ::base91decode are set', async () => {
+      // encode "hello" first to get a valid basE91 string, then use it as input
+      const encFirst = await Base91BoxSource.generateBoxes('hello', {
+        base91: true,
+      });
+      const validEncoded = encFirst[0].props.plaintextOutput;
+
+      const boxes = await Base91BoxSource.generateBoxes(validEncoded, {
+        base91: true,
+        base91decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('basE91 (Encode)');
+      expect(boxes[1].props.name).toBe('basE91 (Decode)');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/Base91BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base91BoxSource.test.ts
@@ -130,4 +130,16 @@ describe('Base91BoxSource', () => {
       expect(boxes[1].props.name).toBe('basE91 (Decode)');
     });
   });
+
+  describe('lenient decode', () => {
+    it('skips out-of-range unicode chars without corrupting output (no NaN)', async () => {
+      const enc = await Base91BoxSource.generateBoxes('hi', { base91: true });
+      const valid = enc[0].props.plaintextOutput;
+      // inject CJK/emoji noise the 256-entry decode table cannot index
+      const boxes = await Base91BoxSource.generateBoxes(`${valid}日本😀`, {
+        base91decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hi');
+    });
+  });
 });

--- a/src/modules/boxSources/__test__/BeaufortBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BeaufortBoxSource.test.ts
@@ -97,5 +97,13 @@ describe('BeaufortBoxSource', () => {
       // headless template — web layer supplies DefaultBoxTemplate
       expect(boxes[0].boxTemplate).toBeUndefined();
     });
+
+    it('a bare ::beaufort (no =key) returns a usage box, not a "TRUE" cipher', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes('HELLO', {
+        beaufort: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/alphabetic key/i);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/BeaufortBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BeaufortBoxSource.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { BeaufortBoxSource } from '../BeaufortBoxSource';
+
+describe('BeaufortBoxSource', () => {
+  describe('no match', () => {
+    it('returns [] when ::beaufort option is absent', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes('DEFEND', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with ::beaufort key', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes('', {
+        beaufort: 'FORTIFICATION',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('canonical Beaufort vector', () => {
+    // reference: https://en.wikipedia.org/wiki/Beaufort_cipher
+    it('DEFENDTHEEASTWALLOFTHECASTLE + FORTIFICATION → CKMPVCPVWPIWUJOGIUAPVWRIWUUK', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes(
+        'DEFENDTHEEASTWALLOFTHECASTLE',
+        { beaufort: 'FORTIFICATION' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'CKMPVCPVWPIWUJOGIUAPVWRIWUUK',
+      );
+    });
+  });
+
+  describe('self-reciprocity', () => {
+    it('applying beaufort twice with the same key recovers the plaintext', async () => {
+      const plain = 'HELLOWORLD';
+      const key = 'SECRET';
+
+      const enc = await BeaufortBoxSource.generateBoxes(plain, {
+        beaufort: key,
+      });
+      expect(enc).toHaveLength(1);
+      const cipher = enc[0].props.plaintextOutput;
+
+      const dec = await BeaufortBoxSource.generateBoxes(cipher, {
+        beaufort: key,
+      });
+      expect(dec).toHaveLength(1);
+      expect(dec[0].props.plaintextOutput).toBe(plain);
+    });
+  });
+
+  describe('non-letters pass through', () => {
+    it('preserves spaces and punctuation in place without advancing key index', async () => {
+      // 'HI, THERE' — letters H I T H E R E are enciphered; ', ' and ' ' pass through.
+      // key ALPHA: A(0) L(11) P(15) H(7) A(0)...
+      // H(7) → (A(0)-7+26)%26=19=T
+      // I(8) → (L(11)-8+26)%26=3=D
+      // T(19) → (P(15)-19+26)%26=22=W
+      // H(7) → (H(7)-7+26)%26=0=A
+      // E(4) → (A(0)-4+26)%26=22=W
+      // R(17) → repeat key from pos5→A(0): (A(0)-17+26)%26=9=J
+      // E(4) → (L(11)-4)%26=7=H
+      const boxes = await BeaufortBoxSource.generateBoxes('HI, THERE', {
+        beaufort: 'ALPHA',
+      });
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      // 'HI, THERE' has a comma at index 2 and a single space at index 3;
+      // index 5 is the letter 'H' and is enciphered, not preserved
+      expect(out[2]).toBe(',');
+      expect(out[3]).toBe(' ');
+      // total length unchanged
+      expect(out).toHaveLength('HI, THERE'.length);
+    });
+  });
+
+  describe('invalid key', () => {
+    it('returns a single box explaining the key requirement when key has no letters', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes('HELLO', {
+        beaufort: '123',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/alphabetic/i);
+    });
+  });
+
+  describe('box properties', () => {
+    it('box is named "Beaufort Cipher" and has expand button hidden', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes('DEFEND', {
+        beaufort: 'KEY',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Beaufort Cipher');
+      expect(boxes[0].props.showExpandButton).toBe(false);
+      expect(boxes[0].props.priority).toBe(10);
+      // headless template — web layer supplies DefaultBoxTemplate
+      expect(boxes[0].boxTemplate).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CountryFlagBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CountryFlagBoxSource.test.ts
@@ -1,0 +1,149 @@
+import { CountryFlagBoxSource } from '@modules/boxSources/CountryFlagBoxSource';
+import { describe, expect, it } from 'vitest';
+
+// regional indicator base code point (🇦 = U+1F1E6)
+const RI_BASE = 0x1f1e6;
+
+describe('CountryFlagBoxSource', () => {
+  describe('no option key → empty array', () => {
+    it('returns [] when no ::flag option is present', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('US', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is present', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('US', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('code → flag', () => {
+    it('converts US to 🇺🇸 (U+1F1FA U+1F1F8)', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('US', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Code).toBe('US');
+
+      const flag = opts.Flag;
+      // verify the two regional indicator code points
+      const cp0 = flag.codePointAt(0);
+      const cp1 = flag.codePointAt(2); // each regional indicator is 2 UTF-16 units
+      expect(cp0).toBe(0x1f1fa); // 🇺 = RI_BASE + ('U' - 'A') = 0x1F1E6 + 20
+      expect(cp1).toBe(0x1f1f8); // 🇸 = RI_BASE + ('S' - 'A') = 0x1F1E6 + 18
+      expect(flag).toBe('🇺🇸');
+    });
+
+    it('converts lowercase jp to 🇯🇵', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('jp', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Code).toBe('JP');
+      expect(opts.Flag).toBe('🇯🇵');
+    });
+
+    it('includes Name "United States" for US', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('US', {
+        flag: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Name).toBe('United States');
+    });
+
+    it('accepts ::countryflag option key', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('US', {
+        countryflag: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Flag).toBe('🇺🇸');
+    });
+
+    it('verifies US flag code points via RI_BASE arithmetic', () => {
+      // U is the 21st letter (0-indexed: 20); S is the 19th (0-indexed: 18)
+      expect(RI_BASE + 20).toBe(0x1f1fa);
+      expect(RI_BASE + 18).toBe(0x1f1f8);
+    });
+  });
+
+  describe('flag → code (reverse)', () => {
+    it('converts 🇺🇸 back to US', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('🇺🇸', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Code).toBe('US');
+    });
+
+    it('converts 🇫🇷 to FR', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('🇫🇷', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Code).toBe('FR');
+    });
+
+    it('round-trips US → 🇺🇸 → US', async () => {
+      const forward = await CountryFlagBoxSource.generateBoxes('US', {
+        flag: true,
+      });
+      const flag = (forward[0].props.options as Record<string, string>).Flag;
+
+      const reverse = await CountryFlagBoxSource.generateBoxes(flag, {
+        flag: true,
+      });
+      const code = (reverse[0].props.options as Record<string, string>).Code;
+      expect(code).toBe('US');
+    });
+  });
+
+  describe('invalid input → info box', () => {
+    it('returns an info box for single-letter input "X"', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('X', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // the box name is still 'Country Flag'
+      expect(boxes[0].props.name).toBe('Country Flag');
+      // the output mentions country code or flag
+      const text = boxes[0].props.plaintextOutput.toLowerCase();
+      expect(text).toMatch(/country.*code|flag/);
+    });
+
+    it('returns an info box for "hello" (more than 2 letters)', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('hello', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const text = boxes[0].props.plaintextOutput.toLowerCase();
+      expect(text).toMatch(/country.*code|flag/);
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets priority to 10', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('TW', {
+        flag: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('sets box name to "Country Flag"', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('TW', {
+        flag: true,
+      });
+      expect(boxes[0].props.name).toBe('Country Flag');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/DataSizeConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DataSizeConvertBoxSource.test.ts
@@ -1,0 +1,173 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DataSizeConvertBoxSource } from '../DataSizeConvertBoxSource';
+
+describe('DataSizeConvertBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no option keys are present', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes(
+        '1.5 GB',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are present', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 GB', {
+        something: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — 1.5 GB (SI)', () => {
+    it('produces one box with KeyValueBoxTemplate and correct priority', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 GB', {
+        datasize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.name).toBe('Data Size');
+    });
+
+    it('converts 1.5 GB → Bytes = 1500000000', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 GB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1500000000' });
+    });
+
+    it('converts 1.5 GB → GB = 1.5', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 GB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ GB: '1.5' });
+    });
+
+    it('converts 1.5 GB → GiB ≈ 1.39698 (1.5e9 / 1024^3)', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 GB', {
+        datasize: true,
+      });
+      const gib = Number.parseFloat(
+        (boxes[0].props.options as Record<string, string>).GiB,
+      );
+      // 1.5e9 / 1024^3 = 1.396984...
+      expect(gib).toBeCloseTo(1.396984, 4);
+    });
+  });
+
+  describe('generateBoxes — 1024 MiB (IEC round trip)', () => {
+    it('converts 1024 MiB → GiB = 1', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1024 MiB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ GiB: '1' });
+    });
+
+    it('converts 1024 MiB → Bytes = 1073741824', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1024 MiB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1073741824' });
+    });
+  });
+
+  describe('generateBoxes — 1 GiB', () => {
+    it('converts 1 GiB → Bytes = 1073741824', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1 GiB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1073741824' });
+    });
+
+    it('converts 1 GiB → MiB = 1024', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1 GiB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ MiB: '1024' });
+    });
+  });
+
+  describe('generateBoxes — target unit via ::datasize=<unit>', () => {
+    it('adds Result key when ::datasize=mib and value is 1 GB', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1 GB', {
+        datasize: 'mib',
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Result).toBeDefined();
+      // 1e9 / 1024^2 = 953.6743...
+      expect(opts.Result).toContain('MIB');
+      const numPart = Number.parseFloat(opts.Result);
+      expect(numPart).toBeCloseTo(953.674, 2);
+    });
+  });
+
+  describe('generateBoxes — bytesize option alias', () => {
+    it('triggers on ::bytesize as well', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1 KB', {
+        bytesize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1000' });
+    });
+  });
+
+  describe('generateBoxes — bare number (no unit → bytes)', () => {
+    it('treats bare 2048 as 2048 bytes → KiB = 2, KB = 2.048', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('2048', {
+        datasize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Bytes).toBe('2048');
+      expect(opts.KiB).toBe('2');
+      expect(opts.KB).toBe('2.048');
+    });
+  });
+
+  describe('generateBoxes — invalid unit', () => {
+    it('returns a box with Error key for unknown unit "floppies"', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('5 floppies', {
+        datasize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+      expect(opts.Error).toContain('floppies');
+      // should list some known units in the message
+      expect(opts.Error).toContain('kb');
+    });
+  });
+
+  describe('generateBoxes — case insensitivity', () => {
+    it('parses "1.5 gb" (lowercase) correctly', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 gb', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1500000000' });
+    });
+
+    it('parses "512 MIB" (uppercase) correctly', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('512 MIB', {
+        datasize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 512 * 1024^2 = 536870912
+      expect(opts.Bytes).toBe('536870912');
+    });
+  });
+
+  describe('generateBoxes — whitespace tolerance', () => {
+    it('handles extra whitespace around "  1.5   GB  "', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes(
+        '  1.5   GB  ',
+        {
+          datasize: true,
+        },
+      );
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1500000000' });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HexTextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HexTextBoxSource.test.ts
@@ -1,0 +1,119 @@
+import { expect } from 'vitest';
+
+import { HexTextBoxSource } from '../HexTextBoxSource';
+
+describe('HexTextBoxSource', () => {
+  describe('generateBoxes — no match', () => {
+    it('should return [] when no option keys are given', async () => {
+      const boxes = await HexTextBoxSource.generateBoxes('Hi', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] for empty input even with ::hex', async () => {
+      const boxes = await HexTextBoxSource.generateBoxes('', { hex: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] for whitespace-only input', async () => {
+      const boxes = await HexTextBoxSource.generateBoxes('   ', { hex: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode (::hex / ::tohex)', () => {
+    it('should encode "Hi" to "4869"', async () => {
+      const boxes = await HexTextBoxSource.generateBoxes('Hi', { hex: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Text to Hex');
+      expect(boxes[0].props.plaintextOutput).toBe('4869');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBeUndefined();
+    });
+
+    it('should encode "Hi" using ::tohex alias', async () => {
+      const boxes = await HexTextBoxSource.generateBoxes('Hi', { tohex: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('4869');
+    });
+
+    it('should encode "café" to "636166c3a9" (UTF-8 multi-byte for é)', async () => {
+      // c=63, a=61, f=66, é=c3 a9
+      const boxes = await HexTextBoxSource.generateBoxes('café', { hex: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('636166c3a9');
+    });
+  });
+
+  describe('decode (::hexdecode / ::fromhex)', () => {
+    it('should decode "4869" to "Hi"', async () => {
+      const boxes = await HexTextBoxSource.generateBoxes('4869', {
+        hexdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Hex to Text');
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('should decode using ::fromhex alias', async () => {
+      const boxes = await HexTextBoxSource.generateBoxes('4869', {
+        fromhex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('should strip leading "0x" and spaces: "0x48 69" → "Hi"', async () => {
+      const boxes = await HexTextBoxSource.generateBoxes('0x48 69', {
+        hexdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('should return error box for odd-length hex "abc"', async () => {
+      const boxes = await HexTextBoxSource.generateBoxes('abc', {
+        hexdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/odd/i);
+    });
+
+    it('should return error box for invalid hex chars "zz"', async () => {
+      const boxes = await HexTextBoxSource.generateBoxes('zz', {
+        hexdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid hex/i);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('should round-trip "Hello, 世界!"', async () => {
+      const original = 'Hello, 世界!';
+      const encBoxes = await HexTextBoxSource.generateBoxes(original, {
+        hex: true,
+      });
+      expect(encBoxes).toHaveLength(1);
+      const hexStr = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await HexTextBoxSource.generateBoxes(hexStr, {
+        hexdecode: true,
+      });
+      expect(decBoxes).toHaveLength(1);
+      expect(decBoxes[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('both options', () => {
+    it('should return 2 boxes when both ::hex and ::hexdecode are set', async () => {
+      // "4869" is valid hex, so decode succeeds; encode of "4869" is also valid
+      const boxes = await HexTextBoxSource.generateBoxes('4869', {
+        hex: true,
+        hexdecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Text to Hex');
+      expect(boxes[1].props.name).toBe('Hex to Text');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/IniBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/IniBoxSource.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { IniBoxSource } from '../IniBoxSource';
+
+describe('IniBoxSource', () => {
+  describe('generateBoxes - option gating', () => {
+    it('returns empty array when no matching option is provided', async () => {
+      const boxes = await IniBoxSource.generateBoxes('[s]\nk=v', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await IniBoxSource.generateBoxes('[s]\nk=v', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('INI → JSON', () => {
+    it('parses a basic section with scalar values', async () => {
+      const boxes = await IniBoxSource.generateBoxes(
+        '[server]\nhost = localhost\nport = 8080',
+        { ini: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('INI → JSON');
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ server: { host: 'localhost', port: '8080' } });
+    });
+
+    it('handles comments and top-level keys before a section', async () => {
+      const input = '; this is a comment\nname=app\n[db]\nuser=admin';
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ name: 'app', db: { user: 'admin' } });
+    });
+
+    it('strips one layer of double quotes from values', async () => {
+      const boxes = await IniBoxSource.generateBoxes('msg = "hello world"', {
+        ini: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed.msg).toBe('hello world');
+    });
+
+    it('strips one layer of single quotes from values', async () => {
+      const boxes = await IniBoxSource.generateBoxes("path = '/usr/local'", {
+        ini: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed.path).toBe('/usr/local');
+    });
+
+    it('sets language option to json', async () => {
+      const boxes = await IniBoxSource.generateBoxes('[s]\nk=v', { ini: true });
+      expect(boxes[0].props.options?.language).toBe('json');
+    });
+  });
+
+  describe('JSON → INI', () => {
+    it('serialises a nested JSON object to INI sections', async () => {
+      const input = '{"server":{"host":"localhost","port":"8080"}}';
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → INI');
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('[server]');
+      expect(output).toContain('host=localhost');
+      expect(output).toContain('port=8080');
+    });
+
+    it('places top-level scalars before sections', async () => {
+      const input = '{"version":"1.0","db":{"host":"localhost"}}';
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      const output = boxes[0].props.plaintextOutput;
+      const versionLine = output.indexOf('version=1.0');
+      const sectionLine = output.indexOf('[db]');
+      expect(versionLine).toBeGreaterThanOrEqual(0);
+      expect(sectionLine).toBeGreaterThan(versionLine);
+    });
+
+    it('triggers on ::inijson option as well', async () => {
+      const input = '{"k":"v"}';
+      const boxes = await IniBoxSource.generateBoxes(input, { inijson: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → INI');
+    });
+
+    it('sets language option to ini', async () => {
+      const input = '{"k":"v"}';
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(boxes[0].props.options?.language).toBe('ini');
+    });
+
+    it('returns an error box for invalid JSON-looking input', async () => {
+      const boxes = await IniBoxSource.generateBoxes('{bad json', {
+        ini: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/error/i);
+    });
+  });
+
+  describe('prototype pollution guard', () => {
+    it('does not pollute Object.prototype via __proto__ section', async () => {
+      const input = '[__proto__]\npolluted=evil';
+      await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('does not pollute Object.prototype via top-level __proto__ key', async () => {
+      const input = '__proto__=evil';
+      await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(({} as Record<string, unknown>).__proto__).not.toBe('evil');
+    });
+
+    it('does not pollute via constructor key', async () => {
+      const input = '[constructor]\nx=1';
+      await IniBoxSource.generateBoxes(input, { ini: true });
+      // the section should have been silently skipped
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      // the forbidden section must not appear as an own key (reading
+      // parsed.constructor returns the inherited Object constructor)
+      expect(Object.hasOwn(parsed, 'constructor')).toBe(false);
+    });
+
+    it('produces a valid (empty) JSON object when all keys are forbidden', async () => {
+      const input = '__proto__=a\nconstructor=b\nprototype=c';
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(boxes).toHaveLength(1);
+      // output should be a valid JSON object, just empty (or with no forbidden keys)
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(typeof parsed).toBe('object');
+      // all keys forbidden → no own keys survive (reading parsed.__proto__
+      // would return Object.prototype, so assert on own-key presence instead)
+      expect(Object.hasOwn(parsed, '__proto__')).toBe(false);
+      expect(Object.keys(parsed)).toHaveLength(0);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('INI → JSON → INI preserves section and key/value content', async () => {
+      const originalIni = '[app]\nname=magic\nversion=2';
+      const toJsonBoxes = await IniBoxSource.generateBoxes(originalIni, {
+        ini: true,
+      });
+      const jsonStr = toJsonBoxes[0].props.plaintextOutput;
+
+      const toIniBoxes = await IniBoxSource.generateBoxes(jsonStr, {
+        ini: true,
+      });
+      const roundTripped = toIniBoxes[0].props.plaintextOutput;
+      expect(roundTripped).toContain('[app]');
+      expect(roundTripped).toContain('name=magic');
+      expect(roundTripped).toContain('version=2');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LengthConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LengthConvertBoxSource.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { LengthConvertBoxSource } from '../LengthConvertBoxSource';
+
+describe('LengthConvertBoxSource', () => {
+  it('returns [] when no ::length option', async () => {
+    const boxes = await LengthConvertBoxSource.generateBoxes('1 mi', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] when unrelated option is given', async () => {
+    const boxes = await LengthConvertBoxSource.generateBoxes('1 mi', {
+      base64: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  describe('1 mi ::length', () => {
+    it('produces one box with correct conversions', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('1 mi', {
+        length: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 mi = 1609.344 m exactly
+      expect(opts.m).toBe('1609.344');
+      // 1 mi = 1.609344 km exactly
+      expect(opts.km).toBe('1.609344');
+      // 1 mi = 5280 ft exactly
+      expect(opts.ft).toBe('5280');
+      // 1 mi = 1760 yd exactly
+      expect(opts.yd).toBe('1760');
+    });
+  });
+
+  describe('1000 m ::length', () => {
+    it('converts to km=1 and mi≈0.621371', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('1000 m', {
+        length: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.km).toBe('1');
+      // 1000 / 1609.344 ≈ 0.621371...
+      expect(Number.parseFloat(opts.mi)).toBeCloseTo(0.621371, 5);
+    });
+  });
+
+  describe('5 km ::length=mi', () => {
+    it('includes a Result key with the target unit value', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('5 km', {
+        length: 'mi',
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Result).toContain('mi');
+      // 5 km = 5000 m; 5000 / 1609.344 ≈ 3.10686
+      expect(Number.parseFloat(opts.Result)).toBeCloseTo(3.10686, 4);
+    });
+  });
+
+  describe('1 in ::length', () => {
+    it('converts to cm=2.54', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('1 in', {
+        length: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.cm).toBe('2.54');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('returns an error box for non-numeric input "abc"', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('abc', {
+        length: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeTruthy();
+      expect(opts['Supported Units']).toContain('mi');
+    });
+
+    it('returns an error box for unknown unit "5 furlong"', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('5 furlong', {
+        length: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/furlong/i);
+      expect(opts['Supported Units']).toContain('km');
+    });
+  });
+
+  describe('Input key is normalized', () => {
+    it('includes Input key with parsed value and unit', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('1 mi', {
+        length: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('1 mi');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,16 +1,24 @@
+import AngleConvertBoxSource from './AngleConvertBoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import Base91BoxSource from './Base91BoxSource';
+import BeaufortBoxSource from './BeaufortBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CountryFlagBoxSource from './CountryFlagBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
+import DataSizeConvertBoxSource from './DataSizeConvertBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HexTextBoxSource from './HexTextBoxSource';
+import IniBoxSource from './IniBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LengthConvertBoxSource from './LengthConvertBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
@@ -29,15 +37,23 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  AngleConvertBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  Base91BoxSource,
+  BeaufortBoxSource,
+  CountryFlagBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
+  DataSizeConvertBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HexTextBoxSource,
+  IniBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LengthConvertBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,


### PR DESCRIPTION
## Summary

Twenty-fourth exploration batch — **8 more BoxSource tools** (encodings, unit converters, config, cipher).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Text to Hex | `::hex` | text ⇄ hex string (UTF-8) |
| Length Convert | `::length` | mm/cm/m/km/in/ft/yd/mi/nmi |
| Data Size | `::datasize` | SI (KB/MB/GB) ⇄ IEC (KiB/MiB/GiB) |
| Angle Convert | `::angle` | deg/rad/grad/turn |
| INI / JSON | `::ini` | INI ⇄ JSON (prototype-pollution guarded) |
| Country Flag | `::flag` | ISO alpha-2 ⇄ flag emoji |
| Beaufort Cipher | `::beaufort=key` | self-reciprocal Vigenère variant |
| basE91 | `::base91` | Henke basE91 encode/decode |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Hardening rules pre-loaded (manual `k: v` plaintext, input caps, prototype-pollution guard via `Object.create(null)` + forbidden-key set in INI, code-point iteration for flag round-trip).
- **Verified vectors**: `Hi`→`4869`, `café`→`636166c3a9`; `1 mi`=`1609.344` m/`5280` ft; `1.5 GB`=`1500000000` B, `1024 MiB`=`1 GiB`; `180 deg`=π rad/`200` grad/`0.5` turn; `US`↔`🇺🇸`; Beaufort `DEFEND…`/`FORTIFICATION`→`CKMPVCPVWPIWUJOGIUAPVWRIWUUK`; basE91 ascii+unicode round-trip.

## Self-review fixes (pre-PR)

- **Sig-fig formatter corrupted exact values** in Data Size + Length — `1073741824`→`1073740000`, `1609.344`→`1609.34`. Switched to integer-exact + 6-decimal rounding.
- **LengthConvert shipped `''` plaintextOutput** (blank in headless TUI) — now renders `k: v`.
- Three buggy test assertions fixed (Beaufort space-index miscount; two INI checks that read inherited prototype props instead of own keys).

## Verification

- ✅ `bun run test run` — **430 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of #260–#282 — branched from `main`. The KeyValue sources here still hand-roll plaintext; once #281's `keyValueBox()` helper merges they can adopt it.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6