### PR TITLE
feat(boxSources): add 8 more tools (pbkdf2, sort-lines, json-merge, text-wrap, note, area, objectid, braille)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>Pbkdf2Box</b> </summary>
+
+| match rule        | description                          | example               |
+| ----------------- | ------------------------------------ | --------------------- |
+| `::pbkdf2=<pw>`   | derive key bits (PBKDF2-HMAC-SHA256; password not echoed/shared) | `salt ::pbkdf2=secret` |
+
+</details>
+
+<details>
+<summary> <b>SortLinesBox</b> </summary>
+
+| match rule      | description                          | example                  |
+| --------------- | ------------------------------------ | ------------------------ |
+| `::sortlines`   | sort lines (`::desc` `::numeric` `::unique` `::ci`) | `b\na\nc ::sortlines` |
+
+</details>
+
+<details>
+<summary> <b>JsonMergeBox</b> </summary>
+
+| match rule      | description                          | example                       |
+| --------------- | ------------------------------------ | ----------------------------- |
+| `::jsonmerge`   | deep-merge two JSON docs (split by `---`) | `{...}`<br>`---`<br>`{...}` `::jsonmerge` |
+
+</details>
+
+<details>
+<summary> <b>TextWrapBox</b> </summary>
+
+| match rule      | description                          | example                  |
+| --------------- | ------------------------------------ | ------------------------ |
+| `::wrap=<n>`    | word-wrap text to a column width     | `long text ::wrap=20`    |
+
+</details>
+
+<details>
+<summary> <b>MusicalNoteBox</b> </summary>
+
+| match rule  | description                          | example      |
+| ----------- | ------------------------------------ | ------------ |
+| `::note`    | note name ⇄ frequency (A4=440, 12-TET) | `A4 ::note` |
+
+</details>
+
+<details>
+<summary> <b>AreaConvertBox</b> </summary>
+
+| match rule  | description                          | example           |
+| ----------- | ------------------------------------ | ----------------- |
+| `::area`    | m²/km²/ft²/acre/hectare/mile²        | `1 acre ::area`   |
+
+</details>
+
+<details>
+<summary> <b>ObjectIdBox</b> </summary>
+
+| match rule     | description                          | example                          |
+| -------------- | ------------------------------------ | -------------------------------- |
+| `::objectid`   | parse a MongoDB ObjectId (timestamp, counter) | `507f1f77bcf86cd799439011 ::objectid` |
+
+</details>
+
+<details>
+<summary> <b>BrailleBox</b> </summary>
+
+| match rule    | description                          | example            |
+| ------------- | ------------------------------------ | ------------------ |
+| `::braille`   | text ⇄ Unicode Braille (Grade 1)     | `hello ::braille`  |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/functions/__test__/shareLink.test.ts
+++ b/src/functions/__test__/shareLink.test.ts
@@ -65,4 +65,22 @@ describe('buildShareLink', () => {
     const url = new URL(result);
     expect(url.origin).toBe(window.location.origin);
   });
+
+  it('redacts secret option values (::pbkdf2 / ::hmac / ::jwtsign)', () => {
+    const cases: [string, string][] = [
+      ['salt ::pbkdf2=mypassword', 'mypassword'],
+      ['message ::hmac=mysecretkey', 'mysecretkey'],
+      ['payload ::jwtsign=topsecret', 'topsecret'],
+    ];
+    for (const [input, secret] of cases) {
+      const result = buildShareLink({
+        input,
+        pathname: '/',
+        origin: 'http://localhost:3000',
+      });
+      const shared = new URL(result).searchParams.get('input') ?? '';
+      expect(shared).not.toContain(secret);
+      expect(shared).toContain('<redacted>');
+    }
+  });
 });

--- a/src/functions/shareLink.ts
+++ b/src/functions/shareLink.ts
@@ -16,6 +16,22 @@ const setParamIfPresent = (
   }
 };
 
+// option keys whose values are secrets and must never appear in a shareable
+// URL (which lands in browser history and server logs). the value is replaced
+// with a placeholder while the option itself is preserved so the link still
+// demonstrates the tool.
+const SECRET_OPTION_PATTERNS: RegExp[] = [
+  /(::pbkdf2=)\S+/gi,
+  /(::hmac(?:sha256)?=)\S+/gi,
+  /(::jwtsign=)\S+/gi,
+];
+
+const redactSecrets = (input: string): string =>
+  SECRET_OPTION_PATTERNS.reduce(
+    (acc, pattern) => acc.replace(pattern, '$1<redacted>'),
+    input,
+  );
+
 export const buildShareLink = ({
   box,
   input,
@@ -24,6 +40,10 @@ export const buildShareLink = ({
 }: ShareLinkParams & { origin?: string }): string => {
   const url = new URL(pathname, origin);
   setParamIfPresent(url.searchParams, 'box', box);
-  setParamIfPresent(url.searchParams, 'input', input);
+  setParamIfPresent(
+    url.searchParams,
+    'input',
+    input ? redactSecrets(input) : input,
+  );
   return url.toString();
 };

--- a/src/modules/boxSources/AreaConvertBoxSource.ts
+++ b/src/modules/boxSources/AreaConvertBoxSource.ts
@@ -1,0 +1,136 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit (normalized) -> square meters
+const TO_M2: Record<string, number> = {
+  m2: 1,
+  km2: 1e6,
+  cm2: 1e-4,
+  mm2: 1e-6,
+  ft2: 0.09290304,
+  in2: 0.00064516,
+  yd2: 0.83612736,
+  acre: 4046.8564224,
+  hectare: 10000,
+  ha: 10000,
+  mi2: 2589988.110336,
+};
+
+// output units with display labels, in display order
+const OUTPUT_UNITS: { key: string; label: string }[] = [
+  { key: 'm2', label: 'm²' },
+  { key: 'km2', label: 'km²' },
+  { key: 'cm2', label: 'cm²' },
+  { key: 'ft2', label: 'ft²' },
+  { key: 'in2', label: 'in²' },
+  { key: 'yd2', label: 'yd²' },
+  { key: 'acre', label: 'acre' },
+  { key: 'hectare', label: 'hectare' },
+  { key: 'mi2', label: 'mile²' },
+];
+
+// normalize a raw unit string into a key for TO_M2 lookup
+function normalizeUnit(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/\^2/g, '2')
+    .replace(/²/g, '2')
+    .replace(/\s+/g, '');
+}
+
+// format as integer when exact, otherwise 6 decimal places stripped of trailing zeros
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// build a plaintext k:v block for the KeyValueBoxTemplate
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// list of supported unit names for error messages
+const SUPPORTED_UNITS = Object.keys(TO_M2).join(', ');
+
+export const AreaConvertBoxSource = {
+  name: 'Area Convert',
+  description: 'Convert an area between m², km², ft², acre, hectare, and more.',
+  defaultInput: '1 acre ::area',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'area')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > 64) return [];
+
+    // parse "<number> <unit>" with optional whitespace
+    const match = raw.match(/^(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s+(.+)$/);
+    if (!match) {
+      return [
+        new BoxBuilder(
+          'Area Convert',
+          `Format: "<number> <unit>"\nSupported units: ${SUPPORTED_UNITS}`,
+        )
+          .setOptions({
+            Error: 'invalid format',
+            Format: '<number> <unit>',
+            'Supported units': SUPPORTED_UNITS,
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitKey = normalizeUnit(match[2]);
+
+    if (!(unitKey in TO_M2)) {
+      return [
+        new BoxBuilder(
+          'Area Convert',
+          `Unknown unit "${match[2]}"\nSupported units: ${SUPPORTED_UNITS}`,
+        )
+          .setOptions({
+            Error: `unknown unit "${match[2]}"`,
+            'Supported units': SUPPORTED_UNITS,
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const valueInM2 = value * TO_M2[unitKey];
+
+    const kvPairs: Record<string, string> = {
+      Input: `${formatValue(value)} ${match[2]}`,
+    };
+    for (const { key, label } of OUTPUT_UNITS) {
+      const converted = valueInM2 / TO_M2[key];
+      kvPairs[label] = formatValue(converted);
+    }
+
+    return [
+      new BoxBuilder('Area Convert', kvToPlaintext(kvPairs))
+        .setOptions(kvPairs)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default AreaConvertBoxSource;

--- a/src/modules/boxSources/BrailleBoxSource.ts
+++ b/src/modules/boxSources/BrailleBoxSource.ts
@@ -1,0 +1,115 @@
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// grade 1 english braille: each letter maps to a unicode braille cell.
+// braille cell bitmask: dot1=1, dot2=2, dot3=4, dot4=8, dot5=16, dot6=32.
+// unicode braille block starts at U+2800; char = U+2800 + bitmask.
+const LETTER_TO_BRAILLE: ReadonlyMap<string, string> = new Map([
+  ['a', '⠁'], // dot1
+  ['b', '⠃'], // dots 1,2
+  ['c', '⠉'], // dots 1,4
+  ['d', '⠙'], // dots 1,4,5
+  ['e', '⠑'], // dots 1,5
+  ['f', '⠋'], // dots 1,2,4
+  ['g', '⠛'], // dots 1,2,4,5
+  ['h', '⠓'], // dots 1,2,5
+  ['i', '⠊'], // dots 2,4
+  ['j', '⠚'], // dots 2,4,5
+  ['k', '⠅'], // dots 1,3
+  ['l', '⠇'], // dots 1,2,3
+  ['m', '⠍'], // dots 1,3,4
+  ['n', '⠝'], // dots 1,3,4,5
+  ['o', '⠕'], // dots 1,3,5
+  ['p', '⠏'], // dots 1,2,3,4
+  ['q', '⠟'], // dots 1,2,3,4,5
+  ['r', '⠗'], // dots 1,2,3,5
+  ['s', '⠎'], // dots 2,3,4
+  ['t', '⠞'], // dots 2,3,4,5
+  ['u', '⠥'], // dots 1,3,6
+  ['v', '⠧'], // dots 1,2,3,6
+  ['w', '⠺'], // dots 2,4,5,6
+  ['x', '⠭'], // dots 1,3,4,6
+  ['y', '⠽'], // dots 1,3,4,5,6
+  ['z', '⠵'], // dots 1,3,5,6
+  [' ', '⠀'], // blank braille cell for space
+]);
+
+// reverse map built once at module load
+const BRAILLE_TO_LETTER: ReadonlyMap<string, string> = new Map(
+  Array.from(LETTER_TO_BRAILLE.entries()).map(([letter, braille]) => [
+    braille,
+    letter,
+  ]),
+);
+
+function encode(input: string): string {
+  const lower = input.toLowerCase();
+  let result = '';
+  for (const ch of lower) {
+    const braille = LETTER_TO_BRAILLE.get(ch);
+    result += braille !== undefined ? braille : ch;
+  }
+  return result;
+}
+
+function decode(input: string): string {
+  let result = '';
+  for (const ch of input) {
+    const letter = BRAILLE_TO_LETTER.get(ch);
+    result += letter !== undefined ? letter : ch;
+  }
+  return result;
+}
+
+export const BrailleBoxSource = {
+  name: 'Braille',
+  description:
+    'Convert text to Unicode Braille (Grade 1) or decode Braille back to text. ::braille to encode, ::brailledecode to decode.',
+  defaultInput: 'hello ::braille',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'braille', 'brailleencode');
+    const wantDecode = hasOptionKeys(options, 'brailledecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      boxes.push(
+        new BoxBuilder('Braille (Encode)', encode(input))
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      boxes.push(
+        new BoxBuilder('Braille (Decode)', decode(input))
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default BrailleBoxSource;

--- a/src/modules/boxSources/JsonMergeBoxSource.ts
+++ b/src/modules/boxSources/JsonMergeBoxSource.ts
@@ -1,0 +1,144 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// keys that must never be assigned during merge to prevent prototype pollution
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** recursively merge `target` with `source`; source wins on conflict. arrays are replaced, not concatenated. */
+function deepMerge(
+  target: { [key: string]: JsonValue },
+  source: { [key: string]: JsonValue },
+): { [key: string]: JsonValue } {
+  const result: { [key: string]: JsonValue } = { ...target };
+
+  for (const key of Object.keys(source)) {
+    if (FORBIDDEN_KEYS.has(key)) continue;
+
+    const srcVal = source[key];
+    const tgtVal = result[key];
+
+    if (
+      srcVal !== null &&
+      typeof srcVal === 'object' &&
+      !Array.isArray(srcVal) &&
+      tgtVal !== null &&
+      typeof tgtVal === 'object' &&
+      !Array.isArray(tgtVal)
+    ) {
+      result[key] = deepMerge(
+        tgtVal as { [key: string]: JsonValue },
+        srcVal as { [key: string]: JsonValue },
+      );
+    } else {
+      result[key] = srcVal;
+    }
+  }
+
+  return result;
+}
+
+export const JsonMergeBoxSource = {
+  name: 'JSON Merge',
+  description:
+    'Deep-merge two JSON documents (the second overrides the first). Separate them with a line containing only ---.',
+  defaultInput: '{"a":1,"b":{"x":1}}\n---\n{"b":{"y":2},"c":3} ::jsonmerge',
+  tag: '{}+',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonmerge', 'merge')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    // split on a line that is exactly '---'
+    const parts = trimmed.split(/^---$/m);
+
+    if (parts.length !== 2) {
+      return [
+        new BoxBuilder(
+          'JSON Merge',
+          'Provide two JSON documents separated by a line containing only ---.',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const [rawFirst, rawSecond] = parts;
+
+    let first: { [key: string]: JsonValue };
+    try {
+      const parsed = JSON.parse(trim(rawFirst));
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        throw new SyntaxError('not a JSON object');
+      }
+      first = parsed as { [key: string]: JsonValue };
+    } catch {
+      return [
+        new BoxBuilder(
+          'JSON Merge',
+          'The first document is not valid JSON. Check its syntax and try again.',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    let second: { [key: string]: JsonValue };
+    try {
+      const parsed = JSON.parse(trim(rawSecond));
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        throw new SyntaxError('not a JSON object');
+      }
+      second = parsed as { [key: string]: JsonValue };
+    } catch {
+      return [
+        new BoxBuilder(
+          'JSON Merge',
+          'The second document is not valid JSON. Check its syntax and try again.',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const merged = deepMerge(first, second);
+    const output = JSON.stringify(merged, null, 2);
+
+    return [
+      new BoxBuilder('JSON Merge', output)
+        .setOptions({ language: 'json' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonMergeBoxSource;

--- a/src/modules/boxSources/JsonMergeBoxSource.ts
+++ b/src/modules/boxSources/JsonMergeBoxSource.ts
@@ -128,8 +128,22 @@ export const JsonMergeBoxSource = {
       ];
     }
 
-    const merged = deepMerge(first, second);
-    const output = JSON.stringify(merged, null, 2);
+    let output: string;
+    try {
+      // deepMerge recurses per nesting level; a pathologically deep document
+      // (that JSON.parse still accepted) could overflow the stack — contain it
+      const merged = deepMerge(first, second);
+      output = JSON.stringify(merged, null, 2);
+    } catch {
+      return [
+        new BoxBuilder(
+          'JSON Merge',
+          'The documents are nested too deeply to merge.',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
 
     return [
       new BoxBuilder('JSON Merge', output)

--- a/src/modules/boxSources/NoteFrequencyBoxSource.ts
+++ b/src/modules/boxSources/NoteFrequencyBoxSource.ts
@@ -1,0 +1,158 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// standard 12-TET pitch class mapping: C=0, C#/Db=1, ..., B=11
+const NOTE_NAMES = [
+  'C',
+  'C#',
+  'D',
+  'D#',
+  'E',
+  'F',
+  'F#',
+  'G',
+  'G#',
+  'A',
+  'A#',
+  'B',
+];
+
+const PITCH_CLASS: Record<string, number> = {
+  C: 0,
+  D: 2,
+  E: 4,
+  F: 5,
+  G: 7,
+  A: 9,
+  B: 11,
+};
+
+// regex for a note name with optional accidental and octave
+const NOTE_PATTERN = /^([A-Ga-g])(#|b)?(-?\d+)$/;
+
+// regex for a bare numeric frequency (Hz)
+const FREQ_PATTERN = /^\d+(\.\d+)?$/;
+
+function noteToMidi(
+  noteLetter: string,
+  accidental: string | undefined,
+  octave: number,
+): number {
+  const base = PITCH_CLASS[noteLetter.toUpperCase()];
+  const shift = accidental === '#' ? 1 : accidental === 'b' ? -1 : 0;
+  // midi middle-C (C4) = 60; formula: (octave+1)*12 + pitchClass
+  return (octave + 1) * 12 + base + shift;
+}
+
+function midiToFreq(midi: number): number {
+  return 440 * 2 ** ((midi - 69) / 12);
+}
+
+function midiToNoteName(midi: number): string {
+  const pitchClass = ((midi % 12) + 12) % 12;
+  const octave = Math.floor(midi / 12) - 1;
+  return `${NOTE_NAMES[pitchClass]}${octave}`;
+}
+
+// build a plaintext representation of key:value pairs for KeyValueBoxTemplate fallback
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const NoteFrequencyBoxSource = {
+  name: 'Musical Note',
+  description:
+    'Convert a musical note (e.g. A4) to its frequency in Hz, or a frequency to the nearest note (A4=440, 12-TET).',
+  defaultInput: 'A4 ::note',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'note', 'pitch')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > 32) return [];
+
+    // note name → frequency
+    const noteMatch = NOTE_PATTERN.exec(raw);
+    if (noteMatch) {
+      const [, letter, accidental, octaveStr] = noteMatch;
+      const octave = Number.parseInt(octaveStr, 10);
+      const midi = noteToMidi(letter, accidental, octave);
+      const freq = midiToFreq(midi);
+      const freqStr = freq.toFixed(2);
+      const noteName = midiToNoteName(midi);
+
+      const pairs: Record<string, string> = {
+        Note: noteName,
+        Frequency: `${freqStr} Hz`,
+        MIDI: String(midi),
+      };
+
+      return [
+        new BoxBuilder('Musical Note', kvToPlaintext(pairs))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(pairs)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // frequency (Hz) → nearest note
+    const freqMatch = FREQ_PATTERN.exec(raw);
+    if (freqMatch) {
+      const freq = Number.parseFloat(raw);
+      if (freq <= 0) return [];
+
+      const midiExact = 69 + 12 * Math.log2(freq / 440);
+      const midi = Math.round(midiExact);
+      const noteName = midiToNoteName(midi);
+      const noteFreq = midiToFreq(midi);
+      const cents = Math.round((midiExact - midi) * 100);
+      const centsStr = cents >= 0 ? `+${cents}` : String(cents);
+
+      const pairs: Record<string, string> = {
+        Frequency: `${freq} Hz`,
+        'Nearest Note': noteName,
+        'Note Frequency': `${noteFreq.toFixed(2)} Hz`,
+        Cents: centsStr,
+        MIDI: String(midi),
+      };
+
+      return [
+        new BoxBuilder('Musical Note', kvToPlaintext(pairs))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(pairs)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // unrecognized input — explain accepted formats
+    const helpText =
+      'Enter a note name (e.g. A4, C#5, Bb3) or a frequency in Hz (e.g. 440).';
+    const pairs: Record<string, string> = {
+      Format: helpText,
+    };
+
+    return [
+      new BoxBuilder('Musical Note', kvToPlaintext(pairs))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(pairs)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NoteFrequencyBoxSource;

--- a/src/modules/boxSources/ObjectIdBoxSource.ts
+++ b/src/modules/boxSources/ObjectIdBoxSource.ts
@@ -1,0 +1,93 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// regex to strip an optional ObjectId("...") or ObjectId('...') wrapper
+const WRAPPER_RE = /^ObjectId\(["']([0-9a-f]{24})["']\)$/i;
+const HEX24_RE = /^[0-9a-f]{24}$/i;
+
+/** strips an ObjectId("...") wrapper and returns the bare hex string, or null if invalid */
+function parseObjectId(raw: string): string | null {
+  const trimmed = trim(raw);
+
+  const wrapperMatch = WRAPPER_RE.exec(trimmed);
+  if (wrapperMatch) {
+    return wrapperMatch[1].toLowerCase();
+  }
+
+  if (HEX24_RE.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+
+  return null;
+}
+
+export const ObjectIdBoxSource = {
+  name: 'MongoDB ObjectId',
+  description:
+    'Parse a MongoDB ObjectId (24 hex chars) into its embedded timestamp, machine, and counter.',
+  defaultInput: '507f1f77bcf86cd799439011 ::objectid',
+  tag: '#',
+  kind: 'Decode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'objectid', 'oid')) return [];
+
+    const id = parseObjectId(input);
+
+    if (id === null) {
+      // return an explanatory box for invalid input
+      const plaintext =
+        'ObjectId: (invalid)\nReason: a 24-character hex ObjectId is required';
+      return [
+        new BoxBuilder('MongoDB ObjectId', plaintext)
+          .setOptions({
+            ObjectId: '(invalid)',
+            Reason: 'a 24-character hex ObjectId is required',
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const timestampHex = id.slice(0, 8);
+    const randomMachine = id.slice(8, 18);
+    const counterHex = id.slice(18, 24);
+
+    const timestampUnix = Number.parseInt(timestampHex, 16);
+    const counter = Number.parseInt(counterHex, 16);
+    const timestampUTC = new Date(timestampUnix * 1000).toISOString();
+
+    // build k:v plaintext for copy-to-clipboard
+    const kvData: Record<string, string> = {
+      'Timestamp (hex)': timestampHex,
+      'Timestamp (unix)': String(timestampUnix),
+      'Timestamp (UTC)': timestampUTC,
+      'Random / Machine': randomMachine,
+      Counter: String(counter),
+      ObjectId: id,
+    };
+
+    const plaintext = Object.entries(kvData)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('MongoDB ObjectId', plaintext)
+        .setOptions(kvData)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ObjectIdBoxSource;

--- a/src/modules/boxSources/Pbkdf2BoxSource.ts
+++ b/src/modules/boxSources/Pbkdf2BoxSource.ts
@@ -1,0 +1,151 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max iterations capped to prevent UI freezes from absurdly large values
+const MAX_ITERATIONS = 1_000_000;
+const DEFAULT_ITERATIONS = 100_000;
+const DEFAULT_DKLEN = 32;
+const MAX_DKLEN = 256;
+
+function bufToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// clamp a numeric value within [min, max], falling back to fallback when non-numeric
+function clampNumericOption(
+  raw: string | boolean | null,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (typeof raw !== 'string') return fallback;
+  const n = parseInt(raw, 10);
+  if (Number.isNaN(n)) return fallback;
+  return Math.min(Math.max(n, min), max);
+}
+
+// converts a key-value record to a human-readable plaintext listing
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const Pbkdf2BoxSource = {
+  name: 'PBKDF2',
+  description:
+    'Derive key bits from a password via PBKDF2 (HMAC-SHA256). Input is the salt; ::pbkdf2=<password>. Options ::iterations=<n>, ::dklen=<bytes>.',
+  defaultInput: 'salt ::pbkdf2=password',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const password = extractOptionKeys(options, 'pbkdf2');
+
+    // no ::pbkdf2 option at all — not our trigger
+    if (password === null) return [];
+
+    // bare ::pbkdf2 without a value — show usage hint
+    if (typeof password !== 'string') {
+      return [
+        new BoxBuilder('PBKDF2', 'provide a password, e.g. ::pbkdf2=secret')
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // guard against non-secure contexts where crypto.subtle is unavailable
+    if (typeof crypto === 'undefined' || !crypto?.subtle) {
+      return [
+        new BoxBuilder(
+          'PBKDF2',
+          'PBKDF2 requires a secure context (HTTPS). crypto.subtle is not available.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const iterationsRaw = extractOptionKeys(options, 'iterations');
+    const dklenRaw = extractOptionKeys(options, 'dklen');
+
+    const iterations = clampNumericOption(
+      iterationsRaw,
+      DEFAULT_ITERATIONS,
+      1,
+      MAX_ITERATIONS,
+    );
+    const dklen = clampNumericOption(dklenRaw, DEFAULT_DKLEN, 1, MAX_DKLEN);
+
+    const encoder = new TextEncoder();
+    const passwordBytes = encoder.encode(password);
+    const saltBytes = encoder.encode(input);
+
+    try {
+      const baseKey = await crypto.subtle.importKey(
+        'raw',
+        passwordBytes,
+        'PBKDF2',
+        false,
+        ['deriveBits'],
+      );
+
+      const derivedBits = await crypto.subtle.deriveBits(
+        {
+          name: 'PBKDF2',
+          salt: saltBytes,
+          iterations,
+          hash: 'SHA-256',
+        },
+        baseKey,
+        dklen * 8,
+      );
+
+      const hexKey = bufToHex(derivedBits);
+
+      // password is intentionally excluded from the output — it's a secret
+      const kv: Record<string, string> = {
+        'Derived Key (hex)': hexKey,
+        Salt: input,
+        Iterations: String(iterations),
+        'Key Length (bytes)': String(dklen),
+        Hash: 'SHA-256',
+      };
+
+      return [
+        new BoxBuilder('PBKDF2', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return [
+        new BoxBuilder('PBKDF2', `Key derivation failed: ${message}`)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+  },
+};
+
+export default Pbkdf2BoxSource;

--- a/src/modules/boxSources/SortLinesBoxSource.ts
+++ b/src/modules/boxSources/SortLinesBoxSource.ts
@@ -1,0 +1,78 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// stable code-point comparison — avoids locale-dependent collation
+function cmpString(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+// NaN-last numeric comparator with string fallback
+function cmpNumeric(a: string, b: string): number {
+  const na = parseFloat(a);
+  const nb = parseFloat(b);
+  const aIsNaN = Number.isNaN(na);
+  const bIsNaN = Number.isNaN(nb);
+  if (aIsNaN && bIsNaN) return cmpString(a, b);
+  if (aIsNaN) return 1;
+  if (bIsNaN) return -1;
+  return na < nb ? -1 : na > nb ? 1 : 0;
+}
+
+export const SortLinesBoxSource = {
+  name: 'Sort Lines',
+  description:
+    'Sort the lines of text. ::sortlines (asc), modifiers ::desc, ::numeric, ::unique, ::ci (case-insensitive).',
+  defaultInput: 'banana\napple\ncherry ::sortlines',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'sortlines', 'sort')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const isNumeric = hasOptionKeys(options, 'numeric');
+    const isCi = hasOptionKeys(options, 'ci', 'caseinsensitive');
+    const isDesc = hasOptionKeys(options, 'desc', 'reverse');
+    const isUnique = hasOptionKeys(options, 'unique', 'uniq');
+
+    // normalize CRLF before splitting
+    const lines = input.replace(/\r\n/g, '\n').split('\n');
+
+    const sorted = lines.slice().sort((a, b) => {
+      let cmp: number;
+      if (isNumeric) {
+        cmp = cmpNumeric(a, b);
+      } else if (isCi) {
+        cmp = cmpString(a.toLowerCase(), b.toLowerCase());
+      } else {
+        cmp = cmpString(a, b);
+      }
+      return isDesc ? -cmp : cmp;
+    });
+
+    const deduped = isUnique
+      ? sorted.filter((line, idx, arr) => arr.indexOf(line) === idx)
+      : sorted;
+
+    const output = deduped.join('\n');
+
+    return [
+      new BoxBuilder('Sort Lines', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default SortLinesBoxSource;

--- a/src/modules/boxSources/TextWrapBoxSource.ts
+++ b/src/modules/boxSources/TextWrapBoxSource.ts
@@ -1,0 +1,80 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+const DEFAULT_WIDTH = 80;
+const MIN_WIDTH = 1;
+const MAX_WIDTH = 1000;
+
+// greedy word-wrap a single line of text to the given column width.
+// words longer than width are placed on their own line without breaking.
+function wrapLine(line: string, width: number): string {
+  const words = line.split(' ').filter((w) => w.length > 0);
+  if (words.length === 0) return '';
+
+  const result: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    if (current.length === 0) {
+      current = word;
+    } else if (current.length + 1 + word.length <= width) {
+      current = `${current} ${word}`;
+    } else {
+      result.push(current);
+      current = word;
+    }
+  }
+  if (current.length > 0) {
+    result.push(current);
+  }
+
+  return result.join('\n');
+}
+
+// wrap text paragraph-by-paragraph, preserving blank lines as paragraph boundaries.
+function wrapText(text: string, width: number): string {
+  const lines = text.split('\n');
+  return lines.map((line) => wrapLine(line, width)).join('\n');
+}
+
+function resolveWidth(raw: string | boolean | null): number {
+  if (raw === null || raw === true || raw === false) return DEFAULT_WIDTH;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed)) return DEFAULT_WIDTH;
+  return Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, parsed));
+}
+
+export const TextWrapBoxSource = {
+  name: 'Text Wrap',
+  description: 'Word-wrap text to a column width. ::wrap=<width> (default 80).',
+  defaultInput: 'The quick brown fox jumps over the lazy dog ::wrap=20',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'wrap', 'wordwrap')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const rawWidth = extractOptionKeys(options, 'wrap', 'wordwrap');
+    const width = resolveWidth(rawWidth);
+    const wrapped = wrapText(input, width);
+
+    return [
+      new BoxBuilder('Text Wrap', wrapped)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default TextWrapBoxSource;

--- a/src/modules/boxSources/__test__/AreaConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AreaConvertBoxSource.test.ts
@@ -1,0 +1,123 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { AreaConvertBoxSource } from '../AreaConvertBoxSource';
+
+describe('AreaConvertBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] when no options are provided', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 acre', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 acre', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('1 acre conversions', () => {
+    it('converts 1 acre to m², ft², and hectare correctly', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 acre', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Area Convert');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.priority).toBe(10);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 acre = 4046.8564224 m² → 6dp → 4046.856422
+      expect(opts['m²']).toBe('4046.856422');
+      // 1 acre = 43560 ft² exactly
+      expect(opts['ft²']).toBe('43560');
+      // 1 acre ≈ 0.404686 hectare
+      expect(opts.hectare).toBe('0.404686');
+    });
+  });
+
+  describe('1 hectare conversions', () => {
+    it('converts 1 hectare to m² and acre correctly', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 hectare', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 hectare = exactly 10000 m²
+      expect(opts['m²']).toBe('10000');
+      // 1 hectare ≈ 2.471054 acres
+      expect(opts.acre).toBe('2.471054');
+    });
+  });
+
+  describe('1 km2 conversions', () => {
+    it('converts 1 km2 to m² and hectare correctly', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 km2', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['m²']).toBe('1000000');
+      expect(opts.hectare).toBe('100');
+    });
+  });
+
+  describe('unit notation variants', () => {
+    it('accepts m^2 notation', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('5 m^2', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['m²']).toBe('5');
+    });
+
+    it('accepts m² superscript notation', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('5 m²', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['m²']).toBe('5');
+    });
+  });
+
+  describe('1 mi2 conversions', () => {
+    it('converts 1 mi2 to exactly 640 acres', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 mi2', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 square mile = exactly 640 acres
+      expect(opts.acre).toBe('640');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns an error box for unparseable input', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('abc', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toBeDefined();
+      expect(opts['Supported units']).toContain('acre');
+    });
+
+    it('returns an error box for unknown unit', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('5 foo', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toBeDefined();
+      expect(opts['Supported units']).toContain('acre');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/BrailleBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BrailleBoxSource.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { BrailleBoxSource } from '../BrailleBoxSource';
+
+describe('BrailleBoxSource', () => {
+  it('returns [] when no option present', async () => {
+    expect(await BrailleBoxSource.generateBoxes('abc', null)).toHaveLength(0);
+  });
+
+  it('returns [] for empty input', async () => {
+    expect(
+      await BrailleBoxSource.generateBoxes('', { braille: true }),
+    ).toHaveLength(0);
+  });
+
+  it('encodes "abc" to ⠁⠃⠉ (U+2801 U+2803 U+2809)', async () => {
+    const boxes = await BrailleBoxSource.generateBoxes('abc', {
+      braille: true,
+    });
+    const out = boxes[0].props.plaintextOutput;
+    expect(out).toBe('⠁⠃⠉');
+    const cps = [...out].map((c) => c.codePointAt(0));
+    expect(cps).toEqual([0x2801, 0x2803, 0x2809]);
+  });
+
+  it('encodes "hello" to ⠓⠑⠇⠇⠕', async () => {
+    const boxes = await BrailleBoxSource.generateBoxes('hello', {
+      braille: true,
+    });
+    expect(boxes[0].props.plaintextOutput).toBe('⠓⠑⠇⠇⠕');
+  });
+
+  it('maps a space to U+2800', async () => {
+    const boxes = await BrailleBoxSource.generateBoxes('a b', {
+      braille: true,
+    });
+    const out = boxes[0].props.plaintextOutput;
+    expect([...out][1].codePointAt(0)).toBe(0x2800);
+  });
+
+  it('decodes ⠓⠑⠇⠇⠕ back to "hello"', async () => {
+    const boxes = await BrailleBoxSource.generateBoxes('⠓⠑⠇⠇⠕', {
+      brailledecode: true,
+    });
+    expect(boxes[0].props.plaintextOutput).toBe('hello');
+  });
+
+  it('round-trips "the quick brown fox"', async () => {
+    const text = 'the quick brown fox';
+    const enc = await BrailleBoxSource.generateBoxes(text, { braille: true });
+    const encoded = enc[0].props.plaintextOutput;
+    const dec = await BrailleBoxSource.generateBoxes(encoded, {
+      brailledecode: true,
+    });
+    expect(dec[0].props.plaintextOutput).toBe(text);
+  });
+
+  it('returns 2 boxes when both options are set', async () => {
+    const boxes = await BrailleBoxSource.generateBoxes('abc', {
+      braille: true,
+      brailledecode: true,
+    });
+    expect(boxes).toHaveLength(2);
+  });
+
+  it('has the expected static metadata', () => {
+    expect(BrailleBoxSource.tag).toBe('#');
+    expect(BrailleBoxSource.kind).toBe('Encode');
+    expect(typeof BrailleBoxSource.priority).toBe('number');
+  });
+});

--- a/src/modules/boxSources/__test__/JsonMergeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonMergeBoxSource.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonMergeBoxSource } from '../JsonMergeBoxSource';
+
+describe('JsonMergeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no trigger option is present', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"b":2}',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options object has no matching key', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"b":2}',
+        { format: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('deep-merges nested objects (second overrides first on conflict)', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1,"b":{"x":1}}\n---\n{"b":{"y":2},"c":3}',
+        { jsonmerge: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON Merge');
+      expect(JSON.parse(boxes[0].props.plaintextOutput)).toEqual({
+        a: 1,
+        b: { x: 1, y: 2 },
+        c: 3,
+      });
+    });
+
+    it('triggers on ::merge option as well', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"a":2}',
+        { merge: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('overrides scalar value from first doc with second', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"a":2}',
+        { jsonmerge: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(JSON.parse(boxes[0].props.plaintextOutput)).toEqual({ a: 2 });
+    });
+
+    it('replaces arrays rather than concatenating them', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":[1,2]}\n---\n{"a":[3]}',
+        { jsonmerge: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(JSON.parse(boxes[0].props.plaintextOutput)).toEqual({ a: [3] });
+    });
+
+    it('guards against prototype pollution via __proto__ key', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{}\n---\n{"__proto__":{"polluted":true}}',
+        { jsonmerge: true },
+      );
+      // merge itself must succeed without throwing
+      expect(boxes).toHaveLength(1);
+      // Object.prototype must remain clean
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('returns an error box when the separator is missing', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes('{"a":1}', {
+        jsonmerge: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/---/);
+    });
+
+    it('returns an error box when the first document is invalid JSON', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes('{bad\n---\n{}', {
+        jsonmerge: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/first/i);
+    });
+
+    it('returns an error box when the second document is invalid JSON', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes('{}\n---\n{bad', {
+        jsonmerge: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/second/i);
+    });
+
+    it('uses CodeBoxTemplate with language:json for successful merge', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"b":2}',
+        { jsonmerge: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.language).toBe('json');
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+
+    it('sets priority on the returned box', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"b":2}',
+        { jsonmerge: true },
+      );
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NoteFrequencyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NoteFrequencyBoxSource.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { NoteFrequencyBoxSource } from '../NoteFrequencyBoxSource';
+
+describe('NoteFrequencyBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no option key is present', async () => {
+      const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('note name → frequency', () => {
+      it('A4 → 440 Hz, MIDI 69', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', {
+          note: true,
+        });
+        expect(boxes).toHaveLength(1);
+
+        const opts = boxes[0].props.options as Record<string, string>;
+        // frequency should be 440.00 Hz
+        expect(opts.Frequency).toMatch(/^440/);
+        expect(opts.MIDI).toBe('69');
+      });
+
+      it('C4 → ~261.63 Hz (middle C)', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('C4', {
+          note: true,
+        });
+        expect(boxes).toHaveLength(1);
+
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Frequency).toMatch(/^261\.6/);
+        expect(opts.MIDI).toBe('60');
+      });
+
+      it('A5 → 880 Hz', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A5', {
+          note: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Frequency).toMatch(/^880/);
+      });
+
+      it('A3 → 220 Hz', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A3', {
+          note: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Frequency).toMatch(/^220/);
+      });
+
+      it('C#5 and Db5 produce the same frequency (~554.37 Hz)', async () => {
+        const sharpBoxes = await NoteFrequencyBoxSource.generateBoxes('C#5', {
+          note: true,
+        });
+        const flatBoxes = await NoteFrequencyBoxSource.generateBoxes('Db5', {
+          note: true,
+        });
+
+        const sharpOpts = sharpBoxes[0].props.options as Record<string, string>;
+        const flatOpts = flatBoxes[0].props.options as Record<string, string>;
+
+        // both should start with 554.3
+        expect(sharpOpts.Frequency).toMatch(/^554\.3/);
+        expect(flatOpts.Frequency).toMatch(/^554\.3/);
+        // same MIDI number
+        expect(sharpOpts.MIDI).toBe(flatOpts.MIDI);
+      });
+
+      it('accepts ::pitch option', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', {
+          pitch: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Frequency).toMatch(/^440/);
+      });
+
+      it('box name is "Musical Note"', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', {
+          note: true,
+        });
+        expect(boxes[0].props.name).toBe('Musical Note');
+      });
+
+      it('plaintextOutput contains key:value pairs', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', {
+          note: true,
+        });
+        expect(boxes[0].props.plaintextOutput).toContain('Frequency:');
+        expect(boxes[0].props.plaintextOutput).toContain('MIDI:');
+      });
+    });
+
+    describe('frequency (Hz) → nearest note', () => {
+      it('440 Hz → Nearest Note A4, Cents 0', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('440', {
+          note: true,
+        });
+        expect(boxes).toHaveLength(1);
+
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Nearest Note']).toBe('A4');
+        expect(opts.Cents).toBe('+0');
+        expect(opts.MIDI).toBe('69');
+      });
+
+      it('261.63 Hz → Nearest Note C4', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('261.63', {
+          note: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Nearest Note']).toBe('C4');
+      });
+
+      it('450 Hz → Nearest Note A4, positive cents deviation', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('450', {
+          note: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Nearest Note']).toBe('A4');
+        // 450 Hz is above 440 Hz so cents should be positive
+        const cents = Number.parseInt(opts.Cents, 10);
+        expect(cents).toBeGreaterThan(0);
+        // approximately +39 cents
+        expect(cents).toBeGreaterThanOrEqual(38);
+        expect(cents).toBeLessThanOrEqual(40);
+      });
+
+      it('frequency result includes Note Frequency field', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('440', {
+          note: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Note Frequency']).toMatch(/^440/);
+      });
+    });
+
+    describe('invalid / unrecognized input', () => {
+      it('unrecognized text produces a help box', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('hello', {
+          note: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Format).toBeTruthy();
+      });
+
+      it('input longer than 32 chars returns []', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes(
+          'A4 some very long extra text that exceeds',
+          { note: true },
+        );
+        expect(boxes).toHaveLength(0);
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ObjectIdBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ObjectIdBoxSource.test.ts
@@ -1,0 +1,133 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ObjectIdBoxSource } from '../ObjectIdBoxSource';
+
+const VALID_ID = '507f1f77bcf86cd799439011';
+
+describe('ObjectIdBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes(VALID_ID, null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes(VALID_ID, {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — valid ObjectId (::objectid)', () => {
+    it('parses 507f1f77bcf86cd799439011 correctly', async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes(VALID_ID, {
+        objectid: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Timestamp (hex)']).toBe('507f1f77');
+      // 0x507f1f77 === 1350508407
+      expect(options?.['Timestamp (unix)']).toBe('1350508407');
+      expect(options?.['Timestamp (UTC)']).toBe('2012-10-17T21:13:27.000Z');
+      expect(options?.['Random / Machine']).toBe('bcf86cd799');
+      // parseInt('439011', 16) === 4427793
+      expect(options?.Counter).toBe('4427793');
+      expect(options?.ObjectId).toBe('507f1f77bcf86cd799439011');
+
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('accepts ::oid option alias', async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes(VALID_ID, {
+        oid: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Timestamp (unix)']).toBe('1350508407');
+    });
+  });
+
+  describe('generateBoxes — uppercase normalization', () => {
+    it('normalizes uppercase hex to lowercase and parses identically', async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes(
+        '507F1F77BCF86CD799439011',
+        { objectid: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.ObjectId).toBe('507f1f77bcf86cd799439011');
+      expect(options?.['Timestamp (unix)']).toBe('1350508407');
+      expect(options?.['Timestamp (UTC)']).toBe('2012-10-17T21:13:27.000Z');
+      expect(options?.Counter).toBe('4427793');
+    });
+  });
+
+  describe('generateBoxes — ObjectId("...") wrapper', () => {
+    it('strips the wrapper and parses correctly', async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes(
+        'ObjectId("507f1f77bcf86cd799439011")',
+        { objectid: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.ObjectId).toBe('507f1f77bcf86cd799439011');
+      expect(boxes[0].props.options?.['Timestamp (unix)']).toBe('1350508407');
+    });
+
+    it("strips ObjectId('...') single-quote variant", async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes(
+        "ObjectId('507f1f77bcf86cd799439011')",
+        { objectid: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.ObjectId).toBe('507f1f77bcf86cd799439011');
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns an error box for a too-short hex string', async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes('123', {
+        objectid: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Reason).toBe(
+        'a 24-character hex ObjectId is required',
+      );
+    });
+
+    it('returns an error box for non-hex characters', async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes(
+        'xyzxyzxyzxyzxyzxyzxyzxyz',
+        { objectid: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Reason).toBe(
+        'a 24-character hex ObjectId is required',
+      );
+    });
+
+    it('returns an error box for empty string', async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes('', {
+        objectid: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.ObjectId).toBe('(invalid)');
+    });
+  });
+
+  describe('generateBoxes — all-zero ObjectId', () => {
+    it('parses 000000000000000000000000 as epoch', async () => {
+      const boxes = await ObjectIdBoxSource.generateBoxes(
+        '000000000000000000000000',
+        { objectid: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.['Timestamp (unix)']).toBe('0');
+      expect(options?.['Timestamp (UTC)']).toBe('1970-01-01T00:00:00.000Z');
+      expect(options?.Counter).toBe('0');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/Pbkdf2BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Pbkdf2BoxSource.test.ts
@@ -1,0 +1,162 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Pbkdf2BoxSource } from '../Pbkdf2BoxSource';
+
+describe('Pbkdf2BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - bare ::pbkdf2 (no password value)', () => {
+    it('returns a usage hint box when ::pbkdf2 is boolean true', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/provide a password/i);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+
+  describe('generateBoxes - PBKDF2-HMAC-SHA256 known vectors', () => {
+    // RFC 6070 test vectors translated to SHA-256 (SHA-256 canonical vectors)
+    it('derives correct key for password=password, salt=salt, c=1, dklen=32', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+        iterations: '1',
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Derived Key (hex)']).toBe(
+        '120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b',
+      );
+      expect(opts.Salt).toBe('salt');
+      expect(opts.Iterations).toBe('1');
+      expect(opts['Key Length (bytes)']).toBe('32');
+      expect(opts.Hash).toBe('SHA-256');
+    });
+
+    it('derives correct key for password=password, salt=salt, c=2, dklen=32', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+        iterations: '2',
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Derived Key (hex)']).toBe(
+        'ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43',
+      );
+    });
+
+    it('custom dklen=16 returns first 16 bytes of c=1 vector', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+        iterations: '1',
+        dklen: '16',
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // first 32 hex chars = 16 bytes
+      expect(opts['Derived Key (hex)']).toBe(
+        '120fb6cffcf8b32c43e7225256c4f837',
+      );
+      expect(opts['Key Length (bytes)']).toBe('16');
+    });
+  });
+
+  describe('generateBoxes - password redaction', () => {
+    it('does not echo the password in plaintextOutput', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+        iterations: '1',
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).not.toContain('password');
+    });
+
+    it('does not include the password in options', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+        iterations: '1',
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // none of the option values should be the literal password string
+      const values = Object.values(opts);
+      expect(values).not.toContain('password');
+      // the option key 'pbkdf2' must not be present in output options
+      expect(Object.keys(opts)).not.toContain('pbkdf2');
+    });
+  });
+
+  describe('generateBoxes - non-secure context fallback', () => {
+    const originalCrypto = globalThis.crypto;
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { subtle: undefined },
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('returns an informational box when crypto.subtle is unavailable', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+
+  describe('generateBoxes - default iterations and dklen', () => {
+    it('uses default iterations=100000 and dklen=32 when not specified', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Iterations).toBe('100000');
+      expect(opts['Key Length (bytes)']).toBe('32');
+      // derived key should be 64 hex chars (32 bytes)
+      expect(opts['Derived Key (hex)']).toHaveLength(64);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Pbkdf2BoxSource.name).toBe('PBKDF2');
+      expect(Pbkdf2BoxSource.tag).toBe('#');
+      expect(Pbkdf2BoxSource.kind).toBe('Encode');
+      expect(typeof Pbkdf2BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/SortLinesBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SortLinesBoxSource.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+
+import { SortLinesBoxSource } from '../SortLinesBoxSource';
+
+describe('SortLinesBoxSource', () => {
+  describe('generateBoxes - guard conditions', () => {
+    it('returns empty array when no sort option is provided', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\napple',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options object has no sort key', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('banana\napple', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input string', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('', {
+        sortlines: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ascending (default)', () => {
+    it('sorts lines alphabetically ascending', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        { sortlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nbanana\ncherry');
+    });
+
+    it('triggers on ::sort alias', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        { sort: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nbanana\ncherry');
+    });
+
+    it('uses code-point order — uppercase sorts before lowercase', async () => {
+      // 'B' (0x42) < 'a' (0x61) in code-point order
+      const boxes = await SortLinesBoxSource.generateBoxes('a\nB', {
+        sortlines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('B\na');
+    });
+  });
+
+  describe('generateBoxes - descending', () => {
+    it('sorts lines descending with ::desc', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        { sortlines: true, desc: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('cherry\nbanana\napple');
+    });
+
+    it('sorts lines descending with ::reverse', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        { sortlines: true, reverse: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('cherry\nbanana\napple');
+    });
+  });
+
+  describe('generateBoxes - numeric', () => {
+    it('sorts numbers numerically, not lexicographically', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('10\n2\n1', {
+        sortlines: true,
+        numeric: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // numeric: 1 < 2 < 10 (string sort would give '1\n10\n2')
+      expect(boxes[0].props.plaintextOutput).toBe('1\n2\n10');
+    });
+
+    it('places NaN values last', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('5\nfoo\n1', {
+        sortlines: true,
+        numeric: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1\n5\nfoo');
+    });
+  });
+
+  describe('generateBoxes - unique', () => {
+    it('removes duplicate lines after sorting', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('b\na\nb\na', {
+        sortlines: true,
+        unique: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb');
+    });
+
+    it('triggers on ::uniq alias', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('z\na\nz', {
+        sortlines: true,
+        uniq: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\nz');
+    });
+  });
+
+  describe('generateBoxes - case-insensitive', () => {
+    it('sorts case-insensitively with ::ci', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('Banana\napple', {
+        sortlines: true,
+        ci: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // 'apple' < 'banana' case-insensitively; original casing preserved
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nBanana');
+    });
+
+    it('triggers on ::caseinsensitive alias', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('Banana\napple', {
+        sortlines: true,
+        caseinsensitive: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nBanana');
+    });
+  });
+
+  describe('generateBoxes - CRLF normalization', () => {
+    it('handles CRLF line endings', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes(
+        'banana\r\napple\r\ncherry',
+        { sortlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nbanana\ncherry');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets correct name and priority', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('b\na', {
+        sortlines: true,
+      });
+      expect(boxes[0].props.name).toBe('Sort Lines');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('attaches CodeBoxTemplate', async () => {
+      const boxes = await SortLinesBoxSource.generateBoxes('b\na', {
+        sortlines: true,
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+  });
+
+  describe('static metadata', () => {
+    it('has expected static properties', () => {
+      expect(SortLinesBoxSource.name).toBe('Sort Lines');
+      expect(SortLinesBoxSource.kind).toBe('Transform');
+      expect(typeof SortLinesBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/TextWrapBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TextWrapBoxSource.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { TextWrapBoxSource } from '../TextWrapBoxSource';
+
+describe('TextWrapBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no wrap option is present', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes('hello world');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with wrap option', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes('', { wrap: '20' });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('wraps "The quick brown fox..." at width 20 with greedy boundaries', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes(
+        'The quick brown fox jumps over the lazy dog',
+        { wrap: '20' },
+      );
+      expect(boxes).toHaveLength(1);
+      // greedy: 'The quick brown fox' = 19 chars (fits), 'jumps over the lazy' = 19 chars (fits), 'dog'
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'The quick brown fox\njumps over the lazy\ndog',
+      );
+    });
+
+    it('wraps "aaa bbb ccc" at width 10 correctly', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes('aaa bbb ccc', {
+        wrap: '10',
+      });
+      expect(boxes).toHaveLength(1);
+      // 'aaa bbb' = 7 chars, adding ' ccc' = 11 > 10, so new line
+      expect(boxes[0].props.plaintextOutput).toBe('aaa bbb\nccc');
+    });
+
+    it('places a long word exceeding width on its own line without breaking', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes(
+        'supercalifragilistic',
+        { wrap: '5' },
+      );
+      expect(boxes).toHaveLength(1);
+      // the word is longer than width=5 but is not broken mid-word
+      expect(boxes[0].props.plaintextOutput).toBe('supercalifragilistic');
+    });
+
+    it('preserves blank lines between paragraphs', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes(
+        'line one here\n\nline two here',
+        { wrap: '10' },
+      );
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      // blank line must be preserved as a paragraph boundary
+      expect(output).toContain('\n\n');
+      // each paragraph line should not exceed 10 chars where words permit
+      const lines = output.split('\n');
+      for (const line of lines) {
+        if (line.trim().length > 0) {
+          // single words may exceed width, but joined lines should not
+          // 'line one' = 8, 'here' = 4 — all fit within 10
+          expect(line.length).toBeLessThanOrEqual(10);
+        }
+      }
+    });
+
+    it('uses default width 80 when ::wrap has no numeric value', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes('a b c', {
+        wrap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // 'a b c' is 5 chars, well within 80 — no line breaks added
+      expect(boxes[0].props.plaintextOutput).toBe('a b c');
+    });
+
+    it('triggers on ::wordwrap option as well', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes(
+        'The quick brown fox jumps over the lazy dog',
+        { wordwrap: '20' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'The quick brown fox\njumps over the lazy\ndog',
+      );
+    });
+
+    it('sets box name to "Text Wrap" and correct priority', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes('hello world', {
+        wrap: '80',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Text Wrap');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,7 +1,9 @@
+import AreaConvertBoxSource from './AreaConvertBoxSource';
 import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import BrailleBoxSource from './BrailleBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -9,15 +11,21 @@ import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import JsonMergeBoxSource from './JsonMergeBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
+import NoteFrequencyBoxSource from './NoteFrequencyBoxSource';
 import NowBoxSource from './NowBoxSource';
+import ObjectIdBoxSource from './ObjectIdBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import Pbkdf2BoxSource from './Pbkdf2BoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SortLinesBoxSource from './SortLinesBoxSource';
+import TextWrapBoxSource from './TextWrapBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
@@ -29,6 +37,8 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  AreaConvertBoxSource,
+  BrailleBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
@@ -36,15 +46,21 @@ export const boxSources = [
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  JsonMergeBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
+  NoteFrequencyBoxSource,
   NowBoxSource,
+  ObjectIdBoxSource,
   PasswordBoxSource,
+  Pbkdf2BoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
+  SortLinesBoxSource,
+  TextWrapBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,


### PR DESCRIPTION
## Summary

Thirtieth exploration batch — **8 more BoxSource tools** (crypto, text, JSON, audio, converters).

| Tool | Trigger | What it does |
|------|---------|--------------|
| PBKDF2 | `::pbkdf2=<pw>` | derive key bits (PBKDF2-HMAC-SHA256) |
| Sort Lines | `::sortlines` | asc/desc/numeric/unique/case-insensitive |
| JSON Merge | `::jsonmerge` | deep-merge two docs (split by `---`) |
| Text Wrap | `::wrap=<n>` | greedy word-wrap to a column width |
| Musical Note | `::note` | note name ⇄ frequency (A4=440, 12-TET) |
| Area Convert | `::area` | m²/km²/ft²/acre/hectare/mile² |
| MongoDB ObjectId | `::objectid` | parse timestamp/counter |
| Braille | `::braille` | text ⇄ Unicode Braille (Grade 1) |

## Security

**PBKDF2's password is a secret** passed via `::pbkdf2=<pw>` — the same leak class as last batch's HMAC key. `shareLink.ts` now redacts `::pbkdf2` / `::hmac` / `::jwtsign` values from shareable URLs (which land in history/logs). The password is also never echoed in the box output (only salt, iterations, key length, derived key). (`main`'s shareLink had no redaction — this batch adds it.)

## Design notes

- 8 sources by isolated subagents (2 retried after transient 529s); `index.ts` wired in one step. Hardening rules pre-loaded (PBKDF2 secure-context guard + try/catch + password redaction; JSON-merge `FORBIDDEN_KEYS` prototype guard + array-replace; ObjectId deterministic — timestamp comes *from* the id, only `new Date(seconds*1000)`; code-point iteration for Braille; integer-exact formatting for area).
- **Verified vectors**: **PBKDF2-SHA256 `password`/`salt`/c=1→`120fb6cf…be17b`** (password redacted); sort `::numeric` puts 10 after 2; json-merge deep + array-replace + proto-safe; wrap width 20 greedy; `A4`→`440Hz`/MIDI 69; **1 acre=43560 ft², 1 mi²=640 acre**; ObjectId `507f1f77…`→`2012-10-17T21:13:27Z`/counter 4427793; braille `abc`→`⠁⠃⠉`.

## Verification

- ✅ `bun run test run` — **426 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of #260–#288 — branched from `main`.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6