### PR TITLE
feat(boxSources): add 8 more tools (base32, energy, power, factorial, ncr, quadratic, ipv6, fibonacci)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>Base32Box</b> </summary>
+
+| match rule   | description                          | example          |
+| ------------ | ------------------------------------ | ---------------- |
+| `::base32`   | RFC 4648 Base32 (`::base32decode` to decode) | `hello ::base32` |
+
+</details>
+
+<details>
+<summary> <b>EnergyConvertBox</b> </summary>
+
+| match rule  | description                          | example            |
+| ----------- | ------------------------------------ | ------------------ |
+| `::energy`  | J/kJ/cal/kcal/Wh/kWh/BTU/eV          | `1 kWh ::energy`   |
+
+</details>
+
+<details>
+<summary> <b>PowerConvertBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::power`   | W/kW/MW/hp/PS/BTU·h⁻¹                 | `100 hp ::power` |
+
+</details>
+
+<details>
+<summary> <b>FactorialBox</b> </summary>
+
+| match rule     | description                          | example            |
+| -------------- | ------------------------------------ | ------------------ |
+| `::factorial`  | n! exactly (BigInt)                  | `20 ::factorial`   |
+
+</details>
+
+<details>
+<summary> <b>CombinationsBox</b> </summary>
+
+| match rule  | description                          | example         |
+| ----------- | ------------------------------------ | --------------- |
+| `::ncr`     | C(n,r) + P(n,r) exactly              | `52 5 ::ncr`    |
+
+</details>
+
+<details>
+<summary> <b>QuadraticBox</b> </summary>
+
+| match rule     | description                          | example              |
+| -------------- | ------------------------------------ | -------------------- |
+| `::quadratic`  | solve ax² + bx + c = 0 (real/complex) | `1 -3 2 ::quadratic` |
+
+</details>
+
+<details>
+<summary> <b>Ipv6Box</b> </summary>
+
+| match rule  | description                          | example              |
+| ----------- | ------------------------------------ | -------------------- |
+| `::ipv6`    | expand + compress IPv6 (RFC 5952)    | `2001:db8::1 ::ipv6` |
+
+</details>
+
+<details>
+<summary> <b>FibonacciBox</b> </summary>
+
+| match rule  | description                          | example       |
+| ----------- | ------------------------------------ | ------------- |
+| `::fib`     | nth Fibonacci number (BigInt)        | `100 ::fib`   |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/Base32BoxSource.ts
+++ b/src/modules/boxSources/Base32BoxSource.ts
@@ -1,0 +1,134 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// RFC 4648 §6 standard alphabet (no padding char)
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+// reverse lookup: char → 5-bit value
+const DECODE_MAP: Record<string, number> = {};
+for (let i = 0; i < ALPHABET.length; i++) {
+  DECODE_MAP[ALPHABET[i]] = i;
+}
+
+/** Encode arbitrary UTF-8 text to RFC 4648 Base32 with '=' padding. */
+function base32Encode(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let bits = 0;
+  let accumulator = 0;
+  let output = '';
+
+  for (const byte of bytes) {
+    accumulator = (accumulator << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      output += ALPHABET[(accumulator >> bits) & 0x1f];
+    }
+  }
+
+  // flush remaining bits (left-aligned in the 5-bit window)
+  if (bits > 0) {
+    output += ALPHABET[(accumulator << (5 - bits)) & 0x1f];
+  }
+
+  // pad to a multiple of 8 per RFC 4648 §6
+  while (output.length % 8 !== 0) {
+    output += '=';
+  }
+
+  return output;
+}
+
+/** Decode RFC 4648 Base32 back to UTF-8 text, or throw on invalid input. */
+function base32Decode(input: string): string {
+  // strip whitespace, uppercase, and trailing padding
+  const normalised = input.replace(/\s/g, '').toUpperCase().replace(/=+$/, '');
+
+  let bits = 0;
+  let accumulator = 0;
+  const bytes: number[] = [];
+
+  for (const ch of normalised) {
+    const val = DECODE_MAP[ch];
+    if (val === undefined) {
+      throw new Error(`invalid Base32 character: '${ch}'`);
+    }
+    accumulator = (accumulator << 5) | val;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((accumulator >> bits) & 0xff);
+    }
+  }
+
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+export const Base32BoxSource = {
+  name: 'Base32',
+  description:
+    'RFC 4648 Base32 encode/decode. ::base32 to encode, ::base32decode to decode.',
+  defaultInput: 'hello ::base32',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'base32', 'base32encode');
+    const wantDecode = hasOptionKeys(options, 'base32decode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = base32Encode(input);
+      boxes.push(
+        new BoxBuilder('Base32 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      try {
+        const decoded = base32Decode(input);
+        boxes.push(
+          new BoxBuilder('Base32 (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'invalid Base32';
+        boxes.push(
+          new BoxBuilder('Base32 (Decode)', message)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Base32BoxSource;

--- a/src/modules/boxSources/CombinationsBoxSource.ts
+++ b/src/modules/boxSources/CombinationsBoxSource.ts
@@ -1,0 +1,113 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_N = 1_000_000;
+
+// builds a "key: value\n..." plaintext string for headless rendering
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// computes C(n, r) via the integer-safe multiplicative formula using BigInt.
+// uses r' = min(r, n-r) for efficiency and avoids huge intermediate factorials.
+function combination(n: bigint, r: bigint): bigint {
+  const k = r < n - r ? r : n - r;
+  let result = 1n;
+  for (let i = 0n; i < k; i++) {
+    // multiply before divide keeps the running product integral at each step
+    result = (result * (n - i)) / (i + 1n);
+  }
+  return result;
+}
+
+// computes P(n, r) = product of (n, n-1, ..., n-r+1) via BigInt
+function permutation(n: bigint, r: bigint): bigint {
+  let result = 1n;
+  for (let i = 0n; i < r; i++) {
+    result *= n - i;
+  }
+  return result;
+}
+
+const PARSE_RE = /^(\d+)[\s,]+(\d+)$/;
+const CONSTRAINT_MSG = '0 ≤ r ≤ n ≤ 1000000';
+
+export const CombinationsBoxSource = {
+  name: 'Combinations / Permutations',
+  description:
+    'Compute C(n, r) and P(n, r) exactly. Input: "n r" (e.g. "52 5").',
+  defaultInput: '52 5 ::ncr',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ncr', 'npr', 'choose')) return [];
+
+    const raw = trim(input).slice(0, 100);
+    const match = PARSE_RE.exec(raw);
+
+    if (!match) {
+      // invalid format — explain expected input
+      const pairs = {
+        Error: 'expected two non-negative integers, e.g. "52 5"',
+        Constraints: CONSTRAINT_MSG,
+      };
+      return [
+        new BoxBuilder('Combinations / Permutations', kvToPlaintext(pairs))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(pairs)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const n = Number(match[1]);
+    const r = Number(match[2]);
+
+    if (r > n || n > MAX_N) {
+      const pairs = {
+        Error:
+          r > n ? `r (${r}) must be ≤ n (${n})` : `n (${n}) must be ≤ 1000000`,
+        Constraints: CONSTRAINT_MSG,
+      };
+      return [
+        new BoxBuilder('Combinations / Permutations', kvToPlaintext(pairs))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(pairs)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const bn = BigInt(n);
+    const br = BigInt(r);
+    const c = combination(bn, br);
+    const p = permutation(bn, br);
+
+    const pairs = {
+      n: String(n),
+      r: String(r),
+      'C(n, r)': String(c),
+      'P(n, r)': String(p),
+    };
+
+    return [
+      new BoxBuilder('Combinations / Permutations', kvToPlaintext(pairs))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(pairs)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CombinationsBoxSource;

--- a/src/modules/boxSources/CombinationsBoxSource.ts
+++ b/src/modules/boxSources/CombinationsBoxSource.ts
@@ -4,7 +4,11 @@ import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
-const MAX_N = 1_000_000;
+const MAX_N = 100_000;
+// independently cap k = min(r, n-r): cost is O(k) BigInt mults on a product
+// that grows to ~k*log(n) digits, so a large k (even with n in range) can
+// hang the main thread for minutes. 10000 keeps worst-case well under a second.
+const MAX_K = 10_000;
 
 // builds a "key: value\n..." plaintext string for headless rendering
 function kvToPlaintext(pairs: Record<string, string>): string {
@@ -73,10 +77,18 @@ export const CombinationsBoxSource = {
     const n = Number(match[1]);
     const r = Number(match[2]);
 
-    if (r > n || n > MAX_N) {
+    const effectiveK = Math.min(r, n - r);
+    if (r > n || n > MAX_N || effectiveK > MAX_K) {
+      let error: string;
+      if (r > n) {
+        error = `r (${r}) must be ≤ n (${n})`;
+      } else if (n > MAX_N) {
+        error = `n (${n}) must be ≤ ${MAX_N}`;
+      } else {
+        error = `min(r, n-r) = ${effectiveK} is too large; must be ≤ ${MAX_K}`;
+      }
       const pairs = {
-        Error:
-          r > n ? `r (${r}) must be ≤ n (${n})` : `n (${n}) must be ≤ 1000000`,
+        Error: error,
         Constraints: CONSTRAINT_MSG,
       };
       return [

--- a/src/modules/boxSources/EnergyConvertBoxSource.ts
+++ b/src/modules/boxSources/EnergyConvertBoxSource.ts
@@ -1,0 +1,128 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit -> joules conversion factors (SI exact where defined by convention)
+const TO_J: Record<string, number> = {
+  j: 1,
+  kj: 1000,
+  mj: 1e6,
+  cal: 4.184,
+  kcal: 4184,
+  wh: 3600,
+  kwh: 3.6e6,
+  btu: 1055.05585262,
+  ev: 1.602176634e-19,
+};
+
+// display labels in output order
+const OUTPUT_UNITS: Array<[string, string]> = [
+  ['J', 'j'],
+  ['kJ', 'kj'],
+  ['cal', 'cal'],
+  ['kcal', 'kcal'],
+  ['Wh', 'wh'],
+  ['kWh', 'kwh'],
+  ['BTU', 'btu'],
+  ['eV', 'ev'],
+];
+
+// format a joule-based result value for display:
+// - very large or very small non-zero values use exponential notation (6 decimal places)
+// - integers display without decimal point
+// - otherwise toFixed(6) with trailing zeros stripped
+function formatValue(n: number): string {
+  const abs = Math.abs(n);
+  if (n !== 0 && (abs >= 1e15 || abs < 1e-4)) {
+    return n.toExponential(6);
+  }
+  if (Number.isInteger(n)) {
+    return n.toString();
+  }
+  return n.toFixed(6).replace(/\.?0+$/, '');
+}
+
+// build plaintext k:v representation for headless consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+const SUPPORTED_UNITS = Object.keys(TO_J).join(', ');
+const INPUT_RE = /^(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*([a-zA-Z]+)$/;
+
+export const EnergyConvertBoxSource = {
+  name: 'Energy Convert',
+  description: 'Convert energy between J, kJ, cal, kcal, Wh, kWh, BTU, and eV.',
+  defaultInput: '1 kWh ::energy',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'energy')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > 64) {
+      return [];
+    }
+
+    const match = INPUT_RE.exec(raw);
+    if (!match) {
+      const kv: Record<string, string> = {
+        Error: 'Invalid format. Use: <number> <unit>',
+        'Supported units': SUPPORTED_UNITS,
+      };
+      return [
+        new BoxBuilder('Energy Convert', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitKey = match[2].toLowerCase();
+
+    if (!(unitKey in TO_J)) {
+      const kv: Record<string, string> = {
+        Error: `Unknown unit: ${match[2]}`,
+        'Supported units': SUPPORTED_UNITS,
+      };
+      return [
+        new BoxBuilder('Energy Convert', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const joules = value * TO_J[unitKey];
+
+    const kv: Record<string, string> = {
+      Input: `${match[1]} ${match[2]}`,
+    };
+    for (const [label, key] of OUTPUT_UNITS) {
+      kv[label] = formatValue(joules / TO_J[key]);
+    }
+
+    return [
+      new BoxBuilder('Energy Convert', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default EnergyConvertBoxSource;

--- a/src/modules/boxSources/FactorialBoxSource.ts
+++ b/src/modules/boxSources/FactorialBoxSource.ts
@@ -6,7 +6,9 @@ import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
 const Priority = 10;
 
 // cap to bound the O(n) bigint product and the output string size
-const MAX_N = 100_000;
+// cap at 20000: 20000! is ~77k digits and computes in ~25ms; 100000! blocks
+// the main thread for ~1.7s (O(n) bigint mults on a growing product)
+const MAX_N = 20_000;
 
 // threshold above which we abbreviate the full decimal expansion
 const FULL_DISPLAY_THRESHOLD = 2000;

--- a/src/modules/boxSources/FactorialBoxSource.ts
+++ b/src/modules/boxSources/FactorialBoxSource.ts
@@ -1,0 +1,113 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// cap to bound the O(n) bigint product and the output string size
+const MAX_N = 100_000;
+
+// threshold above which we abbreviate the full decimal expansion
+const FULL_DISPLAY_THRESHOLD = 2000;
+
+// build plaintext k:v representation for headless consumers
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// compute n! exactly using BigInt
+function factorial(n: number): bigint {
+  let result = 1n;
+  for (let i = 2n; i <= BigInt(n); i++) {
+    result *= i;
+  }
+  return result;
+}
+
+export const FactorialBoxSource = {
+  name: 'Factorial',
+  description:
+    'Compute n! exactly for a non-negative integer. ::factorial=<n> or "<n> ::factorial".',
+  defaultInput: '20 ::factorial',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'factorial')) return [];
+
+    // prefer the option value if it carries a numeric string; else fall back to trimmed input
+    const optionVal = extractOptionKeys(options, 'factorial');
+    const raw =
+      typeof optionVal === 'string' && /^\d+$/.test(optionVal)
+        ? optionVal
+        : trim(input);
+
+    if (!/^\d+$/.test(raw)) {
+      const kv: Record<string, string> = {
+        Error: 'n must be a non-negative integer (digits only)',
+        Hint: `Use ::factorial=<n> or "<n> ::factorial" where n <= ${MAX_N}`,
+      };
+      return [
+        new BoxBuilder('Factorial', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const n = Number.parseInt(raw, 10);
+
+    if (n > MAX_N) {
+      const kv: Record<string, string> = {
+        Error: `n must be <= ${MAX_N} (got ${n})`,
+      };
+      return [
+        new BoxBuilder('Factorial', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const result = factorial(n);
+    const resultStr = result.toString();
+    const digits = resultStr.length;
+
+    const kv: Record<string, string> = {
+      n: n.toString(),
+    };
+
+    if (n <= FULL_DISPLAY_THRESHOLD) {
+      kv['n!'] = resultStr;
+    } else {
+      kv['n!'] = 'too long to display in full';
+      // scientific approximation: first digit + exponent
+      const firstDigit = resultStr[0];
+      const exp = digits - 1;
+      kv.Approx = `${firstDigit}.???e+${exp}`;
+      kv['First 20'] = resultStr.slice(0, 20);
+      kv['Last 20'] = resultStr.slice(-20);
+    }
+
+    kv.Digits = digits.toString();
+
+    return [
+      new BoxBuilder('Factorial', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FactorialBoxSource;

--- a/src/modules/boxSources/FibonacciBoxSource.ts
+++ b/src/modules/boxSources/FibonacciBoxSource.ts
@@ -1,0 +1,108 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// caps the O(n) loop and protects against absurdly large output strings
+const MAX_N = 100_000;
+
+// build plaintext k:v representation for headless consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// iterative BigInt fibonacci — O(n) time, O(1) extra space
+function fibonacci(n: number): bigint {
+  let a = 0n;
+  let b = 1n;
+  for (let i = 0; i < n; i++) {
+    [a, b] = [b, a + b];
+  }
+  return a;
+}
+
+export const FibonacciBoxSource = {
+  name: 'Fibonacci',
+  description:
+    'Compute the nth Fibonacci number (F(0)=0, F(1)=1). ::fib=<n> or "<n> ::fib".',
+  defaultInput: '100 ::fib',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'fib', 'fibonacci')) return [];
+
+    // prefer the option value when it carries a numeric argument (e.g. ::fib=20),
+    // otherwise fall back to the trimmed input string
+    const optionValue = extractOptionKeys(options, 'fib', 'fibonacci');
+    const rawN =
+      typeof optionValue === 'string' && /^\d+$/.test(optionValue.trim())
+        ? optionValue.trim()
+        : trim(input);
+
+    if (!/^\d+$/.test(rawN)) {
+      const kv: Record<string, string> = {
+        Error: `"${rawN}" is not a valid non-negative integer`,
+        Range: `n must be an integer between 0 and ${MAX_N}`,
+      };
+      return [
+        new BoxBuilder('Fibonacci', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const n = Number.parseInt(rawN, 10);
+
+    if (n > MAX_N) {
+      const kv: Record<string, string> = {
+        Error: `n=${n} exceeds the maximum allowed value of ${MAX_N}`,
+        Range: `n must be an integer between 0 and ${MAX_N}`,
+      };
+      return [
+        new BoxBuilder('Fibonacci', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const result = fibonacci(n);
+    const resultStr = result.toString();
+    const digits = resultStr.length;
+
+    const tooLong = digits > 1000;
+
+    const kv: Record<string, string> = {
+      n: String(n),
+      'F(n)': tooLong ? 'too long to display' : resultStr,
+      Digits: String(digits),
+    };
+
+    if (tooLong) {
+      kv['First 20'] = resultStr.slice(0, 20);
+      kv['Last 20'] = resultStr.slice(-20);
+    }
+
+    return [
+      new BoxBuilder('Fibonacci', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FibonacciBoxSource;

--- a/src/modules/boxSources/Ipv6BoxSource.ts
+++ b/src/modules/boxSources/Ipv6BoxSource.ts
@@ -1,0 +1,192 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to avoid pathological parsing
+const MAX_INPUT_LENGTH = 100;
+
+// pattern for a single hextet (1-4 hex digits)
+const HEXTET_RE = /^[0-9a-fA-F]{1,4}$/;
+
+// pattern for an embedded IPv4 address (reject for simplicity)
+const IPV4_RE = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+interface ParseResult {
+  groups: number[]; // 8 groups as numbers (0-65535)
+}
+
+// parse an IPv6 address string into 8 numeric groups, or return an error string
+function parseIPv6(raw: string): ParseResult | string {
+  const addr = raw.toLowerCase();
+
+  // count '::' occurrences — RFC 5952 allows at most one
+  const doubleColonCount = (addr.match(/::/g) ?? []).length;
+  if (doubleColonCount > 1) {
+    return 'double "::" found more than once';
+  }
+
+  let left: string[];
+  let right: string[];
+
+  if (doubleColonCount === 1) {
+    const parts = addr.split('::');
+    left = parts[0] ? parts[0].split(':') : [];
+    right = parts[1] ? parts[1].split(':') : [];
+  } else {
+    left = addr.split(':');
+    right = [];
+  }
+
+  // check for embedded IPv4 in the rightmost group
+  if (right.length > 0 && IPV4_RE.test(right[right.length - 1])) {
+    return 'embedded IPv4 addresses are not supported';
+  }
+
+  const allGroups = [...left, ...right];
+
+  // validate each hextet
+  for (const group of allGroups) {
+    if (!HEXTET_RE.test(group)) {
+      return `invalid hextet: "${group}"`;
+    }
+  }
+
+  const totalExplicit = left.length + right.length;
+
+  if (doubleColonCount === 1) {
+    // '::' fills the remaining zero groups
+    const zeroCount = 8 - totalExplicit;
+    if (zeroCount < 1) {
+      return 'too many groups for a valid IPv6 address with "::"';
+    }
+    const groups: number[] = [
+      ...left.map((h) => Number.parseInt(h, 16)),
+      ...Array(zeroCount).fill(0),
+      ...right.map((h) => Number.parseInt(h, 16)),
+    ];
+    return { groups };
+  }
+
+  // no '::' — must be exactly 8 groups
+  if (totalExplicit !== 8) {
+    return `expected 8 groups, got ${totalExplicit}`;
+  }
+
+  return {
+    groups: left.map((h) => Number.parseInt(h, 16)),
+  };
+}
+
+// produce the full expanded form: 8 groups, each 4 lowercase hex digits
+function expand(groups: number[]): string {
+  return groups.map((g) => g.toString(16).padStart(4, '0')).join(':');
+}
+
+// produce the RFC 5952 compressed form:
+// - drop leading zeros per group
+// - replace the longest run of consecutive all-zero groups (>=2) with '::'
+//   (leftmost run wins on tie)
+function compress(groups: number[]): string {
+  // find the longest run of zeros (length >= 2), leftmost on tie
+  let bestStart = -1;
+  let bestLen = 0;
+  let runStart = -1;
+  let runLen = 0;
+
+  for (let i = 0; i < 8; i++) {
+    if (groups[i] === 0) {
+      if (runStart === -1) {
+        runStart = i;
+        runLen = 1;
+      } else {
+        runLen++;
+      }
+      // update best only when strictly longer (leftmost on tie)
+      if (runLen > bestLen) {
+        bestLen = runLen;
+        bestStart = runStart;
+      }
+    } else {
+      runStart = -1;
+      runLen = 0;
+    }
+  }
+
+  // RFC 5952: only compress if the run is >= 2 consecutive zero groups
+  if (bestLen < 2) {
+    return groups.map((g) => g.toString(16)).join(':');
+  }
+
+  const before = groups.slice(0, bestStart).map((g) => g.toString(16));
+  const after = groups.slice(bestStart + bestLen).map((g) => g.toString(16));
+
+  const left = before.join(':');
+  const right = after.join(':');
+
+  if (left === '' && right === '') return '::';
+  if (left === '') return `::${right}`;
+  if (right === '') return `${left}::`;
+  return `${left}::${right}`;
+}
+
+export const Ipv6BoxSource = {
+  name: 'IPv6',
+  description: 'Expand and compress an IPv6 address (RFC 5952).',
+  defaultInput: '2001:db8::1 ::ipv6',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ipv6')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT_LENGTH) return [];
+
+    const result = parseIPv6(raw);
+
+    if (typeof result === 'string') {
+      // return an explanatory box instead of silently dropping
+      const kv = { Input: raw, Error: `Not a valid IPv6 address: ${result}` };
+      return [
+        new BoxBuilder('IPv6', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { groups } = result;
+    const expanded = expand(groups);
+    const compressed = compress(groups);
+
+    const kv: Record<string, string> = {
+      Input: raw,
+      Expanded: expanded,
+      Compressed: compressed,
+    };
+
+    return [
+      new BoxBuilder('IPv6', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Ipv6BoxSource;

--- a/src/modules/boxSources/PowerConvertBoxSource.ts
+++ b/src/modules/boxSources/PowerConvertBoxSource.ts
@@ -61,11 +61,14 @@ export const PowerConvertBoxSource = {
 
     if (!match) {
       // invalid — return a box listing supported units
-      const plaintext = kvToPlaintext({ 'Supported units': SUPPORTED_UNITS });
+      const pairs = {
+        Error: 'Invalid format. Expected: <number> <unit>',
+        'Supported units': SUPPORTED_UNITS,
+      };
       return [
-        new BoxBuilder('Power Convert', plaintext)
+        new BoxBuilder('Power Convert', kvToPlaintext(pairs))
           .setTemplate(KeyValueBoxTemplate)
-          .setOptions({ 'Supported units': SUPPORTED_UNITS })
+          .setOptions(pairs)
           .setPriority(this.priority)
           .build(),
       ];
@@ -77,11 +80,14 @@ export const PowerConvertBoxSource = {
 
     if (factor === undefined) {
       // unknown unit — return a box listing supported units
-      const plaintext = kvToPlaintext({ 'Supported units': SUPPORTED_UNITS });
+      const pairs = {
+        Error: `Unknown unit: ${match[2]}`,
+        'Supported units': SUPPORTED_UNITS,
+      };
       return [
-        new BoxBuilder('Power Convert', plaintext)
+        new BoxBuilder('Power Convert', kvToPlaintext(pairs))
           .setTemplate(KeyValueBoxTemplate)
-          .setOptions({ 'Supported units': SUPPORTED_UNITS })
+          .setOptions(pairs)
           .setPriority(this.priority)
           .build(),
       ];

--- a/src/modules/boxSources/PowerConvertBoxSource.ts
+++ b/src/modules/boxSources/PowerConvertBoxSource.ts
@@ -1,0 +1,113 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// watts per unit — used for all conversions via W as intermediate
+const TO_W: Record<string, number> = {
+  w: 1,
+  kw: 1000,
+  mw: 1e6,
+  hp: 745.6998715822702, // mechanical horsepower (NIST)
+  ps: 735.49875, // metric horsepower
+  'btu/h': 0.29307107017,
+  btuh: 0.29307107017,
+};
+
+// display labels for each output unit, in order
+const OUTPUT_UNITS: { key: string; label: string }[] = [
+  { key: 'w', label: 'W' },
+  { key: 'kw', label: 'kW' },
+  { key: 'mw', label: 'MW' },
+  { key: 'hp', label: 'hp' },
+  { key: 'ps', label: 'PS' },
+  { key: 'btu/h', label: 'BTU/h' },
+];
+
+// formats a converted value: exact integer if whole, else 6 decimal places stripped of trailing zeros
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// builds a plaintext "key: value" block suitable for headless rendering
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+const PARSE_RE = /^(-?\d+(?:\.\d+)?)\s*([a-zA-Z/]+)$/;
+const SUPPORTED_UNITS = 'W, kW, MW, hp, PS, BTU/h';
+
+export const PowerConvertBoxSource = {
+  name: 'Power Convert',
+  description: `Convert power between ${SUPPORTED_UNITS}.`,
+  defaultInput: '100 hp ::power',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'power')) return [];
+
+    const raw = trim(input).slice(0, 64);
+    const match = PARSE_RE.exec(raw);
+
+    if (!match) {
+      // invalid — return a box listing supported units
+      const plaintext = kvToPlaintext({ 'Supported units': SUPPORTED_UNITS });
+      return [
+        new BoxBuilder('Power Convert', plaintext)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ 'Supported units': SUPPORTED_UNITS })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitKey = match[2].toLowerCase();
+    const factor = TO_W[unitKey];
+
+    if (factor === undefined) {
+      // unknown unit — return a box listing supported units
+      const plaintext = kvToPlaintext({ 'Supported units': SUPPORTED_UNITS });
+      return [
+        new BoxBuilder('Power Convert', plaintext)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ 'Supported units': SUPPORTED_UNITS })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const watts = value * factor;
+
+    // build ordered key-value pairs for all output units + the original input
+    const kvPairs: Record<string, string> = {
+      Input: raw,
+    };
+
+    for (const { key, label } of OUTPUT_UNITS) {
+      kvPairs[label] = formatValue(watts / TO_W[key]);
+    }
+
+    const plaintext = kvToPlaintext(kvPairs);
+
+    return [
+      new BoxBuilder('Power Convert', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvPairs)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PowerConvertBoxSource;

--- a/src/modules/boxSources/QuadraticBoxSource.ts
+++ b/src/modules/boxSources/QuadraticBoxSource.ts
@@ -64,6 +64,21 @@ export const QuadraticBoxSource = {
     const b = Number.parseFloat(tokens[1]);
     const c = Number.parseFloat(tokens[2]);
 
+    // reject coefficients that overflow float64 (e.g. 1e309 → Infinity),
+    // which would propagate NaN into the roots
+    if (!Number.isFinite(a) || !Number.isFinite(b) || !Number.isFinite(c)) {
+      const kv: Record<string, string> = {
+        Error: 'Coefficients must be finite numbers.',
+      };
+      return [
+        new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
     const equation = `${formatNum(a)}x² + ${formatNum(b)}x + ${formatNum(c)} = 0`;
 
     // degenerate or linear case when a == 0
@@ -137,7 +152,8 @@ export const QuadraticBoxSource = {
 
     // discriminant < 0: two complex conjugate roots
     const realPart = -b / (2 * a);
-    const imagPart = Math.sqrt(-discriminant) / (2 * a);
+    // use the magnitude for display so the ± formatting never yields "+ -1i"
+    const imagPart = Math.abs(Math.sqrt(-discriminant) / (2 * a));
     const kv: Record<string, string> = {
       Equation: equation,
       Discriminant: formatNum(discriminant),

--- a/src/modules/boxSources/QuadraticBoxSource.ts
+++ b/src/modules/boxSources/QuadraticBoxSource.ts
@@ -1,0 +1,157 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// strip trailing zeros and decimal point from a fixed-notation string
+function stripTrailingZeros(s: string): string {
+  return s.replace(/\.?0+$/, '');
+}
+
+// format a number to at most 6 decimal places, keeping integers exact
+function formatNum(n: number): string {
+  if (Number.isInteger(n)) return n.toString();
+  return stripTrailingZeros(n.toFixed(6));
+}
+
+// build plaintext k:v representation for headless consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// token pattern: optional sign, digits with optional decimal and/or exponent
+const NUM_RE = /[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/g;
+
+export const QuadraticBoxSource = {
+  name: 'Quadratic Solver',
+  description: 'Solve ax² + bx + c = 0. Input the three coefficients: "a b c".',
+  defaultInput: '1 -3 2 ::quadratic',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'quadratic', 'quad')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > 200) return [];
+
+    const tokens = raw.match(NUM_RE);
+
+    // return an informational box when input cannot be parsed to exactly 3 numbers
+    if (!tokens || tokens.length !== 3) {
+      const kv: Record<string, string> = {
+        Error: 'Expected exactly three coefficients a, b, c (e.g. "1 -3 2").',
+        Usage: 'Solves ax² + bx + c = 0',
+      };
+      return [
+        new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const a = Number.parseFloat(tokens[0]);
+    const b = Number.parseFloat(tokens[1]);
+    const c = Number.parseFloat(tokens[2]);
+
+    const equation = `${formatNum(a)}x² + ${formatNum(b)}x + ${formatNum(c)} = 0`;
+
+    // degenerate or linear case when a == 0
+    if (a === 0) {
+      if (b === 0) {
+        const kv: Record<string, string> = {
+          Equation: equation,
+          Error: 'Degenerate: a = 0 and b = 0. No variable to solve for.',
+        };
+        return [
+          new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+            .setOptions(kv)
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+      // linear: bx + c = 0 → x = -c / b
+      const root = -c / b;
+      const kv: Record<string, string> = {
+        Equation: equation,
+        Note: 'a = 0 — solving as linear equation bx + c = 0',
+        'Linear root': formatNum(root),
+      };
+      return [
+        new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const discriminant = b * b - 4 * a * c;
+
+    if (discriminant > 0) {
+      const sqrtD = Math.sqrt(discriminant);
+      // root ordering: larger root first ((-b + √D) / 2a when a > 0)
+      const root1 = (-b + sqrtD) / (2 * a);
+      const root2 = (-b - sqrtD) / (2 * a);
+      const kv: Record<string, string> = {
+        Equation: equation,
+        Discriminant: formatNum(discriminant),
+        'Root 1': formatNum(root1),
+        'Root 2': formatNum(root2),
+      };
+      return [
+        new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (discriminant === 0) {
+      const root = -b / (2 * a);
+      const kv: Record<string, string> = {
+        Equation: equation,
+        Discriminant: '0',
+        Root: formatNum(root),
+      };
+      return [
+        new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // discriminant < 0: two complex conjugate roots
+    const realPart = -b / (2 * a);
+    const imagPart = Math.sqrt(-discriminant) / (2 * a);
+    const kv: Record<string, string> = {
+      Equation: equation,
+      Discriminant: formatNum(discriminant),
+      'Root 1': `${formatNum(realPart)} + ${formatNum(imagPart)}i`,
+      'Root 2': `${formatNum(realPart)} - ${formatNum(imagPart)}i`,
+    };
+    return [
+      new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default QuadraticBoxSource;

--- a/src/modules/boxSources/__test__/Base32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base32BoxSource.test.ts
@@ -1,0 +1,146 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Base32BoxSource } from '../Base32BoxSource';
+
+describe('Base32BoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with encode option', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('', { base32: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('   ', {
+        base32: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding MAX_INPUT', async () => {
+      const huge = 'a'.repeat(100_001);
+      const boxes = await Base32BoxSource.generateBoxes(huge, { base32: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — RFC 4648 §10 test vectors', () => {
+    const cases: [string, string][] = [
+      ['f', 'MY======'],
+      ['fo', 'MZXQ===='],
+      ['foo', 'MZXW6==='],
+      ['foob', 'MZXW6YQ='],
+      ['fooba', 'MZXW6YTB'],
+      ['foobar', 'MZXW6YTBOI======'],
+    ];
+
+    for (const [plaintext, expected] of cases) {
+      it(`encodes '${plaintext}' → '${expected}'`, async () => {
+        const boxes = await Base32BoxSource.generateBoxes(plaintext, {
+          base32: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput).toBe(expected);
+        expect(boxes[0].props.name).toBe('Base32 (Encode)');
+        expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+        expect(boxes[0].props.showExpandButton).toBe(false);
+      });
+    }
+
+    it('also triggers via ::base32encode option key', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', {
+        base32encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('MZXW6YTBOI======');
+    });
+  });
+
+  describe('decode', () => {
+    it("decodes 'MZXW6YTBOI======' → 'foobar'", async () => {
+      const boxes = await Base32BoxSource.generateBoxes('MZXW6YTBOI======', {
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('foobar');
+      expect(boxes[0].props.name).toBe('Base32 (Decode)');
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('decodes each RFC 4648 vector back to the original plaintext', async () => {
+      const cases: [string, string][] = [
+        ['MY======', 'f'],
+        ['MZXQ====', 'fo'],
+        ['MZXW6===', 'foo'],
+        ['MZXW6YQ=', 'foob'],
+        ['MZXW6YTB', 'fooba'],
+        ['MZXW6YTBOI======', 'foobar'],
+      ];
+      for (const [encoded, expected] of cases) {
+        const boxes = await Base32BoxSource.generateBoxes(encoded, {
+          base32decode: true,
+        });
+        expect(boxes[0].props.plaintextOutput).toBe(expected);
+      }
+    });
+
+    it('returns an error box for invalid Base32 input (chars not in alphabet)', async () => {
+      // '1', '8', '9', '0' are not in the RFC 4648 standard alphabet
+      const boxes = await Base32BoxSource.generateBoxes('1890', {
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid Base32/i);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encodes then decodes Unicode back to the original string', async () => {
+      const original = 'Hello, 世界! 😀';
+
+      const encodeBoxes = await Base32BoxSource.generateBoxes(original, {
+        base32: true,
+      });
+      expect(encodeBoxes).toHaveLength(1);
+      const encoded = encodeBoxes[0].props.plaintextOutput;
+
+      const decodeBoxes = await Base32BoxSource.generateBoxes(encoded, {
+        base32decode: true,
+      });
+      expect(decodeBoxes).toHaveLength(1);
+      expect(decodeBoxes[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('both options simultaneously', () => {
+    it('returns 2 boxes when both encode and decode options are set', async () => {
+      // input is valid Base32 so decode succeeds; encode treats it as plaintext
+      const boxes = await Base32BoxSource.generateBoxes('MZXW6YTBOI======', {
+        base32: true,
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Base32 (Encode)');
+      expect(names).toContain('Base32 (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Base32BoxSource.name).toBe('Base32');
+      expect(Base32BoxSource.kind).toBe('Encode');
+      expect(typeof Base32BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CombinationsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CombinationsBoxSource.test.ts
@@ -126,6 +126,18 @@ describe('CombinationsBoxSource', () => {
       expect(kv.Constraints).toContain('r ≤ n');
     });
 
+    it('rejects a large min(r, n-r) to avoid a main-thread hang (DoS guard)', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes(
+        '1000000 500000',
+        {
+          ncr: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toMatch(/too large|10000|min/i);
+    });
+
     it('invalid input "a b" returns an error box', async () => {
       const boxes = await CombinationsBoxSource.generateBoxes('a b', {
         ncr: true,

--- a/src/modules/boxSources/__test__/CombinationsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CombinationsBoxSource.test.ts
@@ -1,0 +1,158 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { CombinationsBoxSource } from '../CombinationsBoxSource';
+
+describe('CombinationsBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] when no options are provided', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when no matching option key is present', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('accepts ::ncr option', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('accepts ::npr option', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        npr: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('accepts ::choose option', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        choose: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('poker hands — C(52, 5) and P(52, 5)', () => {
+    it('computes C(52,5) = 2598960 and P(52,5) = 311875200', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.n).toBe('52');
+      expect(kv.r).toBe('5');
+      expect(kv['C(n, r)']).toBe('2598960');
+      expect(kv['P(n, r)']).toBe('311875200');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        ncr: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        ncr: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('edge cases r = 0 and r = n', () => {
+    it('C(5,0) = 1 and P(5,0) = 1', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('5 0', {
+        ncr: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['C(n, r)']).toBe('1');
+      expect(kv['P(n, r)']).toBe('1');
+    });
+
+    it('C(5,5) = 1 and P(5,5) = 120', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('5 5', {
+        ncr: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['C(n, r)']).toBe('1');
+      expect(kv['P(n, r)']).toBe('120');
+    });
+  });
+
+  describe('C(10,3) and P(10,3)', () => {
+    it('C(10,3) = 120 and P(10,3) = 720', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('10 3', {
+        ncr: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['C(n, r)']).toBe('120');
+      expect(kv['P(n, r)']).toBe('720');
+    });
+  });
+
+  describe('large input — C(1000, 500)', () => {
+    it('returns an exact BigInt result with no precision loss (>200 digits)', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('1000 500', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const c = kv['C(n, r)'];
+      // C(1000,500) has ~299 decimal digits — verify no floating-point rounding occurred
+      expect(c.length).toBeGreaterThan(200);
+      // must be all digits — no 'e' notation which would indicate float fallback
+      expect(c).toMatch(/^\d+$/);
+    });
+  });
+
+  describe('constraint violations', () => {
+    it('r > n returns an error box mentioning r ≤ n', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('3 5', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+      // error must reference the constraint
+      expect(kv.Constraints).toContain('r ≤ n');
+    });
+
+    it('invalid input "a b" returns an error box', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('a b', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+
+    it('n > MAX_N returns an error box', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('2000000 1', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+      expect(kv.Constraints).toContain('1000000');
+    });
+  });
+
+  describe('comma-separated input', () => {
+    it('accepts "52,5" with comma separator', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52,5', {
+        ncr: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['C(n, r)']).toBe('2598960');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/EnergyConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/EnergyConvertBoxSource.test.ts
@@ -1,0 +1,121 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { EnergyConvertBoxSource } from '../EnergyConvertBoxSource';
+
+describe('EnergyConvertBoxSource', () => {
+  describe('generateBoxes — no option key', () => {
+    it('returns [] when no options are provided', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 kWh', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when ::energy option is absent', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 kWh', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — 1 kWh', () => {
+    it('produces one box with correct energy conversions', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 kWh', {
+        energy: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options).not.toBeNull();
+      const kv = options as Record<string, string>;
+
+      expect(kv.Input).toBe('1 kWh');
+      // 1 kWh = 3 600 000 J exactly
+      expect(kv.J).toBe('3600000');
+      // 1 kWh = 3 600 kJ exactly
+      expect(kv.kJ).toBe('3600');
+      // 1 kWh = 1 000 Wh exactly
+      expect(kv.Wh).toBe('1000');
+      // 1 kWh = 3 600 000 / 4 184 kcal ≈ 860.420650
+      expect(Number.parseFloat(kv.kcal)).toBeCloseTo(860.42065, 3);
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 kWh', {
+        energy: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 kWh', {
+        energy: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes — 1 cal', () => {
+    it('converts 1 cal to J = 4.184', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 cal', {
+        energy: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.J).toBe('4.184');
+    });
+  });
+
+  describe('generateBoxes — 1000 cal', () => {
+    it('converts 1000 cal to exactly 1 kcal', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1000 cal', {
+        energy: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.kcal).toBe('1');
+    });
+  });
+
+  describe('generateBoxes — 1 BTU', () => {
+    it('converts 1 BTU to J ≈ 1055.055853', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 BTU', {
+        energy: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.J)).toBeCloseTo(1055.05585262, 5);
+    });
+  });
+
+  describe('generateBoxes — eV exponential notation', () => {
+    it('1 J → eV is ~6.241509e18 and uses exponential notation', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 J', {
+        energy: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      // value must be in exponential notation (contains 'e' or 'E')
+      expect(kv.eV).toMatch(/e/i);
+      // numeric value should be close to 1/1.602176634e-19
+      expect(Number.parseFloat(kv.eV)).toBeCloseTo(6.241509e18, 10);
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns an error box for bare text "abc"', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('abc', {
+        energy: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Supported units']).toBeTruthy();
+    });
+
+    it('returns an error box for unknown unit "5 foo"', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('5 foo', {
+        energy: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Supported units']).toBeTruthy();
+      expect(kv.Error).toMatch(/foo/i);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/FactorialBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FactorialBoxSource.test.ts
@@ -129,7 +129,7 @@ describe('FactorialBoxSource', () => {
       });
       expect(boxes).toHaveLength(1);
       const kv = boxes[0].props.options as Record<string, string>;
-      expect(kv.Error).toMatch(/100000/);
+      expect(kv.Error).toMatch(/20000/);
     });
 
     it('returns error box for negative-like input "-5" (non-digit chars)', async () => {

--- a/src/modules/boxSources/__test__/FactorialBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FactorialBoxSource.test.ts
@@ -1,0 +1,167 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { FactorialBoxSource } from '../FactorialBoxSource';
+
+describe('FactorialBoxSource', () => {
+  describe('generateBoxes — no option key', () => {
+    it('returns [] when options are null', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when ::factorial option is absent', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — option value carries n (::factorial=<n>)', () => {
+    it('computes 10! = 3628800 from option value', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('', {
+        factorial: '10',
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.n).toBe('10');
+      expect(kv['n!']).toBe('3628800');
+    });
+
+    it('ignores input when option value is numeric', async () => {
+      // option value '10' takes precedence over input 'abc'
+      const boxes = await FactorialBoxSource.generateBoxes('abc', {
+        factorial: '10',
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['n!']).toBe('3628800');
+    });
+  });
+
+  describe('generateBoxes — n from input (::factorial flag)', () => {
+    it('computes 5! = 120', async () => {
+      // verified: 5! = 120
+      const boxes = await FactorialBoxSource.generateBoxes('5', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.n).toBe('5');
+      expect(kv['n!']).toBe('120');
+      expect(kv.Digits).toBe('3');
+    });
+
+    it('computes 0! = 1', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('0', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['n!']).toBe('1');
+    });
+
+    it('computes 1! = 1', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('1', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['n!']).toBe('1');
+    });
+
+    it('computes 20! = 2432902008176640000', async () => {
+      // verified: 20! = 2432902008176640000
+      const boxes = await FactorialBoxSource.generateBoxes('20', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.n).toBe('20');
+      expect(kv['n!']).toBe('2432902008176640000');
+    });
+
+    it('computes 100! and reports 158 digits', async () => {
+      // verified: 100! has exactly 158 decimal digits
+      const boxes = await FactorialBoxSource.generateBoxes('100', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Digits).toBe('158');
+      // 100 <= 2000 so full value is shown
+      expect(kv['n!']).not.toBe('too long to display in full');
+      expect(kv['n!'].length).toBe(158);
+    });
+  });
+
+  describe('generateBoxes — large n (n > 2000)', () => {
+    it('abbreviates 5000! and provides First 20 / Last 20 / Digits', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5000', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['n!']).toBe('too long to display in full');
+      // verified: 5000! has 16326 digits
+      expect(kv.Digits).toBe('16326');
+      expect(kv['First 20']).toHaveLength(20);
+      expect(kv['Last 20']).toHaveLength(20);
+      // last 20 digits of 5000! must end in many zeros
+      expect(kv['Last 20']).toMatch(/0+$/);
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns error box for non-integer input "abc"', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('abc', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+
+    it('returns error box when n exceeds MAX_N (200000)', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('200000', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toMatch(/100000/);
+    });
+
+    it('returns error box for negative-like input "-5" (non-digit chars)', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('-5', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5', {
+        factorial: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5', {
+        factorial: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('sets box name to "Factorial"', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5', {
+        factorial: true,
+      });
+      expect(boxes[0].props.name).toBe('Factorial');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/FibonacciBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FibonacciBoxSource.test.ts
@@ -1,0 +1,139 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { FibonacciBoxSource } from '../FibonacciBoxSource';
+
+// F(10) = 55, F(20) = 6765, F(100) = 354224848179261915075
+
+describe('FibonacciBoxSource', () => {
+  describe('generateBoxes — no option key', () => {
+    it('returns [] when no options are provided', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('10', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when ::fib option is absent', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('10', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — small known values', () => {
+    it('F(0) = 0', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('0', { fib: true });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['F(n)']).toBe('0');
+    });
+
+    it('F(1) = 1', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('1', { fib: true });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['F(n)']).toBe('1');
+    });
+
+    it('F(2) = 1', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('2', { fib: true });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['F(n)']).toBe('1');
+    });
+
+    it('F(10) = 55', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('10', { fib: true });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['F(n)']).toBe('55');
+      expect(kv.n).toBe('10');
+      expect(kv.Digits).toBe('2');
+    });
+
+    it('F(100) = 354224848179261915075', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('100', {
+        fib: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['F(n)']).toBe('354224848179261915075');
+    });
+  });
+
+  describe('generateBoxes — option value carries n', () => {
+    it('::fib=20 picks n from the option value and returns F(20) = 6765', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('', { fib: '20' });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['F(n)']).toBe('6765');
+      expect(kv.n).toBe('20');
+    });
+  });
+
+  describe('generateBoxes — large n', () => {
+    it('F(10000) Digits is "2090" and value is "too long to display"', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('10000', {
+        fib: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Digits).toBe('2090');
+      expect(kv['F(n)']).toBe('too long to display');
+      // when too long, first/last 20 digits must be present and non-empty
+      expect(kv['First 20']).toHaveLength(20);
+      expect(kv['Last 20']).toHaveLength(20);
+    });
+  });
+
+  describe('generateBoxes — out of range', () => {
+    it('n=200000 returns an error box mentioning 100000', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('200000', {
+        fib: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toMatch(/100000/);
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('"abc" returns an error box', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('abc', {
+        fib: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+
+    it('also accepts ::fibonacci option key', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('10', {
+        fibonacci: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['F(n)']).toBe('55');
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('10', { fib: true });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('10', { fib: true });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('box name is "Fibonacci"', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('10', { fib: true });
+      expect(boxes[0].props.name).toBe('Fibonacci');
+    });
+
+    it('plaintextOutput contains "F(n): 55" for n=10', async () => {
+      const boxes = await FibonacciBoxSource.generateBoxes('10', { fib: true });
+      expect(boxes[0].props.plaintextOutput).toContain('F(n): 55');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/Ipv6BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Ipv6BoxSource.test.ts
@@ -1,0 +1,157 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Ipv6BoxSource } from '../Ipv6BoxSource';
+
+describe('Ipv6BoxSource', () => {
+  describe('generateBoxes — guard conditions', () => {
+    it('returns [] when no ipv6 option is provided', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('2001:db8::1', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is empty object (no ipv6 key)', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('2001:db8::1', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — valid addresses', () => {
+    it('expands and compresses 2001:db8::1', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('2001:db8::1', {
+        ipv6: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Expanded).toBe('2001:0db8:0000:0000:0000:0000:0000:0001');
+      expect(opts.Compressed).toBe('2001:db8::1');
+    });
+
+    it('compresses an already-expanded address back to canonical form', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes(
+        '2001:0db8:0000:0000:0000:0000:0000:0001',
+        { ipv6: true },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Expanded).toBe('2001:0db8:0000:0000:0000:0000:0000:0001');
+      expect(opts.Compressed).toBe('2001:db8::1');
+    });
+
+    it('handles loopback address ::1', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('::1', { ipv6: true });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Expanded).toBe('0000:0000:0000:0000:0000:0000:0000:0001');
+      expect(opts.Compressed).toBe('::1');
+    });
+
+    it('handles all-zeros address ::', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('::', { ipv6: true });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Expanded).toBe('0000:0000:0000:0000:0000:0000:0000:0000');
+      expect(opts.Compressed).toBe('::');
+    });
+
+    it('RFC 5952 longest-run rule: 2001:db8:0:0:1:0:0:1 compresses to 2001:db8::1:0:0:1', async () => {
+      // the first zero-run (positions 2-3) is length 2
+      // the second zero-run (positions 5-6) is also length 2
+      // leftmost wins on tie → compress positions 2-3
+      const boxes = await Ipv6BoxSource.generateBoxes('2001:db8:0:0:1:0:0:1', {
+        ipv6: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Expanded).toBe('2001:0db8:0000:0000:0001:0000:0000:0001');
+      expect(opts.Compressed).toBe('2001:db8::1:0:0:1');
+    });
+
+    it('normalizes uppercase input to lowercase', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('2001:DB8::1', {
+        ipv6: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Expanded).toBe('2001:0db8:0000:0000:0000:0000:0000:0001');
+      expect(opts.Compressed).toBe('2001:db8::1');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('::1', { ipv6: true });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('::1', { ipv6: true });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('box name is IPv6', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('::1', { ipv6: true });
+      expect(boxes[0].props.name).toBe('IPv6');
+    });
+  });
+
+  describe('generateBoxes — round-trip verify', () => {
+    it('expand then re-compress gives same compressed form', async () => {
+      const addr = '2001:db8::1';
+      const boxes = await Ipv6BoxSource.generateBoxes(addr, { ipv6: true });
+      const opts = boxes[0].props.options as Record<string, string>;
+
+      // re-parse the expanded form
+      const boxes2 = await Ipv6BoxSource.generateBoxes(opts.Expanded, {
+        ipv6: true,
+      });
+      const opts2 = boxes2[0].props.options as Record<string, string>;
+
+      expect(opts2.Compressed).toBe(opts.Compressed);
+    });
+  });
+
+  describe('generateBoxes — invalid addresses', () => {
+    it('returns an error box for "hello"', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('hello', { ipv6: true });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/not a valid ipv6 address/i);
+    });
+
+    it('returns an error box for "2001:db8:::1" (triple colon)', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('2001:db8:::1', {
+        ipv6: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for "gggg::1" (invalid hex)', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('gggg::1', {
+        ipv6: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/not a valid ipv6 address/i);
+    });
+
+    it('returns an error box for embedded IPv4', async () => {
+      const boxes = await Ipv6BoxSource.generateBoxes('::ffff:192.168.1.1', {
+        ipv6: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/ipv4/i);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PowerConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PowerConvertBoxSource.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { PowerConvertBoxSource } from '../PowerConvertBoxSource';
+
+describe('PowerConvertBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when ::power option is absent', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('100 hp', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options object has no power key', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('100 hp', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert 1 hp to correct watt value', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1 hp', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 mechanical hp = 745.6998715822702 W → rounded to 6 dp → 745.699872
+      expect(opts.W).toBe('745.699872');
+      expect(opts.kW).toBe('0.7457');
+    });
+
+    it('should convert 1000 W to exactly 1 kW', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1000 W', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.kW).toBe('1');
+    });
+
+    it('should convert 1 kW to correct hp value', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1 kW', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1000 / 745.6998715822702 = 1.341022...
+      expect(opts.hp).toBe('1.341022');
+    });
+
+    it('should convert 1 PS to correct watt value', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1 PS', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 PS = 735.49875 W (exact)
+      expect(opts.W).toBe('735.49875');
+    });
+
+    it('should include Input key in options', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1 hp', {
+        power: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('1 hp');
+    });
+
+    it('should return a box with supported units for fully invalid input', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('abc', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toContain('W');
+      expect(opts['Supported units']).toContain('hp');
+    });
+
+    it('should return a box with supported units for unknown unit', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('5 foo', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toContain('W');
+      expect(opts['Supported units']).toContain('PS');
+    });
+
+    it('should produce a non-empty plaintextOutput', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1 hp', {
+        power: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('W: 745.699872');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/QuadraticBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/QuadraticBoxSource.test.ts
@@ -1,0 +1,143 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { QuadraticBoxSource } from '../QuadraticBoxSource';
+
+describe('QuadraticBoxSource', () => {
+  describe('no option key', () => {
+    it('returns [] when options are null', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when ::quadratic / ::quad are absent', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('two distinct real roots — x²-3x+2=0 → 2, 1', () => {
+    it('produces one box with Root 1=2 and Root 2=1', async () => {
+      // (x-1)(x-2)=0: roots 1 and 2. (-b+√D)/2a = (3+1)/2 = 2 is Root 1
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Root 1']).toBe('2');
+      expect(kv['Root 2']).toBe('1');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', {
+        quadratic: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', {
+        quadratic: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('accepts ::quad alias', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', {
+        quad: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Root 1']).toBe('2');
+      expect(kv['Root 2']).toBe('1');
+    });
+  });
+
+  describe('double root — x²-2x+1=0 → 1', () => {
+    it('has Discriminant 0 and a single Root key', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -2 1', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Discriminant).toBe('0');
+      expect(kv.Root).toBe('1');
+      // no split roots
+      expect(kv['Root 1']).toBeUndefined();
+      expect(kv['Root 2']).toBeUndefined();
+    });
+  });
+
+  describe('complex roots — x²+1=0 → ±i', () => {
+    it('produces 0 + 1i and 0 - 1i', async () => {
+      // D = 0-4 = -4; real = 0, imag = 2/2 = 1
+      const boxes = await QuadraticBoxSource.generateBoxes('1 0 1', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Root 1']).toBe('0 + 1i');
+      expect(kv['Root 2']).toBe('0 - 1i');
+    });
+  });
+
+  describe('two distinct real roots — x²-5x+6=0 → 3, 2', () => {
+    it('returns Root 1=3 Root 2=2', async () => {
+      // (x-2)(x-3)=0: (-b+√D)/2a = (5+1)/2 = 3
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -5 6', {
+        quadratic: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Root 1']).toBe('3');
+      expect(kv['Root 2']).toBe('2');
+    });
+  });
+
+  describe('linear fallback — a=0, 2x-4=0 → root 2', () => {
+    it('returns Linear root 2 for "0 2 -4"', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('0 2 -4', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Linear root']).toBe('2');
+    });
+  });
+
+  describe('degenerate case — a=0 b=0', () => {
+    it('returns an error box for "0 0 5"', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('0 0 5', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns an error box for non-numeric "a b c"', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('a b c', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+
+    it('returns an error box for too few coefficients "1 2"', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 2', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,20 +1,28 @@
+import Base32BoxSource from './Base32BoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CombinationsBoxSource from './CombinationsBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import EnergyConvertBoxSource from './EnergyConvertBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FactorialBoxSource from './FactorialBoxSource';
+import FibonacciBoxSource from './FibonacciBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import Ipv6BoxSource from './Ipv6BoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PowerConvertBoxSource from './PowerConvertBoxSource';
+import QuadraticBoxSource from './QuadraticBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
@@ -29,19 +37,27 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  Base32BoxSource,
+  CombinationsBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  EnergyConvertBoxSource,
+  FactorialBoxSource,
+  FibonacciBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  Ipv6BoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  PowerConvertBoxSource,
+  QuadraticBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,


### PR DESCRIPTION
## Summary

Twenty-seventh exploration batch — **8 more BoxSource tools** (encoding, converters, number theory, networking).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Base32 | `::base32` | RFC 4648 encode/decode |
| Energy Convert | `::energy` | J/kJ/cal/kcal/Wh/kWh/BTU/eV |
| Power Convert | `::power` | W/kW/MW/hp/PS/BTU·h⁻¹ |
| Factorial | `::factorial` | n! exactly (BigInt) |
| Combinations / Permutations | `::ncr` | C(n,r) + P(n,r) exactly |
| Quadratic Solver | `::quadratic` | real + complex roots |
| IPv6 | `::ipv6` | expand + compress (RFC 5952) |
| Fibonacci | `::fib` | nth Fibonacci (BigInt) |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Hardening rules pre-loaded (BigInt + `BigInt(str)` for factorial/ncr/fib, integer-safe multiplicative `C(n,r)` to avoid huge intermediates, output-size caps with first/last-20-digit abbreviation for huge factorials/fibs, exponential-notation fallback for eV, `kvToPlaintext` helper for all KeyValue sources, RFC 5952 longest-leftmost-run for IPv6, linear regexes).
- **Verified vectors**: base32 `foobar`→`MZXW6YTBOI======` (full RFC 4648 f/fo/foo/foob/fooba/foobar set); `1 kWh`→`3.6e6` J; `1 hp`→`745.7` W; `5!=120`, `20!=2432902008176640000`, `100!` = 158 digits; **C(52,5)=`2598960`, P(52,5)=`311875200`**; `x²-3x+2`→{`2`,`1`}, `x²+1`→`±i`; `2001:db8::1` expand + RFC 5952 longest-run; `F(10)=55`, `F(100)=354224848179261915075`.

## Verification

- ✅ `bun run test run` — **445 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of #260–#285 — branched from `main`.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6