### PR TITLE
feat(boxSources): add 8 more tools (hmac, hsv, ascii-code, char-freq, duration, popcount, ascii85, chinese-numerals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>HmacBox</b> </summary>
+
+| match rule      | description                          | example                  |
+| --------------- | ------------------------------------ | ------------------------ |
+| `::hmac=<key>`  | HMAC-SHA256/SHA1/SHA512 (key not echoed) | `message ::hmac=secret` |
+
+</details>
+
+<details>
+<summary> <b>HsvBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::hsv`     | color hex/RGB ⇄ HSV (HSB)            | `#ff6347 ::hsv`  |
+
+</details>
+
+<details>
+<summary> <b>AsciiCodeBox</b> </summary>
+
+| match rule  | description                          | example       |
+| ----------- | ------------------------------------ | ------------- |
+| `::ascii`   | character ⇄ code point (dec/hex/oct/bin) | `A ::ascii` |
+
+</details>
+
+<details>
+<summary> <b>CharFrequencyBox</b> </summary>
+
+| match rule     | description                          | example                |
+| -------------- | ------------------------------------ | ---------------------- |
+| `::charfreq`   | count character frequency            | `hello world ::charfreq` |
+
+</details>
+
+<details>
+<summary> <b>DurationBox</b> </summary>
+
+| match rule    | description                          | example            |
+| ------------- | ------------------------------------ | ------------------ |
+| `::duration`  | seconds ⇄ human duration (1h 1m 1s)  | `3661 ::duration`  |
+
+</details>
+
+<details>
+<summary> <b>PopcountBox</b> </summary>
+
+| match rule    | description                          | example            |
+| ------------- | ------------------------------------ | ------------------ |
+| `::popcount`  | set bits + bit length (dec/0x/0b)    | `255 ::popcount`   |
+
+</details>
+
+<details>
+<summary> <b>Ascii85Box</b> </summary>
+
+| match rule    | description                          | example            |
+| ------------- | ------------------------------------ | ------------------ |
+| `::ascii85`   | Ascii85 (base85) encode/decode       | `hello ::ascii85`  |
+
+</details>
+
+<details>
+<summary> <b>ChineseNumeralsBox</b> </summary>
+
+| match rule       | description                          | example              |
+| ---------------- | ------------------------------------ | -------------------- |
+| `::chinesenum`   | integer ⇄ Chinese numerals (everyday + financial) | `1234 ::chinesenum` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/functions/__test__/shareLink.test.ts
+++ b/src/functions/__test__/shareLink.test.ts
@@ -65,4 +65,25 @@ describe('buildShareLink', () => {
     const url = new URL(result);
     expect(url.origin).toBe(window.location.origin);
   });
+
+  it('redacts the ::hmac key value so it never leaks into the URL', () => {
+    const result = buildShareLink({
+      input: 'message ::hmac=mysecretkey',
+      pathname: '/',
+      origin: 'http://localhost:3000',
+    });
+    const shared = new URL(result).searchParams.get('input') ?? '';
+    expect(shared).not.toContain('mysecretkey');
+    expect(shared).toContain('::hmac=<redacted>');
+  });
+
+  it('redacts the ::jwtsign secret value', () => {
+    const result = buildShareLink({
+      input: 'payload ::jwtsign=topsecret',
+      pathname: '/',
+      origin: 'http://localhost:3000',
+    });
+    const shared = new URL(result).searchParams.get('input') ?? '';
+    expect(shared).not.toContain('topsecret');
+  });
 });

--- a/src/functions/shareLink.ts
+++ b/src/functions/shareLink.ts
@@ -16,6 +16,21 @@ const setParamIfPresent = (
   }
 };
 
+// option keys whose values are secrets and must never appear in a shareable
+// URL (which lands in browser history and server logs). the value is replaced
+// with a placeholder while the option itself is preserved so the link still
+// demonstrates the tool.
+const SECRET_OPTION_PATTERNS: RegExp[] = [
+  /(::hmac(?:sha256)?=)\S+/gi,
+  /(::jwtsign=)\S+/gi,
+];
+
+const redactSecrets = (input: string): string =>
+  SECRET_OPTION_PATTERNS.reduce(
+    (acc, pattern) => acc.replace(pattern, '$1<redacted>'),
+    input,
+  );
+
 export const buildShareLink = ({
   box,
   input,
@@ -24,6 +39,10 @@ export const buildShareLink = ({
 }: ShareLinkParams & { origin?: string }): string => {
   const url = new URL(pathname, origin);
   setParamIfPresent(url.searchParams, 'box', box);
-  setParamIfPresent(url.searchParams, 'input', input);
+  setParamIfPresent(
+    url.searchParams,
+    'input',
+    input ? redactSecrets(input) : input,
+  );
   return url.toString();
 };

--- a/src/modules/boxSources/Ascii85BoxSource.ts
+++ b/src/modules/boxSources/Ascii85BoxSource.ts
@@ -1,0 +1,178 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// encodes raw bytes to Ascii85 (Adobe variant without <~ ~> framing)
+function encodeAscii85(bytes: Uint8Array): string {
+  const out: string[] = [];
+
+  for (let i = 0; i < bytes.length; i += 4) {
+    const remaining = bytes.length - i;
+    const chunkLen = Math.min(4, remaining);
+
+    // pack up to 4 bytes into a uint32 (big-endian), padding with 0
+    let val =
+      (((bytes[i] ?? 0) << 24) |
+        ((bytes[i + 1] ?? 0) << 16) |
+        ((bytes[i + 2] ?? 0) << 8) |
+        (bytes[i + 3] ?? 0)) >>>
+      0;
+
+    // special case: 4 zero bytes → single 'z'
+    if (chunkLen === 4 && val === 0) {
+      out.push('z');
+      continue;
+    }
+
+    // encode into 5 base-85 digits
+    const digits: number[] = new Array(5);
+    for (let d = 4; d >= 0; d--) {
+      digits[d] = val % 85;
+      val = Math.floor(val / 85);
+    }
+
+    // for a partial chunk of n bytes, output n+1 chars
+    const outLen = chunkLen + 1;
+    for (let d = 0; d < outLen; d++) {
+      out.push(String.fromCharCode(digits[d] + 33));
+    }
+  }
+
+  return out.join('');
+}
+
+// decodes Ascii85 string (Adobe variant without <~ ~> framing) to raw bytes
+function decodeAscii85(encoded: string): Uint8Array | Error {
+  // strip all whitespace characters
+  const stripped = encoded.replace(/\s/g, '');
+
+  const out: number[] = [];
+  let i = 0;
+
+  while (i < stripped.length) {
+    const ch = stripped[i];
+
+    // 'z' expands to 4 zero bytes
+    if (ch === 'z') {
+      out.push(0, 0, 0, 0);
+      i++;
+      continue;
+    }
+
+    // collect up to 5 chars for a group
+    const groupChars: number[] = [];
+    for (let g = 0; g < 5 && i + g < stripped.length; g++) {
+      const c = stripped.charCodeAt(i + g);
+      // valid range is '!' (33) to 'u' (117), but 'z' (122) handled above
+      if (c < 33 || c > 117) {
+        return new Error(`invalid Ascii85 character: '${stripped[i + g]}'`);
+      }
+      groupChars.push(c - 33);
+    }
+
+    const groupLen = groupChars.length;
+    i += groupLen;
+
+    if (groupLen === 1) {
+      // a single trailing char is not a valid Ascii85 group
+      return new Error('invalid Ascii85: trailing single character');
+    }
+
+    // pad the group to 5 with 84 ('u') and decode
+    while (groupChars.length < 5) {
+      groupChars.push(84);
+    }
+
+    let val =
+      (groupChars[0] * 85 ** 4 +
+        groupChars[1] * 85 ** 3 +
+        groupChars[2] * 85 ** 2 +
+        groupChars[3] * 85 +
+        groupChars[4]) >>>
+      0;
+
+    // for n input chars, emit n-1 bytes
+    const byteCount = groupLen - 1;
+    const bytes: number[] = new Array(4);
+    for (let b = 3; b >= 0; b--) {
+      bytes[b] = val & 0xff;
+      val = (val >>> 8) >>> 0;
+    }
+    for (let b = 0; b < byteCount; b++) {
+      out.push(bytes[b]);
+    }
+  }
+
+  return new Uint8Array(out);
+}
+
+export const Ascii85BoxSource = {
+  name: 'Ascii85',
+  description:
+    'Ascii85 (base85) encode/decode. ::ascii85 to encode, ::ascii85decode to decode.',
+  defaultInput: 'hello ::ascii85',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'ascii85', 'base85', 'a85');
+    const wantDecode = hasOptionKeys(options, 'ascii85decode', 'a85decode');
+
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const bytes = new TextEncoder().encode(input);
+      const encoded = encodeAscii85(bytes);
+      boxes.push(
+        new BoxBuilder('Ascii85 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const result = decodeAscii85(input);
+
+      if (result instanceof Error) {
+        boxes.push(
+          new BoxBuilder('Ascii85 (Decode)', `Error: ${result.message}`)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        const decoded = new TextDecoder().decode(result);
+        boxes.push(
+          new BoxBuilder('Ascii85 (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Ascii85BoxSource;

--- a/src/modules/boxSources/AsciiTableBoxSource.ts
+++ b/src/modules/boxSources/AsciiTableBoxSource.ts
@@ -1,0 +1,154 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// c0 control character names (0-31 and 127)
+const C0_NAMES: Record<number, string> = {
+  0: 'NUL',
+  1: 'SOH',
+  2: 'STX',
+  3: 'ETX',
+  4: 'EOT',
+  5: 'ENQ',
+  6: 'ACK',
+  7: 'BEL',
+  8: 'BS',
+  9: 'HT',
+  10: 'LF',
+  11: 'VT',
+  12: 'FF',
+  13: 'CR',
+  14: 'SO',
+  15: 'SI',
+  16: 'DLE',
+  17: 'DC1',
+  18: 'DC2',
+  19: 'DC3',
+  20: 'DC4',
+  21: 'NAK',
+  22: 'SYN',
+  23: 'ETB',
+  24: 'CAN',
+  25: 'EM',
+  26: 'SUB',
+  27: 'ESC',
+  28: 'FS',
+  29: 'GS',
+  30: 'RS',
+  31: 'US',
+  127: 'DEL',
+};
+
+// build a single key:value plaintext string for copy
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// resolve the display label for a code point's glyph
+function glyphLabel(cp: number): string {
+  const name = C0_NAMES[cp];
+  if (name != null) return `(${name})`;
+  return String.fromCodePoint(cp);
+}
+
+// try to parse the trimmed input as a code point number; returns -1 on failure
+function parseCodePoint(s: string): number {
+  if (/^\d+$/.test(s)) return Number.parseInt(s, 10);
+  // strip the radix prefix: parseInt('0b101', 2) reads only the leading 0 then
+  // stops at 'b', so the 0b/0o/0x prefix must be removed before parsing
+  if (/^0x[0-9a-f]+$/i.test(s)) return Number.parseInt(s.slice(2), 16);
+  if (/^0b[01]+$/i.test(s)) return Number.parseInt(s.slice(2), 2);
+  if (/^0o[0-7]+$/i.test(s)) return Number.parseInt(s.slice(2), 8);
+  return -1;
+}
+
+// build the result box for a valid code point
+function buildCodePointBox(cp: number, priority: number): Box {
+  const kv: Record<string, string> = {
+    Character: glyphLabel(cp),
+    Decimal: String(cp),
+    Hex: `0x${cp.toString(16).toUpperCase()}`,
+    Octal: `0o${cp.toString(8)}`,
+    Binary: `0b${cp.toString(2)}`,
+    'HTML Entity': `&#${cp};`,
+  };
+  return new BoxBuilder('ASCII Code', kvToPlaintext(kv))
+    .setOptions(kv)
+    .setTemplate(KeyValueBoxTemplate)
+    .setPriority(priority)
+    .build();
+}
+
+// build an informational box when the input is not a valid lookup
+function buildInfoBox(message: string, priority: number): Box {
+  const kv: Record<string, string> = { Info: message };
+  return new BoxBuilder('ASCII Code', kvToPlaintext(kv))
+    .setOptions(kv)
+    .setTemplate(KeyValueBoxTemplate)
+    .setPriority(priority)
+    .build();
+}
+
+export const AsciiTableBoxSource = {
+  name: 'ASCII Code',
+  description:
+    'Look up a character or a code point: decimal, hex, octal, binary, and the glyph.',
+  defaultInput: 'A ::ascii',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ascii', 'charcode')) return [];
+
+    const trimmed = trim(input);
+
+    // limit extremely long inputs early
+    if (trimmed.length > 32 && [...trimmed].length > 32) {
+      return [
+        buildInfoBox(
+          'Enter a single character OR a code point (decimal / 0x / 0b / 0o).',
+          Priority,
+        ),
+      ];
+    }
+
+    // single unicode character branch
+    if ([...trimmed].length === 1) {
+      const cp = trimmed.codePointAt(0) as number;
+      return [buildCodePointBox(cp, Priority)];
+    }
+
+    // numeric code point branch
+    const cp = parseCodePoint(trimmed);
+    if (cp >= 0) {
+      if (cp > 0x10ffff) {
+        return [
+          buildInfoBox(
+            `Code point 0x${cp.toString(16).toUpperCase()} is outside the Unicode range (0..0x10FFFF).`,
+            Priority,
+          ),
+        ];
+      }
+      return [buildCodePointBox(cp, Priority)];
+    }
+
+    // neither a single char nor a recognisable number
+    return [
+      buildInfoBox(
+        'Enter a single character OR a code point (decimal / 0x / 0b / 0o).',
+        Priority,
+      ),
+    ];
+  },
+};
+
+export default AsciiTableBoxSource;

--- a/src/modules/boxSources/CharFrequencyBoxSource.ts
+++ b/src/modules/boxSources/CharFrequencyBoxSource.ts
@@ -1,0 +1,93 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+// maximum rows shown to bound output size
+const MAX_DISPLAY_ROWS = 100;
+
+// visible token labels for whitespace/control characters
+function charToken(char: string): string {
+  if (char === ' ') return 'SPACE';
+  if (char === '\t') return 'TAB';
+  if (char === '\n') return 'LF';
+  if (char === '\r') return 'CR';
+  return char;
+}
+
+export const CharFrequencyBoxSource = {
+  name: 'Character Frequency',
+  description: 'Count how often each character appears in the text.',
+  defaultInput: 'hello world ::charfreq',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'charfreq', 'charfrequency')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    // build frequency map keyed by code point to avoid prototype pollution;
+    // for..of iterates by Unicode code point, so surrogate pairs count as 1
+    const freq = new Map<string, number>();
+    let totalChars = 0;
+    for (const char of input) {
+      freq.set(char, (freq.get(char) ?? 0) + 1);
+      totalChars++;
+    }
+
+    const uniqueChars = freq.size;
+
+    // sort by count desc, then by code point asc for ties
+    const sorted = [...freq.entries()].sort(
+      ([charA, countA], [charB, countB]) => {
+        if (countB !== countA) return countB - countA;
+        const cpA = charA.codePointAt(0) ?? 0;
+        const cpB = charB.codePointAt(0) ?? 0;
+        return cpA - cpB;
+      },
+    );
+
+    const truncated = sorted.length > MAX_DISPLAY_ROWS;
+    const displayed = truncated ? sorted.slice(0, MAX_DISPLAY_ROWS) : sorted;
+
+    // summary entries come first; character entries follow
+    const kvOptions: Record<string, string> = {
+      'Total Characters': String(totalChars),
+      'Unique Characters': String(uniqueChars),
+    };
+    for (const [char, count] of displayed) {
+      kvOptions[charToken(char)] = String(count);
+    }
+    if (truncated) {
+      kvOptions['(truncated)'] =
+        `showing top ${MAX_DISPLAY_ROWS} of ${sorted.length} unique chars`;
+    }
+
+    // build plaintext as a readable key:value list for headless / TUI use
+    const plaintextLines = Object.entries(kvOptions).map(
+      ([k, v]) => `${k}: ${v}`,
+    );
+    const plaintextOutput = plaintextLines.join('\n');
+
+    return [
+      new BoxBuilder('Character Frequency', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CharFrequencyBoxSource;

--- a/src/modules/boxSources/ChineseNumeralBoxSource.ts
+++ b/src/modules/boxSources/ChineseNumeralBoxSource.ts
@@ -1,0 +1,316 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT_LEN = 64;
+
+// max supported value: 999,999,999,999 (up to 千億)
+const MAX_VALUE = 999_999_999_999;
+
+// everyday digit characters (零 is special — used for placeholder zeros)
+const everydayDigits = [
+  '零',
+  '一',
+  '二',
+  '三',
+  '四',
+  '五',
+  '六',
+  '七',
+  '八',
+  '九',
+];
+const financialDigits = [
+  '零',
+  '壹',
+  '貳',
+  '參',
+  '肆',
+  '伍',
+  '陸',
+  '柒',
+  '捌',
+  '玖',
+];
+
+// place-value units: shared for everyday, distinct for financial
+const everydayUnits = ['', '十', '百', '千'];
+const financialUnits = ['', '拾', '佰', '仟'];
+
+// group-level units (10^4 and 10^8)
+const groupUnits = ['', '萬', '億'];
+
+// build k:v plaintext for KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// convert a 4-digit group (0–9999) to Chinese, using the provided digit/unit arrays.
+// `isLeadingGroup` controls whether a leading 一 is suppressed for values 10–19 in the
+// top-level group (i.e. '十' not '一十' for standalone tens in the outermost group).
+function groupToChineseSegment(
+  n: number,
+  digits: string[],
+  units: string[],
+  isLeadingGroup: boolean,
+): string {
+  if (n === 0) return '';
+
+  let result = '';
+  const thousands = Math.floor(n / 1000);
+  const hundreds = Math.floor((n % 1000) / 100);
+  const tens = Math.floor((n % 100) / 10);
+  const ones = n % 10;
+
+  if (thousands > 0) {
+    result += digits[thousands] + units[3];
+  }
+  if (hundreds > 0) {
+    result += digits[hundreds] + units[2];
+  } else if (thousands > 0 && (tens > 0 || ones > 0)) {
+    // internal zero: e.g. 1001 → 千零一
+    result += digits[0];
+  }
+
+  if (tens > 0) {
+    // suppress leading 一 for 十–十九 only in the outermost (leading) group
+    if (tens === 1 && isLeadingGroup && thousands === 0 && hundreds === 0) {
+      result += units[1];
+    } else {
+      result += digits[tens] + units[1];
+    }
+  } else if (
+    ones > 0 &&
+    (thousands > 0 || hundreds > 0) &&
+    !result.endsWith(digits[0])
+  ) {
+    // zero before ones when tens is 0 and a higher digit exists, but only if no zero already emitted
+    result += digits[0];
+  }
+
+  if (ones > 0) {
+    result += digits[ones];
+  }
+
+  return result;
+}
+
+// convert an integer (0 to MAX_VALUE) to Chinese numerals using the given digit/unit arrays.
+function intToChineseNumerals(
+  n: number,
+  digits: string[],
+  units: string[],
+): string {
+  if (n === 0) return digits[0];
+
+  // split into 億-group, 萬-group, and 個-group
+  const yi = Math.floor(n / 100_000_000);
+  const wan = Math.floor((n % 100_000_000) / 10_000);
+  const ge = n % 10_000;
+
+  const parts: string[] = [];
+
+  if (yi > 0) {
+    parts.push(groupToChineseSegment(yi, digits, units, true) + groupUnits[2]);
+  }
+  if (wan > 0) {
+    // insert zero if there's a higher group and wan < 1000 (leading zero)
+    if (yi > 0 && wan < 1000) {
+      parts.push(digits[0]);
+    }
+    parts.push(
+      groupToChineseSegment(wan, digits, units, yi === 0 && wan < 20) +
+        groupUnits[1],
+    );
+  } else if (yi > 0 && ge > 0) {
+    // zero bridge between 億 and 個 groups when 萬 group is absent
+    parts.push(digits[0]);
+  }
+
+  if (ge > 0) {
+    const gePart = groupToChineseSegment(
+      ge,
+      digits,
+      units,
+      yi === 0 && wan === 0,
+    );
+
+    // zero bridge from 萬 group when ge < 1000 (leading zero in 個 group)
+    if (wan > 0 && ge < 1000 && !parts[parts.length - 1]?.endsWith(digits[0])) {
+      parts.push(digits[0]);
+    }
+    parts.push(gePart);
+  }
+
+  return parts.join('');
+}
+
+// maps everyday Chinese digit characters to their numeric values (for parsing)
+const everydayCharMap: Record<string, number> = {
+  零: 0,
+  一: 1,
+  二: 2,
+  三: 3,
+  四: 4,
+  五: 5,
+  六: 6,
+  七: 7,
+  八: 8,
+  九: 9,
+  兩: 2, // colloquial alternative for 二
+};
+
+// parse everyday Chinese numeral string to an integer.
+// supports 零一二三四五六七八九十百千萬億 and 兩.
+// returns null if parsing fails or the string is not recognisable as a Chinese numeral.
+//
+// algorithm: `pending` holds the most recent digit; a place-value char (十百千) multiplies
+// pending and accumulates into `section`; 萬/億 flush (section+pending)×unit into `result`.
+function parseChineseToInt(s: string): number | null {
+  const chineseNumeralRe = /^[零一二三四五六七八九兩十百千萬億]+$/;
+  if (!chineseNumeralRe.test(s)) return null;
+
+  let result = 0; // sum of all completed 萬/億 groups
+  let section = 0; // accumulator within the current group
+  let pending = 0; // last digit seen, waiting for a place-value multiplier
+
+  for (const ch of s) {
+    const dv = everydayCharMap[ch];
+    if (dv !== undefined) {
+      // digit character — store as pending (零 just resets pending to 0)
+      pending = dv;
+      continue;
+    }
+
+    // place-value multipliers
+    if (ch === '十') {
+      section += (pending === 0 ? 1 : pending) * 10;
+      pending = 0;
+    } else if (ch === '百') {
+      section += (pending === 0 ? 1 : pending) * 100;
+      pending = 0;
+    } else if (ch === '千') {
+      section += (pending === 0 ? 1 : pending) * 1000;
+      pending = 0;
+    } else if (ch === '萬') {
+      // flush: (section + pending) represents the 萬-multiplier group
+      result += (section + pending) * 10_000;
+      section = 0;
+      pending = 0;
+    } else if (ch === '億') {
+      result += (section + pending) * 100_000_000;
+      section = 0;
+      pending = 0;
+    } else {
+      return null;
+    }
+  }
+
+  // add any remaining section + unflushed pending digit
+  result += section + pending;
+  return result;
+}
+
+// build k:v plaintext for KeyValueBoxTemplate — helper
+function buildIntToChinese(
+  n: number,
+  negative: boolean,
+): { kv: Record<string, string>; plaintext: string } {
+  const prefix = negative ? '負' : '';
+
+  const everyday =
+    prefix + intToChineseNumerals(n, everydayDigits, everydayUnits);
+  const financial =
+    prefix + intToChineseNumerals(n, financialDigits, financialUnits);
+
+  const kv: Record<string, string> = {
+    Number: `${negative ? '-' : ''}${n}`,
+    Everyday: everyday,
+    Financial: financial,
+  };
+  return { kv, plaintext: kvToPlaintext(kv) };
+}
+
+export const ChineseNumeralBoxSource = {
+  name: 'Chinese Numerals',
+  description:
+    'Convert an integer to Chinese numerals (everyday and financial), or parse Chinese numerals to an integer.',
+  defaultInput: '1234 ::chinesenum',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'chinesenum', 'chinesenumber')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT_LEN) return [];
+
+    // integer → chinese numeral conversion
+    if (/^-?\d+$/.test(raw)) {
+      const negative = raw.startsWith('-');
+      const abs = Number.parseInt(negative ? raw.slice(1) : raw, 10);
+
+      if (Number.isNaN(abs) || abs > MAX_VALUE) {
+        const kv: Record<string, string> = {
+          Input: raw,
+          Error: `Value out of range (max ±${MAX_VALUE})`,
+        };
+        return [
+          new BoxBuilder('Chinese Numerals', kvToPlaintext(kv))
+            .setOptions(kv)
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      const { kv, plaintext } = buildIntToChinese(abs, negative);
+      return [
+        new BoxBuilder('Chinese Numerals', plaintext)
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // chinese numeral → integer parsing
+    const parsed = parseChineseToInt(raw);
+    if (parsed === null) {
+      // unrecognised input — show an error box so the user knows why no result appeared
+      const kv: Record<string, string> = {
+        Input: raw,
+        Error: 'Cannot parse as integer or Chinese numeral',
+      };
+      return [
+        new BoxBuilder('Chinese Numerals', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const kv: Record<string, string> = {
+      Chinese: raw,
+      Number: String(parsed),
+    };
+    return [
+      new BoxBuilder('Chinese Numerals', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ChineseNumeralBoxSource;

--- a/src/modules/boxSources/DurationFormatBoxSource.ts
+++ b/src/modules/boxSources/DurationFormatBoxSource.ts
@@ -1,0 +1,174 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100;
+
+// unit constants in seconds
+const WEEK = 604800;
+const DAY = 86400;
+const HOUR = 3600;
+const MINUTE = 60;
+
+// build k:v plaintext for the KeyValueBoxTemplate plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// convert a total-seconds value to a human-readable string, e.g. '1h 1m 1s'
+function secondsToHuman(totalSeconds: number): string {
+  if (totalSeconds === 0) return '0s';
+
+  const w = Math.floor(totalSeconds / WEEK);
+  const remaining1 = totalSeconds % WEEK;
+  const d = Math.floor(remaining1 / DAY);
+  const remaining2 = remaining1 % DAY;
+  const h = Math.floor(remaining2 / HOUR);
+  const remaining3 = remaining2 % HOUR;
+  const m = Math.floor(remaining3 / MINUTE);
+  const s = remaining3 % MINUTE;
+
+  const parts: string[] = [];
+  if (w > 0) parts.push(`${w}w`);
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
+  if (s > 0) parts.push(`${s}s`);
+
+  return parts.join(' ');
+}
+
+// format a total-seconds value as a clock string HH:MM:SS or D:HH:MM:SS
+function secondsToClock(totalSeconds: number): string {
+  const d = Math.floor(totalSeconds / DAY);
+  const remaining = totalSeconds % DAY;
+  const h = Math.floor(remaining / HOUR);
+  const m = Math.floor((remaining % HOUR) / MINUTE);
+  const s = remaining % MINUTE;
+
+  const hh = String(h).padStart(2, '0');
+  const mm = String(m).padStart(2, '0');
+  const ss = String(s).padStart(2, '0');
+
+  if (d > 0) {
+    return `${d}:${hh}:${mm}:${ss}`;
+  }
+  return `${hh}:${mm}:${ss}`;
+}
+
+// parse a human duration string to total seconds using a linear regex
+// supports tokens like 1w, 2d, 3h, 4m, 5s (case-insensitive, optional spaces between)
+function humanToSeconds(input: string): number {
+  const tokenRegex = /(\d+(?:\.\d+)?)\s*(w|d|h|m|s)/gi;
+  const unitMap: Record<string, number> = {
+    w: WEEK,
+    d: DAY,
+    h: HOUR,
+    m: MINUTE,
+    s: 1,
+  };
+
+  let total = 0;
+  let match: RegExpExecArray | null;
+
+  // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex loop
+  while ((match = tokenRegex.exec(input)) !== null) {
+    const value = Number.parseFloat(match[1]);
+    const unit = match[2].toLowerCase();
+    total += value * (unitMap[unit] ?? 0);
+  }
+
+  return total;
+}
+
+// count how many tokens the humanToSeconds parser matched
+function countTokens(input: string): number {
+  const tokenRegex = /(\d+(?:\.\d+)?)\s*(w|d|h|m|s)/gi;
+  let count = 0;
+  while (tokenRegex.exec(input) !== null) count++;
+  return count;
+}
+
+export const DurationFormatBoxSource = {
+  name: 'Duration',
+  description:
+    'Convert seconds to a human duration (1h 1m 1s) or parse a duration back to seconds.',
+  defaultInput: '3661 ::duration',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'duration', 'humantime')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT) return [];
+
+    // plain number → treat as seconds and convert to human form
+    if (/^\d+(\.\d+)?$/.test(raw)) {
+      const totalSeconds = Number.parseInt(raw, 10);
+      const human = secondsToHuman(totalSeconds);
+      const clock = secondsToClock(totalSeconds);
+
+      const kv: Record<string, string> = {
+        Seconds: String(totalSeconds),
+        Human: human,
+        Clock: clock,
+      };
+
+      return [
+        new BoxBuilder('Duration', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // human string → parse to total seconds
+    const tokenCount = countTokens(raw);
+
+    if (tokenCount === 0) {
+      // no recognizable tokens — show a usage hint
+      const hint =
+        'No duration tokens found. Use units: w d h m s, e.g. "1h 30m" or "2d 4h".';
+      const kv: Record<string, string> = {
+        Input: raw,
+        Hint: hint,
+      };
+      return [
+        new BoxBuilder('Duration', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const totalSeconds = humanToSeconds(raw);
+    const human = secondsToHuman(totalSeconds);
+
+    const kv: Record<string, string> = {
+      Input: raw,
+      'Total Seconds': String(Math.round(totalSeconds)),
+      Human: human,
+    };
+
+    return [
+      new BoxBuilder('Duration', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DurationFormatBoxSource;

--- a/src/modules/boxSources/DurationFormatBoxSource.ts
+++ b/src/modules/boxSources/DurationFormatBoxSource.ts
@@ -113,7 +113,9 @@ export const DurationFormatBoxSource = {
 
     // plain number → treat as seconds and convert to human form
     if (/^\d+(\.\d+)?$/.test(raw)) {
-      const totalSeconds = Number.parseInt(raw, 10);
+      // parseFloat (not parseInt) so a fractional input like 3661.5 isn't
+      // silently truncated; the %/floor math below preserves the fraction
+      const totalSeconds = Number.parseFloat(raw);
       const human = secondsToHuman(totalSeconds);
       const clock = secondsToClock(totalSeconds);
 

--- a/src/modules/boxSources/HmacBoxSource.ts
+++ b/src/modules/boxSources/HmacBoxSource.ts
@@ -1,0 +1,135 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// supported HMAC hash algorithms
+type HmacAlgorithm = 'SHA-1' | 'SHA-256' | 'SHA-512';
+
+function bufToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function computeHmac(
+  algorithm: HmacAlgorithm,
+  keyBytes: Uint8Array,
+  messageBytes: Uint8Array,
+): Promise<string> {
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    // cast: a Uint8Array is a valid BufferSource at runtime; the TS 5.7
+    // ArrayBufferLike-vs-ArrayBuffer narrowing is overly strict here
+    keyBytes as BufferSource,
+    { name: 'HMAC', hash: algorithm },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    cryptoKey,
+    messageBytes as BufferSource,
+  );
+  return bufToHex(signature);
+}
+
+// build k:v plaintext for the KeyValueBoxTemplate plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const HmacBoxSource = {
+  name: 'HMAC',
+  description:
+    'Compute HMAC-SHA256/SHA1/SHA512 of the input using a key. ::hmac=<key>.',
+  defaultInput: 'The quick brown fox jumps over the lazy dog ::hmac=key',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hmac', 'hmacsha256')) {
+      return [];
+    }
+
+    const key = extractOptionKeys(options, 'hmac', 'hmacsha256');
+
+    // bare ::hmac without a value → show usage hint
+    if (key === true) {
+      return [
+        new BoxBuilder('HMAC', 'provide a key, e.g. ::hmac=secret')
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // key must be a non-empty string
+    if (!isString(key) || key === null) {
+      return [];
+    }
+
+    if (!isString(input) || input.length > MAX_INPUT) {
+      return [];
+    }
+
+    // crypto.subtle requires a secure context (HTTPS or localhost)
+    if (typeof crypto === 'undefined' || !crypto?.subtle) {
+      return [
+        new BoxBuilder(
+          'HMAC',
+          'a secure context (HTTPS) is required — crypto.subtle is not available.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const keyStr = key as string;
+    const encoder = new TextEncoder();
+    const keyBytes = encoder.encode(keyStr);
+    const messageBytes = encoder.encode(input);
+
+    const [sha256, sha1, sha512] = await Promise.all([
+      computeHmac('SHA-256', keyBytes, messageBytes),
+      computeHmac('SHA-1', keyBytes, messageBytes),
+      computeHmac('SHA-512', keyBytes, messageBytes),
+    ]);
+
+    // key length in bytes (UTF-8); do NOT expose the key itself
+    const keyByteLength = keyBytes.byteLength;
+
+    const kv: Record<string, string> = {
+      'HMAC-SHA256': sha256,
+      'HMAC-SHA1': sha1,
+      'HMAC-SHA512': sha512,
+      'Key Length': String(keyByteLength),
+    };
+
+    return [
+      new BoxBuilder('HMAC', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HmacBoxSource;

--- a/src/modules/boxSources/HmacBoxSource.ts
+++ b/src/modules/boxSources/HmacBoxSource.ts
@@ -77,8 +77,8 @@ export const HmacBoxSource = {
       ];
     }
 
-    // key must be a non-empty string
-    if (!isString(key) || key === null) {
+    // key must be a non-empty string (typeof narrows for TS; isString does not)
+    if (typeof key !== 'string' || key.length === 0) {
       return [];
     }
 
@@ -100,16 +100,28 @@ export const HmacBoxSource = {
       ];
     }
 
-    const keyStr = key as string;
     const encoder = new TextEncoder();
-    const keyBytes = encoder.encode(keyStr);
+    const keyBytes = encoder.encode(key);
     const messageBytes = encoder.encode(input);
 
-    const [sha256, sha1, sha512] = await Promise.all([
-      computeHmac('SHA-256', keyBytes, messageBytes),
-      computeHmac('SHA-1', keyBytes, messageBytes),
-      computeHmac('SHA-512', keyBytes, messageBytes),
-    ]);
+    let sha256: string;
+    let sha1: string;
+    let sha512: string;
+    try {
+      [sha256, sha1, sha512] = await Promise.all([
+        computeHmac('SHA-256', keyBytes, messageBytes),
+        computeHmac('SHA-1', keyBytes, messageBytes),
+        computeHmac('SHA-512', keyBytes, messageBytes),
+      ]);
+    } catch {
+      return [
+        new BoxBuilder('HMAC', 'HMAC computation failed in this environment.')
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
 
     // key length in bytes (UTF-8); do NOT expose the key itself
     const keyByteLength = keyBytes.byteLength;

--- a/src/modules/boxSources/HsvBoxSource.ts
+++ b/src/modules/boxSources/HsvBoxSource.ts
@@ -1,0 +1,249 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+const MAX_INPUT_LEN = 64;
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+interface HSV {
+  h: number;
+  s: number;
+  v: number;
+}
+
+// convert rgb integers 0-255 to hsv (h in [0,360), s/v in [0,100])
+export function rgbToHsv(r: number, g: number, b: number): HSV {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rn) {
+      h = 60 * (((gn - bn) / delta) % 6);
+    } else if (max === gn) {
+      h = 60 * ((bn - rn) / delta + 2);
+    } else {
+      h = 60 * ((rn - gn) / delta + 4);
+    }
+  }
+  if (h < 0) h += 360;
+
+  const s = max === 0 ? 0 : delta / max;
+  const v = max;
+
+  return {
+    h: Math.round(h),
+    s: Math.round(s * 100),
+    v: Math.round(v * 100),
+  };
+}
+
+// convert hsv (h deg, s/v percent) to rgb integers 0-255
+export function hsvToRgb(h: number, s: number, v: number): RGB {
+  const sn = s / 100;
+  const vn = v / 100;
+
+  const c = vn * sn;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = vn - c;
+
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  if (h < 60) {
+    [r, g, b] = [c, x, 0];
+  } else if (h < 120) {
+    [r, g, b] = [x, c, 0];
+  } else if (h < 180) {
+    [r, g, b] = [0, c, x];
+  } else if (h < 240) {
+    [r, g, b] = [0, x, c];
+  } else if (h < 300) {
+    [r, g, b] = [x, 0, c];
+  } else {
+    [r, g, b] = [c, 0, x];
+  }
+
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255),
+  };
+}
+
+// format rgb as lowercase 6-digit hex
+export function rgbToHex(r: number, g: number, b: number): string {
+  const hex = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+// parse 3 or 6-digit hex to rgb, or null if invalid
+function parseHex(input: string): RGB | null {
+  const m = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(input);
+  if (!m) return null;
+  const h = m[1];
+  if (h.length === 3) {
+    return {
+      r: Number.parseInt(h[0] + h[0], 16),
+      g: Number.parseInt(h[1] + h[1], 16),
+      b: Number.parseInt(h[2] + h[2], 16),
+    };
+  }
+  return {
+    r: Number.parseInt(h.slice(0, 2), 16),
+    g: Number.parseInt(h.slice(2, 4), 16),
+    b: Number.parseInt(h.slice(4, 6), 16),
+  };
+}
+
+// parse rgb(r,g,b) to rgb, or null if invalid
+function parseRgb(input: string): RGB | null {
+  const m = /^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/.exec(input);
+  if (!m) return null;
+  const r = Number.parseInt(m[1], 10);
+  const g = Number.parseInt(m[2], 10);
+  const b = Number.parseInt(m[3], 10);
+  if (r > 255 || g > 255 || b > 255) return null;
+  return { r, g, b };
+}
+
+// parse hsv(h,s%,v%) or hsb(h,s%,v%) to hsv, or null if invalid
+function parseHsv(input: string): HSV | null {
+  const m =
+    /^hs[vb]\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)%?\s*,\s*(\d+(?:\.\d+)?)%?\s*\)$/i.exec(
+      input,
+    );
+  if (!m) return null;
+  const h = Number.parseFloat(m[1]);
+  const s = Number.parseFloat(m[2]);
+  const v = Number.parseFloat(m[3]);
+  if (h < 0 || h > 360 || s < 0 || s > 100 || v < 0 || v > 100) return null;
+  return { h: Math.round(h), s: Math.round(s), v: Math.round(v) };
+}
+
+// build the key:value plaintext for headless/TUI consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, val]) => `${k}: ${val}`)
+    .join('\n');
+}
+
+type Direction = 'toHsv' | 'toRgb' | 'unknown';
+
+interface Match {
+  direction: Direction;
+  rgb?: RGB;
+  hsv?: HSV;
+}
+
+export const HsvBoxSource = {
+  name: 'HSV',
+  description: 'Convert a color between hex/RGB and HSV (HSB).',
+  defaultInput: '#ff6347 ::hsv',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  checkMatch(input: string): Match | undefined {
+    const s = trim(input);
+    if (!s || s.length > MAX_INPUT_LEN) return undefined;
+
+    const lower = s.toLowerCase();
+
+    // hsv()/hsb() → rgb/hex direction
+    const hsv = parseHsv(lower);
+    if (hsv) return { direction: 'toRgb', hsv };
+
+    // hex or rgb() → hsv direction
+    const rgb = parseHex(lower) ?? parseRgb(lower);
+    if (rgb) return { direction: 'toHsv', rgb };
+
+    // input is present but unparseable — show format hint
+    if (s.length > 0) return { direction: 'unknown' };
+
+    return undefined;
+  },
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hsv', 'hsb')) return [];
+
+    const match = this.checkMatch(input);
+    if (!match) return [];
+
+    if (match.direction === 'toHsv' && match.rgb) {
+      const { r, g, b } = match.rgb;
+      const { h, s, v } = rgbToHsv(r, g, b);
+      const hexStr = rgbToHex(r, g, b);
+      const rgbStr = `rgb(${r}, ${g}, ${b})`;
+      const hsvStr = `hsv(${h}, ${s}%, ${v}%)`;
+
+      const kv: Record<string, string> = {
+        Hex: hexStr,
+        RGB: rgbStr,
+        HSV: hsvStr,
+      };
+
+      return [
+        new BoxBuilder('HSV', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (match.direction === 'toRgb' && match.hsv) {
+      const { h, s, v } = match.hsv;
+      const { r, g, b } = hsvToRgb(h, s, v);
+      const hexStr = rgbToHex(r, g, b);
+      const rgbStr = `rgb(${r}, ${g}, ${b})`;
+      const hsvStr = `hsv(${h}, ${s}%, ${v}%)`;
+
+      const kv: Record<string, string> = {
+        HSV: hsvStr,
+        RGB: rgbStr,
+        Hex: hexStr,
+      };
+
+      return [
+        new BoxBuilder('HSV', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // unknown direction: show format hint
+    const kv: Record<string, string> = {
+      Accepted: '#RRGGBB, #RGB, rgb(r,g,b), hsv(h,s%,v%), hsb(h,s%,v%)',
+    };
+
+    return [
+      new BoxBuilder('HSV', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HsvBoxSource;

--- a/src/modules/boxSources/PopcountBoxSource.ts
+++ b/src/modules/boxSources/PopcountBoxSource.ts
@@ -1,0 +1,135 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// maximum input string length to accept (guards against pathological inputs)
+const MAX_INPUT_LEN = 5000;
+
+// count set bits via iterative bit-scan (BigInt safe, no overflow)
+function popcount(n: bigint): bigint {
+  let count = 0n;
+  let v = n;
+  while (v > 0n) {
+    count += v & 1n;
+    v >>= 1n;
+  }
+  return count;
+}
+
+// number of trailing zero bits; defined as 0 for the value 0
+function trailingZeros(n: bigint): bigint {
+  if (n === 0n) return 0n;
+  let count = 0n;
+  let v = n;
+  while ((v & 1n) === 0n) {
+    count++;
+    v >>= 1n;
+  }
+  return count;
+}
+
+// position of the highest set bit (bit length); 0 for the value 0
+function bitLength(n: bigint): number {
+  if (n === 0n) return 0;
+  return n.toString(2).length;
+}
+
+// render k:v pairs as a plaintext string for plaintextOutput
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const PopcountBoxSource = {
+  name: 'Popcount',
+  description:
+    'Count set bits (population count) and bit length of a non-negative integer.',
+  defaultInput: '255 ::popcount',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'popcount', 'bitcount')) return [];
+
+    const raw = trim(input);
+
+    // guard against unreasonably large strings
+    if (raw.length > MAX_INPUT_LEN) {
+      const kv = { Error: 'Input too long (max 5000 chars).' };
+      return [
+        new BoxBuilder('Popcount', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // accept decimal, 0x hex, or 0b binary — all non-negative
+    const isDecimal = /^\d+$/.test(raw);
+    const isHex = /^0x[0-9a-f]+$/i.test(raw);
+    const isBinary = /^0b[01]+$/i.test(raw);
+
+    if (!isDecimal && !isHex && !isBinary) {
+      const kv = {
+        Error:
+          'A non-negative integer (decimal, 0x hex, or 0b binary) is required.',
+      };
+      return [
+        new BoxBuilder('Popcount', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    let n: bigint;
+    try {
+      n = BigInt(raw);
+    } catch {
+      const kv = {
+        Error:
+          'A non-negative integer (decimal, 0x hex, or 0b binary) is required.',
+      };
+      return [
+        new BoxBuilder('Popcount', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const setBits = popcount(n);
+    const bitLen = bitLength(n);
+    const trailing = trailingZeros(n);
+
+    const kv: Record<string, string> = {
+      Decimal: n.toString(10),
+      Binary: `0b${n.toString(2)}`,
+      Hex: `0x${n.toString(16)}`,
+      'Set Bits': setBits.toString(),
+      'Bit Length': bitLen.toString(),
+      'Trailing Zeros': trailing.toString(),
+    };
+
+    return [
+      new BoxBuilder('Popcount', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PopcountBoxSource;

--- a/src/modules/boxSources/__test__/Ascii85BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Ascii85BoxSource.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { Ascii85BoxSource } from '../Ascii85BoxSource';
+
+describe('Ascii85BoxSource', () => {
+  describe('generateBoxes — no match', () => {
+    it('returns [] when no option key is present', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is empty string', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is only whitespace', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('   ', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ::ascii85 / ::base85 / ::a85', () => {
+    it('encodes "Man " → "9jqo^" (canonical Wikipedia example)', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Ascii85 (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('9jqo^');
+    });
+
+    it('accepts ::base85 as an alias', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        base85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('9jqo^');
+    });
+
+    it('accepts ::a85 as an alias', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        a85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('9jqo^');
+    });
+
+    it('encodes 4 null bytes using the "z" shortcut', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('\x00\x00\x00\x00', {
+        ascii85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('z');
+    });
+
+    it('round-trips "The quick brown fox"', async () => {
+      const input = 'The quick brown fox';
+      const encBoxes = await Ascii85BoxSource.generateBoxes(input, {
+        ascii85: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Ascii85BoxSource.generateBoxes(encoded, {
+        ascii85decode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe(input);
+    });
+
+    it('round-trips unicode string "héllo 世界"', async () => {
+      const input = 'héllo 世界';
+      const encBoxes = await Ascii85BoxSource.generateBoxes(input, {
+        ascii85: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Ascii85BoxSource.generateBoxes(encoded, {
+        ascii85decode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe(input);
+    });
+
+    it('round-trips "sure." (5-byte partial group)', async () => {
+      const input = 'sure.';
+      const encBoxes = await Ascii85BoxSource.generateBoxes(input, {
+        ascii85: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Ascii85BoxSource.generateBoxes(encoded, {
+        ascii85decode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe(input);
+    });
+  });
+
+  describe('decode — ::ascii85decode / ::a85decode', () => {
+    it('decodes "9jqo^" → "Man "', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('9jqo^', {
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Ascii85 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('Man ');
+    });
+
+    it('accepts ::a85decode as an alias', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('9jqo^', {
+        a85decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Man ');
+    });
+
+    it('decodes "z" → 4 null bytes', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('z', {
+        ascii85decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('\x00\x00\x00\x00');
+    });
+
+    it('returns an error box for invalid characters', async () => {
+      // '~' is outside the valid '!'..'u' range
+      const boxes = await Ascii85BoxSource.generateBoxes('v~', {
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/^Error:/);
+    });
+  });
+
+  describe('both encode and decode options', () => {
+    it('returns 2 boxes when both ::ascii85 and ::ascii85decode are set', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        ascii85: true,
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Ascii85 (Encode)');
+      expect(names).toContain('Ascii85 (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('sets showExpandButton to false', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        ascii85: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('sets priority from BoxSource.priority', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        ascii85: true,
+      });
+      expect(boxes[0].props.priority).toBe(Ascii85BoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/AsciiTableBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AsciiTableBoxSource.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import { AsciiTableBoxSource } from '../AsciiTableBoxSource';
+
+describe('AsciiTableBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('A', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('A', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('activates on ::ascii option', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('A', {
+        ascii: true,
+      });
+      expect(boxes.length).toBeGreaterThan(0);
+    });
+
+    it('activates on ::charcode option', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('A', {
+        charcode: true,
+      });
+      expect(boxes.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('single character → code point', () => {
+    it('A → Decimal 65, Hex 0x41, Octal 0o101, Binary 0b1000001', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('A', {
+        ascii: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('65');
+      expect(opts.Hex).toBe('0x41'.toUpperCase().replace('0X', '0x'));
+      expect(opts.Octal).toBe('0o101');
+      expect(opts.Binary).toBe('0b1000001');
+    });
+
+    it('A → Hex is 0x41', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('A', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Hex).toBe(
+        '0x41'.replace('41', '41').toUpperCase().replace('0X', '0x'),
+      );
+      // explicit assertion
+      expect(opts.Hex).toBe('0x41'.toUpperCase().replace('0X41', '0x41'));
+    });
+
+    it('lowercase a → Decimal 97', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('a', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('97');
+    });
+
+    it('! → Decimal 33', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('!', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('33');
+    });
+
+    it('€ → Decimal 8364, Hex 0x20AC', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('€', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('8364');
+      expect(opts.Hex).toBe('0x20AC');
+    });
+
+    it('sets box name to ASCII Code', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('A', {
+        ascii: true,
+      });
+      expect(boxes[0].props.name).toBe('ASCII Code');
+    });
+
+    it('sets priority', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('A', {
+        ascii: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('includes HTML Entity', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('A', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['HTML Entity']).toBe('&#65;');
+    });
+  });
+
+  describe('code point number → character', () => {
+    it('decimal 65 → Character A', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('65', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Character).toBe('A');
+      expect(opts.Decimal).toBe('65');
+    });
+
+    it('hex 0x41 → Character A', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('0x41', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Character).toBe('A');
+    });
+
+    it('binary 0b1000001 → Character A', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('0b1000001', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Character).toBe('A');
+    });
+
+    it('octal 0o101 → Character A', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('0o101', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Character).toBe('A');
+    });
+
+    it('decimal 8364 → Character €', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('8364', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Character).toBe('€');
+    });
+  });
+
+  describe('control characters', () => {
+    it('code point 0 (via 0x0) → Character (NUL)', async () => {
+      // a bare '0' is a single character (the digit, cp 48); use an
+      // unambiguous numeric form to address code point 0
+      const boxes = await AsciiTableBoxSource.generateBoxes('0x0', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Character).toBe('(NUL)');
+    });
+
+    it('single digit "0" is the glyph (code point 48)', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('0', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('48');
+    });
+
+    it('code point 10 → Character contains LF', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('10', {
+        ascii: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Character).toContain('LF');
+    });
+  });
+
+  describe('error / info boxes', () => {
+    it('out-of-range code point 1114112 → info box', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('1114112', {
+        ascii: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Info).toBeTruthy();
+    });
+
+    it('two-character input AB (not a number) → info box', async () => {
+      const boxes = await AsciiTableBoxSource.generateBoxes('AB', {
+        ascii: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Info).toBeTruthy();
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CharFrequencyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CharFrequencyBoxSource.test.ts
@@ -1,0 +1,144 @@
+import { CharFrequencyBoxSource } from '@modules/boxSources/CharFrequencyBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('CharFrequencyBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option key is present', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('   ', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('counts characters correctly for "hello"', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('hello', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Characters']).toBe('5');
+      expect(opts['Unique Characters']).toBe('4');
+      expect(opts.l).toBe('2');
+      expect(opts.h).toBe('1');
+      expect(opts.e).toBe('1');
+      expect(opts.o).toBe('1');
+    });
+
+    it('counts characters correctly for "aaa"', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('aaa', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Characters']).toBe('3');
+      expect(opts['Unique Characters']).toBe('1');
+      expect(opts.a).toBe('3');
+    });
+
+    it('counts characters correctly for "hello world" including SPACE token', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('hello world', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Characters']).toBe('11');
+      expect(opts.l).toBe('3');
+      expect(opts.o).toBe('2');
+      expect(opts.SPACE).toBe('1');
+    });
+
+    it('counts emoji as single code points', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('😀😀', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // for..of counts code points, so '😀😀' = 2 code points, not 4 UTF-16 units
+      expect(opts['Total Characters']).toBe('2');
+      expect(opts['Unique Characters']).toBe('1');
+      expect(opts['😀']).toBe('2');
+    });
+
+    it('accepts ::charfrequency as an alias', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('hi', {
+        charfrequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('handles "__proto__" input without prototype pollution', async () => {
+      const proto = Object.prototype;
+      const beforeKeys = Object.getOwnPropertyNames(proto);
+
+      const boxes = await CharFrequencyBoxSource.generateBoxes('__proto__', {
+        charfreq: true,
+      });
+
+      // must not crash and must return a valid box
+      expect(boxes).toHaveLength(1);
+
+      // prototype must be unmodified
+      const afterKeys = Object.getOwnPropertyNames(proto);
+      expect(afterKeys).toEqual(beforeKeys);
+
+      // '__proto__' = _ _ p r o t o _ _ → 4 underscores, 2 o, 1 each p/r/t
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts._).toBe('4');
+      expect(opts.o).toBe('2');
+      expect(opts.p).toBe('1');
+      expect(opts.r).toBe('1');
+      expect(opts.t).toBe('1');
+    });
+
+    it('box name is "Character Frequency" and template is KeyValueBoxTemplate', async () => {
+      const { KeyValueBoxTemplate } = await import('@components/BoxTemplate');
+      const boxes = await CharFrequencyBoxSource.generateBoxes('abc', {
+        charfreq: true,
+      });
+      expect(boxes[0].props.name).toBe('Character Frequency');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('sorts by count desc then code point asc', async () => {
+      // 'b' x3, 'a' x2, 'c' x1 — after that for ties 'a'(97) before 'c'(99)
+      const boxes = await CharFrequencyBoxSource.generateBoxes('bbbaacc', {
+        charfreq: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      const keys = Object.keys(opts).filter(
+        (k) => !['Total Characters', 'Unique Characters'].includes(k),
+      );
+      // expected order: b(3), a(2), c(2) — 'a'(97) before 'c'(99) for the tie
+      expect(keys).toEqual(['b', 'a', 'c']);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has correct static properties', () => {
+      expect(CharFrequencyBoxSource.name).toBe('Character Frequency');
+      expect(CharFrequencyBoxSource.tag).toBe('#');
+      expect(CharFrequencyBoxSource.kind).toBe('Calculate');
+      expect(CharFrequencyBoxSource.priority).toBe(10);
+      expect(CharFrequencyBoxSource.defaultInput).toBe(
+        'hello world ::charfreq',
+      );
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ChineseNumeralBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ChineseNumeralBoxSource.test.ts
@@ -1,0 +1,175 @@
+import { ChineseNumeralBoxSource } from '@modules/boxSources/ChineseNumeralBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('ChineseNumeralBoxSource', () => {
+  describe('no option key → empty', () => {
+    it('returns [] when no option is present', async () => {
+      const boxes = await ChineseNumeralBoxSource.generateBoxes('1234', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is present', async () => {
+      const boxes = await ChineseNumeralBoxSource.generateBoxes('1234', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('integer → Chinese numerals', () => {
+    async function convert(input: string) {
+      const boxes = await ChineseNumeralBoxSource.generateBoxes(input, {
+        chinesenum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      return boxes[0].props.options as Record<string, string>;
+    }
+
+    it('converts 0 → 零', async () => {
+      const opts = await convert('0');
+      expect(opts.Everyday).toBe('零');
+      expect(opts.Financial).toBe('零');
+    });
+
+    it('converts 10 → 十', async () => {
+      const opts = await convert('10');
+      expect(opts.Everyday).toBe('十');
+    });
+
+    it('converts 15 → 十五', async () => {
+      const opts = await convert('15');
+      expect(opts.Everyday).toBe('十五');
+    });
+
+    it('converts 20 → 二十', async () => {
+      const opts = await convert('20');
+      expect(opts.Everyday).toBe('二十');
+    });
+
+    it('converts 100 → 一百', async () => {
+      const opts = await convert('100');
+      expect(opts.Everyday).toBe('一百');
+    });
+
+    it('converts 110 → 一百一十', async () => {
+      const opts = await convert('110');
+      expect(opts.Everyday).toBe('一百一十');
+    });
+
+    it('converts 1001 → 一千零一 (zero-bridge, no double 零)', async () => {
+      const opts = await convert('1001');
+      expect(opts.Everyday).toBe('一千零一');
+    });
+
+    it('converts 1234 → 一千二百三十四 (everyday)', async () => {
+      const opts = await convert('1234');
+      expect(opts.Everyday).toBe('一千二百三十四');
+    });
+
+    it('converts 1234 → 壹仟貳佰參拾肆 (financial)', async () => {
+      const opts = await convert('1234');
+      expect(opts.Financial).toBe('壹仟貳佰參拾肆');
+      // financial uses 仟/佰/拾, not 千/百/十
+      expect(opts.Financial).toMatch(/^壹仟/);
+    });
+
+    it('converts 10001 → 一萬零一', async () => {
+      const opts = await convert('10001');
+      expect(opts.Everyday).toBe('一萬零一');
+    });
+
+    it('also triggers on ::chinesenumber alias', async () => {
+      const boxes = await ChineseNumeralBoxSource.generateBoxes('5', {
+        chinesenumber: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Everyday).toBe('五');
+    });
+
+    it('handles negative integers', async () => {
+      const opts = await convert('-1');
+      expect(opts.Everyday).toBe('負一');
+      expect(opts.Number).toBe('-1');
+    });
+
+    it('returns error box for value exceeding MAX_VALUE', async () => {
+      const boxes = await ChineseNumeralBoxSource.generateBoxes(
+        '1000000000000',
+        { chinesenum: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeTruthy();
+    });
+  });
+
+  describe('Chinese numerals → integer', () => {
+    async function parse(input: string) {
+      const boxes = await ChineseNumeralBoxSource.generateBoxes(input, {
+        chinesenum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      return boxes[0].props.options as Record<string, string>;
+    }
+
+    it('parses 一千二百三十四 → 1234', async () => {
+      const opts = await parse('一千二百三十四');
+      expect(opts.Number).toBe('1234');
+    });
+
+    it('parses 十五 → 15', async () => {
+      const opts = await parse('十五');
+      expect(opts.Number).toBe('15');
+    });
+
+    it('parses 一千零一 → 1001 (round-trip)', async () => {
+      const opts = await parse('一千零一');
+      expect(opts.Number).toBe('1001');
+    });
+
+    it('round-trips 1234 → 一千二百三十四 → 1234', async () => {
+      const fwd = await ChineseNumeralBoxSource.generateBoxes('1234', {
+        chinesenum: true,
+      });
+      const everyday = (fwd[0].props.options as Record<string, string>)
+        .Everyday;
+      expect(everyday).toBe('一千二百三十四');
+
+      const rev = await ChineseNumeralBoxSource.generateBoxes(everyday, {
+        chinesenum: true,
+      });
+      const num = (rev[0].props.options as Record<string, string>).Number;
+      expect(num).toBe('1234');
+    });
+
+    it('returns an error box for unrecognised input', async () => {
+      const boxes = await ChineseNumeralBoxSource.generateBoxes('hello', {
+        chinesenum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeTruthy();
+    });
+  });
+
+  describe('plaintext output is non-empty k:v lines', () => {
+    it('plaintext contains key: value pairs for int→chinese', async () => {
+      const boxes = await ChineseNumeralBoxSource.generateBoxes('1234', {
+        chinesenum: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Everyday: 一千二百三十四');
+      expect(text).toContain('Financial: 壹仟貳佰參拾肆');
+    });
+
+    it('plaintext contains key: value pairs for chinese→int', async () => {
+      const boxes = await ChineseNumeralBoxSource.generateBoxes(
+        '一千二百三十四',
+        { chinesenum: true },
+      );
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Number: 1234');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/DurationFormatBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DurationFormatBoxSource.test.ts
@@ -1,0 +1,194 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DurationFormatBoxSource } from '../DurationFormatBoxSource';
+
+describe('DurationFormatBoxSource', () => {
+  describe('no option key → empty array', () => {
+    it('returns [] when options is null', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options has no duration/humantime key', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', {
+        foo: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('seconds → human conversion', () => {
+    it('3661 → Human "1h 1m 1s", Clock "01:01:01"', async () => {
+      // verify: 1*3600 + 1*60 + 1 = 3661
+      expect(1 * 3600 + 1 * 60 + 1).toBe(3661);
+
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1h 1m 1s');
+      expect(opts.Clock).toBe('01:01:01');
+      expect(opts.Seconds).toBe('3661');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('90 → Human "1m 30s", Clock "00:01:30"', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('90', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1m 30s');
+      expect(opts.Clock).toBe('00:01:30');
+    });
+
+    it('0 → Human "0s"', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('0', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('0s');
+      expect(opts.Clock).toBe('00:00:00');
+    });
+
+    it('604800 (1 week) → Human contains "1w", Clock uses D:HH:MM:SS', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('604800', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toContain('1w');
+      // 7 days → clock should use D:HH:MM:SS form
+      expect(opts.Clock).toBe('7:00:00:00');
+    });
+
+    it('86461 (1d 1m 1s) → Human "1d 1m 1s"', async () => {
+      // verify: 86400 + 60 + 1 = 86461
+      expect(86400 + 60 + 1).toBe(86461);
+
+      const boxes = await DurationFormatBoxSource.generateBoxes('86461', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1d 1m 1s');
+      expect(opts.Clock).toBe('1:00:01:01');
+    });
+
+    it('also triggers on ::humantime option', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', {
+        humantime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1h 1m 1s');
+    });
+  });
+
+  describe('human string → seconds conversion', () => {
+    it('"1h30m" → Total Seconds "5400"', async () => {
+      // verify: 1*3600 + 30*60 = 5400
+      expect(1 * 3600 + 30 * 60).toBe(5400);
+
+      const boxes = await DurationFormatBoxSource.generateBoxes('1h30m', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('5400');
+    });
+
+    it('"2d 4h" → Total Seconds "187200"', async () => {
+      // verify: 2*86400 + 4*3600 = 172800 + 14400 = 187200
+      expect(2 * 86400 + 4 * 3600).toBe(187200);
+
+      const boxes = await DurationFormatBoxSource.generateBoxes('2d 4h', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('187200');
+    });
+
+    it('"90m" → Total Seconds "5400"', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('90m', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('5400');
+    });
+
+    it('"1h 1m 1s" → Total Seconds "3661"', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('1h 1m 1s', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('3661');
+    });
+
+    it('"1w" → Total Seconds "604800"', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('1w', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('604800');
+    });
+  });
+
+  describe('invalid / unrecognized input', () => {
+    it('"hello" → returns a box with a hint (not empty)', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('hello', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // should contain a hint key explaining the supported formats
+      expect(opts.Hint).toBeTruthy();
+      expect(opts.Input).toBe('hello');
+    });
+
+    it('input over 100 chars → []', async () => {
+      const long = 'a'.repeat(101);
+      const boxes = await DurationFormatBoxSource.generateBoxes(long, {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('box metadata', () => {
+    it('box name is "Duration" and uses KeyValueBoxTemplate', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', {
+        duration: true,
+      });
+      expect(boxes[0].props.name).toBe('Duration');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('plaintextOutput is non-empty k:v text', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', {
+        duration: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('Human: 1h 1m 1s');
+      expect(boxes[0].props.plaintextOutput).toContain('Clock: 01:01:01');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HmacBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HmacBoxSource.test.ts
@@ -1,0 +1,166 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { HmacBoxSource } from '../HmacBoxSource';
+
+// canonical test message and key used across most test cases
+const MESSAGE = 'The quick brown fox jumps over the lazy dog';
+const KEY = 'key';
+
+// RFC 4231 / Wikipedia HMAC known vectors for message=MESSAGE, key=KEY
+const EXPECTED_SHA256 =
+  'f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8';
+const EXPECTED_SHA1 = 'de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9';
+
+describe('HmacBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HmacBoxSource.name).toBe('HMAC');
+      expect(HmacBoxSource.tag).toBe('#');
+      expect(HmacBoxSource.kind).toBe('Encode');
+      expect(HmacBoxSource.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes — no trigger option', () => {
+    it('returns empty array when no option is provided (null)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is set', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, {
+        sha256: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — bare ::hmac (boolean true) → usage box', () => {
+    it('returns a usage hint box when key value is boolean true', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('HMAC');
+      expect(boxes[0].props.plaintextOutput).toMatch(/provide a key/i);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+
+  describe('generateBoxes — HMAC-SHA256 known vector', () => {
+    it('produces the canonical HMAC-SHA256 digest (Wikipedia / RFC 4231)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['HMAC-SHA256']).toBe(EXPECTED_SHA256);
+    });
+
+    it('also accepts the ::hmacsha256 alias', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, {
+        hmacsha256: KEY,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['HMAC-SHA256']).toBe(EXPECTED_SHA256);
+    });
+  });
+
+  describe('generateBoxes — HMAC-SHA1 known vector', () => {
+    it('produces the canonical HMAC-SHA1 digest (Wikipedia)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes[0].props.options?.['HMAC-SHA1']).toBe(EXPECTED_SHA1);
+    });
+  });
+
+  describe('generateBoxes — Key Length field', () => {
+    it('reports key byte length as "3" for key "key" — does NOT echo the key', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes[0].props.options?.['Key Length']).toBe('3');
+      // confirm the raw key string is absent from plaintext output
+      expect(boxes[0].props.plaintextOutput).not.toContain(`${KEY}:`);
+    });
+
+    it('reports correct byte length for a multi-byte UTF-8 key', async () => {
+      // '€' is 3 UTF-8 bytes
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: '€' });
+      expect(boxes[0].props.options?.['Key Length']).toBe('3');
+    });
+  });
+
+  describe('generateBoxes — output shape', () => {
+    it('returns a single HMAC box using KeyValueBoxTemplate', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('HMAC');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('options record contains all four expected keys', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      const opts = boxes[0].props.options ?? {};
+      expect(Object.keys(opts)).toEqual([
+        'HMAC-SHA256',
+        'HMAC-SHA1',
+        'HMAC-SHA512',
+        'Key Length',
+      ]);
+    });
+
+    it('plaintextOutput is non-empty k:v lines', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('HMAC-SHA256:');
+      expect(text).toContain('HMAC-SHA1:');
+      expect(text).toContain('HMAC-SHA512:');
+      expect(text).toContain('Key Length:');
+    });
+
+    it('priority is set on the box', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes — empty input', () => {
+    it('still returns an HMAC box (HMAC of empty message is valid)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('', { hmac: KEY });
+      expect(boxes).toHaveLength(1);
+      // HMAC-SHA256('', 'key') is a fixed deterministic value — just assert it is 64 hex chars
+      const sha256 = boxes[0].props.options?.['HMAC-SHA256'] as string;
+      expect(sha256).toHaveLength(64);
+      expect(sha256).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+
+  describe('generateBoxes — non-secure context fallback', () => {
+    const originalCrypto = globalThis.crypto;
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { subtle: undefined },
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('returns an informational box when crypto.subtle is unavailable', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HsvBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HsvBoxSource.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+
+import { HsvBoxSource, hsvToRgb, rgbToHex, rgbToHsv } from '../HsvBoxSource';
+
+// ─── conversion helper unit tests ────────────────────────────────────────────
+
+describe('rgbToHsv', () => {
+  it('converts red rgb(255,0,0) to hsv(0, 100%, 100%)', () => {
+    expect(rgbToHsv(255, 0, 0)).toEqual({ h: 0, s: 100, v: 100 });
+  });
+
+  it('converts green rgb(0,255,0) to hsv(120, 100%, 100%)', () => {
+    expect(rgbToHsv(0, 255, 0)).toEqual({ h: 120, s: 100, v: 100 });
+  });
+
+  it('converts blue rgb(0,0,255) to hsv(240, 100%, 100%)', () => {
+    expect(rgbToHsv(0, 0, 255)).toEqual({ h: 240, s: 100, v: 100 });
+  });
+
+  it('converts white rgb(255,255,255) to hsv(0, 0%, 100%)', () => {
+    expect(rgbToHsv(255, 255, 255)).toEqual({ h: 0, s: 0, v: 100 });
+  });
+
+  it('converts black rgb(0,0,0) to hsv(0, 0%, 0%)', () => {
+    expect(rgbToHsv(0, 0, 0)).toEqual({ h: 0, s: 0, v: 0 });
+  });
+
+  it('converts tomato rgb(255,99,71) to hsv(9, 72%, 100%)', () => {
+    // max=255(v=100%), min=71, delta=184
+    // s=184/255≈72%, h=60*((99-71)/184 % 6)=60*(28/184)≈9.13→9
+    expect(rgbToHsv(255, 99, 71)).toEqual({ h: 9, s: 72, v: 100 });
+  });
+});
+
+describe('hsvToRgb', () => {
+  it('converts hsv(0, 100%, 100%) to rgb(255,0,0)', () => {
+    expect(hsvToRgb(0, 100, 100)).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it('converts hsv(120, 100%, 100%) to rgb(0,255,0)', () => {
+    expect(hsvToRgb(120, 100, 100)).toEqual({ r: 0, g: 255, b: 0 });
+  });
+
+  it('converts hsv(240, 100%, 100%) to rgb(0,0,255)', () => {
+    expect(hsvToRgb(240, 100, 100)).toEqual({ r: 0, g: 0, b: 255 });
+  });
+
+  it('converts hsv(0, 0%, 100%) to rgb(255,255,255)', () => {
+    expect(hsvToRgb(0, 0, 100)).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it('converts hsv(0, 0%, 0%) to rgb(0,0,0)', () => {
+    expect(hsvToRgb(0, 0, 0)).toEqual({ r: 0, g: 0, b: 0 });
+  });
+});
+
+describe('rgbToHex', () => {
+  it('formats rgb(255,0,0) as #ff0000', () => {
+    expect(rgbToHex(255, 0, 0)).toBe('#ff0000');
+  });
+
+  it('formats rgb(0,255,0) as #00ff00', () => {
+    expect(rgbToHex(0, 255, 0)).toBe('#00ff00');
+  });
+
+  it('formats rgb(0,0,255) as #0000ff', () => {
+    expect(rgbToHex(0, 0, 255)).toBe('#0000ff');
+  });
+});
+
+// ─── HsvBoxSource.generateBoxes ───────────────────────────────────────────────
+
+describe('HsvBoxSource.generateBoxes', () => {
+  it('returns [] when no ::hsv/::hsb option is present', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff6347', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] when options is empty object', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff6347', {});
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('tomato #ff6347 + ::hsv → HSV hsv(9, 72%, 100%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff6347', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(9, 72%, 100%)');
+    expect(kv.Hex).toBe('#ff6347');
+    expect(kv.RGB).toBe('rgb(255, 99, 71)');
+  });
+
+  it('pure red #ff0000 → hsv(0, 100%, 100%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff0000', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(0, 100%, 100%)');
+  });
+
+  it('white #ffffff → hsv(0, 0%, 100%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ffffff', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(0, 0%, 100%)');
+  });
+
+  it('black #000000 → hsv(0, 0%, 0%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#000000', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(0, 0%, 0%)');
+  });
+
+  it('green #00ff00 → hsv(120, 100%, 100%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#00ff00', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(120, 100%, 100%)');
+  });
+
+  it('blue #0000ff → hsv(240, 100%, 100%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#0000ff', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(240, 100%, 100%)');
+  });
+
+  it('accepts ::hsb alias', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff0000', { hsb: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(0, 100%, 100%)');
+  });
+
+  it('rgb(255,99,71) input → same HSV as hex tomato', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('rgb(255, 99, 71)', {
+      hsv: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(9, 72%, 100%)');
+  });
+
+  // reverse: hsv → rgb/hex
+
+  it('reverse hsv(120, 100%, 100%) → Hex #00ff00', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('hsv(120, 100%, 100%)', {
+      hsv: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Hex).toBe('#00ff00');
+    expect(kv.RGB).toBe('rgb(0, 255, 0)');
+  });
+
+  it('reverse hsv(0, 0%, 100%) → Hex #ffffff', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('hsv(0, 0%, 100%)', {
+      hsv: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Hex).toBe('#ffffff');
+  });
+
+  it('reverse hsv without % signs hsv(120, 100, 100) → Hex #00ff00', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('hsv(120, 100, 100)', {
+      hsv: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Hex).toBe('#00ff00');
+  });
+
+  it('reverse hsb(240, 100%, 100%) → Hex #0000ff', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('hsb(240, 100%, 100%)', {
+      hsv: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Hex).toBe('#0000ff');
+  });
+
+  // invalid input → format hint box
+
+  it('invalid input "hello" → returns a hint box', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('hello', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Accepted).toBeDefined();
+  });
+
+  // box metadata
+
+  it('box name is "HSV"', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff0000', { hsv: true });
+    expect(boxes[0].props.name).toBe('HSV');
+  });
+
+  it('box priority matches HsvBoxSource.priority', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff0000', { hsv: true });
+    expect(boxes[0].props.priority).toBe(HsvBoxSource.priority);
+  });
+
+  it('plaintext contains key:value pairs', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff0000', { hsv: true });
+    const text = boxes[0].props.plaintextOutput;
+    expect(text).toContain('Hex:');
+    expect(text).toContain('RGB:');
+    expect(text).toContain('HSV:');
+  });
+});

--- a/src/modules/boxSources/__test__/PopcountBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PopcountBoxSource.test.ts
@@ -1,0 +1,251 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { PopcountBoxSource } from '../PopcountBoxSource';
+
+describe('PopcountBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::popcount option', () => {
+    it('activates on ::popcount', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('activates on ::bitcount', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        bitcount: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('255 (0xff = 11111111)', () => {
+    it('has Set Bits = 8', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('8');
+    });
+
+    it('has Bit Length = 8', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Bit Length']).toBe('8');
+    });
+
+    it('has Trailing Zeros = 0', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('0');
+    });
+
+    it('has correct Decimal, Binary, Hex fields', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      const opts = boxes[0].props.options;
+      expect(opts?.Decimal).toBe('255');
+      expect(opts?.Binary).toBe('0b11111111');
+      expect(opts?.Hex).toBe('0xff');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+
+  describe('0 edge case', () => {
+    it('has Set Bits = 0', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('0');
+    });
+
+    it('has Bit Length = 0', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Bit Length']).toBe('0');
+    });
+
+    it('has Trailing Zeros = 0', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('0');
+    });
+  });
+
+  describe('8 (0b1000)', () => {
+    it('has Set Bits = 1', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('8', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('1');
+    });
+
+    it('has Trailing Zeros = 3', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('8', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('3');
+    });
+  });
+
+  describe('hex input 0xff', () => {
+    it('has Set Bits = 8', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0xff', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('8');
+    });
+  });
+
+  describe('binary input 0b1010', () => {
+    it('has Set Bits = 2', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0b1010', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('2');
+    });
+
+    it('has Trailing Zeros = 1', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0b1010', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('1');
+    });
+  });
+
+  describe('64-bit all-ones: 0xffffffffffffffff', () => {
+    it('has Set Bits = 64 (BigInt — no overflow)', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes(
+        '0xffffffffffffffff',
+        {
+          popcount: true,
+        },
+      );
+      expect(boxes[0].props.options?.['Set Bits']).toBe('64');
+    });
+
+    it('has Bit Length = 64', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes(
+        '0xffffffffffffffff',
+        {
+          popcount: true,
+        },
+      );
+      expect(boxes[0].props.options?.['Bit Length']).toBe('64');
+    });
+
+    it('has Trailing Zeros = 0', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes(
+        '0xffffffffffffffff',
+        {
+          popcount: true,
+        },
+      );
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('0');
+    });
+  });
+
+  describe('power of two: 1024 (0b10000000000)', () => {
+    it('has Set Bits = 1', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('1024', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('1');
+    });
+
+    it('has Bit Length = 11', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('1024', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Bit Length']).toBe('11');
+    });
+
+    it('has Trailing Zeros = 10', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('1024', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('10');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('returns an error box for "abc"', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('abc', {
+        popcount: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeTruthy();
+    });
+
+    it('returns an error box for "-5"', async () => {
+      // -5 starts with '-', not matched by decimal/hex/binary patterns → error box
+      const boxes = await PopcountBoxSource.generateBoxes('-5', {
+        popcount: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeTruthy();
+    });
+
+    it('returns an error box for empty string', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('', {
+        popcount: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeTruthy();
+    });
+  });
+
+  describe('box metadata', () => {
+    it('box name is Popcount', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('1', {
+        popcount: true,
+      });
+      expect(boxes[0].props.name).toBe('Popcount');
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('1', {
+        popcount: true,
+      });
+      expect(boxes[0].props.priority).toBe(PopcountBoxSource.priority);
+    });
+  });
+
+  describe('static metadata', () => {
+    it('has expected name, tag, kind', () => {
+      expect(PopcountBoxSource.name).toBe('Popcount');
+      expect(PopcountBoxSource.tag).toBe('#');
+      expect(PopcountBoxSource.kind).toBe('Calculate');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,20 +1,28 @@
+import Ascii85BoxSource from './Ascii85BoxSource';
+import AsciiTableBoxSource from './AsciiTableBoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import CharFrequencyBoxSource from './CharFrequencyBoxSource';
+import ChineseNumeralBoxSource from './ChineseNumeralBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DurationFormatBoxSource from './DurationFormatBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HmacBoxSource from './HmacBoxSource';
+import HsvBoxSource from './HsvBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PopcountBoxSource from './PopcountBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
@@ -29,19 +37,27 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  AsciiTableBoxSource,
+  CharFrequencyBoxSource,
+  ChineseNumeralBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
+  Ascii85BoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  DurationFormatBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HmacBoxSource,
+  HsvBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  PopcountBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,


### PR DESCRIPTION
## Summary

Twenty-ninth exploration batch — **8 more BoxSource tools** (crypto, color, encoding, text, time, bits, numerals).

| Tool | Trigger | What it does |
|------|---------|--------------|
| HMAC | `::hmac=<key>` | HMAC-SHA256/SHA1/SHA512 (Web Crypto) |
| HSV | `::hsv` | color hex/RGB ⇄ HSV (HSB) |
| ASCII Code | `::ascii` | character ⇄ code point (dec/hex/oct/bin) |
| Character Frequency | `::charfreq` | per-character counts |
| Duration | `::duration` | seconds ⇄ human duration (1h 1m 1s) |
| Popcount | `::popcount` | set bits + bit length (BigInt) |
| Ascii85 | `::ascii85` | base85 encode/decode |
| Chinese Numerals | `::chinesenum` | integer ⇄ 一二三 / 壹貳參 (zh-TW) |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Hardening rules pre-loaded (HMAC **never echoes the key** — only its byte length; secure-context guard; `Map` for char-frequency to dodge prototype pollution; code-point iteration; BigInt for popcount; `>>> 0` for Ascii85).
- **Verified vectors**: **HMAC-SHA256 `'The quick brown fox…'`/`key`→`f7bc83f4…3cd8`** (Wikipedia canonical) + HMAC-SHA1 `de7c9b85…`; tomato→`hsv(9, 72%, 100%)`, green↔`hsv(120,100,100)`; `A`↔`65`/`0x41`; `hello`→`l:2`, Total 5/Unique 4; `3661`→`1h 1m 1s`/`01:01:01`, `1h30m`→`5400`; `255`→8 set bits, 64-bit all-ones→64; **`'Man '`→`9jqo^`**; **`1234`→`一千二百三十四`, `1001`→`一千零一`**.

## Self-review fixes (pre-PR)

- **HMAC** `Uint8Array`→`BufferSource` cast (TS 5.7 `ArrayBufferLike` strictness).
- **ASCII** `parseInt('0b1000001', 2)` returns `0` (stops at `b`) → strip the `0b`/`0o`/`0x` prefix before parsing.
- Corrected three test assertions (ambiguous single `'0'` = the digit not NUL; `__proto__` has 4 underscores).

## Verification

- ✅ `bun run test run` — **497 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of #260–#287 — branched from `main`.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6