### PR TITLE
feat(boxSources): add 8 more tools (gray-code, hamming, cmyk, speed, json-pointer, columnar, scytale, crc8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>GrayCodeBox</b> </summary>
+
+| match rule  | description                          | example     |
+| ----------- | ------------------------------------ | ----------- |
+| `::gray`    | integer ⇄ reflected binary Gray code | `5 ::gray`  |
+
+</details>
+
+<details>
+<summary> <b>HammingDistanceBox</b> </summary>
+
+| match rule   | description                          | example                    |
+| ------------ | ------------------------------------ | -------------------------- |
+| `::hamming`  | Hamming distance of two equal-length strings (comma/newline separated) | `karolin, kathrin ::hamming` |
+
+</details>
+
+<details>
+<summary> <b>CmykBox</b> </summary>
+
+| match rule  | description                          | example            |
+| ----------- | ------------------------------------ | ------------------ |
+| `::cmyk`    | color hex/RGB ⇄ CMYK                 | `#ff6347 ::cmyk`   |
+
+</details>
+
+<details>
+<summary> <b>SpeedConvertBox</b> </summary>
+
+| match rule  | description                          | example              |
+| ----------- | ------------------------------------ | -------------------- |
+| `::speed`   | convert m/s, km/h, mph, knot, ft/s   | `100 km/h ::speed`   |
+
+</details>
+
+<details>
+<summary> <b>JsonPointerBox</b> </summary>
+
+| match rule              | description                          | example                              |
+| ----------------------- | ------------------------------------ | ------------------------------------ |
+| `::jsonpointer=/path`   | evaluate an RFC 6901 JSON Pointer    | `{"a":{"b":[1,2]}} ::jsonpointer=/a/b/1` |
+
+</details>
+
+<details>
+<summary> <b>ColumnarTranspositionBox</b> </summary>
+
+| match rule              | description                          | example                          |
+| ----------------------- | ------------------------------------ | -------------------------------- |
+| `::columnar=KEY`        | columnar transposition cipher (`::columnardecode=KEY` to decrypt) | `WEAREDISCOVERED ::columnar=ZEBRAS` |
+
+</details>
+
+<details>
+<summary> <b>ScytaleBox</b> </summary>
+
+| match rule          | description                          | example                |
+| ------------------- | ------------------------------------ | ---------------------- |
+| `::scytale=N`       | scytale transposition (`::scytaledecode=N` to decrypt) | `HELLOWORLD ::scytale=3` |
+
+</details>
+
+<details>
+<summary> <b>Crc8Box</b> </summary>
+
+| match rule  | description                          | example              |
+| ----------- | ------------------------------------ | -------------------- |
+| `::crc8`    | CRC-8 (SMBUS + Maxim/Dallas)         | `123456789 ::crc8`   |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/CmykBoxSource.ts
+++ b/src/modules/boxSources/CmykBoxSource.ts
@@ -1,0 +1,210 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length guard
+const MAX_LEN = 64;
+
+interface RgbColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+interface CmykColor {
+  c: number;
+  m: number;
+  y: number;
+  k: number;
+}
+
+// parses #RGB or #RRGGBB into r,g,b integers 0..255
+function parseHex(hex: string): RgbColor | null {
+  const s = hex.startsWith('#') ? hex.slice(1) : hex;
+  if (s.length === 3) {
+    const r = Number.parseInt(s[0] + s[0], 16);
+    const g = Number.parseInt(s[1] + s[1], 16);
+    const b = Number.parseInt(s[2] + s[2], 16);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+    return { r, g, b };
+  }
+  if (s.length === 6) {
+    const r = Number.parseInt(s.slice(0, 2), 16);
+    const g = Number.parseInt(s.slice(2, 4), 16);
+    const b = Number.parseInt(s.slice(4, 6), 16);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+    return { r, g, b };
+  }
+  return null;
+}
+
+// parses rgb(r,g,b) — values may be integers 0..255
+function parseRgb(input: string): RgbColor | null {
+  const m = input.match(/^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/i);
+  if (!m) return null;
+  const r = Number.parseInt(m[1], 10);
+  const g = Number.parseInt(m[2], 10);
+  const b = Number.parseInt(m[3], 10);
+  if ([r, g, b].some((v) => Number.isNaN(v) || v < 0 || v > 255)) return null;
+  return { r, g, b };
+}
+
+// converts r,g,b (0..255) to cmyk percentages rounded to integer
+function rgbToCmyk({ r, g, b }: RgbColor): CmykColor {
+  const rp = r / 255;
+  const gp = g / 255;
+  const bp = b / 255;
+  const k = 1 - Math.max(rp, gp, bp);
+  if (k === 1) {
+    return { c: 0, m: 0, y: 0, k: 100 };
+  }
+  const denom = 1 - k;
+  const c = Math.round(((1 - rp - k) / denom) * 100);
+  const m = Math.round(((1 - gp - k) / denom) * 100);
+  const y = Math.round(((1 - bp - k) / denom) * 100);
+  return { c, m, y, k: Math.round(k * 100) };
+}
+
+// converts cmyk percentages (0..100) to r,g,b integers 0..255
+function cmykToRgb({ c, m, y, k }: CmykColor): RgbColor {
+  const r = Math.round(255 * (1 - c / 100) * (1 - k / 100));
+  const g = Math.round(255 * (1 - m / 100) * (1 - k / 100));
+  const b = Math.round(255 * (1 - y / 100) * (1 - k / 100));
+  return { r, g, b };
+}
+
+// formats a channel byte as two uppercase hex digits
+function byteToHex(v: number): string {
+  return v.toString(16).padStart(2, '0').toUpperCase();
+}
+
+function rgbToHex({ r, g, b }: RgbColor): string {
+  return `#${byteToHex(r)}${byteToHex(g)}${byteToHex(b)}`;
+}
+
+// parses cmyk(c,m,y,k) where each value is 0..100 (with or without %)
+function parseCmyk(input: string): CmykColor | null {
+  const m = input.match(
+    /^cmyk\(\s*([\d.]+)%?\s*,\s*([\d.]+)%?\s*,\s*([\d.]+)%?\s*,\s*([\d.]+)%?\s*\)$/i,
+  );
+  if (!m) return null;
+  const [c, my, y, k] = [m[1], m[2], m[3], m[4]].map((v) =>
+    Number.parseFloat(v),
+  );
+  if ([c, my, y, k].some((v) => Number.isNaN(v) || v < 0 || v > 100))
+    return null;
+  return { c, m: my, y, k };
+}
+
+function formatCmyk({ c, m, y, k }: CmykColor): string {
+  return `cmyk(${c}%, ${m}%, ${y}%, ${k}%)`;
+}
+
+export const CmykBoxSource = {
+  name: 'CMYK',
+  description: 'Convert a color between hex/RGB and CMYK.',
+  defaultInput: '#ff6347 ::cmyk',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cmyk')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_LEN) return [];
+
+    // attempt hex → cmyk
+    const hexMatch = raw.match(/^(#[0-9a-fA-F]{3,6})$/);
+    if (hexMatch) {
+      const rgb = parseHex(hexMatch[1]);
+      if (rgb) {
+        const cmyk = rgbToCmyk(rgb);
+        const kv: Record<string, string> = {
+          Hex: raw
+            .toUpperCase()
+            .replace(/^(#[0-9a-f]{3,6})$/i, (s) => s.toUpperCase()),
+          RGB: `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`,
+          CMYK: formatCmyk(cmyk),
+        };
+        const plaintext = Object.entries(kv)
+          .map(([k, v]) => `${k}: ${v}`)
+          .join('\n');
+        return [
+          new BoxBuilder('CMYK', plaintext)
+            .setOptions(kv)
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // attempt rgb(r,g,b) → cmyk
+    const rgbMatch = raw.match(/^(rgb\([^)]*\))$/i);
+    if (rgbMatch) {
+      const rgb = parseRgb(rgbMatch[1]);
+      if (rgb) {
+        const cmyk = rgbToCmyk(rgb);
+        const kv: Record<string, string> = {
+          Hex: rgbToHex(rgb),
+          RGB: `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`,
+          CMYK: formatCmyk(cmyk),
+        };
+        const plaintext = Object.entries(kv)
+          .map(([k, v]) => `${k}: ${v}`)
+          .join('\n');
+        return [
+          new BoxBuilder('CMYK', plaintext)
+            .setOptions(kv)
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // attempt cmyk(c,m,y,k) → hex/rgb
+    const cmykMatch = raw.match(/^(cmyk\([^)]*\))$/i);
+    if (cmykMatch) {
+      const cmyk = parseCmyk(cmykMatch[1]);
+      if (cmyk) {
+        const rgb = cmykToRgb(cmyk);
+        const kv: Record<string, string> = {
+          CMYK: formatCmyk(cmyk),
+          RGB: `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`,
+          Hex: rgbToHex(rgb),
+        };
+        const plaintext = Object.entries(kv)
+          .map(([k, v]) => `${k}: ${v}`)
+          .join('\n');
+        return [
+          new BoxBuilder('CMYK', plaintext)
+            .setOptions(kv)
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // unrecognized format — return a hint box
+    const hint =
+      'Expected: #RGB, #RRGGBB, rgb(r,g,b), or cmyk(c,m,y,k) (0–100%)';
+    return [
+      new BoxBuilder('CMYK', hint)
+        .setOptions({ Format: hint })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CmykBoxSource;

--- a/src/modules/boxSources/CmykBoxSource.ts
+++ b/src/modules/boxSources/CmykBoxSource.ts
@@ -121,7 +121,7 @@ export const CmykBoxSource = {
     if (!raw || raw.length > MAX_LEN) return [];
 
     // attempt hex → cmyk
-    const hexMatch = raw.match(/^(#[0-9a-fA-F]{3,6})$/);
+    const hexMatch = raw.match(/^(#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?)$/);
     if (hexMatch) {
       const rgb = parseHex(hexMatch[1]);
       if (rgb) {

--- a/src/modules/boxSources/ColumnarTranspositionBoxSource.ts
+++ b/src/modules/boxSources/ColumnarTranspositionBoxSource.ts
@@ -42,11 +42,14 @@ function columnarEncrypt(plaintext: string, key: string): string {
 // filling each grid column (in key-sorted reading order) from the ciphertext chunks,
 // then reads back row-by-row to recover the plaintext.
 function columnarDecrypt(ciphertext: string, key: string): string {
+  // strip whitespace to mirror columnarEncrypt (which strips before grouping),
+  // so space-formatted ciphertext still decrypts correctly
+  const cipher = ciphertext.replace(/\s/g, '');
   const k = key.length;
-  if (k === 0) return ciphertext;
+  if (k === 0) return cipher;
 
   const colOrder = getColumnOrder(key);
-  const n = ciphertext.length;
+  const n = cipher.length;
   const numRows = Math.ceil(n / k);
   const extra = n % k;
 
@@ -59,7 +62,7 @@ function columnarDecrypt(ciphertext: string, key: string): string {
   const grid: string[][] = Array.from({ length: k }, () => []);
   let pos = 0;
   for (const col of colOrder) {
-    grid[col] = [...ciphertext.slice(pos, pos + colLens[col])];
+    grid[col] = [...cipher.slice(pos, pos + colLens[col])];
     pos += colLens[col];
   }
 

--- a/src/modules/boxSources/ColumnarTranspositionBoxSource.ts
+++ b/src/modules/boxSources/ColumnarTranspositionBoxSource.ts
@@ -1,0 +1,146 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const MAX_INPUT = 100_000;
+const Priority = 10;
+
+// returns the original column indices in the order they should be read during
+// encryption: sort key chars alphabetically (stable), extract their original positions.
+// e.g. ZEBRAS → sorted [A(4),B(2),E(1),R(3),S(5),Z(0)] → [4,2,1,3,5,0]
+function getColumnOrder(key: string): number[] {
+  const pairs = [...key].map((c, i) => [c, i] as [string, number]);
+  pairs.sort((a, b) => a[0].localeCompare(b[0]) || a[1] - b[1]);
+  return pairs.map(([, i]) => i);
+}
+
+// writes plaintext row-by-row into keyLen columns, then reads columns in sorted
+// key order. columns with grid index < (msgLen % keyLen) are one row taller than
+// the rest (standard row-major fill, no padding).
+function columnarEncrypt(plaintext: string, key: string): string {
+  const msg = plaintext.replace(/\s/g, '');
+  const k = key.length;
+  if (k === 0) return msg;
+
+  const colOrder = getColumnOrder(key);
+  const n = msg.length;
+  const numRows = Math.ceil(n / k);
+  const extra = n % k; // leftmost `extra` grid columns each have one extra row
+
+  let result = '';
+  for (const col of colOrder) {
+    const colLen = extra === 0 ? numRows : col < extra ? numRows : numRows - 1;
+    for (let row = 0; row < colLen; row++) {
+      result += msg[row * k + col];
+    }
+  }
+  return result;
+}
+
+// inverse of columnarEncrypt: given ciphertext and key, reconstructs the grid by
+// filling each grid column (in key-sorted reading order) from the ciphertext chunks,
+// then reads back row-by-row to recover the plaintext.
+function columnarDecrypt(ciphertext: string, key: string): string {
+  const k = key.length;
+  if (k === 0) return ciphertext;
+
+  const colOrder = getColumnOrder(key);
+  const n = ciphertext.length;
+  const numRows = Math.ceil(n / k);
+  const extra = n % k;
+
+  // length of each grid column (same irregular-column rule as encryption)
+  const colLens = Array.from({ length: k }, (_, col) =>
+    extra === 0 ? numRows : col < extra ? numRows : numRows - 1,
+  );
+
+  // distribute ciphertext chunks back into the grid columns in reading order
+  const grid: string[][] = Array.from({ length: k }, () => []);
+  let pos = 0;
+  for (const col of colOrder) {
+    grid[col] = [...ciphertext.slice(pos, pos + colLens[col])];
+    pos += colLens[col];
+  }
+
+  // read row-by-row to reconstruct plaintext
+  let result = '';
+  for (let row = 0; row < numRows; row++) {
+    for (let col = 0; col < k; col++) {
+      if (row < grid[col].length) {
+        result += grid[col][row];
+      }
+    }
+  }
+  return result;
+}
+
+function usageBox(priority: number): Box {
+  return new BoxBuilder(
+    'Columnar Transposition (Usage)',
+    'Usage: ::columnar=KEY to encrypt, ::columnardecode=KEY to decrypt. KEY must be a non-empty string.',
+  )
+    .setPriority(priority)
+    .setShowExpandButton(false)
+    .setTemplate(DefaultBoxTemplate)
+    .build();
+}
+
+export const ColumnarTranspositionBoxSource = {
+  name: 'Columnar Transposition',
+  description:
+    'Columnar transposition cipher. ::columnar=KEY to encrypt, ::columnardecode=KEY to decrypt.',
+  defaultInput: 'WEAREDISCOVEREDFLEEATONCE ::columnar=ZEBRAS',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const encVal = extractOptionKeys(options, 'columnar', 'columnarencode');
+    const decVal = extractOptionKeys(options, 'columnardecode');
+
+    if (encVal === null && decVal === null) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT) {
+      return [];
+    }
+
+    const boxes: Box[] = [];
+
+    if (encVal !== null) {
+      if (typeof encVal !== 'string' || encVal.length === 0) {
+        boxes.push(usageBox(this.priority));
+      } else {
+        const encrypted = columnarEncrypt(input, encVal);
+        boxes.push(
+          new BoxBuilder('Columnar Transposition (Encrypt)', encrypted)
+            .setPriority(this.priority)
+            .setShowExpandButton(false)
+            .setTemplate(DefaultBoxTemplate)
+            .build(),
+        );
+      }
+    }
+
+    if (decVal !== null) {
+      if (typeof decVal !== 'string' || decVal.length === 0) {
+        boxes.push(usageBox(this.priority));
+      } else {
+        const decrypted = columnarDecrypt(input, decVal);
+        boxes.push(
+          new BoxBuilder('Columnar Transposition (Decrypt)', decrypted)
+            .setPriority(this.priority)
+            .setShowExpandButton(false)
+            .setTemplate(DefaultBoxTemplate)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default ColumnarTranspositionBoxSource;

--- a/src/modules/boxSources/Crc8BoxSource.ts
+++ b/src/modules/boxSources/Crc8BoxSource.ts
@@ -55,7 +55,8 @@ export const Crc8BoxSource = {
     )
       return [];
 
-    const bytes = new TextEncoder().encode(input);
+    // hash the trimmed input so the guard and the computed bytes agree
+    const bytes = new TextEncoder().encode(trim(input));
     const smbus = crc8Smbus(bytes);
     const maxim = crc8Maxim(bytes);
 

--- a/src/modules/boxSources/Crc8BoxSource.ts
+++ b/src/modules/boxSources/Crc8BoxSource.ts
@@ -1,0 +1,82 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// CRC-8/SMBUS: poly 0x07, init 0x00, no reflect, no xorout
+function crc8Smbus(bytes: Uint8Array): number {
+  let crc = 0x00;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i++) {
+      crc = crc & 0x80 ? ((crc << 1) ^ 0x07) & 0xff : (crc << 1) & 0xff;
+    }
+  }
+  return crc & 0xff;
+}
+
+// CRC-8/MAXIM (Dallas 1-Wire): poly 0x31 reflected as 0x8C, refin/refout true
+function crc8Maxim(bytes: Uint8Array): number {
+  let crc = 0x00;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i++) {
+      crc = crc & 1 ? ((crc >> 1) ^ 0x8c) & 0xff : (crc >> 1) & 0xff;
+    }
+  }
+  return crc & 0xff;
+}
+
+function toHex2(value: number): string {
+  return `0x${value.toString(16).padStart(2, '0')}`;
+}
+
+export const Crc8BoxSource = {
+  name: 'CRC-8',
+  description:
+    'Compute CRC-8 (SMBUS and Maxim/Dallas) checksums of the input text.',
+  defaultInput: '123456789 ::crc8',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'crc8')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const bytes = new TextEncoder().encode(input);
+    const smbus = crc8Smbus(bytes);
+    const maxim = crc8Maxim(bytes);
+
+    const kv: Record<string, string> = {
+      SMBUS: toHex2(smbus),
+      Maxim: toHex2(maxim),
+    };
+
+    const plaintextOutput = Object.entries(kv)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('CRC-8', plaintextOutput)
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Crc8BoxSource;

--- a/src/modules/boxSources/GrayCodeBoxSource.ts
+++ b/src/modules/boxSources/GrayCodeBoxSource.ts
@@ -6,12 +6,14 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 const Priority = 10;
 
 // max input length guard to avoid runaway allocations on huge strings
-const MAX_INPUT_LENGTH = 5000;
+// cap kept low: BigInt() decimal parsing is O(n^2) in digit count, and 100
+// digits covers any realistic Gray-code use while preventing a main-thread stall
+const MAX_INPUT_LENGTH = 100;
 
 export const GrayCodeBoxSource = {
   name: 'Gray Code',
   description:
-    'Convert a non-negative integer to/from reflected binary Gray code.',
+    'Convert a non-negative integer to its reflected binary Gray code.',
   defaultInput: '5 ::gray',
   tag: '#',
   kind: 'Convert',

--- a/src/modules/boxSources/GrayCodeBoxSource.ts
+++ b/src/modules/boxSources/GrayCodeBoxSource.ts
@@ -1,0 +1,73 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length guard to avoid runaway allocations on huge strings
+const MAX_INPUT_LENGTH = 5000;
+
+export const GrayCodeBoxSource = {
+  name: 'Gray Code',
+  description:
+    'Convert a non-negative integer to/from reflected binary Gray code.',
+  defaultInput: '5 ::gray',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'gray', 'graycode')) return [];
+
+    const raw = trim(input);
+    if (raw.length > MAX_INPUT_LENGTH) return [];
+
+    // only accept non-negative decimal integers
+    if (!/^\d+$/.test(raw)) {
+      const plaintextOutput = 'Error: a non-negative integer is required.';
+      return [
+        new BoxBuilder('Gray Code', plaintextOutput)
+          .setOptions({ Error: 'a non-negative integer is required.' })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    const n = BigInt(raw);
+    const gray = n ^ (n >> 1n);
+
+    const decimalStr = n.toString();
+    const binaryStr = n === 0n ? '0' : n.toString(2);
+    const grayBinaryStr = gray === 0n ? '0' : gray.toString(2);
+    const grayDecimalStr = gray.toString();
+
+    const plaintextOutput = [
+      `Decimal: ${decimalStr}`,
+      `Binary: ${binaryStr}`,
+      `Gray (binary): ${grayBinaryStr}`,
+      `Gray (decimal): ${grayDecimalStr}`,
+    ].join('\n');
+
+    const outputOptions: Record<string, string> = {
+      Decimal: decimalStr,
+      Binary: binaryStr,
+      'Gray (binary)': grayBinaryStr,
+      'Gray (decimal)': grayDecimalStr,
+    };
+
+    return [
+      new BoxBuilder('Gray Code', plaintextOutput)
+        .setOptions(outputOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default GrayCodeBoxSource;

--- a/src/modules/boxSources/HammingDistanceBoxSource.ts
+++ b/src/modules/boxSources/HammingDistanceBoxSource.ts
@@ -9,6 +9,13 @@ const MAX_INPUT = 100_000;
 // pure hex string (case-insensitive)
 const HEX_RE = /^[0-9a-f]+$/i;
 
+// render key/value pairs as `k: v` lines for the headless/TUI plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
 // count the number of set bits in a number using Brian Kernighan's algorithm
 function popcount(n: number): number {
   let count = 0;
@@ -107,14 +114,15 @@ export const HammingDistanceBoxSource = {
     const lenB = codePointCount(b);
 
     if (lenA !== lenB) {
+      const kv = {
+        Error: `Hamming distance requires equal-length strings (got ${lenA} and ${lenB}).`,
+        'Length A': String(lenA),
+        'Length B': String(lenB),
+      };
       return [
-        new BoxBuilder('Hamming Distance', '')
+        new BoxBuilder('Hamming Distance', kvToPlaintext(kv))
           .setTemplate(KeyValueBoxTemplate)
-          .setOptions({
-            Error: `Hamming distance requires equal-length strings (got ${lenA} and ${lenB}).`,
-            'Length A': String(lenA),
-            'Length B': String(lenB),
-          })
+          .setOptions(kv)
           .setPriority(this.priority)
           .build(),
       ];
@@ -134,7 +142,7 @@ export const HammingDistanceBoxSource = {
     }
 
     return [
-      new BoxBuilder('Hamming Distance', '')
+      new BoxBuilder('Hamming Distance', kvToPlaintext(kvOptions))
         .setTemplate(KeyValueBoxTemplate)
         .setOptions(kvOptions)
         .setPriority(this.priority)

--- a/src/modules/boxSources/HammingDistanceBoxSource.ts
+++ b/src/modules/boxSources/HammingDistanceBoxSource.ts
@@ -1,0 +1,146 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// pure hex string (case-insensitive)
+const HEX_RE = /^[0-9a-f]+$/i;
+
+// count the number of set bits in a number using Brian Kernighan's algorithm
+function popcount(n: number): number {
+  let count = 0;
+  let v = n;
+  while (v !== 0) {
+    v &= v - 1;
+    count++;
+  }
+  return count;
+}
+
+// compute bit-level hamming distance between two equal-length hex strings
+// processes nibble by nibble to avoid bigint overflow on long inputs
+function hexBitDistance(a: string, b: string): number {
+  let dist = 0;
+  for (let i = 0; i < a.length; i++) {
+    const na = Number.parseInt(a[i], 16);
+    const nb = Number.parseInt(b[i], 16);
+    dist += popcount(na ^ nb);
+  }
+  return dist;
+}
+
+// count code points (not UTF-16 units) to handle surrogate pairs correctly
+function codePointCount(s: string): number {
+  return [...s].length;
+}
+
+// compute char-level hamming distance; caller must ensure equal lengths
+function charDistance(a: string, b: string): number {
+  const aPoints = [...a];
+  const bPoints = [...b];
+  let dist = 0;
+  for (let i = 0; i < aPoints.length; i++) {
+    if (aPoints[i] !== bPoints[i]) {
+      dist++;
+    }
+  }
+  return dist;
+}
+
+export const HammingDistanceBoxSource = {
+  name: 'Hamming Distance',
+  description:
+    'Hamming distance between two equal-length strings. Separate the two with a comma or newline. ::hamming',
+  defaultInput: 'karolin, kathrin ::hamming',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hamming')) return [];
+
+    const capped = input.slice(0, MAX_INPUT);
+
+    // prefer newline split; fall back to first comma
+    let operands: string[];
+    if (capped.includes('\n')) {
+      operands = capped
+        .split('\n')
+        .map(trim)
+        .filter((s) => s.length > 0);
+    } else {
+      const commaIdx = capped.indexOf(',');
+      if (commaIdx === -1) {
+        operands = [trim(capped)];
+      } else {
+        operands = [
+          trim(capped.slice(0, commaIdx)),
+          trim(capped.slice(commaIdx + 1)),
+        ];
+      }
+    }
+
+    if (operands.length < 2) {
+      return [
+        new BoxBuilder(
+          'Hamming Distance',
+          'Two strings are required. Separate them with a comma or newline.',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({
+            Error: 'Two strings are required (comma or newline separated).',
+          })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const a = operands[0];
+    const b = operands[1];
+    const lenA = codePointCount(a);
+    const lenB = codePointCount(b);
+
+    if (lenA !== lenB) {
+      return [
+        new BoxBuilder('Hamming Distance', '')
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({
+            Error: `Hamming distance requires equal-length strings (got ${lenA} and ${lenB}).`,
+            'Length A': String(lenA),
+            'Length B': String(lenB),
+          })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const distance = charDistance(a, b);
+    const kvOptions: Record<string, string> = {
+      A: a,
+      B: b,
+      Length: String(lenA),
+      Distance: String(distance),
+    };
+
+    // bonus: bit-level distance for equal-length pure-hex inputs
+    if (HEX_RE.test(a) && HEX_RE.test(b)) {
+      kvOptions['Bit Distance'] = String(hexBitDistance(a, b));
+    }
+
+    return [
+      new BoxBuilder('Hamming Distance', '')
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HammingDistanceBoxSource;

--- a/src/modules/boxSources/JsonPointerBoxSource.ts
+++ b/src/modules/boxSources/JsonPointerBoxSource.ts
@@ -1,0 +1,129 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// unescape a single RFC 6901 reference token: ~1 → / then ~0 → ~
+function unescapeToken(token: string): string {
+  return token.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+// evaluate an RFC 6901 JSON Pointer against a parsed document.
+// returns the resolved value or throws with a descriptive message.
+function evaluatePointer(doc: unknown, pointer: string): unknown {
+  if (pointer === '') {
+    return doc;
+  }
+
+  if (!pointer.startsWith('/')) {
+    throw new Error(`Invalid pointer: must be empty or start with '/'`);
+  }
+
+  const tokens = pointer.slice(1).split('/').map(unescapeToken);
+  let current: unknown = doc;
+
+  for (const token of tokens) {
+    if (Array.isArray(current)) {
+      if (token === '-') {
+        throw new Error(
+          `Pointer token '-' refers to a non-existent array element`,
+        );
+      }
+      if (!/^\d+$/.test(token)) {
+        throw new Error(`Pointer token '${token}' is not a valid array index`);
+      }
+      const index = Number(token);
+      if (index >= current.length) {
+        throw new Error(
+          `Pointer did not resolve: index ${index} out of bounds (length ${current.length})`,
+        );
+      }
+      current = current[index];
+    } else if (current !== null && typeof current === 'object') {
+      // only allow own-property access — never prototype traversal
+      if (!Object.hasOwn(current as Record<string, unknown>, token)) {
+        throw new Error(`Pointer did not resolve: key '${token}' not found`);
+      }
+      current = (current as Record<string, unknown>)[token];
+    } else {
+      throw new Error(
+        `Pointer did not resolve: cannot index into ${JSON.stringify(current)} with '${token}'`,
+      );
+    }
+  }
+
+  return current;
+}
+
+function makeErrorBox(message: string, priority: number): Box {
+  return new BoxBuilder('JSON Pointer', message)
+    .setOptions({ language: 'text' })
+    .setTemplate(CodeBoxTemplate)
+    .setPriority(priority)
+    .build();
+}
+
+export const JsonPointerBoxSource = {
+  name: 'JSON Pointer',
+  description:
+    'Evaluate an RFC 6901 JSON Pointer against a JSON document. ::jsonpointer=/path/to/value',
+  defaultInput: '{"a":{"b":[1,2,3]}} ::jsonpointer=/a/b/1',
+  tag: '#',
+  kind: 'Extract',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const pointer = extractOptionKeys(options, 'jsonpointer', 'jsonptr');
+
+    // option absent entirely — not our job
+    if (pointer === null) return [];
+
+    // bare flag (e.g. ::jsonpointer without a value) — show usage hint
+    if (typeof pointer !== 'string') {
+      return [
+        makeErrorBox(
+          'Usage: ::jsonpointer=/path/to/value\nExample: {"a":{"b":[1,2,3]}} ::jsonpointer=/a/b/1',
+          this.priority,
+        ),
+      ];
+    }
+
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    let doc: unknown;
+    try {
+      doc = JSON.parse(trimmed);
+    } catch {
+      return [
+        makeErrorBox(`Invalid JSON: ${trimmed.slice(0, 120)}`, this.priority),
+      ];
+    }
+
+    let resolved: unknown;
+    try {
+      resolved = evaluatePointer(doc, pointer);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return [makeErrorBox(msg, this.priority)];
+    }
+
+    const output = JSON.stringify(resolved, null, 2);
+    return [
+      new BoxBuilder('JSON Pointer', output)
+        .setOptions({ language: 'json' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonPointerBoxSource;

--- a/src/modules/boxSources/JsonPointerBoxSource.ts
+++ b/src/modules/boxSources/JsonPointerBoxSource.ts
@@ -32,7 +32,8 @@ function evaluatePointer(doc: unknown, pointer: string): unknown {
           `Pointer token '-' refers to a non-existent array element`,
         );
       }
-      if (!/^\d+$/.test(token)) {
+      if (!/^(0|[1-9]\d*)$/.test(token)) {
+        // RFC 6901 §4: array index is "0" or a digit1-9 run (no leading zeros)
         throw new Error(`Pointer token '${token}' is not a valid array index`);
       }
       const index = Number(token);

--- a/src/modules/boxSources/ScytaleBoxSource.ts
+++ b/src/modules/boxSources/ScytaleBoxSource.ts
@@ -62,8 +62,10 @@ function parseN(
   if (value === null || value === true || value === false) return null;
   const n = Number.parseInt(value, 10);
   if (Number.isNaN(n) || n < 2) return null;
-  // clamp N so it never exceeds input length
-  return Math.min(n, inputLen);
+  // clamp N so it never exceeds input length, but reject a clamp below 2
+  // (a 1-column scytale is an identity no-op, not a real cipher)
+  const clamped = Math.min(n, inputLen);
+  return clamped < 2 ? null : clamped;
 }
 
 function usageBox(priority: number): Box {

--- a/src/modules/boxSources/ScytaleBoxSource.ts
+++ b/src/modules/boxSources/ScytaleBoxSource.ts
@@ -1,0 +1,138 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const MAX_INPUT = 100_000;
+const Priority = 10;
+
+// scytale encrypt: write text row-by-row into N columns, read back column-by-column.
+// handles irregular last row — only existing chars are included (no padding).
+function scytaleEncrypt(text: string, cols: number): string {
+  const len = text.length;
+  const rows = Math.ceil(len / cols);
+  let result = '';
+  for (let c = 0; c < cols; c++) {
+    for (let r = 0; r < rows; r++) {
+      const idx = r * cols + c;
+      if (idx < len) {
+        result += text[idx];
+      }
+    }
+  }
+  return result;
+}
+
+// scytale decrypt: inverse of encrypt. given N cols, reconstruct column lengths
+// then read row-major to recover original text.
+function scytaleDecrypt(text: string, cols: number): string {
+  const len = text.length;
+  const rows = Math.ceil(len / cols);
+  // columns in the last row that actually exist
+  const extraCols = len % cols === 0 ? cols : len % cols;
+  // first extraCols columns have `rows` chars; remaining cols have `rows - 1` chars
+  const colLengths: number[] = Array.from({ length: cols }, (_, c) =>
+    c < extraCols ? rows : rows - 1,
+  );
+
+  // distribute ciphertext back into columns
+  const columns: string[] = [];
+  let pos = 0;
+  for (let c = 0; c < cols; c++) {
+    columns.push(text.slice(pos, pos + colLengths[c]));
+    pos += colLengths[c];
+  }
+
+  // read row-major
+  let result = '';
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (r < columns[c].length) {
+        result += columns[c][r];
+      }
+    }
+  }
+  return result;
+}
+
+function parseN(
+  value: string | boolean | null,
+  inputLen: number,
+): number | null {
+  if (value === null || value === true || value === false) return null;
+  const n = Number.parseInt(value, 10);
+  if (Number.isNaN(n) || n < 2) return null;
+  // clamp N so it never exceeds input length
+  return Math.min(n, inputLen);
+}
+
+function usageBox(priority: number): Box {
+  return new BoxBuilder(
+    'Scytale (Usage)',
+    'Usage: ::scytale=N to encrypt, ::scytaledecode=N to decrypt. N must be an integer >= 2.',
+  )
+    .setPriority(priority)
+    .setShowExpandButton(false)
+    .setTemplate(DefaultBoxTemplate)
+    .build();
+}
+
+export const ScytaleBoxSource = {
+  name: 'Scytale',
+  description:
+    'Scytale transposition cipher. ::scytale=N to encrypt with N columns, ::scytaledecode=N to decrypt.',
+  defaultInput: 'IAMHURTVERYBADLYHELP ::scytale=5',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const encVal = extractOptionKeys(options, 'scytale', 'scytaleencode');
+    const decVal = extractOptionKeys(options, 'scytaledecode');
+
+    if (encVal === null && decVal === null) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (encVal !== null) {
+      const n = parseN(encVal as string | boolean, input.length);
+      if (n === null) {
+        boxes.push(usageBox(this.priority));
+      } else {
+        const encrypted = scytaleEncrypt(input, n);
+        boxes.push(
+          new BoxBuilder('Scytale (Encrypt)', encrypted)
+            .setPriority(this.priority)
+            .setShowExpandButton(false)
+            .setTemplate(DefaultBoxTemplate)
+            .build(),
+        );
+      }
+    }
+
+    if (decVal !== null) {
+      const n = parseN(decVal as string | boolean, input.length);
+      if (n === null) {
+        boxes.push(usageBox(this.priority));
+      } else {
+        const decrypted = scytaleDecrypt(input, n);
+        boxes.push(
+          new BoxBuilder('Scytale (Decrypt)', decrypted)
+            .setPriority(this.priority)
+            .setShowExpandButton(false)
+            .setTemplate(DefaultBoxTemplate)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default ScytaleBoxSource;

--- a/src/modules/boxSources/SpeedConvertBoxSource.ts
+++ b/src/modules/boxSources/SpeedConvertBoxSource.ts
@@ -1,0 +1,111 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit alias -> m/s conversion factor
+const TO_MS: Record<string, number> = {
+  'm/s': 1,
+  mps: 1,
+  'km/h': 1000 / 3600,
+  kmh: 1000 / 3600,
+  kph: 1000 / 3600,
+  mph: 1609.344 / 3600,
+  knot: 1852 / 3600,
+  kn: 1852 / 3600,
+  knots: 1852 / 3600,
+  'ft/s': 0.3048,
+  fps: 0.3048,
+};
+
+// canonical output units in display order
+const OUTPUT_UNITS: Array<[string, number]> = [
+  ['m/s', 1],
+  ['km/h', 3600 / 1000],
+  ['mph', 3600 / 1609.344],
+  ['knot', 3600 / 1852],
+  ['ft/s', 1 / 0.3048],
+];
+
+// formats to integer string if exact, otherwise rounds to 6 decimal places and strips trailing zeros
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+const SUPPORTED_UNITS = Object.keys(TO_MS).join(', ');
+
+export const SpeedConvertBoxSource = {
+  name: 'Speed Convert',
+  description: 'Convert a speed between m/s, km/h, mph, knots, and ft/s.',
+  defaultInput: '100 km/h ::speed',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'speed')) return [];
+
+    const trimmed = trim(input).slice(0, 64);
+    const match = trimmed.match(/^(-?\d+(?:\.\d+)?)\s*(.+)$/);
+
+    if (!match) {
+      const errorOutput: Record<string, string> = {
+        Input: trimmed,
+        Error: 'Invalid format. Expected: <number> <unit>',
+        'Supported units': SUPPORTED_UNITS,
+      };
+      return [
+        new BoxBuilder('Speed Convert', '')
+          .setOptions(errorOutput)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitRaw = match[2].trim().toLowerCase();
+
+    const factor = TO_MS[unitRaw];
+    if (factor === undefined) {
+      const errorOutput: Record<string, string> = {
+        Input: trimmed,
+        Error: `Unknown unit: "${match[2].trim()}"`,
+        'Supported units': SUPPORTED_UNITS,
+      };
+      return [
+        new BoxBuilder('Speed Convert', '')
+          .setOptions(errorOutput)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    // convert to m/s first, then to each output unit
+    const ms = value * factor;
+
+    const kvOutput: Record<string, string> = {
+      Input: trimmed,
+    };
+    for (const [unit, fromMs] of OUTPUT_UNITS) {
+      kvOutput[unit] = formatValue(ms * fromMs);
+    }
+
+    return [
+      new BoxBuilder('Speed Convert', '')
+        .setOptions(kvOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default SpeedConvertBoxSource;

--- a/src/modules/boxSources/SpeedConvertBoxSource.ts
+++ b/src/modules/boxSources/SpeedConvertBoxSource.ts
@@ -5,6 +5,13 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 
+// render key/value pairs as `k: v` lines for the headless/TUI plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
 // unit alias -> m/s conversion factor
 const TO_MS: Record<string, number> = {
   'm/s': 1,
@@ -61,10 +68,10 @@ export const SpeedConvertBoxSource = {
         'Supported units': SUPPORTED_UNITS,
       };
       return [
-        new BoxBuilder('Speed Convert', '')
+        new BoxBuilder('Speed Convert', kvToPlaintext(errorOutput))
           .setOptions(errorOutput)
           .setTemplate(KeyValueBoxTemplate)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       ];
     }
@@ -80,10 +87,10 @@ export const SpeedConvertBoxSource = {
         'Supported units': SUPPORTED_UNITS,
       };
       return [
-        new BoxBuilder('Speed Convert', '')
+        new BoxBuilder('Speed Convert', kvToPlaintext(errorOutput))
           .setOptions(errorOutput)
           .setTemplate(KeyValueBoxTemplate)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build(),
       ];
     }
@@ -99,10 +106,10 @@ export const SpeedConvertBoxSource = {
     }
 
     return [
-      new BoxBuilder('Speed Convert', '')
+      new BoxBuilder('Speed Convert', kvToPlaintext(kvOutput))
         .setOptions(kvOutput)
         .setTemplate(KeyValueBoxTemplate)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build(),
     ];
   },

--- a/src/modules/boxSources/__test__/CmykBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CmykBoxSource.test.ts
@@ -1,0 +1,152 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { CmykBoxSource } from '../CmykBoxSource';
+
+describe('CmykBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when ::cmyk option is absent', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ff0000', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object lacks cmyk key', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ff0000', {
+        color: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('hex → CMYK', () => {
+    it('converts pure red #ff0000 to cmyk(0%,100%,100%,0%)', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ff0000', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.CMYK).toBe('cmyk(0%, 100%, 100%, 0%)');
+      expect(kv.Hex).toMatch(/^#FF0000$/i);
+      expect(kv.RGB).toBe('rgb(255, 0, 0)');
+    });
+
+    it('converts tomato #ff6347 — C=0%, K=0%, M≈61-62%, Y≈71-72%', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ff6347', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      // extract numeric values from cmyk(c%, m%, y%, k%)
+      const match = kv.CMYK.match(
+        /cmyk\((\d+)%,\s*(\d+)%,\s*(\d+)%,\s*(\d+)%\)/,
+      );
+      expect(match).not.toBeNull();
+      const [c, m, y, k] = (match ?? []).slice(1).map(Number);
+      expect(c).toBe(0);
+      expect(k).toBe(0);
+      // rgb(255,99,71): m=(1-99/255)/(1-0)≈0.612→61%, y=(1-71/255)≈0.722→72%
+      expect(m).toBeGreaterThanOrEqual(61);
+      expect(m).toBeLessThanOrEqual(62);
+      expect(y).toBeGreaterThanOrEqual(71);
+      expect(y).toBeLessThanOrEqual(72);
+    });
+
+    it('converts black #000000 to cmyk(0%,0%,0%,100%)', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#000000', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.CMYK).toBe('cmyk(0%, 0%, 0%, 100%)');
+    });
+
+    it('converts white #ffffff to cmyk(0%,0%,0%,0%)', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ffffff', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.CMYK).toBe('cmyk(0%, 0%, 0%, 0%)');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ff0000', {
+        cmyk: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('#ff0000', {
+        cmyk: true,
+      });
+      expect(boxes[0].props.priority).toBe(CmykBoxSource.priority);
+    });
+
+    it('handles shorthand #RGB notation', async () => {
+      // #f00 expands to #ff0000
+      const boxes = await CmykBoxSource.generateBoxes('#f00', { cmyk: true });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.CMYK).toBe('cmyk(0%, 100%, 100%, 0%)');
+    });
+  });
+
+  describe('rgb() → CMYK', () => {
+    it('converts rgb(255,0,0) to cmyk(0%,100%,100%,0%)', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('rgb(255,0,0)', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.CMYK).toBe('cmyk(0%, 100%, 100%, 0%)');
+      expect(kv.Hex).toMatch(/^#FF0000$/i);
+    });
+  });
+
+  describe('cmyk() → hex/RGB', () => {
+    it('converts cmyk(0,100,100,0) to #FF0000', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('cmyk(0,100,100,0)', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Hex).toBe('#FF0000');
+      expect(kv.RGB).toBe('rgb(255, 0, 0)');
+    });
+
+    it('converts cmyk(0,100,100,0) with % suffixes to #FF0000', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('cmyk(0%,100%,100%,0%)', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Hex).toBe('#FF0000');
+    });
+
+    it('converts cmyk(0,0,0,100) to #000000', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('cmyk(0,0,0,100)', {
+        cmyk: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Hex).toBe('#000000');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns a hint box for unrecognized input "hello"', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('hello', { cmyk: true });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      // hint box mentions expected formats
+      const hint = Object.values(kv).join(' ');
+      expect(hint.toLowerCase()).toMatch(/rgb|hex|cmyk/i);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await CmykBoxSource.generateBoxes('', { cmyk: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ColumnarTranspositionBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ColumnarTranspositionBoxSource.test.ts
@@ -1,0 +1,213 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { ColumnarTranspositionBoxSource } from '../ColumnarTranspositionBoxSource';
+
+const opts = (key: string, value: string | boolean = true) => ({
+  [key]: value,
+});
+
+describe('ColumnarTranspositionBoxSource', () => {
+  describe('no-match / guard conditions', () => {
+    it('returns [] when no columnar option is present', async () => {
+      expect(
+        await ColumnarTranspositionBoxSource.generateBoxes('HELLO', null),
+      ).toHaveLength(0);
+    });
+
+    it('returns [] when input is empty', async () => {
+      expect(
+        await ColumnarTranspositionBoxSource.generateBoxes(
+          '',
+          opts('columnar', 'KEY'),
+        ),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('encrypt — ::columnar=KEY', () => {
+    it('encrypts the canonical ZEBRAS vector', async () => {
+      // Wikipedia columnar transposition example:
+      // msg=WEAREDISCOVEREDFLEEATONCE (25 chars), key=ZEBRAS
+      // expected ciphertext=EVLNACDTESEAROFODEECWIREE
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        opts('columnar', 'ZEBRAS'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Encrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('EVLNACDTESEAROFODEECWIREE');
+    });
+
+    it('strips whitespace from plaintext before encrypting', async () => {
+      // "WE ARE DISCOVERED FLEE AT ONCE" with spaces stripped == WEAREDISCOVEREDFLEEATONCE
+      const withSpaces = await ColumnarTranspositionBoxSource.generateBoxes(
+        'WE ARE DISCOVERED FLEE AT ONCE',
+        opts('columnar', 'ZEBRAS'),
+      );
+      const withoutSpaces = await ColumnarTranspositionBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        opts('columnar', 'ZEBRAS'),
+      );
+      expect(withSpaces[0].props.plaintextOutput).toBe(
+        withoutSpaces[0].props.plaintextOutput,
+      );
+    });
+
+    it('encrypts when msgLen is exactly divisible by keyLen', async () => {
+      // WEAREDISCOVEREDFLEEATONCE is 25 chars; use ABCD (4) with a 24-char msg
+      // HELLOWORLD123456789012 (22 chars) → not exact; use 20-char msg with key of len 4
+      // HELLOWORLD1234567890 (20 chars), key=ABCD (4): 20%4=0, all cols have 5 rows
+      // sorted ABCD: A(0),B(1),C(2),D(3) → read order [0,1,2,3]
+      // grid: HELL / OWOR / LD12 / 3456 / 7890
+      // col0: H,O,L,3,7  col1: E,W,D,4,8  col2: L,O,1,5,9  col3: L,R,2,6,0
+      // read order [0,1,2,3]: HOL37 + EWD48 + LO159 + LR260
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLOWORLD1234567890',
+        opts('columnar', 'ABCD'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('HOL37EWD48LO159LR260');
+    });
+
+    it('accepts ::columnarencode alias', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        opts('columnarencode', 'KEY'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Encrypt)');
+    });
+  });
+
+  describe('decrypt — ::columnardecode=KEY', () => {
+    it('decrypts the canonical ZEBRAS vector', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'EVLNACDTESEAROFODEECWIREE',
+        opts('columnardecode', 'ZEBRAS'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Decrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('WEAREDISCOVEREDFLEEATONCE');
+    });
+  });
+
+  describe('round-trips', () => {
+    const roundTrip = async (text: string, key: string) => {
+      const enc = await ColumnarTranspositionBoxSource.generateBoxes(
+        text,
+        opts('columnar', key),
+      );
+      const ciphertext = enc[0].props.plaintextOutput;
+      const dec = await ColumnarTranspositionBoxSource.generateBoxes(
+        ciphertext,
+        opts('columnardecode', key),
+      );
+      return dec[0].props.plaintextOutput;
+    };
+
+    it('round-trips when msgLen is not divisible by keyLen', async () => {
+      expect(await roundTrip('HELLOWORLD', 'KEY')).toBe('HELLOWORLD');
+    });
+
+    it('round-trips when msgLen is exactly divisible by keyLen', async () => {
+      expect(await roundTrip('ATTACKATDAWN', 'KEY')).toBe('ATTACKATDAWN');
+    });
+
+    it('round-trips single-char key (identity)', async () => {
+      expect(await roundTrip('HELLO', 'A')).toBe('HELLO');
+    });
+
+    it('round-trips key longer than message', async () => {
+      expect(await roundTrip('HI', 'LONGKEY')).toBe('HI');
+    });
+
+    it('round-trips mixed-case input after whitespace strip', async () => {
+      const enc = await ColumnarTranspositionBoxSource.generateBoxes(
+        'Hello World',
+        opts('columnar', 'KEY'),
+      );
+      const dec = await ColumnarTranspositionBoxSource.generateBoxes(
+        enc[0].props.plaintextOutput,
+        opts('columnardecode', 'KEY'),
+      );
+      // spaces are stripped before encryption, so plaintext recovered is spaceless
+      expect(dec[0].props.plaintextOutput).toBe('HelloWorld');
+    });
+
+    it('round-trips ZEBRAS canonical vector', async () => {
+      expect(await roundTrip('WEAREDISCOVEREDFLEEATONCE', 'ZEBRAS')).toBe(
+        'WEAREDISCOVEREDFLEEATONCE',
+      );
+    });
+  });
+
+  describe('usage box', () => {
+    it('returns usage box for bare ::columnar (boolean true)', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        opts('columnar', true),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Usage)');
+    });
+
+    it('returns usage box for empty key string', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        { columnar: '' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Usage)');
+    });
+
+    it('returns usage box for bare ::columnardecode (boolean true)', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        opts('columnardecode', true),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Usage)');
+    });
+  });
+
+  describe('both options present', () => {
+    it('returns 2 boxes when both encrypt and decrypt options are present', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLOWORLD',
+        { columnar: 'KEY', columnardecode: 'KEY' },
+      );
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Encrypt)');
+      expect(boxes[1].props.name).toBe('Columnar Transposition (Decrypt)');
+    });
+  });
+
+  describe('box properties', () => {
+    it('uses DefaultBoxTemplate', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        opts('columnar', 'KEY'),
+      );
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        opts('columnar', 'KEY'),
+      );
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(ColumnarTranspositionBoxSource.name).toBe(
+        'Columnar Transposition',
+      );
+      expect(ColumnarTranspositionBoxSource.tag).toBe('#');
+      expect(ColumnarTranspositionBoxSource.kind).toBe('Encode');
+      expect(typeof ColumnarTranspositionBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ColumnarTranspositionBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ColumnarTranspositionBoxSource.test.ts
@@ -210,4 +210,14 @@ describe('ColumnarTranspositionBoxSource', () => {
       expect(typeof ColumnarTranspositionBoxSource.priority).toBe('number');
     });
   });
+
+  describe('whitespace-formatted ciphertext', () => {
+    it('decrypts space-grouped ciphertext (strips whitespace like encrypt)', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'EVLN ACDT ESEA ROFO DEEC WIREE',
+        { columnardecode: 'ZEBRAS' },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('WEAREDISCOVEREDFLEEATONCE');
+    });
+  });
 });

--- a/src/modules/boxSources/__test__/Crc8BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Crc8BoxSource.test.ts
@@ -1,0 +1,103 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Crc8BoxSource } from '../Crc8BoxSource';
+
+describe('Crc8BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is provided', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns [] for empty string with ::crc8', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('', { crc8: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::crc8', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('   ', { crc8: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - canonical check values for "123456789"', () => {
+    it('returns one CRC-8 box', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('box name is CRC-8', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      expect(boxes[0].props.name).toBe('CRC-8');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('SMBUS check value is 0xf4 (canonical CRC-8/SMBUS)', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.SMBUS).toBe('0xf4');
+    });
+
+    it('Maxim check value is 0xa1 (canonical CRC-8/MAXIM)', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Maxim).toBe('0xa1');
+    });
+
+    it('plaintextOutput is non-empty and contains SMBUS: 0xf4', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      const pt = boxes[0].props.plaintextOutput;
+      expect(pt.length).toBeGreaterThan(0);
+      expect(pt).toContain('SMBUS: 0xf4');
+    });
+
+    it('plaintextOutput contains Maxim: 0xa1', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('Maxim: 0xa1');
+    });
+  });
+
+  describe('generateBoxes - priority', () => {
+    it('box priority matches source priority', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('hello', { crc8: true });
+      expect(boxes[0].props.priority).toBe(Crc8BoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Crc8BoxSource.name).toBe('CRC-8');
+      expect(Crc8BoxSource.tag).toBe('#');
+      expect(Crc8BoxSource.kind).toBe('Encode');
+      expect(typeof Crc8BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/GrayCodeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/GrayCodeBoxSource.test.ts
@@ -1,0 +1,136 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { GrayCodeBoxSource } from '../GrayCodeBoxSource';
+
+describe('GrayCodeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no option key is provided', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('5', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated option key is provided', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('5', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert 5 to Gray code 7 (101 → 111)', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('5', { gray: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Gray Code');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('5');
+      expect(opts.Binary).toBe('101');
+      expect(opts['Gray (binary)']).toBe('111');
+      expect(opts['Gray (decimal)']).toBe('7');
+    });
+
+    it('should accept ::graycode option key', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('5', {
+        graycode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Gray (decimal)']).toBe('7');
+    });
+
+    it('should convert 0 → Gray 0', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('0', { gray: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('0');
+      expect(opts.Binary).toBe('0');
+      expect(opts['Gray (binary)']).toBe('0');
+      expect(opts['Gray (decimal)']).toBe('0');
+    });
+
+    it('should convert 1 → Gray 1 (1 ^ 0 = 1)', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('1', { gray: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('1');
+      expect(opts.Binary).toBe('1');
+      expect(opts['Gray (binary)']).toBe('1');
+      expect(opts['Gray (decimal)']).toBe('1');
+    });
+
+    it('should convert 4 → Gray 6 (100 → 110)', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('4', { gray: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('4');
+      expect(opts.Binary).toBe('100');
+      expect(opts['Gray (binary)']).toBe('110');
+      expect(opts['Gray (decimal)']).toBe('6');
+    });
+
+    it('should convert 255 → Gray 128 (11111111 ^ 01111111 = 10000000)', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('255', {
+        gray: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('255');
+      expect(opts.Binary).toBe('11111111');
+      expect(opts['Gray (binary)']).toBe('10000000');
+      expect(opts['Gray (decimal)']).toBe('128');
+    });
+
+    it('should handle 2^32 (4294967296) without overflow using BigInt', async () => {
+      // 4294967296 = 0x1_0000_0000; gray = n ^ (n >> 1) = 0x1_0000_0000 ^ 0x8000_0000 = 0x1_8000_0000 = 6442450944
+      const boxes = await GrayCodeBoxSource.generateBoxes('4294967296', {
+        gray: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(() => boxes[0].props.options).not.toThrow();
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('4294967296');
+      expect(opts['Gray (decimal)']).toBe('6442450944');
+      // binary of 4294967296 = 100000000000000000000000000000000 (33 bits)
+      expect(opts.Binary).toBe('100000000000000000000000000000000');
+      expect(opts['Gray (binary)']).toBe('110000000000000000000000000000000');
+    });
+
+    it('should return an error box for invalid input "abc"', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('abc', {
+        gray: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Gray Code');
+      // plaintext must mention non-negative integer
+      expect(boxes[0].props.plaintextOutput).toMatch(/non-negative integer/);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/non-negative integer/);
+    });
+
+    it('should return an error box for negative input "-1"', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('-1', { gray: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/non-negative integer/);
+    });
+
+    it('should return an error box for float input "3.14"', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('3.14', {
+        gray: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/non-negative integer/);
+    });
+
+    it('plaintextOutput should be non-empty k:v lines for valid input', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('5', { gray: true });
+      const pt = boxes[0].props.plaintextOutput;
+      expect(pt).toContain('Decimal: 5');
+      expect(pt).toContain('Binary: 101');
+      expect(pt).toContain('Gray (binary): 111');
+      expect(pt).toContain('Gray (decimal): 7');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HammingDistanceBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HammingDistanceBoxSource.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import { HammingDistanceBoxSource } from '../HammingDistanceBoxSource';
+
+describe('HammingDistanceBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin, kathrin',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is provided', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin, kathrin',
+        { sha256: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('char-level distance', () => {
+    it('karolin vs kathrin → Distance 3, Length 7', async () => {
+      // positions 2(r/t), 3(o/h), 4(l/r) differ
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin, kathrin',
+        { hamming: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('3');
+      expect(opts.Length).toBe('7');
+      expect(opts.A).toBe('karolin');
+      expect(opts.B).toBe('kathrin');
+    });
+
+    it('newline-separated "abc\\nabd" → Distance 1', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('abc\nabd', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('1');
+    });
+
+    it('"1011101, 1001001" → Distance 2', async () => {
+      // positions 1(0/0 same), compare: 1011101 vs 1001001
+      // idx0:1=1, idx1:0=0, idx2:1=0 ✗, idx3:1=1, idx4:1=0 ✗, idx5:0=0, idx6:1=1 → 2 diffs
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        '1011101, 1001001',
+        { hamming: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('2');
+    });
+
+    it('equal strings "foo, foo" → Distance 0', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('foo, foo', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('0');
+    });
+  });
+
+  describe('error cases', () => {
+    it('unequal-length strings "abc, ab" → error box mentioning equal-length', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('abc, ab', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/equal-length/i);
+      expect(opts['Length A']).toBe('3');
+      expect(opts['Length B']).toBe('2');
+    });
+
+    it('single operand "abc" (no separator) → error box mentioning two strings', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('abc', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/two strings/i);
+    });
+  });
+
+  describe('hex bit distance bonus', () => {
+    it('"ff, 0f" → Bit Distance 4 (0xff ^ 0x0f = 0xf0 = 4 bits set)', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('ff, 0f', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // char-level: 'f'≠'0', 'f'='f' → Distance 1
+      expect(opts.Distance).toBe('1');
+      // bit-level: 0xf ^ 0x0 = 0xf (4 bits), 0xf ^ 0xf = 0x0 (0 bits) → 4
+      expect(opts['Bit Distance']).toBe('4');
+    });
+
+    it('"00, ff" → Bit Distance 8', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('00, ff', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Bit Distance']).toBe('8');
+    });
+
+    it('non-hex inputs do not produce Bit Distance key', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin, kathrin',
+        { hamming: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Bit Distance']).toBeUndefined();
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HammingDistanceBoxSource.name).toBe('Hamming Distance');
+      expect(HammingDistanceBoxSource.tag).toBe('#');
+      expect(HammingDistanceBoxSource.kind).toBe('Calculate');
+      expect(typeof HammingDistanceBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JsonPointerBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonPointerBoxSource.test.ts
@@ -118,5 +118,10 @@ describe('JsonPointerBoxSource', () => {
       const boxes = await gen('{"a":1}', { jsonpointer: '/a' });
       expect(boxes[0].props.name).toBe('JSON Pointer');
     });
+
+    it('rejects a leading-zero array index per RFC 6901', async () => {
+      const boxes = await gen('{"a":[10,20,30]}', { jsonpointer: '/a/01' });
+      expect(boxes[0].props.plaintextOutput).toMatch(/valid array index|not/i);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/JsonPointerBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonPointerBoxSource.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonPointerBoxSource } from '../JsonPointerBoxSource';
+
+const gen = (input: string, options: Record<string, string | boolean>) =>
+  JsonPointerBoxSource.generateBoxes(input, options);
+
+describe('JsonPointerBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is present', async () => {
+      const boxes = await gen('{"a":1}', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is null', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes('{"a":1}', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('shows a usage box for bare ::jsonpointer (boolean true)', async () => {
+      const boxes = await gen('{"a":1}', { jsonpointer: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/Usage/i);
+    });
+  });
+
+  describe('JSON parse errors', () => {
+    it('returns an error box for invalid JSON', async () => {
+      const boxes = await gen('{bad', { jsonpointer: '/a' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid json/i);
+    });
+  });
+
+  describe('pointer resolution', () => {
+    it('resolves /a/b/1 to 2', async () => {
+      const boxes = await gen('{"a":{"b":[1,2,3]}}', { jsonpointer: '/a/b/1' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('2');
+    });
+
+    it('resolves empty pointer to the whole document', async () => {
+      const doc = '{"a":{"b":[1,2,3]}}';
+      const boxes = await gen(doc, { jsonpointer: '' });
+      expect(boxes).toHaveLength(1);
+      expect(JSON.parse(boxes[0].props.plaintextOutput)).toEqual(
+        JSON.parse(doc),
+      );
+    });
+
+    it('resolves nested string value /x/y', async () => {
+      const boxes = await gen('{"x":{"y":"hi"}}', { jsonpointer: '/x/y' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('"hi"');
+    });
+
+    it('accepts ::jsonptr alias', async () => {
+      const boxes = await gen('{"a":1}', { jsonptr: '/a' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1');
+    });
+  });
+
+  describe('RFC 6901 escape sequences', () => {
+    it('unescapes ~1 to / in key lookup', async () => {
+      const boxes = await gen('{"a/b":1}', { jsonpointer: '/a~1b' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1');
+    });
+
+    it('unescapes ~0 to ~ in key lookup', async () => {
+      const boxes = await gen('{"m~n":2}', { jsonpointer: '/m~0n' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('2');
+    });
+  });
+
+  describe('not-found / type errors', () => {
+    it('returns an error box when key does not exist', async () => {
+      const boxes = await gen('{"a":{"b":1}}', { jsonpointer: '/a/z' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/not found|not resolve/i);
+    });
+
+    it('returns an error box when array index is out of bounds', async () => {
+      const boxes = await gen('[1,2,3]', { jsonpointer: '/5' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(
+        /out of bounds|not resolve/i,
+      );
+    });
+  });
+
+  describe('prototype safety', () => {
+    it('does NOT resolve __proto__ to the prototype object', async () => {
+      const boxes = await gen('{}', { jsonpointer: '/__proto__' });
+      expect(boxes).toHaveLength(1);
+      // must be an error box, not the prototype
+      expect(boxes[0].props.plaintextOutput).toMatch(/not found|not resolve/i);
+      // make sure it did not accidentally return the Object prototype
+      expect(boxes[0].props.plaintextOutput).not.toContain('isPrototypeOf');
+    });
+
+    it('does NOT resolve /constructor to Function via prototype', async () => {
+      const boxes = await gen('{}', { jsonpointer: '/constructor' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/not found|not resolve/i);
+    });
+  });
+
+  describe('metadata', () => {
+    it('sets priority on the result box', async () => {
+      const boxes = await gen('{"a":1}', { jsonpointer: '/a' });
+      expect(boxes[0].props.priority).toBe(JsonPointerBoxSource.priority);
+    });
+
+    it('sets box name to JSON Pointer', async () => {
+      const boxes = await gen('{"a":1}', { jsonpointer: '/a' });
+      expect(boxes[0].props.name).toBe('JSON Pointer');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ScytaleBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ScytaleBoxSource.test.ts
@@ -1,0 +1,192 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { ScytaleBoxSource } from '../ScytaleBoxSource';
+
+// helpers to build option maps matching BoxOptions shape
+const opts = (key: string, value: string | boolean = true) => ({
+  [key]: value,
+});
+
+describe('ScytaleBoxSource', () => {
+  describe('no-match / guard conditions', () => {
+    it('returns [] when no scytale option is present', async () => {
+      expect(
+        await ScytaleBoxSource.generateBoxes('HELLOWORLD', null),
+      ).toHaveLength(0);
+    });
+
+    it('returns [] when input is empty', async () => {
+      expect(
+        await ScytaleBoxSource.generateBoxes('', opts('scytale', '3')),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('encrypt — ::scytale=N', () => {
+    it('encrypts HELLOWORLD with N=3 → HLODEORLWL', async () => {
+      // L=10, cols=3, rows=ceil(10/3)=4
+      // grid: HEL / LOW / ORL / D
+      // col-major: HLOD + EOR + LWL = HLODEORLWL
+      const boxes = await ScytaleBoxSource.generateBoxes(
+        'HELLOWORLD',
+        opts('scytale', '3'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Scytale (Encrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('HLODEORLWL');
+    });
+
+    it('encrypts ATTACKATDAWN with N=4', async () => {
+      // L=12, cols=4, rows=3 (12/4=3 exact)
+      // grid: ATTA / CKAT / DAWN
+      // col-major: ACD + TAA + KWT + TAN = ACDTAAKWTTANWAITANC... let me recompute
+      // col0: A C D  col1: T K A  col2: T A W  col3: A T N
+      // → ACDT KATAW TATN... = ACDTKATAWTATN
+      // Actually: col0=ACD, col1=TKA, col2=TAW, col3=ATN → ACDTKATAWTATN? len=12 ✓
+      // col0: idx 0,4,8 = A,C,D → ACD
+      // col1: idx 1,5,9 = T,K,A → TKA
+      // col2: idx 2,6,10= T,A,W → TAW
+      // col3: idx 3,7,11= A,T,N → ATN
+      // concat: ACD+TKA+TAW+ATN = ACDTKATAWATNA... wait:
+      // ACDTKATAWATNA? let me be precise: ACD TKA TAW ATN = "ACDTKATAWATNA"? no, 3+3+3+3=12
+      // "ACD" + "TKA" + "TAW" + "ATN" = "ACDTKATAWATNA"? No: A-C-D-T-K-A-T-A-W-A-T-N = ACDTKATAWATNA? 12 chars: ACDTKATAWATNA is 13. Let me count:
+      // A(1)C(2)D(3)T(4)K(5)A(6)T(7)A(8)W(9)A(10)T(11)N(12) = "ACDTKATOWN"... I'll just round-trip test this
+      const boxes = await ScytaleBoxSource.generateBoxes(
+        'ATTACKATDAWN',
+        opts('scytale', '4'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Scytale (Encrypt)');
+      // round-trip: decrypt the result with same N must give back original
+      const encrypted = boxes[0].props.plaintextOutput;
+      const dec = await ScytaleBoxSource.generateBoxes(
+        encrypted,
+        opts('scytaledecode', '4'),
+      );
+      expect(dec[0].props.plaintextOutput).toBe('ATTACKATDAWN');
+    });
+  });
+
+  describe('decrypt — ::scytaledecode=N', () => {
+    it('decrypts HLODEORLWL with N=3 → HELLOWORLD', async () => {
+      const boxes = await ScytaleBoxSource.generateBoxes(
+        'HLODEORLWL',
+        opts('scytaledecode', '3'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Scytale (Decrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('HELLOWORLD');
+    });
+  });
+
+  describe('round-trips', () => {
+    const roundTrip = async (text: string, n: number) => {
+      const enc = await ScytaleBoxSource.generateBoxes(
+        text,
+        opts('scytale', String(n)),
+      );
+      const ciphertext = enc[0].props.plaintextOutput;
+      const dec = await ScytaleBoxSource.generateBoxes(
+        ciphertext,
+        opts('scytaledecode', String(n)),
+      );
+      return dec[0].props.plaintextOutput;
+    };
+
+    it('round-trips HELLOWORLD/3 (L not divisible by N)', async () => {
+      expect(await roundTrip('HELLOWORLD', 3)).toBe('HELLOWORLD');
+    });
+
+    it('round-trips ATTACKATDAWN/4 (L divisible by N)', async () => {
+      expect(await roundTrip('ATTACKATDAWN', 4)).toBe('ATTACKATDAWN');
+    });
+
+    it('round-trips ABCDEFG/3 (L not divisible by N)', async () => {
+      expect(await roundTrip('ABCDEFG', 3)).toBe('ABCDEFG');
+    });
+
+    it('round-trips with N=2', async () => {
+      expect(await roundTrip('HELLOWORLD', 2)).toBe('HELLOWORLD');
+    });
+
+    it('round-trips longer sentence with spaces', async () => {
+      const msg = 'THE QUICK BROWN FOX';
+      expect(await roundTrip(msg, 5)).toBe(msg);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns usage box for bare ::scytale (no N)', async () => {
+      // bare option → value is `true` (boolean), parseN returns null → usage box
+      const boxes = await ScytaleBoxSource.generateBoxes(
+        'HELLO',
+        opts('scytale', true),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Scytale (Usage)');
+    });
+
+    it('returns usage box for non-numeric N', async () => {
+      const boxes = await ScytaleBoxSource.generateBoxes(
+        'HELLO',
+        opts('scytale', 'abc'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Scytale (Usage)');
+    });
+
+    it('clamps N=1 to usage (< 2 is invalid)', async () => {
+      const boxes = await ScytaleBoxSource.generateBoxes(
+        'HELLO',
+        opts('scytale', '1'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Scytale (Usage)');
+    });
+
+    it('clamps N >= input length to input length and still round-trips', async () => {
+      // N=999 gets clamped to len=5, which is identity (one row of 5)
+      const boxes = await ScytaleBoxSource.generateBoxes(
+        'HELLO',
+        opts('scytale', '999'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Scytale (Encrypt)');
+    });
+
+    it('returns 2 boxes when both encode and decode options are present', async () => {
+      const boxes = await ScytaleBoxSource.generateBoxes('HELLOWORLD', {
+        scytale: '3',
+        scytaledecode: '3',
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Scytale (Encrypt)');
+      expect(boxes[1].props.name).toBe('Scytale (Decrypt)');
+    });
+
+    it('uses DefaultBoxTemplate', async () => {
+      const boxes = await ScytaleBoxSource.generateBoxes(
+        'HELLOWORLD',
+        opts('scytale', '3'),
+      );
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await ScytaleBoxSource.generateBoxes(
+        'HELLOWORLD',
+        opts('scytale', '3'),
+      );
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(ScytaleBoxSource.name).toBe('Scytale');
+      expect(ScytaleBoxSource.tag).toBe('#');
+      expect(ScytaleBoxSource.kind).toBe('Encode');
+      expect(typeof ScytaleBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/SpeedConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SpeedConvertBoxSource.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { SpeedConvertBoxSource } from '../SpeedConvertBoxSource';
+
+describe('SpeedConvertBoxSource', () => {
+  it('returns [] when ::speed option is absent', async () => {
+    const boxes = await SpeedConvertBoxSource.generateBoxes('100 km/h', null);
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when options object has no speed key', async () => {
+    const boxes = await SpeedConvertBoxSource.generateBoxes('100 km/h', {
+      foo: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  describe('100 km/h conversion', () => {
+    it('produces a single box', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('100 km/h', {
+        speed: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('converts m/s to 27.777778', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('100 km/h', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['m/s']).toBe('27.777778');
+    });
+
+    it('converts mph to 62.137119', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('100 km/h', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.mph).toBe('62.137119');
+    });
+
+    it('converts knot to 53.99568', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('100 km/h', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 100 km/h = 100000/3600 m/s; knot = 1852/3600 m/s => 100000/1852 = 53.995680...
+      expect(opts.knot).toBe('53.99568');
+    });
+
+    it('preserves Input label', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('100 km/h', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('100 km/h');
+    });
+  });
+
+  describe('1 m/s conversion', () => {
+    it('km/h is exactly 3.6', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('1 m/s', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['km/h']).toBe('3.6');
+    });
+
+    it('ft/s is approximately 3.28084', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('1 m/s', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1/0.3048 = 3.280839895... -> rounds to 3.28084
+      expect(opts['ft/s']).toBe('3.28084');
+    });
+
+    it('m/s is exactly 1', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('1 m/s', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['m/s']).toBe('1');
+    });
+  });
+
+  describe('60 mph conversion', () => {
+    it('km/h is 96.56064', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('60 mph', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 60 * 1609.344 / 3600 * 3600/1000 = 60 * 1609.344 / 1000 = 96.56064
+      expect(opts['km/h']).toBe('96.56064');
+    });
+  });
+
+  describe('1 knot conversion', () => {
+    it('km/h is exactly 1.852', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('1 knot', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['km/h']).toBe('1.852');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('bare word "fast" produces an error box mentioning supported units', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('fast', {
+        speed: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toBeTruthy();
+      expect(opts.Error).toBeTruthy();
+    });
+
+    it('"5 warp" produces an error box for unknown unit', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('5 warp', {
+        speed: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toBeTruthy();
+      expect(opts.Error).toMatch(/warp/i);
+    });
+  });
+
+  describe('alias support', () => {
+    it('kph alias works same as km/h', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('100 kph', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['m/s']).toBe('27.777778');
+    });
+
+    it('fps alias works same as ft/s', async () => {
+      const boxes = await SpeedConvertBoxSource.generateBoxes('1 fps', {
+        speed: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 ft/s = 0.3048 m/s -> 0.3048 * 3600/1000 = 1.09728 km/h
+      expect(opts['m/s']).toBe('0.3048');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -2,13 +2,19 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import CmykBoxSource from './CmykBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import ColumnarTranspositionBoxSource from './ColumnarTranspositionBoxSource';
+import Crc8BoxSource from './Crc8BoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
+import GrayCodeBoxSource from './GrayCodeBoxSource';
+import HammingDistanceBoxSource from './HammingDistanceBoxSource';
 import HashBoxSource from './HashBoxSource';
+import JsonPointerBoxSource from './JsonPointerBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
@@ -17,7 +23,9 @@ import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import ScytaleBoxSource from './ScytaleBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SpeedConvertBoxSource from './SpeedConvertBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
@@ -29,13 +37,19 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  CmykBoxSource,
+  ColumnarTranspositionBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  Crc8BoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
+  GrayCodeBoxSource,
+  HammingDistanceBoxSource,
   HashBoxSource,
+  JsonPointerBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
@@ -44,7 +58,9 @@ export const boxSources = [
   PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
+  ScytaleBoxSource,
   ShortenURLBoxSource,
+  SpeedConvertBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,


### PR DESCRIPTION
## Summary

Twenty-fifth exploration batch — **8 more BoxSource tools** (encodings, checksums, color, converters, ciphers, extractor).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Gray Code | `::gray` | integer ⇄ reflected binary Gray code |
| Hamming Distance | `::hamming` | char + bit distance of two equal-length strings |
| CMYK | `::cmyk` | color hex/RGB ⇄ CMYK |
| Speed Convert | `::speed` | m/s, km/h, mph, knot, ft/s |
| JSON Pointer | `::jsonpointer=/p` | RFC 6901, prototype-safe traversal |
| Columnar Transposition | `::columnar=KEY` | keyword-ordered transposition cipher |
| Scytale | `::scytale=N` | rod transposition cipher |
| CRC-8 | `::crc8` | SMBUS + Maxim/Dallas checksums |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Hardening rules pre-loaded (BigInt for Gray code, `& 0xff` masking, `Object.hasOwn` traversal + RFC 6901 `~0`/`~1` unescaping in JSON Pointer, integer-exact + 6-decimal formatting for Speed, code-point iteration for Hamming).
- **Verified vectors**: gray `5`→`7`, `255`→`128`, `2^32` via BigInt; hamming `karolin`/`kathrin`→`3`, `ff`/`0f` bit→`4`; cmyk red↔`cmyk(0,100,100,0)`; speed `100 km/h`→`27.777778` m/s; **jsonpointer `/a/b/1`→`2`, `~0`/`~1` escaping, `__proto__` blocked**; columnar `WEAREDISCOVERED…`/`ZEBRAS`→`EVLNACDTESEAROFODEECWIREE`; scytale round-trips non-divisible lengths; crc8 `123456789`→SMBUS `0xf4`/Maxim `0xa1`.

## Self-review fixes (pre-PR)

- **`isString()` is not a TS type guard** (returns `boolean`, not `x is string`) — it does NOT narrow `BoxOptionValues`, so Columnar's key checks used `typeof === 'string'` instead (caught by tsc).
- Scytale unused param removed; a Cmyk test that destructured a possibly-`undefined` regex match guarded with `?? []`.

## Verification

- ✅ `bun run test run` — **452 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of #260–#283 — branched from `main`.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6