### PR TITLE
feat(boxSources): add 8 more tools (julian-day, day-of-week, easter, bitwise, twos-complement, byte-swap, cooking, fuel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>JulianDayBox</b> </summary>
+
+| match rule     | description                          | example                |
+| -------------- | ------------------------------------ | ---------------------- |
+| `::julianday`  | Gregorian date ⇄ Julian Day Number   | `2000-01-01 ::julianday` |
+
+</details>
+
+<details>
+<summary> <b>DayOfWeekBox</b> </summary>
+
+| match rule     | description                          | example                  |
+| -------------- | ------------------------------------ | ------------------------ |
+| `::dayofweek`  | weekday + day-of-year + ISO week     | `2025-12-25 ::dayofweek` |
+
+</details>
+
+<details>
+<summary> <b>EasterBox</b> </summary>
+
+| match rule   | description                          | example          |
+| ------------ | ------------------------------------ | ---------------- |
+| `::easter`   | Easter Sunday (Gregorian computus)   | `2025 ::easter`  |
+
+</details>
+
+<details>
+<summary> <b>BitwiseBox</b> </summary>
+
+| match rule    | description                          | example             |
+| ------------- | ------------------------------------ | ------------------- |
+| `::bitwise`   | AND/OR/XOR/shifts (dec, 0x, 0b)      | `12 & 10 ::bitwise` |
+
+</details>
+
+<details>
+<summary> <b>TwosComplementBox</b> </summary>
+
+| match rule       | description                          | example            |
+| ---------------- | ------------------------------------ | ------------------ |
+| `::twos=<bits>`  | two's-complement binary/hex          | `-42 ::twos=8`     |
+
+</details>
+
+<details>
+<summary> <b>ByteSwapBox</b> </summary>
+
+| match rule     | description                          | example                |
+| -------------- | ------------------------------------ | ---------------------- |
+| `::byteswap`   | swap byte order (endianness) of hex  | `0x12345678 ::byteswap` |
+
+</details>
+
+<details>
+<summary> <b>CookingConvertBox</b> </summary>
+
+| match rule    | description                          | example            |
+| ------------- | ------------------------------------ | ------------------ |
+| `::cooking`   | cup/tbsp/tsp/fl oz/ml/L/pint/quart/gallon | `1 cup ::cooking` |
+
+</details>
+
+<details>
+<summary> <b>FuelEconomyBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::fuel`    | MPG (US/imp) ⇄ L/100km ⇄ km/L        | `30 mpg ::fuel`  |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/BitwiseBoxSource.ts
+++ b/src/modules/boxSources/BitwiseBoxSource.ts
@@ -35,7 +35,11 @@ function parseOperand(token: string): bigint {
   if (t === '') {
     throw new Error(`empty operand`);
   }
-  // BigInt() natively handles decimal, 0x..., and 0b... literals including leading minus
+  // BigInt() handles decimal incl. a leading minus, but throws on negative
+  // radix literals like -0xff / -0b101, so peel the sign off those
+  if (/^-0[xXbBoO]/.test(t)) {
+    return -BigInt(t.slice(1));
+  }
   return BigInt(t);
 }
 

--- a/src/modules/boxSources/BitwiseBoxSource.ts
+++ b/src/modules/boxSources/BitwiseBoxSource.ts
@@ -1,0 +1,216 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max shift amount to prevent absurdly large binary strings
+const MAX_SHIFT = 4096n;
+
+// formats a BigInt as decimal and hex, e.g. "8 (0x8)"
+function fmtDecHex(n: bigint): string {
+  const sign = n < 0n ? '-' : '';
+  const abs = n < 0n ? -n : n;
+  return `${sign}${abs} (${sign}0x${abs.toString(16)})`;
+}
+
+// formats a BigInt as decimal, hex, and binary
+function fmtFull(n: bigint): string {
+  const sign = n < 0n ? '-' : '';
+  const abs = n < 0n ? -n : n;
+  return `${sign}${abs} (${sign}0x${abs.toString(16)}) (${sign}0b${abs.toString(2)})`;
+}
+
+// builds the kvToPlaintext-style string from a Record for plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// parses a single operand token; accepts leading minus, decimal, 0x, 0b
+function parseOperand(token: string): bigint {
+  const t = token.trim();
+  if (t === '') {
+    throw new Error(`empty operand`);
+  }
+  // BigInt() natively handles decimal, 0x..., and 0b... literals including leading minus
+  return BigInt(t);
+}
+
+type BitwiseOp = '&' | '|' | '^' | '<<' | '>>';
+
+// applies the named operator to two BigInt values; throws for invalid shifts
+function applyOp(a: bigint, op: BitwiseOp, b: bigint): bigint {
+  switch (op) {
+    case '&':
+      return a & b;
+    case '|':
+      return a | b;
+    case '^':
+      return a ^ b;
+    case '<<':
+      if (b < 0n || b > MAX_SHIFT) {
+        throw new RangeError(
+          `shift amount ${b} out of range [0, ${MAX_SHIFT}]`,
+        );
+      }
+      return a << b;
+    case '>>':
+      if (b < 0n || b > MAX_SHIFT) {
+        throw new RangeError(
+          `shift amount ${b} out of range [0, ${MAX_SHIFT}]`,
+        );
+      }
+      return a >> b;
+  }
+}
+
+// error box shown for invalid input, explaining accepted formats
+function errorBox(priority: number, message: string): Box {
+  const kv: Record<string, string> = {
+    Error: message,
+    Formats: 'a & b  |  a | b  |  a ^ b  |  a << n  |  a >> n',
+    Literals:
+      'decimal (123), hex (0xff), binary (0b1010); leading minus allowed',
+  };
+  return new BoxBuilder('Bitwise', kvToPlaintext(kv))
+    .setOptions(kv)
+    .setTemplate(KeyValueBoxTemplate)
+    .setShowExpandButton(false)
+    .setPriority(priority)
+    .build();
+}
+
+// parses "a OP b" where OP is one of &, |, ^, <<, >>; returns null if no op found
+function parseExplicitOp(
+  s: string,
+): { a: string; op: BitwiseOp; b: string } | null {
+  // match the longest operators first (<<, >>) before single-char ones
+  const m = s.match(
+    /^([+-]?(?:0[xX][0-9a-fA-F]+|0[bB][01]+|\d+))\s*(<<|>>|[&|^])\s*([+-]?(?:0[xX][0-9a-fA-F]+|0[bB][01]+|\d+))$/,
+  );
+  if (!m) {
+    return null;
+  }
+  return { a: m[1], op: m[2] as BitwiseOp, b: m[3] };
+}
+
+// splits "a b" or "a,b" into two operand tokens; returns null if not exactly two
+function parseTwoOperands(s: string): [string, string] | null {
+  // split on comma or whitespace
+  const parts = s.split(/[\s,]+/).filter((p) => p !== '');
+  if (parts.length !== 2) {
+    return null;
+  }
+  return [parts[0], parts[1]];
+}
+
+export const BitwiseBoxSource = {
+  name: 'Bitwise',
+  description:
+    'Bitwise AND/OR/XOR/shifts of two integers (decimal, 0x hex, or 0b binary).',
+  defaultInput: '12 & 10 ::bitwise',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'bitwise', 'bitop')) {
+      return [];
+    }
+
+    const raw = trim(input);
+    if (raw.length > 200) {
+      return [errorBox(this.priority, 'input too long (max 200 characters)')];
+    }
+
+    // try explicit operator form first: "a OP b"
+    const explicit = parseExplicitOp(raw);
+    if (explicit !== null) {
+      let a: bigint;
+      let b: bigint;
+      try {
+        a = parseOperand(explicit.a);
+        b = parseOperand(explicit.b);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return [errorBox(this.priority, `parse error: ${msg}`)];
+      }
+
+      let result: bigint;
+      try {
+        result = applyOp(a, explicit.op, b);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return [errorBox(this.priority, msg)];
+      }
+
+      const kv: Record<string, string> = {
+        Expression: `${explicit.a} ${explicit.op} ${explicit.b}`,
+        'Result (dec)': String(result),
+        'Result (hex)': `${result < 0n ? '-' : ''}0x${(result < 0n ? -result : result).toString(16)}`,
+        'Result (bin)': `${result < 0n ? '-' : ''}0b${(result < 0n ? -result : result).toString(2)}`,
+      };
+      return [
+        new BoxBuilder('Bitwise', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // try two-operand form: "a b" or "a,b" — computes all ops
+    const pair = parseTwoOperands(raw);
+    if (pair !== null) {
+      let a: bigint;
+      let b: bigint;
+      try {
+        a = parseOperand(pair[0]);
+        b = parseOperand(pair[1]);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return [errorBox(this.priority, `parse error: ${msg}`)];
+      }
+
+      const kv: Record<string, string> = {
+        A: fmtDecHex(a),
+        B: fmtDecHex(b),
+        AND: fmtDecHex(a & b),
+        OR: fmtDecHex(a | b),
+        XOR: fmtDecHex(a ^ b),
+      };
+
+      // include shifts only when b is non-negative and within cap
+      if (b >= 0n && b <= MAX_SHIFT) {
+        kv['A<<B'] = fmtFull(a << b);
+        kv['A>>B'] = fmtFull(a >> b);
+      }
+
+      return [
+        new BoxBuilder('Bitwise', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // nothing matched
+    return [
+      errorBox(
+        this.priority,
+        `cannot parse "${raw}" — expected "a OP b" or two operands`,
+      ),
+    ];
+  },
+};
+
+export default BitwiseBoxSource;

--- a/src/modules/boxSources/ByteSwapBoxSource.ts
+++ b/src/modules/boxSources/ByteSwapBoxSource.ts
@@ -1,0 +1,112 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// size thresholds (in bytes) for which we emit integer interpretations
+const WORD_SIZES = new Set([2, 4, 8]);
+
+/** build a `key: value` plaintext string from an ordered entries list */
+function kvToPlaintext(entries: [string, string][]): string {
+  return entries.map(([k, v]) => `${k}: ${v}`).join('\n');
+}
+
+/** swap byte order of a lowercase hex string that has an even number of digits */
+function swapBytes(hex: string): string {
+  const bytes: string[] = [];
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes.push(hex.slice(i, i + 2));
+  }
+  return bytes.reverse().join('');
+}
+
+export const ByteSwapBoxSource = {
+  name: 'Byte Swap',
+  description:
+    'Swap the byte order (endianness) of a hex value. ::byteswap or ::endian.',
+  defaultInput: '0x12345678 ::byteswap',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'byteswap', 'endian')) return [];
+
+    if (input.length > MAX_INPUT) return [];
+
+    const raw = trim(input);
+
+    // strip optional 0x / 0X prefix
+    const stripped =
+      raw.startsWith('0x') || raw.startsWith('0X') ? raw.slice(2) : raw;
+
+    const hex = stripped.toLowerCase();
+
+    // validate: must be pure hex digits
+    if (!/^[0-9a-f]+$/.test(hex)) {
+      const entries: [string, string][] = [
+        ['Error', 'Input must be a valid hex value (digits 0-9 and a-f).'],
+      ];
+      return [
+        new BoxBuilder('Byte Swap', kvToPlaintext(entries))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(Object.fromEntries(entries))
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // must have an even number of digits to represent whole bytes
+    if (hex.length % 2 !== 0) {
+      const entries: [string, string][] = [
+        [
+          'Error',
+          'A hex value with an even number of digits is required (each byte is 2 hex digits).',
+        ],
+      ];
+      return [
+        new BoxBuilder('Byte Swap', kvToPlaintext(entries))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(Object.fromEntries(entries))
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const swapped = swapBytes(hex);
+    const byteCount = hex.length / 2;
+
+    const entries: [string, string][] = [
+      ['Input', `0x${hex}`],
+      ['Swapped', `0x${swapped}`],
+      ['Bytes', String(byteCount)],
+    ];
+
+    // for 2, 4, or 8-byte values add big-endian / little-endian decimal views
+    if (WORD_SIZES.has(byteCount)) {
+      // interpret the original bytes as big-endian unsigned integer
+      const beValue = BigInt(`0x${hex}`);
+      // interpret the swapped bytes as big-endian unsigned integer (== LE of original)
+      const leValue = BigInt(`0x${swapped}`);
+
+      entries.push(['As BE', String(beValue)]);
+      entries.push(['As LE', String(leValue)]);
+    }
+
+    return [
+      new BoxBuilder('Byte Swap', kvToPlaintext(entries))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(Object.fromEntries(entries))
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ByteSwapBoxSource;

--- a/src/modules/boxSources/CookingConvertBoxSource.ts
+++ b/src/modules/boxSources/CookingConvertBoxSource.ts
@@ -82,7 +82,7 @@ export const CookingConvertBoxSource = {
     }
 
     const value = Number.parseFloat(match[1]);
-    if (!Number.isFinite(value)) {
+    if (!Number.isFinite(value) || value <= 0) {
       return [buildErrorBox()];
     }
 
@@ -116,8 +116,16 @@ export const CookingConvertBoxSource = {
 };
 
 function buildErrorBox(): Box {
-  const msg = `Invalid input. Expected: <number> <unit>\nSupported units: ${SUPPORTED_UNITS}`;
-  return new BoxBuilder('Cooking Convert', msg).setPriority(Priority).build();
+  const kv = {
+    Error: 'Invalid input. Expected a positive: <number> <unit>',
+    'Supported units': SUPPORTED_UNITS,
+    Example: '1 cup ::cooking',
+  };
+  return new BoxBuilder('Cooking Convert', kvToPlaintext(kv))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(kv)
+    .setPriority(Priority)
+    .build();
 }
 
 export default CookingConvertBoxSource;

--- a/src/modules/boxSources/CookingConvertBoxSource.ts
+++ b/src/modules/boxSources/CookingConvertBoxSource.ts
@@ -1,0 +1,123 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit -> milliliters (US customary)
+const TO_ML: Record<string, number> = {
+  ml: 1,
+  l: 1000,
+  liter: 1000,
+  litre: 1000,
+  tsp: 4.92892159375,
+  tbsp: 14.78676478125,
+  floz: 29.5735295625,
+  'fl-oz': 29.5735295625,
+  cup: 236.5882365,
+  pint: 473.176473,
+  pt: 473.176473,
+  quart: 946.352946,
+  qt: 946.352946,
+  gallon: 3785.411784,
+  gal: 3785.411784,
+};
+
+// output units displayed in result, in order
+const OUTPUT_UNITS: Array<{ key: string; label: string }> = [
+  { key: 'ml', label: 'ml' },
+  { key: 'tsp', label: 'tsp' },
+  { key: 'tbsp', label: 'tbsp' },
+  { key: 'floz', label: 'fl oz' },
+  { key: 'cup', label: 'cup' },
+  { key: 'pint', label: 'pint' },
+  { key: 'quart', label: 'quart' },
+  { key: 'gallon', label: 'gallon' },
+  { key: 'l', label: 'L' },
+];
+
+const SUPPORTED_UNITS = Object.keys(TO_ML).join(', ');
+
+// formats a number: integer-exact when possible, otherwise 6 decimal places trimmed of trailing zeros
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// normalizes raw unit text to a TO_ML key: lowercase, collapse internal spaces
+function normalizeUnit(raw: string): string {
+  return raw.toLowerCase().replace(/\s+/g, '');
+}
+
+// builds k:v plaintext from a record for the box plaintextOutput field
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const CookingConvertBoxSource = {
+  name: 'Cooking Convert',
+  description:
+    'Convert cooking volumes between cup, tbsp, tsp, fl oz, ml, L, pint, quart, gallon (US).',
+  defaultInput: '1 cup ::cooking',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cooking', 'volume')) return [];
+
+    const text = trim(input);
+    if (text.length > 64) return [];
+
+    // capture: <number> <rest-as-unit> — allow 'fl oz' with a space
+    const match = /^([+-]?\d+(?:\.\d*)?)[\s]+(.+)$/.exec(text);
+    if (!match) {
+      return [buildErrorBox()];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    if (!Number.isFinite(value)) {
+      return [buildErrorBox()];
+    }
+
+    const unitKey = normalizeUnit(match[2]);
+    const unitML = TO_ML[unitKey];
+    if (unitML === undefined) {
+      return [buildErrorBox()];
+    }
+
+    const valueML = value * unitML;
+
+    const kv: Record<string, string> = {
+      Input: `${formatValue(value)} ${match[2].trim()}`,
+    };
+
+    for (const { key, label } of OUTPUT_UNITS) {
+      const converted = valueML / TO_ML[key];
+      kv[label] = formatValue(converted);
+    }
+
+    const plaintext = kvToPlaintext(kv);
+
+    return [
+      new BoxBuilder('Cooking Convert', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+function buildErrorBox(): Box {
+  const msg = `Invalid input. Expected: <number> <unit>\nSupported units: ${SUPPORTED_UNITS}`;
+  return new BoxBuilder('Cooking Convert', msg).setPriority(Priority).build();
+}
+
+export default CookingConvertBoxSource;

--- a/src/modules/boxSources/DayOfWeekBoxSource.ts
+++ b/src/modules/boxSources/DayOfWeekBoxSource.ts
@@ -1,0 +1,199 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to avoid processing huge strings
+const MAX_INPUT_LENGTH = 40;
+
+const WEEKDAY_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+] as const;
+
+// days in each month for a given year (1-indexed, month 1-12)
+function daysInMonth(year: number, month: number): number {
+  if (month === 2) {
+    return isLeapYear(year) ? 29 : 28;
+  }
+  return [31, 0, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+}
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+// Zeller's congruence (Gregorian) returns 0=Sunday … 6=Saturday
+function zellerWeekday(year: number, month: number, day: number): number {
+  // january and february are treated as months 13 and 14 of the previous year
+  let y = year;
+  let m = month;
+  if (m <= 2) {
+    m += 12;
+    y -= 1;
+  }
+  const k = y % 100;
+  const j = Math.floor(y / 100);
+  // normalize to handle negative JS modulo results
+  const h =
+    (((day +
+      Math.floor((13 * (m + 1)) / 5) +
+      k +
+      Math.floor(k / 4) +
+      Math.floor(j / 4) -
+      2 * j) %
+      7) +
+      7) %
+    7;
+  // h: 0=Sat,1=Sun,2=Mon,3=Tue,4=Wed,5=Thu,6=Fri → convert to 0=Sun…6=Sat
+  return (h + 6) % 7;
+}
+
+// day of year, 1-based
+function dayOfYear(year: number, month: number, day: number): number {
+  const DAYS_BEFORE_MONTH = [
+    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334,
+  ];
+  const base = DAYS_BEFORE_MONTH[month - 1];
+  const leapOffset = month > 2 && isLeapYear(year) ? 1 : 0;
+  return base + leapOffset + day;
+}
+
+// thursday of the week containing this date (ISO weeks pivot on Thursday)
+function isoWeekAndYear(
+  year: number,
+  month: number,
+  day: number,
+): { week: number; isoYear: number } {
+  const doy = dayOfYear(year, month, day);
+
+  // ISO weekday: 1=Mon … 7=Sun
+  const zellerDay = zellerWeekday(year, month, day); // 0=Sun…6=Sat
+  const isoWeekday = zellerDay === 0 ? 7 : zellerDay; // 1=Mon…7=Sun
+
+  // ordinal of the nearest Thursday (ISO weeks are numbered by their Thursday)
+  const thursdayOrdinal = doy + (4 - isoWeekday);
+
+  if (thursdayOrdinal < 1) {
+    // Thursday falls in the previous year
+    const prevYear = year - 1;
+    const daysInPrevYear = isLeapYear(prevYear) ? 366 : 365;
+    const prevThursdayOrdinal = daysInPrevYear + thursdayOrdinal;
+    const week = Math.ceil(prevThursdayOrdinal / 7);
+    return { week, isoYear: prevYear };
+  }
+
+  const daysInCurrentYear = isLeapYear(year) ? 366 : 365;
+  if (thursdayOrdinal > daysInCurrentYear) {
+    // Thursday falls in the next year → week 1 of next year
+    return { week: 1, isoYear: year + 1 };
+  }
+
+  const week = Math.ceil(thursdayOrdinal / 7);
+  return { week, isoYear: year };
+}
+
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+interface ParsedDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+// returns ParsedDate on valid input, or a string describing the error
+function parseDate(raw: string): ParsedDate | string {
+  const match = raw.match(/^(\d{1,6})-(\d{1,2})-(\d{1,2})$/);
+  if (!match) {
+    return 'Input must be a date in YYYY-MM-DD format (e.g. 2025-12-25).';
+  }
+
+  const year = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  const day = Number.parseInt(match[3], 10);
+
+  if (month < 1 || month > 12) {
+    return `Invalid month ${month}. Month must be between 1 and 12.`;
+  }
+
+  const maxDay = daysInMonth(year, month);
+  if (day < 1 || day > maxDay) {
+    return `Invalid day ${day} for ${year}-${String(month).padStart(2, '0')}. Day must be between 1 and ${maxDay}.`;
+  }
+
+  return { year, month, day };
+}
+
+export const DayOfWeekBoxSource = {
+  name: 'Day of Week',
+  description:
+    'Compute the weekday, day-of-year, and ISO week for a date (YYYY-MM-DD).',
+  defaultInput: '2025-12-25 ::dayofweek',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'dayofweek', 'weekday')) return [];
+
+    const raw = trim(input);
+    if (raw.length === 0 || raw.length > MAX_INPUT_LENGTH) return [];
+
+    const parsed = parseDate(raw);
+
+    if (typeof parsed === 'string') {
+      // invalid input — return an explanatory box
+      const errorKv = { 'Invalid Date': parsed };
+      return [
+        new BoxBuilder('Day of Week', kvToPlaintext(errorKv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(errorKv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { year, month, day } = parsed;
+
+    const weekdayIndex = zellerWeekday(year, month, day);
+    const weekday = WEEKDAY_NAMES[weekdayIndex];
+    const doy = dayOfYear(year, month, day);
+    const { week, isoYear } = isoWeekAndYear(year, month, day);
+    const isoWeek = `${isoYear}-W${String(week).padStart(2, '0')}`;
+    const leap = isLeapYear(year) ? 'true' : 'false';
+
+    const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+
+    const kv: Record<string, string> = {
+      Date: dateStr,
+      Weekday: weekday,
+      'Day of Year': String(doy),
+      'ISO Week': isoWeek,
+      'Leap Year': leap,
+    };
+
+    return [
+      new BoxBuilder('Day of Week', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DayOfWeekBoxSource;

--- a/src/modules/boxSources/EasterBoxSource.ts
+++ b/src/modules/boxSources/EasterBoxSource.ts
@@ -1,0 +1,134 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// valid gregorian computus range: 1583–9999
+const MIN_YEAR = 1583;
+const MAX_YEAR = 9999;
+
+const YEAR_PATTERN = /^\d{1,6}$/;
+
+// anonymous gregorian algorithm (meeus/jones/butcher) to compute easter sunday
+function computeEaster(year: number): { month: number; day: number } {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31);
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return { month, day };
+}
+
+// format a UTC date as YYYY-MM-DD
+function formatDate(year: number, month: number, day: number): string {
+  const m = month.toString().padStart(2, '0');
+  const d = day.toString().padStart(2, '0');
+  return `${year}-${m}-${d}`;
+}
+
+// compute a date offset (in days) from an epoch ms using Date.UTC for determinism
+function offsetDate(baseUtcMs: number, offsetDays: number): string {
+  const ms = baseUtcMs + offsetDays * 24 * 60 * 60 * 1000;
+  const d = new Date(ms);
+  return formatDate(d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate());
+}
+
+// build a "key: value\n..." plaintext string from an ordered entry list
+function kvToPlaintext(entries: [string, string][]): string {
+  return entries.map(([k, v]) => `${k}: ${v}`).join('\n');
+}
+
+export const EasterBoxSource = {
+  name: 'Easter',
+  description:
+    'Compute the date of Easter Sunday (Gregorian) for a given year.',
+  defaultInput: '2025 ::easter',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'easter')) return [];
+
+    // prefer the option value if it is a numeric string, else fall back to input
+    const optionValue = extractOptionKeys(options, 'easter');
+    const rawYear =
+      typeof optionValue === 'string' && YEAR_PATTERN.test(optionValue.trim())
+        ? optionValue.trim()
+        : trim(input);
+
+    if (!YEAR_PATTERN.test(rawYear)) {
+      return [
+        new BoxBuilder(
+          'Easter',
+          'Invalid year. Enter a year between 1583 and 9999.',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({
+            Error: 'Invalid year. Enter a year between 1583 and 9999.',
+          })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const year = Number.parseInt(rawYear, 10);
+
+    if (year < MIN_YEAR || year > MAX_YEAR) {
+      const msg = `Year must be between ${MIN_YEAR} and ${MAX_YEAR} for the Gregorian computus.`;
+      return [
+        new BoxBuilder('Easter', msg)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: msg })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { month, day } = computeEaster(year);
+    const easterUtcMs = Date.UTC(year, month - 1, day);
+
+    const easterDate = formatDate(year, month, day);
+    const monthName = month === 3 ? 'March' : 'April';
+    const goodFriday = offsetDate(easterUtcMs, -2);
+    const ashWednesday = offsetDate(easterUtcMs, -46);
+
+    const entries: [string, string][] = [
+      ['Year', year.toString()],
+      ['Easter Sunday', easterDate],
+      ['Month', monthName],
+      ['Good Friday', goodFriday],
+      ['Ash Wednesday', ashWednesday],
+    ];
+
+    const plaintext = kvToPlaintext(entries);
+    const opts: Record<string, string> = Object.fromEntries(entries);
+
+    return [
+      new BoxBuilder('Easter', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(opts)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default EasterBoxSource;

--- a/src/modules/boxSources/FuelEconomyBoxSource.ts
+++ b/src/modules/boxSources/FuelEconomyBoxSource.ts
@@ -1,0 +1,158 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// conversion constants
+const LITERS_PER_US_GALLON = 3.785411784;
+const LITERS_PER_IMP_GALLON = 4.54609;
+const KM_PER_MILE = 1.609344;
+
+// derived shortcut constants for mpg → L/100km
+// L/100km = (litersPerGallon / (mpg * kmPerMile)) * 100
+const US_MPG_TO_L100KM = (LITERS_PER_US_GALLON / KM_PER_MILE) * 100; // ≈ 235.214583
+const IMP_MPG_TO_L100KM = (LITERS_PER_IMP_GALLON / KM_PER_MILE) * 100; // ≈ 282.480936
+
+const MAX_INPUT_LENGTH = 64;
+
+// supported unit aliases → canonical unit key
+const UNIT_MAP: Record<string, string> = {
+  mpg: 'mpgus',
+  mpgus: 'mpgus',
+  'mpg-us': 'mpgus',
+  mpguk: 'mpgimp',
+  'mpg-uk': 'mpgimp',
+  mpgimp: 'mpgimp',
+  'mpg-imp': 'mpgimp',
+  'l/100km': 'l100km',
+  l100km: 'l100km',
+  'km/l': 'kml',
+  kml: 'kml',
+};
+
+function formatValue(n: number): string {
+  if (!Number.isFinite(n)) return '∞';
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// convert any unit to L/100km as the canonical intermediate
+function toL100km(value: number, unit: string): number {
+  switch (unit) {
+    case 'mpgus':
+      return US_MPG_TO_L100KM / value;
+    case 'mpgimp':
+      return IMP_MPG_TO_L100KM / value;
+    case 'l100km':
+      return value;
+    case 'kml':
+      return 100 / value;
+    default:
+      return Number.NaN;
+  }
+}
+
+function buildErrorBox(message: string, priority: number): Box {
+  return new BoxBuilder('Fuel Economy', message)
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions({
+      Error: message,
+      'Supported units':
+        'mpg, mpg-us, mpg-uk, mpgimp, l/100km, l100km, km/l, kml',
+      Example: '30 mpg ::fuel',
+    })
+    .setPriority(priority)
+    .build();
+}
+
+export const FuelEconomyBoxSource = {
+  name: 'Fuel Economy',
+  description:
+    'Convert fuel economy between MPG (US), MPG (imperial), L/100km, and km/L.',
+  defaultInput: '30 mpg ::fuel',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'fuel', 'mpg')) return [];
+
+    const raw = trim(input);
+    if (raw.length === 0 || raw.length > MAX_INPUT_LENGTH) {
+      return [
+        buildErrorBox(
+          'Input is empty or too long (max 64 chars).',
+          this.priority,
+        ),
+      ];
+    }
+
+    // expect "<number> <unit>"
+    const parts = raw.split(/\s+/);
+    if (parts.length !== 2) {
+      return [
+        buildErrorBox(
+          `Invalid format: "${raw}". Use "<number> <unit>".`,
+          this.priority,
+        ),
+      ];
+    }
+
+    const [rawValue, rawUnit] = parts;
+    const value = Number.parseFloat(rawValue);
+
+    if (Number.isNaN(value) || !Number.isFinite(value)) {
+      return [
+        buildErrorBox(`"${rawValue}" is not a valid number.`, this.priority),
+      ];
+    }
+
+    if (value <= 0) {
+      return [buildErrorBox('Value must be greater than 0.', this.priority)];
+    }
+
+    const unit = UNIT_MAP[rawUnit.toLowerCase()];
+    if (!unit) {
+      return [
+        buildErrorBox(
+          `Unknown unit "${rawUnit}". Supported: mpg, mpg-us, mpg-uk, mpgimp, l/100km, l100km, km/l, kml.`,
+          this.priority,
+        ),
+      ];
+    }
+
+    const l100km = toL100km(value, unit);
+    const mpgUS = US_MPG_TO_L100KM / l100km;
+    const mpgImp = IMP_MPG_TO_L100KM / l100km;
+    const kmPerL = 100 / l100km;
+
+    const inputLabel = `${formatValue(value)} ${rawUnit}`;
+    const output: Record<string, string> = {
+      Input: inputLabel,
+      'MPG (US)': formatValue(mpgUS),
+      'MPG (imp)': formatValue(mpgImp),
+      'L/100km': formatValue(l100km),
+      'km/L': formatValue(kmPerL),
+    };
+
+    // build human-readable plaintext for headless/TUI consumers
+    const plaintext = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    const box = new BoxBuilder('Fuel Economy', plaintext)
+      .setTemplate(KeyValueBoxTemplate)
+      .setOptions(output)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default FuelEconomyBoxSource;

--- a/src/modules/boxSources/JulianDayBoxSource.ts
+++ b/src/modules/boxSources/JulianDayBoxSource.ts
@@ -1,0 +1,156 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+const DAY_NAMES = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+];
+
+// standard gregorian-to-jdn algorithm (julian day number at noon)
+function gregorianToJDN(year: number, month: number, day: number): number {
+  const a = Math.floor((14 - month) / 12);
+  const y = year + 4800 - a;
+  const m = month + 12 * a - 3;
+  return (
+    day +
+    Math.floor((153 * m + 2) / 5) +
+    365 * y +
+    Math.floor(y / 4) -
+    Math.floor(y / 100) +
+    Math.floor(y / 400) -
+    32045
+  );
+}
+
+// inverse jdn algorithm — returns [year, month, day] in proleptic gregorian
+function jdnToGregorian(jdn: number): [number, number, number] {
+  const a = jdn + 32044;
+  const b = Math.floor((4 * a + 3) / 146097);
+  const c = a - Math.floor((146097 * b) / 4);
+  const d = Math.floor((4 * c + 3) / 1461);
+  const e = c - Math.floor((1461 * d) / 4);
+  const m = Math.floor((5 * e + 2) / 153);
+  const day = e - Math.floor((153 * m + 2) / 5) + 1;
+  const month = m + 3 - 12 * Math.floor(m / 10);
+  const year = 100 * b + d - 4800 + Math.floor(m / 10);
+  return [year, month, day];
+}
+
+// jdn % 7 → 0=Monday … 6=Sunday (verified: JDN 2451545 = 2000-01-01 = Saturday = index 5)
+function dayOfWeekFromJDN(jdn: number): string {
+  return DAY_NAMES[((jdn % 7) + 7) % 7];
+}
+
+function padDate(year: number, month: number, day: number): string {
+  const y =
+    year < 0
+      ? `-${String(Math.abs(year)).padStart(4, '0')}`
+      : String(year).padStart(4, '0');
+  return `${y}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const JulianDayBoxSource = {
+  name: 'Julian Day',
+  description:
+    'Convert a Gregorian date (YYYY-MM-DD) to its Julian Day Number, or a JDN back to a date.',
+  defaultInput: '2000-01-01 ::julianday',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'julianday', 'jdn')) return [];
+
+    const trimmed = trim(input);
+    if (trimmed.length === 0 || trimmed.length > 40) return [];
+
+    // plain number (possibly with decimal, possibly negative) → treat as jdn
+    const jdnPattern = /^-?\d{1,7}(\.\d+)?$/;
+    if (jdnPattern.test(trimmed)) {
+      const jdn = Math.floor(Number.parseFloat(trimmed));
+      const [year, month, day] = jdnToGregorian(jdn);
+      const dateStr = padDate(year, month, day);
+      const dow = dayOfWeekFromJDN(jdn);
+
+      const kv: Record<string, string> = {
+        'Julian Day Number': String(jdn),
+        Date: dateStr,
+        'Day of Week': dow,
+      };
+      const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(Priority)
+        .build();
+      return [box];
+    }
+
+    // gregorian date → jdn
+    const datePattern = /^(-?\d{1,6})-(\d{1,2})-(\d{1,2})$/;
+    const match = datePattern.exec(trimmed);
+    if (match) {
+      const year = Number.parseInt(match[1], 10);
+      const month = Number.parseInt(match[2], 10);
+      const day = Number.parseInt(match[3], 10);
+
+      if (month < 1 || month > 12 || day < 1 || day > 31) {
+        const kv: Record<string, string> = {
+          Error: 'Invalid date — month must be 1–12, day 1–31.',
+        };
+        const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(Priority)
+          .build();
+        return [box];
+      }
+
+      const jdn = gregorianToJDN(year, month, day);
+      const dow = dayOfWeekFromJDN(jdn);
+      const kv: Record<string, string> = {
+        Date: padDate(year, month, day),
+        'Julian Day Number': String(jdn),
+        'Day of Week': dow,
+      };
+      const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(Priority)
+        .build();
+      return [box];
+    }
+
+    // unrecognised format — return an informational box
+    const kv: Record<string, string> = {
+      Error: `Unrecognised input. Expected YYYY-MM-DD or an integer JDN.`,
+      'Date format': 'YYYY-MM-DD (e.g. 2000-01-01)',
+      'JDN format': 'integer (e.g. 2451545)',
+    };
+    const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
+      .setTemplate(KeyValueBoxTemplate)
+      .setOptions(kv)
+      .setPriority(Priority)
+      .build();
+    return [box];
+  },
+};
+
+export default JulianDayBoxSource;

--- a/src/modules/boxSources/JulianDayBoxSource.ts
+++ b/src/modules/boxSources/JulianDayBoxSource.ts
@@ -98,7 +98,7 @@ export const JulianDayBoxSource = {
       const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
         .setTemplate(KeyValueBoxTemplate)
         .setOptions(kv)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build();
       return [box];
     }
@@ -111,14 +111,31 @@ export const JulianDayBoxSource = {
       const month = Number.parseInt(match[2], 10);
       const day = Number.parseInt(match[3], 10);
 
-      if (month < 1 || month > 12 || day < 1 || day > 31) {
+      const isLeap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+      const monthDays = [
+        31,
+        isLeap ? 29 : 28,
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+      ];
+      const maxDay = month >= 1 && month <= 12 ? monthDays[month - 1] : 0;
+      if (month < 1 || month > 12 || day < 1 || day > maxDay) {
         const kv: Record<string, string> = {
-          Error: 'Invalid date — month must be 1–12, day 1–31.',
+          Error:
+            'Invalid date — month must be 1–12 and day valid for the month.',
         };
         const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
           .setTemplate(KeyValueBoxTemplate)
           .setOptions(kv)
-          .setPriority(Priority)
+          .setPriority(this.priority)
           .build();
         return [box];
       }
@@ -133,7 +150,7 @@ export const JulianDayBoxSource = {
       const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
         .setTemplate(KeyValueBoxTemplate)
         .setOptions(kv)
-        .setPriority(Priority)
+        .setPriority(this.priority)
         .build();
       return [box];
     }

--- a/src/modules/boxSources/TwosComplementBoxSource.ts
+++ b/src/modules/boxSources/TwosComplementBoxSource.ts
@@ -1,0 +1,105 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// build a plaintext representation of key-value pairs for copy/TUI consumers
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// parse bit width from option value, defaulting to 8; clamp to [1, 256]
+function parseBits(raw: string | boolean | null): bigint {
+  if (raw === null || raw === true || raw === false) {
+    return 8n;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (Number.isNaN(n) || n < 1) return 8n;
+  if (n > 256) return 256n;
+  return BigInt(n);
+}
+
+export const TwosComplementBoxSource = {
+  name: "Two's Complement",
+  description:
+    "Show the two's-complement binary/hex of an integer at a bit width. ::twos=<bits> (default 8).",
+  defaultInput: '-42 ::twos=8',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'twos', 'twoscomplement')) return [];
+
+    const rawValue = trim(input);
+
+    // validate that input is an integer (optional leading minus, then digits only)
+    if (!/^-?\d+$/.test(rawValue)) {
+      const kv: Record<string, string> = {
+        Error: `"${rawValue}" is not a valid integer`,
+      };
+      return [
+        new BoxBuilder("Two's Complement", kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = BigInt(rawValue);
+    const bits = parseBits(
+      extractOptionKeys(options, 'twos', 'twoscomplement'),
+    );
+
+    // signed range for a two's-complement integer of `bits` bits
+    const minSigned = -(1n << (bits - 1n));
+    const maxSigned = (1n << (bits - 1n)) - 1n;
+
+    if (value < minSigned || value > maxSigned) {
+      const kv: Record<string, string> = {
+        Error: `${rawValue} does not fit in ${bits}-bit signed range [${minSigned}, ${maxSigned}]`,
+      };
+      return [
+        new BoxBuilder("Two's Complement", kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // two's-complement bit pattern: negative values wrap around 2^bits
+    const pattern = value < 0n ? value + (1n << bits) : value;
+
+    const binary = pattern.toString(2).padStart(Number(bits), '0');
+    const hexDigits = Math.ceil(Number(bits) / 4);
+    const hex = `0x${pattern.toString(16).padStart(hexDigits, '0')}`;
+    const unsigned = pattern.toString(10);
+
+    const kv: Record<string, string> = {
+      Value: rawValue,
+      Bits: bits.toString(),
+      Binary: binary,
+      Hex: hex,
+      Unsigned: unsigned,
+    };
+
+    return [
+      new BoxBuilder("Two's Complement", kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default TwosComplementBoxSource;

--- a/src/modules/boxSources/__test__/BitwiseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BitwiseBoxSource.test.ts
@@ -4,6 +4,17 @@ import { describe, expect, it } from 'vitest';
 import { BitwiseBoxSource } from '../BitwiseBoxSource';
 
 describe('BitwiseBoxSource', () => {
+  describe('negative radix literals', () => {
+    it('handles a negative hex operand (-0xff)', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('-0xff & -1', {
+        bitwise: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // -255 & -1 = -255
+      expect(opts['Result (dec)']).toBe('-255');
+    });
+  });
+
   describe('no option key → empty array', () => {
     it('returns [] when no option provided', async () => {
       const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', null);

--- a/src/modules/boxSources/__test__/BitwiseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BitwiseBoxSource.test.ts
@@ -1,0 +1,186 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { BitwiseBoxSource } from '../BitwiseBoxSource';
+
+describe('BitwiseBoxSource', () => {
+  describe('no option key → empty array', () => {
+    it('returns [] when no option provided', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option provided', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('explicit op form', () => {
+    it('AND: 12 & 10 = 8', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('8');
+    });
+
+    it('OR: 12 | 10 = 14', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 | 10', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('14');
+    });
+
+    it('XOR: 12 ^ 10 = 6', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 ^ 10', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('6');
+    });
+
+    it('left shift: 1 << 8 = 256', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('1 << 8', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('256');
+    });
+
+    it('right shift: 256 >> 2 = 64', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('256 >> 2', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('64');
+    });
+
+    it('hex operands: 0xff & 0x0f = 15', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('0xff & 0x0f', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('15');
+      expect(opts['Result (hex)']).toBe('0xf');
+    });
+
+    it('binary operands: 0b1100 ^ 0b1010 = 6', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('0b1100 ^ 0b1010', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('6');
+    });
+
+    it('64-bit: 0xffffffffffffffff ^ 0x0 = 18446744073709551615 (no 32-bit overflow)', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes(
+        '0xffffffffffffffff ^ 0x0',
+        { bitwise: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // verifies BigInt arithmetic — a 32-bit number would overflow to -1
+      expect(opts['Result (dec)']).toBe('18446744073709551615');
+      expect(opts['Result (hex)']).toBe('0xffffffffffffffff');
+    });
+
+    it('shift too large returns error box mentioning cap', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('1 << 99999', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/4096/);
+    });
+
+    it('accepts ::bitop trigger key', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', {
+        bitop: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('8');
+    });
+
+    it('expression field reflects input tokens', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', {
+        bitwise: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Expression).toContain('12');
+      expect(opts.Expression).toContain('&');
+      expect(opts.Expression).toContain('10');
+    });
+  });
+
+  describe('two-operand form', () => {
+    it('12 10 → AND=8, OR=14, XOR=6', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 10', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.AND).toContain('8');
+      expect(opts.OR).toContain('14');
+      expect(opts.XOR).toContain('6');
+    });
+
+    it('comma-separated: 12,10 → AND contains 8', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12,10', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.AND).toContain('8');
+    });
+
+    it('includes A and B keys', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 10', {
+        bitwise: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.A).toContain('12');
+      expect(opts.B).toContain('10');
+    });
+
+    it('includes shifts when b is in range', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('1 8', {
+        bitwise: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 << 8 = 256
+      expect(opts['A<<B']).toContain('256');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('non-numeric operands return an error box', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('a & b', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('priority is set', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', {
+        bitwise: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ByteSwapBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ByteSwapBoxSource.test.ts
@@ -1,0 +1,144 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ByteSwapBoxSource } from '../ByteSwapBoxSource';
+
+describe('ByteSwapBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(ByteSwapBoxSource.name).toBe('Byte Swap');
+      expect(ByteSwapBoxSource.tag).toBe('#');
+      expect(ByteSwapBoxSource.kind).toBe('Convert');
+      expect(typeof ByteSwapBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - trigger guard', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::byteswap trigger', () => {
+    it('swaps 0x12345678 to 0x78563412', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', {
+        byteswap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('0x12345678');
+      expect(opts.Swapped).toBe('0x78563412');
+      expect(opts.Bytes).toBe('4');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', {
+        byteswap: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority from ByteSwapBoxSource.priority', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', {
+        byteswap: true,
+      });
+      expect(boxes[0].props.priority).toBe(ByteSwapBoxSource.priority);
+    });
+  });
+
+  describe('generateBoxes - ::endian alias', () => {
+    it('works with ::endian option', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', {
+        endian: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Swapped).toBe('0x78563412');
+    });
+  });
+
+  describe('generateBoxes - input without 0x prefix', () => {
+    it('accepts hex without 0x prefix and normalizes output', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('deadbeef', {
+        byteswap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('0xdeadbeef');
+      expect(opts.Swapped).toBe('0xefbeadde');
+    });
+  });
+
+  describe('generateBoxes - 2-byte big-endian / little-endian', () => {
+    it('0x00ff → Swapped 0xff00, As BE 255, As LE 65280', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x00ff', {
+        byteswap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('0x00ff');
+      expect(opts.Swapped).toBe('0xff00');
+      expect(opts.Bytes).toBe('2');
+      expect(opts['As BE']).toBe('255');
+      expect(opts['As LE']).toBe('65280');
+    });
+  });
+
+  describe('generateBoxes - 8-byte round-trip', () => {
+    it('swapping twice returns the original value', async () => {
+      const original = '0x0102030405060708';
+      const firstPass = await ByteSwapBoxSource.generateBoxes(original, {
+        byteswap: true,
+      });
+      const swappedHex = (firstPass[0].props.options as Record<string, string>)
+        .Swapped;
+
+      const secondPass = await ByteSwapBoxSource.generateBoxes(swappedHex, {
+        byteswap: true,
+      });
+      const roundTripped = (
+        secondPass[0].props.options as Record<string, string>
+      ).Swapped;
+
+      // strip leading 0x before comparing to original lowercase hex
+      expect(roundTripped).toBe('0x0102030405060708');
+    });
+  });
+
+  describe('generateBoxes - error cases', () => {
+    it('odd-length hex returns an error box mentioning even number of digits', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0xabc', {
+        byteswap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/even number of digits/i);
+    });
+
+    it('invalid characters return an error box mentioning hex', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('xyz', {
+        byteswap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/hex/i);
+    });
+  });
+
+  describe('generateBoxes - plaintextOutput', () => {
+    it('plaintext output contains key: value pairs', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x1234', {
+        byteswap: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Input: 0x1234');
+      expect(text).toContain('Swapped: 0x3412');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CookingConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CookingConvertBoxSource.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+
+import { CookingConvertBoxSource } from '../CookingConvertBoxSource';
+
+describe('CookingConvertBoxSource', () => {
+  describe('no option', () => {
+    it('returns empty array when no cooking/volume option is provided', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('1 cup with ::cooking', () => {
+    it('returns one box', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('box name is Cooking Convert', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      expect(boxes[0].props.name).toBe('Cooking Convert');
+    });
+
+    it('ml starts with 236.58823', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      const ml = boxes[0].props.options?.ml as string;
+      expect(ml).toMatch(/^236\.58823/);
+    });
+
+    it('tbsp is exactly 16 (1 cup = 16 tbsp)', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      expect(boxes[0].props.options?.tbsp).toBe('16');
+    });
+
+    it('tsp is exactly 48 (1 cup = 48 tsp)', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      expect(boxes[0].props.options?.tsp).toBe('48');
+    });
+
+    it('fl oz is exactly 8', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      expect(boxes[0].props.options?.['fl oz']).toBe('8');
+    });
+  });
+
+  describe('3 tsp', () => {
+    it('tbsp is exactly 1 (3 tsp = 1 tbsp)', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('3 tsp', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.tbsp).toBe('1');
+    });
+  });
+
+  describe('1 tbsp', () => {
+    it('tsp is exactly 3 (1 tbsp = 3 tsp)', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 tbsp', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.tsp).toBe('3');
+    });
+  });
+
+  describe('1 gallon', () => {
+    it('quart is exactly 4', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 gallon', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.quart).toBe('4');
+    });
+
+    it('pint is exactly 8', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 gallon', {
+        cooking: true,
+      });
+      expect(boxes[0].props.options?.pint).toBe('8');
+    });
+
+    it('cup is exactly 16', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 gallon', {
+        cooking: true,
+      });
+      expect(boxes[0].props.options?.cup).toBe('16');
+    });
+  });
+
+  describe('1000 ml', () => {
+    it('L is exactly 1', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1000 ml', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.L).toBe('1');
+    });
+  });
+
+  describe('fl oz with space: 8 fl oz', () => {
+    it('cup is exactly 1 (8 fl oz = 1 cup)', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('8 fl oz', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.cup).toBe('1');
+    });
+  });
+
+  describe('::volume trigger', () => {
+    it('also triggers on ::volume option', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        volume: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.tbsp).toBe('16');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns box mentioning supported units for non-numeric input "abc"', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('abc', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/supported units/i);
+    });
+
+    it('returns box mentioning supported units for unknown unit "5 stones"', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('5 stones', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/supported units/i);
+    });
+
+    it('returns error box for input exceeding 64 characters', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes(
+        '1 cup with a very long trailing string that exceeds the limit here',
+        { cooking: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(CookingConvertBoxSource.name).toBe('Cooking Convert');
+      expect(CookingConvertBoxSource.tag).toBe('#');
+      expect(CookingConvertBoxSource.kind).toBe('Convert');
+      expect(CookingConvertBoxSource.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/DayOfWeekBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DayOfWeekBoxSource.test.ts
@@ -1,0 +1,184 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DayOfWeekBoxSource } from '../DayOfWeekBoxSource';
+
+describe('DayOfWeekBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no options provided', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option provided', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with valid option', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — ::dayofweek trigger', () => {
+    it('2025-12-25 is Thursday', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Day of Week');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.options).toMatchObject({
+        Weekday: 'Thursday',
+        'Leap Year': 'false',
+      });
+    });
+
+    it('2000-01-01 is Saturday', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2000-01-01', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Weekday: 'Saturday' });
+    });
+
+    it('2024-02-29 is Thursday, leap year, day 60', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2024-02-29', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Weekday).toBe('Thursday');
+      expect(opts['Leap Year']).toBe('true');
+      expect(opts['Day of Year']).toBe('60');
+    });
+  });
+
+  describe('generateBoxes — ::weekday trigger', () => {
+    it('accepts ::weekday option', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25', {
+        weekday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Weekday: 'Thursday' });
+    });
+  });
+
+  describe('day of year', () => {
+    it('2025-01-01 → Day of Year 1', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-01-01', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Day of Year': '1' });
+    });
+
+    it('2025-12-31 → Day of Year 365 (non-leap)', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-31', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Day of Year': '365' });
+    });
+
+    it('2024-12-31 → Day of Year 366 (leap)', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2024-12-31', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Day of Year': '366' });
+    });
+  });
+
+  describe('ISO week number', () => {
+    it('2021-01-01 → ISO Week 2020-W53', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2021-01-01', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'ISO Week': '2020-W53' });
+    });
+
+    it('2025-12-29 → ISO Week 2026-W01 (rolls into next year)', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-29', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'ISO Week': '2026-W01' });
+    });
+
+    it('2020-12-28 → ISO Week 2020-W53', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2020-12-28', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'ISO Week': '2020-W53' });
+    });
+  });
+
+  describe('invalid input', () => {
+    it('non-date string returns error box', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('hello', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Invalid Date']).toBeDefined();
+      expect(opts['Invalid Date'].length).toBeGreaterThan(0);
+    });
+
+    it('invalid month 2025-13-01 returns error box', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-13-01', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Invalid Date']).toMatch(/month/i);
+    });
+
+    it('invalid day 2025-02-30 returns error box', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-02-30', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Invalid Date']).toMatch(/day/i);
+    });
+
+    it('2023-02-29 (non-leap) returns error box', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2023-02-29', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Invalid Date']).toBeDefined();
+    });
+  });
+
+  describe('output structure', () => {
+    it('box has all required keys in options', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25', {
+        dayofweek: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(Object.keys(opts)).toEqual(
+        expect.arrayContaining([
+          'Date',
+          'Weekday',
+          'Day of Year',
+          'ISO Week',
+          'Leap Year',
+        ]),
+      );
+    });
+
+    it('plaintextOutput contains key: value pairs', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25', {
+        dayofweek: true,
+      });
+      const plaintext = boxes[0].props.plaintextOutput;
+      expect(plaintext).toContain('Weekday: Thursday');
+      expect(plaintext).toContain('Date: 2025-12-25');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/EasterBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/EasterBoxSource.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import { EasterBoxSource } from '../EasterBoxSource';
+
+describe('EasterBoxSource', () => {
+  describe('generateBoxes — gate', () => {
+    it('returns [] when ::easter option is absent', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no easter key', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', { hash: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — easter dates', () => {
+    it('2025 → Easter Sunday 2025-04-20', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '2025-04-20',
+      });
+    });
+
+    it('2024 → Easter Sunday 2024-03-31', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2024', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '2024-03-31',
+      });
+    });
+
+    it('2000 → Easter Sunday 2000-04-23', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2000', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '2000-04-23',
+      });
+    });
+
+    it('1818 → Easter Sunday 1818-03-22 (earliest possible date)', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('1818', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '1818-03-22',
+      });
+    });
+  });
+
+  describe('generateBoxes — option value takes precedence', () => {
+    it('::easter=2025 uses the option value, not input', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('ignored', {
+        easter: '2025',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '2025-04-20',
+      });
+    });
+
+    it('non-numeric option value falls back to input', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2024', {
+        easter: 'notanumber',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '2024-03-31',
+      });
+    });
+  });
+
+  describe('generateBoxes — related dates for 2025', () => {
+    it('Good Friday 2025 → 2025-04-18 (Easter - 2 days)', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Good Friday': '2025-04-18',
+      });
+    });
+
+    it('Ash Wednesday 2025 → 2025-03-05 (Easter - 46 days)', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Ash Wednesday': '2025-03-05',
+      });
+    });
+
+    it('Month is "April" for 2025', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Month: 'April' });
+    });
+
+    it('Month is "March" for 2024', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2024', {
+        easter: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Month: 'March' });
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('box name is "Easter"', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes[0].props.name).toBe('Easter');
+    });
+
+    it('priority matches EasterBoxSource.priority', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes[0].props.priority).toBe(EasterBoxSource.priority);
+    });
+
+    it('plaintext output contains key: value pairs', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Easter Sunday: 2025-04-20');
+      expect(text).toContain('Good Friday: 2025-04-18');
+    });
+  });
+
+  describe('generateBoxes — out-of-range and invalid input', () => {
+    it('year 1500 (below 1583) → single box with error mentioning year range', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('1500', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const text =
+        boxes[0].props.plaintextOutput + JSON.stringify(boxes[0].props.options);
+      expect(text).toMatch(/1583/);
+      expect(text).toMatch(/9999/);
+    });
+
+    it('non-numeric input "abc" → single box with error', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('abc', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // must produce an error box, not an empty array
+      expect(boxes[0].props.name).toBe('Easter');
+    });
+
+    it('empty input → single box with error', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('', { easter: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Easter');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/FuelEconomyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FuelEconomyBoxSource.test.ts
@@ -1,0 +1,167 @@
+import type { BoxOptions } from '@modules/Box';
+import { describe, expect, it } from 'vitest';
+import { FuelEconomyBoxSource } from '../FuelEconomyBoxSource';
+
+// convenience wrapper — trigger via ::fuel option
+const gen = (input: string, opts: BoxOptions = { fuel: true }) =>
+  FuelEconomyBoxSource.generateBoxes(input, opts);
+
+describe('FuelEconomyBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no matching option is present', async () => {
+      expect(await gen('30 mpg', {})).toHaveLength(0);
+      expect(await gen('30 mpg', null)).toHaveLength(0);
+      expect(await gen('30 mpg', { unrelated: true })).toHaveLength(0);
+    });
+
+    it('triggers on ::fuel', async () => {
+      expect(await gen('30 mpg', { fuel: true })).toHaveLength(1);
+    });
+
+    it('triggers on ::mpg', async () => {
+      expect(await gen('30 mpg', { mpg: true })).toHaveLength(1);
+    });
+  });
+
+  describe('30 mpg (US) via ::fuel', () => {
+    it('produces one box', async () => {
+      const boxes = await gen('30 mpg');
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('box template is KeyValueBoxTemplate', async () => {
+      const { KeyValueBoxTemplate } = await import('@components/BoxTemplate');
+      const boxes = await gen('30 mpg');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is "Fuel Economy"', async () => {
+      const boxes = await gen('30 mpg');
+      expect(boxes[0].props.name).toBe('Fuel Economy');
+    });
+
+    it('L/100km ≈ 7.840486 (235.214583 / 30)', async () => {
+      const boxes = await gen('30 mpg');
+      const opts = boxes[0].props.options as Record<string, string>;
+      // well-known constant: 235.214583 / 30 ≈ 7.840486
+      expect(opts['L/100km']).toMatch(/^7\.84/);
+    });
+
+    it('Input field reflects original input', async () => {
+      const boxes = await gen('30 mpg');
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('30 mpg');
+    });
+
+    it('MPG (US) round-trips back to ~30', async () => {
+      const boxes = await gen('30 mpg');
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(opts['MPG (US)'])).toBeCloseTo(30, 3);
+    });
+  });
+
+  describe('round-trip: L/100km → MPG (US)', () => {
+    it('7.840486 l/100km → MPG (US) ≈ 30', async () => {
+      const boxes = await gen('7.840486 l/100km');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(opts['MPG (US)'])).toBeCloseTo(30, 2);
+    });
+  });
+
+  describe('km/L input', () => {
+    it('10 km/l → L/100km = 10', async () => {
+      const boxes = await gen('10 km/l');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 100 / 10 = 10 exactly
+      expect(opts['L/100km']).toBe('10');
+    });
+
+    it('10 kml alias also works', async () => {
+      const boxes = await gen('10 kml');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['L/100km']).toBe('10');
+    });
+  });
+
+  describe('imperial MPG', () => {
+    it('50 mpguk → L/100km starts with 5.64 (282.480936/50)', async () => {
+      const boxes = await gen('50 mpguk');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 282.480936 / 50 = 5.649619
+      expect(opts['L/100km']).toMatch(/^5\.64/);
+    });
+
+    it('mpg-uk alias works', async () => {
+      const boxes = await gen('50 mpg-uk');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['L/100km']).toMatch(/^5\.64/);
+    });
+
+    it('mpgimp alias works', async () => {
+      const boxes = await gen('50 mpgimp');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['L/100km']).toMatch(/^5\.64/);
+    });
+  });
+
+  describe('error cases — return a box (not [])', () => {
+    it('value 0 → error box', async () => {
+      const boxes = await gen('0 mpg');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('negative value → error box', async () => {
+      const boxes = await gen('-5 mpg');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('non-numeric value "abc" → error box', async () => {
+      const boxes = await gen('abc mpg');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('unknown unit "5 foo" → error box', async () => {
+      const boxes = await gen('5 foo');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('bare word with no unit → error box', async () => {
+      const boxes = await gen('abc');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+  });
+
+  describe('unit aliases', () => {
+    it('mpg-us alias resolves same as mpg', async () => {
+      const a = await gen('30 mpg');
+      const b = await gen('30 mpg-us');
+      const optsA = a[0].props.options as Record<string, string>;
+      const optsB = b[0].props.options as Record<string, string>;
+      expect(optsA['L/100km']).toBe(optsB['L/100km']);
+    });
+
+    it('l100km alias resolves same as l/100km', async () => {
+      const a = await gen('7.840486 l/100km');
+      const b = await gen('7.840486 l100km');
+      const optsA = a[0].props.options as Record<string, string>;
+      const optsB = b[0].props.options as Record<string, string>;
+      expect(optsA['MPG (US)']).toBe(optsB['MPG (US)']);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JulianDayBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JulianDayBoxSource.test.ts
@@ -1,0 +1,187 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { JulianDayBoxSource } from '../JulianDayBoxSource';
+
+describe('JulianDayBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for an unrelated option', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — date → JDN (::julianday)', () => {
+    it('converts 2000-01-01 to JDN 2451545 (J2000 epoch)', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Julian Day Number': '2451545',
+      });
+    });
+
+    it('converts 1970-01-01 to JDN 2440588 (Unix epoch)', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('1970-01-01', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Julian Day Number': '2440588',
+      });
+    });
+
+    it('converts -4713-11-24 to JDN 0 (epoch of the JDN calendar)', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('-4713-11-24', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Julian Day Number': '0',
+      });
+    });
+
+    it('reports Saturday for 2000-01-01', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        julianday: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Day of Week': 'Saturday',
+      });
+    });
+
+    it('includes the input date in the output', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        julianday: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Date: '2000-01-01' });
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        julianday: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets correct priority', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        julianday: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes — date → JDN (::jdn alias)', () => {
+    it('accepts ::jdn option', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        jdn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Julian Day Number': '2451545',
+      });
+    });
+  });
+
+  describe('generateBoxes — JDN → date (reverse)', () => {
+    it('converts JDN 2451545 back to 2000-01-01', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2451545', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Date: '2000-01-01' });
+    });
+
+    it('converts JDN 2440588 back to 1970-01-01', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2440588', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Date: '1970-01-01' });
+    });
+
+    it('JDN 2451545 round-trip preserves JDN in output', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2451545', {
+        julianday: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Julian Day Number': '2451545',
+      });
+    });
+
+    it('JDN 0 round-trip returns -4713-11-24', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('0', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Date: '-4713-11-24' });
+    });
+
+    it('JDN 2451545 day of week is Saturday', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2451545', {
+        julianday: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Day of Week': 'Saturday',
+      });
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns a box with an error for unrecognised text "hello"', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('hello', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // the error box should mention the expected format
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Date format'] ?? opts.Error).toBeTruthy();
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input longer than 40 chars', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes(
+        '2000-01-01-extra-padding-that-is-way-too-long',
+        { julianday: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns an error box for out-of-range month', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-13-01', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeTruthy();
+    });
+  });
+
+  describe('source metadata', () => {
+    it('has the correct name', () => {
+      expect(JulianDayBoxSource.name).toBe('Julian Day');
+    });
+
+    it('has a non-empty description', () => {
+      expect(JulianDayBoxSource.description.length).toBeGreaterThan(0);
+    });
+
+    it('has defaultInput containing ::julianday', () => {
+      expect(JulianDayBoxSource.defaultInput).toContain('::julianday');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JulianDayBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JulianDayBoxSource.test.ts
@@ -183,5 +183,13 @@ describe('JulianDayBoxSource', () => {
     it('has defaultInput containing ::julianday', () => {
       expect(JulianDayBoxSource.defaultInput).toContain('::julianday');
     });
+
+    it('rejects an overflow day-of-month (2025-02-31)', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2025-02-31', {
+        julianday: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/invalid date/i);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/TwosComplementBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TwosComplementBoxSource.test.ts
@@ -1,0 +1,175 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { TwosComplementBoxSource } from '../TwosComplementBoxSource';
+
+describe('TwosComplementBoxSource', () => {
+  describe('no option → empty array', () => {
+    it('returns [] when no twos option is present', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for unrelated option', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe("-42 in 8-bit two's complement", () => {
+    it('produces correct Binary, Hex, and Unsigned for -42 at 8 bits', async () => {
+      // -42 + 256 = 214 = 0xD6 = 11010110
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Binary: '11010110',
+        Hex: '0xd6',
+        Unsigned: '214',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+
+  describe('positive 42 in 8-bit', () => {
+    it('produces correct Binary, Hex, and Unsigned for 42 at 8 bits', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('42', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Binary: '00101010',
+        Hex: '0x2a',
+        Unsigned: '42',
+      });
+    });
+  });
+
+  describe('-1 in 8-bit', () => {
+    it('produces all-ones pattern for -1 at 8 bits', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-1', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Binary: '11111111',
+        Hex: '0xff',
+        Unsigned: '255',
+      });
+    });
+  });
+
+  describe('-1 in 16-bit', () => {
+    it('produces all-ones 16-bit pattern for -1', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-1', {
+        twos: '16',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Binary: '1111111111111111',
+        Unsigned: '65535',
+      });
+    });
+  });
+
+  describe('boundary: -128 and 128 at 8 bits', () => {
+    it('-128 is the minimum signed 8-bit value and has Unsigned 128', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-128', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Unsigned: '128',
+        Binary: '10000000',
+        Hex: '0x80',
+      });
+    });
+
+    it('128 is out of range for 8-bit signed and returns an error box', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('128', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      // the error box should not have Binary/Hex/Unsigned fields
+      expect(boxes[0].props.options).toHaveProperty('Error');
+      expect(boxes[0].props.options).not.toHaveProperty('Binary');
+    });
+  });
+
+  describe('default bits when no value specified for ::twos', () => {
+    it('defaults to 8 bits when option value is boolean true', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {
+        twos: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // 8-bit two's complement of -42
+      expect(boxes[0].props.options).toMatchObject({
+        Bits: '8',
+        Unsigned: '214',
+      });
+    });
+  });
+
+  describe('::twoscomplement alias', () => {
+    it('triggers on ::twoscomplement option key', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {
+        twoscomplement: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Binary: '11010110',
+        Hex: '0xd6',
+        Unsigned: '214',
+      });
+    });
+  });
+
+  describe('-1 in 64-bit (BigInt precision)', () => {
+    it('produces exact unsigned 2^64-1 for -1 at 64 bits', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-1', {
+        twos: '64',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Unsigned: '18446744073709551615',
+        Binary: '1'.repeat(64),
+      });
+    });
+  });
+
+  describe('invalid non-integer input', () => {
+    it('returns a single error box for alphabetic input', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('abc', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toHaveProperty('Error');
+      expect(boxes[0].props.options).not.toHaveProperty('Binary');
+    });
+
+    it('returns a single error box for float input', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('3.14', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toHaveProperty('Error');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(TwosComplementBoxSource.name).toBe("Two's Complement");
+      expect(TwosComplementBoxSource.tag).toBe('#');
+      expect(TwosComplementBoxSource.kind).toBe('Convert');
+      expect(typeof TwosComplementBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -2,13 +2,20 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import BitwiseBoxSource from './BitwiseBoxSource';
+import ByteSwapBoxSource from './ByteSwapBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CookingConvertBoxSource from './CookingConvertBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DayOfWeekBoxSource from './DayOfWeekBoxSource';
+import EasterBoxSource from './EasterBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FuelEconomyBoxSource from './FuelEconomyBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import JulianDayBoxSource from './JulianDayBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
@@ -20,6 +27,7 @@ import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import TwosComplementBoxSource from './TwosComplementBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
@@ -29,13 +37,20 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  BitwiseBoxSource,
+  ByteSwapBoxSource,
+  CookingConvertBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  DayOfWeekBoxSource,
+  EasterBoxSource,
+  FuelEconomyBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  JulianDayBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
@@ -46,6 +61,7 @@ export const boxSources = [
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
+  TwosComplementBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
   TimestampBoxSource,


### PR DESCRIPTION
## Summary

Twenty-eighth exploration batch — **8 more BoxSource tools** (calendar, bit-manipulation, converters).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Julian Day | `::julianday` | Gregorian date ⇄ Julian Day Number |
| Day of Week | `::dayofweek` | weekday (Zeller) + day-of-year + ISO week |
| Easter | `::easter` | Easter Sunday (Gregorian computus) |
| Bitwise | `::bitwise` | AND/OR/XOR/shifts (dec/0x/0b, BigInt) |
| Two's Complement | `::twos=<bits>` | signed binary/hex at a bit width |
| Byte Swap | `::byteswap` | endianness swap of a hex value |
| Cooking Convert | `::cooking` | US volume units |
| Fuel Economy | `::fuel` | MPG (US/imp) ⇄ L/100km ⇄ km/L |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Hardening rules pre-loaded (pure Zeller/computus — no `Date.now()`/`new Date()`; `BigInt(str)` for bitwise/two's-complement, shift-amount cap; `kvToPlaintext` helper for all KeyValue sources; integer-exact + 6-decimal formatting for cooking/fuel).
- **Verified vectors**: `2000-01-01`→JDN `2451545`, `1970-01-01`→`2440588`; `2025-12-25`→Thursday, `2024-02-29` leap day-of-year `60`, `2021-01-01`→ISO `2020-W53`; **Easter 2025→Apr 20, 2024→Mar 31, 2000→Apr 23**; `12&10=8`, `1<<8=256`, 64-bit XOR exact; **`-42`/8-bit→`0xd6`/`214`, `-1`/64-bit→`18446744073709551615`**; `0x12345678`→`0x78563412`; **1 cup=16 tbsp=48 tsp, 1 gal=4 qt**; 30 mpg(US)→`7.84` L/100km.

## Verification

- ✅ `bun run test run` — **478 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of #260–#286 — branched from `main`.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6