### PR TITLE
feat(boxSources): add 8 more tools (loan, compound-interest, html→text, markdown-strip, data-rate, business-days, passphrase, indent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>LoanPaymentBox</b> </summary>
+
+| match rule  | description                          | example              |
+| ----------- | ------------------------------------ | -------------------- |
+| `::loan`    | amortizing loan monthly payment      | `200000 5 30 ::loan` |
+
+</details>
+
+<details>
+<summary> <b>CompoundInterestBox</b> </summary>
+
+| match rule     | description                          | example              |
+| -------------- | ------------------------------------ | -------------------- |
+| `::compound`   | future value with compound interest  | `1000 5 10 ::compound` |
+
+</details>
+
+<details>
+<summary> <b>HtmlToTextBox</b> </summary>
+
+| match rule     | description                          | example                     |
+| -------------- | ------------------------------------ | --------------------------- |
+| `::striptags`  | strip HTML tags + decode entities    | `<p>Hi</p> ::striptags`     |
+
+</details>
+
+<details>
+<summary> <b>MarkdownToTextBox</b> </summary>
+
+| match rule    | description                          | example                |
+| ------------- | ------------------------------------ | ---------------------- |
+| `::stripmd`   | strip Markdown formatting to text    | `# Title ::stripmd`    |
+
+</details>
+
+<details>
+<summary> <b>DataRateBox</b> </summary>
+
+| match rule     | description                          | example              |
+| -------------- | ------------------------------------ | -------------------- |
+| `::datarate`   | bit/s ⇄ byte/s (Mbps ⇄ MB/s)         | `100 Mbps ::datarate` |
+
+</details>
+
+<details>
+<summary> <b>BusinessDaysBox</b> </summary>
+
+| match rule    | description                          | example                          |
+| ------------- | ------------------------------------ | -------------------------------- |
+| `::busdays`   | count weekdays between two dates     | `2025-01-01 to 2025-01-31 ::busdays` |
+
+</details>
+
+<details>
+<summary> <b>PassphraseBox</b> </summary>
+
+| match rule         | description                          | example          |
+| ------------------ | ------------------------------------ | ---------------- |
+| `::passphrase=<n>` | crypto-secure diceware passphrase    | `::passphrase=4` |
+
+</details>
+
+<details>
+<summary> <b>IndentBox</b> </summary>
+
+| match rule       | description                          | example              |
+| ---------------- | ------------------------------------ | -------------------- |
+| `::indent=<n>`   | indent/dedent lines (`::dedent` auto) | `text ::indent=2`   |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/BusinessDaysBoxSource.ts
+++ b/src/modules/boxSources/BusinessDaysBoxSource.ts
@@ -1,0 +1,174 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max loop iterations to prevent runaway computation (100 years)
+const MAX_RANGE_DAYS = 366 * 100;
+
+// convert a key-value record to plaintext lines for box plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+interface ParsedDates {
+  startMs: number;
+  endMs: number;
+  swapped: boolean;
+}
+
+// parse "YYYY-MM-DD" strictly via Date.UTC to avoid timezone drift
+function parseDateStr(s: string): number | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s.trim());
+  if (!m) return null;
+
+  const year = Number.parseInt(m[1], 10);
+  const month = Number.parseInt(m[2], 10);
+  const day = Number.parseInt(m[3], 10);
+
+  // basic range checks before Date.UTC
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+
+  const ms = Date.UTC(year, month - 1, day);
+  // verify round-trip to reject dates like 2025-02-30
+  const d = new Date(ms);
+  if (
+    d.getUTCFullYear() !== year ||
+    d.getUTCMonth() + 1 !== month ||
+    d.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return ms;
+}
+
+// split input on " to " or "," separator and return the two date timestamps
+function parseDatePair(text: string): ParsedDates | null {
+  const parts = text.split(/\s+to\s+|,/).map((p) => p.trim());
+  if (parts.length !== 2) return null;
+
+  const aMs = parseDateStr(parts[0]);
+  const bMs = parseDateStr(parts[1]);
+  if (aMs === null || bMs === null) return null;
+
+  const swapped = aMs > bMs;
+  return {
+    startMs: swapped ? bMs : aMs,
+    endMs: swapped ? aMs : bMs,
+    swapped,
+  };
+}
+
+// count business days (Mon-Fri) inclusive between startMs and endMs (UTC epoch ms)
+function countBusinessDays(
+  startMs: number,
+  endMs: number,
+): { businessDays: number; calendarDays: number; weekendDays: number } {
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+  const calendarDays = Math.round((endMs - startMs) / MS_PER_DAY) + 1;
+
+  let businessDays = 0;
+  let weekendDays = 0;
+  let cur = startMs;
+  while (cur <= endMs) {
+    const dow = new Date(cur).getUTCDay(); // 0=Sun, 6=Sat
+    if (dow >= 1 && dow <= 5) {
+      businessDays++;
+    } else {
+      weekendDays++;
+    }
+    cur += MS_PER_DAY;
+  }
+
+  return { businessDays, calendarDays, weekendDays };
+}
+
+function errorBox(message: string, priority: number): Box {
+  const kv = {
+    Error: message,
+    Format: 'YYYY-MM-DD to YYYY-MM-DD',
+    Example: '2025-01-01 to 2025-01-31',
+  };
+  return new BoxBuilder('Business Days', kvToPlaintext(kv))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(kv)
+    .setPriority(priority)
+    .build();
+}
+
+export const BusinessDaysBoxSource = {
+  name: 'Business Days',
+  description:
+    'Count business days (Mon–Fri) between two dates. Input: "YYYY-MM-DD to YYYY-MM-DD".',
+  defaultInput: '2025-01-01 to 2025-01-31 ::busdays',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'busdays', 'businessdays', 'workdays'))
+      return [];
+
+    const text = trim(input);
+    if (text.length > 60) return [];
+
+    const parsed = parseDatePair(text);
+    if (!parsed) {
+      return [errorBox('invalid date input', this.priority)];
+    }
+
+    const { startMs, endMs, swapped } = parsed;
+    const MS_PER_DAY = 24 * 60 * 60 * 1000;
+    const rangeDays = Math.round((endMs - startMs) / MS_PER_DAY) + 1;
+
+    if (rangeDays > MAX_RANGE_DAYS) {
+      const kv = {
+        Error: 'date range exceeds 100 years',
+        'Max Range': '100 years',
+      };
+      return [
+        new BoxBuilder('Business Days', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { businessDays, calendarDays, weekendDays } = countBusinessDays(
+      startMs,
+      endMs,
+    );
+
+    const fmt = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+    const kv: Record<string, string> = {
+      Start: fmt(startMs),
+      End: fmt(endMs),
+      'Calendar Days': calendarDays.toString(),
+      'Business Days': businessDays.toString(),
+      'Weekend Days': weekendDays.toString(),
+    };
+    if (swapped) {
+      kv.Note = 'dates were swapped (start was after end)';
+    }
+
+    return [
+      new BoxBuilder('Business Days', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default BusinessDaysBoxSource;

--- a/src/modules/boxSources/CompoundInterestBoxSource.ts
+++ b/src/modules/boxSources/CompoundInterestBoxSource.ts
@@ -62,6 +62,7 @@ export const CompoundInterestBoxSource = {
       Number.isNaN(annualRatePct) ||
       Number.isNaN(years) ||
       principal < 0 ||
+      annualRatePct < 0 ||
       years < 0
     ) {
       return [

--- a/src/modules/boxSources/CompoundInterestBoxSource.ts
+++ b/src/modules/boxSources/CompoundInterestBoxSource.ts
@@ -1,0 +1,119 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// build plaintext from key-value pairs as "key: value" lines
+function kvToPlaintext(record: Record<string, string>): string {
+  return Object.entries(record)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const CompoundInterestBoxSource = {
+  name: 'Compound Interest',
+  description:
+    'Future value with compound interest. Input: "<principal> <annualRate%> <years>". ::compound=<n> for compounds/year (default 12).',
+  defaultInput: '1000 5 10 ::compound',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'compound', 'compoundinterest')) return [];
+
+    const trimmed = trim(input);
+
+    // cap to avoid runaway inputs
+    if (trimmed.length > 100) {
+      return [
+        new BoxBuilder(
+          'Compound Interest',
+          'Input too long (max 100 characters).',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const parts = trimmed.split(/\s+/).filter((p) => p.length > 0);
+    if (parts.length !== 3) {
+      return [
+        new BoxBuilder(
+          'Compound Interest',
+          'Invalid input. Expected: "<principal> <annualRate%> <years>".',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const principal = Number.parseFloat(parts[0]);
+    const annualRatePct = Number.parseFloat(parts[1]);
+    const years = Number.parseFloat(parts[2]);
+
+    if (
+      Number.isNaN(principal) ||
+      Number.isNaN(annualRatePct) ||
+      Number.isNaN(years) ||
+      principal < 0 ||
+      years < 0
+    ) {
+      return [
+        new BoxBuilder(
+          'Compound Interest',
+          'Invalid values. Principal and years must be non-negative numbers.',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // resolve compounds/year from option value; default 12 (monthly)
+    let compoundsPerYear = 12;
+    const rawN = extractOptionKeys(options, 'compound', 'compoundinterest');
+    if (rawN !== null && rawN !== true) {
+      const parsed = Number.parseInt(String(rawN), 10);
+      if (!Number.isNaN(parsed)) {
+        // clamp to valid range
+        compoundsPerYear = Math.min(365, Math.max(1, parsed));
+      }
+    }
+
+    const r = annualRatePct / 100;
+    const n = compoundsPerYear;
+    const t = years;
+
+    // A = P * (1 + r/n)^(n*t)
+    const futureValue = principal * (1 + r / n) ** (n * t);
+    const interestEarned = futureValue - principal;
+
+    // EAR = (1 + r/n)^n - 1, expressed as a percentage
+    const ear = ((1 + r / n) ** n - 1) * 100;
+
+    const output: Record<string, string> = {
+      Principal: principal.toFixed(2),
+      'Annual Rate': `${annualRatePct.toFixed(2)}%`,
+      Years: years.toString(),
+      'Compounds/Year': n.toString(),
+      'Future Value': futureValue.toFixed(2),
+      'Interest Earned': interestEarned.toFixed(2),
+      'Effective Annual Rate': `${ear.toFixed(3)}%`,
+    };
+
+    return [
+      new BoxBuilder('Compound Interest', kvToPlaintext(output))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CompoundInterestBoxSource;

--- a/src/modules/boxSources/DataRateBoxSource.ts
+++ b/src/modules/boxSources/DataRateBoxSource.ts
@@ -1,0 +1,127 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit (normalized) -> bits per second (SI: 1 kbit = 1000 bit; bytes: 1 B = 8 bit)
+const TO_BPS: Record<string, number> = {
+  bps: 1,
+  kbps: 1e3,
+  mbps: 1e6,
+  gbps: 1e9,
+  tbps: 1e12,
+  'b/s': 8,
+  'kb/s': 8e3,
+  'mb/s': 8e6,
+  'gb/s': 8e9,
+  'tb/s': 8e12,
+  'kib/s': 8 * 1024,
+  'mib/s': 8 * 1024 ** 2,
+  'gib/s': 8 * 1024 ** 3,
+};
+
+// supported unit aliases for user-facing display in the error message
+const SUPPORTED_UNITS = Object.keys(TO_BPS).join(', ');
+
+// convert k:v record to plaintext lines for box plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// format a bps value to a given output divisor, stripping trailing decimal noise
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// normalize the raw unit string to a key present in TO_BPS
+function normalizeUnit(raw: string): string {
+  // lowercase and preserve '/' so 'MB/s' → 'mb/s', 'Mbps' → 'mbps'
+  return raw.toLowerCase();
+}
+
+export const DataRateBoxSource = {
+  name: 'Data Rate',
+  description:
+    'Convert a data rate between bit/s (bps/Mbps/Gbps) and byte/s (MB/s, MiB/s).',
+  defaultInput: '100 Mbps ::datarate',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'datarate', 'bandwidth')) return [];
+
+    const text = trim(input);
+    if (text.length > 64) return [];
+
+    // parse "<value> <unit>", separated by one or more spaces
+    const spaceIdx = text.indexOf(' ');
+    if (spaceIdx === -1) {
+      return [buildErrorBox(this.priority)];
+    }
+
+    const rawValue = text.slice(0, spaceIdx);
+    const rawUnit = text.slice(spaceIdx + 1).trim();
+
+    if (!rawUnit) {
+      return [buildErrorBox(this.priority)];
+    }
+
+    const value = Number.parseFloat(rawValue);
+    if (Number.isNaN(value) || value < 0) {
+      return [buildErrorBox(this.priority)];
+    }
+
+    const unitKey = normalizeUnit(rawUnit);
+    const multiplier = TO_BPS[unitKey];
+    if (multiplier === undefined) {
+      return [buildErrorBox(this.priority)];
+    }
+
+    const bps = value * multiplier;
+
+    const kv: Record<string, string> = {
+      Input: `${value} ${rawUnit}`,
+      bps: formatValue(bps),
+      Kbps: formatValue(bps / 1e3),
+      Mbps: formatValue(bps / 1e6),
+      Gbps: formatValue(bps / 1e9),
+      'B/s': formatValue(bps / 8),
+      'KB/s': formatValue(bps / 8 / 1e3),
+      'MB/s': formatValue(bps / 8 / 1e6),
+      'GB/s': formatValue(bps / 8 / 1e9),
+      'MiB/s': formatValue(bps / 8 / 1024 ** 2),
+    };
+
+    return [
+      new BoxBuilder('Data Rate', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+function buildErrorBox(priority: number): Box {
+  const kv: Record<string, string> = {
+    'Expected input': '<value> <unit>',
+    Example: '100 Mbps',
+    'Supported units': SUPPORTED_UNITS,
+  };
+  return new BoxBuilder('Data Rate', kvToPlaintext(kv))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(kv)
+    .setPriority(priority)
+    .build();
+}
+
+export default DataRateBoxSource;

--- a/src/modules/boxSources/HtmlToTextBoxSource.ts
+++ b/src/modules/boxSources/HtmlToTextBoxSource.ts
@@ -34,15 +34,40 @@ function decodeEntity(ref: string): string {
   return NAMED_ENTITIES[lower] ?? NAMED_ENTITIES[ref] ?? `&${ref};`;
 }
 
+// remove <tag>...</tag> blocks (content included) via a linear indexOf scan.
+// a regex with [\s\S]*? is O(n^2) on many unclosed opening tags (each is retried
+// as a start point) — a ReDoS risk since input comes from the ?input= URL param.
+function removeBlocks(html: string, tag: string): string {
+  const lower = html.toLowerCase();
+  const open = `<${tag}`;
+  const close = `</${tag}>`;
+  let result = '';
+  let pos = 0;
+  while (pos < html.length) {
+    const start = lower.indexOf(open, pos);
+    if (start === -1) {
+      result += html.slice(pos);
+      break;
+    }
+    const tagEnd = html.indexOf('>', start);
+    if (tagEnd === -1) {
+      result += html.slice(pos);
+      break;
+    }
+    result += html.slice(pos, start);
+    const closeIdx = lower.indexOf(close, tagEnd + 1);
+    pos = closeIdx === -1 ? html.length : closeIdx + close.length;
+  }
+  return result;
+}
+
 // convert html to readable plain text using pure string processing
 function htmlToText(html: string): string {
   let text = html;
 
-  // remove <script> blocks entirely (content included)
-  text = text.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '');
-
-  // remove <style> blocks entirely (content included)
-  text = text.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '');
+  // remove <script> and <style> blocks entirely (content included)
+  text = removeBlocks(text, 'script');
+  text = removeBlocks(text, 'style');
 
   // convert <br> variants to newlines
   text = text.replace(/<br\s*\/?>/gi, '\n');

--- a/src/modules/boxSources/HtmlToTextBoxSource.ts
+++ b/src/modules/boxSources/HtmlToTextBoxSource.ts
@@ -1,0 +1,104 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// named entity table for the most common HTML entities
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  '#39': "'",
+  nbsp: ' ',
+};
+
+// decode a single HTML entity reference (without the surrounding & and ;)
+function decodeEntity(ref: string): string {
+  const lower = ref.toLowerCase();
+
+  // numeric decimal: &#NN;
+  if (lower.startsWith('#x')) {
+    const cp = Number.parseInt(ref.slice(2), 16);
+    return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : '';
+  }
+  if (ref.startsWith('#')) {
+    const cp = Number.parseInt(ref.slice(1), 10);
+    return cp > 0 && cp <= 0x10ffff ? String.fromCodePoint(cp) : '';
+  }
+
+  return NAMED_ENTITIES[lower] ?? NAMED_ENTITIES[ref] ?? `&${ref};`;
+}
+
+// convert html to readable plain text using pure string processing
+function htmlToText(html: string): string {
+  let text = html;
+
+  // remove <script> blocks entirely (content included)
+  text = text.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '');
+
+  // remove <style> blocks entirely (content included)
+  text = text.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, '');
+
+  // convert <br> variants to newlines
+  text = text.replace(/<br\s*\/?>/gi, '\n');
+
+  // convert block-closing tags to newlines so paragraphs separate naturally
+  text = text.replace(/<\/(?:p|div|li|h[1-6]|tr)>/gi, '\n');
+
+  // prefix list items with a dash
+  text = text.replace(/<li\b[^>]*>/gi, '- ');
+
+  // strip all remaining tags — [^>]* is linear (no nested quantifiers)
+  text = text.replace(/<[^>]*>/g, '');
+
+  // decode HTML entities
+  text = text.replace(/&([#a-zA-Z0-9]+);/g, (_, ref: string) =>
+    decodeEntity(ref),
+  );
+
+  // trim trailing whitespace on each line
+  text = text
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n');
+
+  // collapse runs of 3+ newlines down to 2
+  text = text.replace(/\n{3,}/g, '\n\n');
+
+  return text.trim();
+}
+
+export const HtmlToTextBoxSource = {
+  name: 'HTML to Text',
+  description:
+    'Strip HTML tags and decode entities to plain text. ::striptags or ::htmltotext.',
+  defaultInput: '<p>Hello <b>world</b>!</p> ::striptags',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'striptags', 'htmltotext')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const result = htmlToText(input);
+
+    return [
+      new BoxBuilder('HTML to Text', result)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default HtmlToTextBoxSource;

--- a/src/modules/boxSources/LoanPaymentBoxSource.ts
+++ b/src/modules/boxSources/LoanPaymentBoxSource.ts
@@ -101,7 +101,7 @@ export const LoanPaymentBoxSource = {
       'Monthly Payment': round2(monthlyPayment).toFixed(2),
       'Total Paid': round2(totalPaid).toFixed(2),
       'Total Interest': round2(totalInterest).toFixed(2),
-      Payments: n.toString(),
+      Payments: Number.isInteger(n) ? n.toString() : n.toFixed(2),
     };
 
     return [

--- a/src/modules/boxSources/LoanPaymentBoxSource.ts
+++ b/src/modules/boxSources/LoanPaymentBoxSource.ts
@@ -1,0 +1,117 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// convert a key-value record to plaintext lines for box plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// standard amortizing loan: P * r * (1+r)^n / ((1+r)^n - 1)
+function computeMonthlyPayment(
+  principal: number,
+  annualRatePercent: number,
+  years: number,
+): number {
+  const r = annualRatePercent / 100 / 12;
+  const n = years * 12;
+  if (r === 0) {
+    return principal / n;
+  }
+  const factor = (1 + r) ** n;
+  return (principal * r * factor) / (factor - 1);
+}
+
+export const LoanPaymentBoxSource = {
+  name: 'Loan Payment',
+  description:
+    'Compute the monthly payment of an amortizing loan. Input: "<principal> <annualRate%> <years>".',
+  defaultInput: '200000 5 30 ::loan',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'loan', 'mortgage')) return [];
+
+    const text = trim(input);
+    if (text.length > 100) return [];
+
+    // split on whitespace and/or commas to get the three numeric tokens
+    const parts = text.split(/[\s,]+/).filter(Boolean);
+
+    if (parts.length !== 3) {
+      const errorKv = {
+        'Expected input': '<principal> <annualRate%> <years>',
+        Example: '200000 5 30',
+      };
+      return [
+        new BoxBuilder('Loan Payment', kvToPlaintext(errorKv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(errorKv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const principal = Number.parseFloat(parts[0]);
+    const annualRate = Number.parseFloat(parts[1]);
+    const years = Number.parseFloat(parts[2]);
+
+    if (
+      Number.isNaN(principal) ||
+      Number.isNaN(annualRate) ||
+      Number.isNaN(years) ||
+      principal <= 0 ||
+      years <= 0 ||
+      annualRate < 0
+    ) {
+      const errorKv = {
+        'Expected input': '<principal> <annualRate%> <years>',
+        Example: '200000 5 30',
+      };
+      return [
+        new BoxBuilder('Loan Payment', kvToPlaintext(errorKv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(errorKv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const monthlyPayment = computeMonthlyPayment(principal, annualRate, years);
+    const n = years * 12;
+    const totalPaid = monthlyPayment * n;
+    const totalInterest = totalPaid - principal;
+
+    const round2 = (v: number) => Math.round(v * 100) / 100;
+
+    const kv: Record<string, string> = {
+      Principal: round2(principal).toFixed(2),
+      'Annual Rate': `${annualRate}%`,
+      Term: `${years} year${years !== 1 ? 's' : ''}`,
+      'Monthly Payment': round2(monthlyPayment).toFixed(2),
+      'Total Paid': round2(totalPaid).toFixed(2),
+      'Total Interest': round2(totalInterest).toFixed(2),
+      Payments: n.toString(),
+    };
+
+    return [
+      new BoxBuilder('Loan Payment', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LoanPaymentBoxSource;

--- a/src/modules/boxSources/MarkdownStripBoxSource.ts
+++ b/src/modules/boxSources/MarkdownStripBoxSource.ts
@@ -1,0 +1,103 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// strip markdown formatting to plain text, line by line where appropriate
+function stripMarkdown(input: string): string {
+  // remove code fence delimiters (``` or ~~~), keep inner content
+  const lines = input.split('\n');
+  const processedLines: string[] = [];
+  let inCodeFence = false;
+
+  for (const line of lines) {
+    if (/^(`{3,}|~{3,})/.test(line)) {
+      inCodeFence = !inCodeFence;
+      // skip the fence line itself
+      continue;
+    }
+    if (inCodeFence) {
+      processedLines.push(line);
+      continue;
+    }
+    processedLines.push(processLine(line));
+  }
+
+  return processedLines.join('\n');
+}
+
+// apply all inline and block-level stripping to a single line
+function processLine(line: string): string {
+  // horizontal rules: lines of only dashes, asterisks, underscores (with optional spaces)
+  if (/^(\s*[-*_]){3,}\s*$/.test(line)) {
+    return '';
+  }
+
+  // atx headings: remove leading hashes
+  let result = line.replace(/^#{1,6}\s+/, '');
+
+  // blockquotes: remove leading '> '
+  result = result.replace(/^>\s?/, '');
+
+  // ordered list markers: '1. ', '2. ', etc.
+  result = result.replace(/^\s*\d+\.\s+/, '');
+
+  // unordered list markers: '- ', '* ', '+ ' — keep the '- ' prefix for unordered lists
+  // we normalise all markers to '- ' to preserve the list structure
+  result = result.replace(/^(\s*)[-*+]\s+/, '$1- ');
+
+  // images before links so '![alt](url)' is handled first
+  result = result.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');
+
+  // links: '[text](url)' → 'text'
+  result = result.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+
+  // strikethrough: '~~text~~' → 'text'
+  result = result.replace(/~~([^~]+)~~/g, '$1');
+
+  // inline code: '`code`' → 'code' (backtick-delimited, no backtick inside)
+  result = result.replace(/`([^`]+)`/g, '$1');
+
+  // bold: '**text**' or '__text__' → 'text'
+  // use backreference to match same delimiter; non-greedy middle
+  result = result.replace(/(\*\*|__)(.+?)\1/g, '$2');
+
+  // italic: '*text*' or '_text_' → 'text'
+  // only run after bold so we don't partially match bold markers
+  result = result.replace(/(\*|_)(.+?)\1/g, '$2');
+
+  return result;
+}
+
+export const MarkdownStripBoxSource = {
+  name: 'Markdown to Text',
+  description:
+    'Strip Markdown formatting to plain text. ::stripmd or ::mdtotext.',
+  defaultInput: '# Title\n\n**bold** and *italic* and `code` ::stripmd',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'stripmd', 'mdtotext')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const plainText = stripMarkdown(input);
+
+    return [
+      new BoxBuilder('Markdown to Text', plainText)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default MarkdownStripBoxSource;

--- a/src/modules/boxSources/PassphraseBoxSource.ts
+++ b/src/modules/boxSources/PassphraseBoxSource.ts
@@ -1,0 +1,372 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const DEFAULT_WORD_COUNT = 4;
+const MIN_WORD_COUNT = 2;
+const MAX_WORD_COUNT = 20;
+const SEPARATOR = '-';
+
+// built-in wordlist of 256 short common English words (3–6 letters, lowercase, no duplicates)
+export const WORDLIST: readonly string[] = [
+  'able',
+  'acid',
+  'aged',
+  'also',
+  'area',
+  'army',
+  'away',
+  'baby',
+  'back',
+  'ball',
+  'band',
+  'bank',
+  'base',
+  'bath',
+  'bear',
+  'beat',
+  'been',
+  'bell',
+  'best',
+  'bird',
+  'bite',
+  'blow',
+  'blue',
+  'body',
+  'bold',
+  'bone',
+  'book',
+  'born',
+  'both',
+  'bowl',
+  'bulk',
+  'burn',
+  'busy',
+  'buzz',
+  'call',
+  'calm',
+  'came',
+  'camp',
+  'card',
+  'care',
+  'case',
+  'cash',
+  'cast',
+  'cave',
+  'cell',
+  'chat',
+  'chip',
+  'city',
+  'clap',
+  'clay',
+  'clip',
+  'club',
+  'clue',
+  'coal',
+  'coat',
+  'code',
+  'coil',
+  'coin',
+  'cold',
+  'come',
+  'cook',
+  'cool',
+  'cord',
+  'core',
+  'cost',
+  'crop',
+  'cube',
+  'cure',
+  'curl',
+  'cute',
+  'dark',
+  'data',
+  'date',
+  'dawn',
+  'days',
+  'dead',
+  'deal',
+  'dear',
+  'deep',
+  'desk',
+  'diet',
+  'dirt',
+  'dish',
+  'disk',
+  'dock',
+  'does',
+  'done',
+  'door',
+  'dose',
+  'down',
+  'draw',
+  'drew',
+  'drop',
+  'drum',
+  'dual',
+  'dull',
+  'dusk',
+  'dust',
+  'duty',
+  'each',
+  'earn',
+  'east',
+  'easy',
+  'edge',
+  'else',
+  'even',
+  'ever',
+  'exam',
+  'face',
+  'fact',
+  'fail',
+  'fair',
+  'fall',
+  'farm',
+  'fast',
+  'fate',
+  'feed',
+  'feel',
+  'feet',
+  'fell',
+  'felt',
+  'file',
+  'fill',
+  'film',
+  'find',
+  'fine',
+  'fire',
+  'firm',
+  'fish',
+  'fist',
+  'flag',
+  'flat',
+  'flew',
+  'flip',
+  'flow',
+  'foam',
+  'fold',
+  'folk',
+  'fond',
+  'font',
+  'food',
+  'fool',
+  'foot',
+  'ford',
+  'fork',
+  'form',
+  'fort',
+  'foul',
+  'four',
+  'free',
+  'from',
+  'fuel',
+  'full',
+  'fund',
+  'fuse',
+  'gain',
+  'game',
+  'gate',
+  'gave',
+  'gear',
+  'gift',
+  'glad',
+  'glow',
+  'glue',
+  'goal',
+  'goes',
+  'gold',
+  'golf',
+  'gone',
+  'good',
+  'grab',
+  'gray',
+  'grew',
+  'grid',
+  'grin',
+  'grip',
+  'grow',
+  'gulf',
+  'gust',
+  'hack',
+  'half',
+  'hall',
+  'halt',
+  'hand',
+  'hang',
+  'hard',
+  'harm',
+  'harp',
+  'hash',
+  'hate',
+  'have',
+  'head',
+  'heal',
+  'heap',
+  'heat',
+  'heel',
+  'held',
+  'help',
+  'hide',
+  'high',
+  'hill',
+  'hint',
+  'hire',
+  'hold',
+  'hole',
+  'home',
+  'hook',
+  'hope',
+  'horn',
+  'host',
+  'hour',
+  'hunt',
+  'hurt',
+  'icon',
+  'idea',
+  'idle',
+  'iris',
+  'item',
+  'join',
+  'jump',
+  'just',
+  'keen',
+  'keep',
+  'kind',
+  'king',
+  'knew',
+  'knot',
+  'know',
+  'lake',
+  'lamp',
+  'land',
+  'lane',
+  'last',
+  'late',
+  'lawn',
+  'lead',
+  'leaf',
+  'lean',
+  'left',
+  'lend',
+  'lens',
+  'less',
+  'lift',
+  'like',
+  'lime',
+  'line',
+  'link',
+  'list',
+  'live',
+  'load',
+  'lock',
+  'loft',
+  'long',
+  'loop',
+  'lore',
+  'lost',
+  'loud',
+] as const;
+
+// convert a key-value record to plaintext lines for box plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+/** picks count unbiased random indices into WORDLIST using rejection sampling with a power-of-2 mask */
+function pickWords(count: number): string[] {
+  const size = WORDLIST.length;
+
+  // find the smallest power of 2 >= size for efficient rejection sampling
+  let mask = 1;
+  while (mask < size) mask <<= 1;
+  mask -= 1;
+
+  const words: string[] = [];
+  while (words.length < count) {
+    const batch = new Uint32Array(
+      count - words.length + 8,
+    ) as Uint32Array<ArrayBuffer>;
+    crypto.getRandomValues(batch);
+    for (const raw of batch) {
+      if (words.length >= count) break;
+      const idx = raw & mask;
+      if (idx < size) {
+        words.push(WORDLIST[idx]);
+      }
+    }
+  }
+  return words;
+}
+
+export const PassphraseBoxSource = {
+  name: 'Passphrase',
+  description:
+    'Generate a memorable passphrase from a wordlist (crypto-secure). ::passphrase=<wordCount> (default 4).',
+  defaultInput: ' ::passphrase',
+  tag: '#',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    _input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'passphrase', 'diceware')) return [];
+
+    // secure-context guard: crypto.getRandomValues must be available
+    if (
+      typeof crypto === 'undefined' ||
+      typeof crypto.getRandomValues !== 'function'
+    ) {
+      const errKv = {
+        Error:
+          'A secure context (HTTPS or localhost) is required for crypto.getRandomValues.',
+      };
+      return [
+        new BoxBuilder('Passphrase', kvToPlaintext(errKv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(errKv)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // parse word count from option value, default 4, clamp 2..20
+    const optVal = extractOptionKeys(options, 'passphrase', 'diceware');
+    let count = DEFAULT_WORD_COUNT;
+    if (typeof optVal === 'string' && optVal !== '') {
+      const parsed = Number.parseInt(optVal, 10);
+      if (!Number.isNaN(parsed)) {
+        count = Math.min(MAX_WORD_COUNT, Math.max(MIN_WORD_COUNT, parsed));
+      }
+    }
+
+    const words = pickWords(count);
+    const passphrase = words.join(SEPARATOR);
+    const size = WORDLIST.length;
+    const entropy = (count * Math.log2(size)).toFixed(1);
+
+    const kv: Record<string, string> = {
+      Passphrase: passphrase,
+      Words: count.toString(),
+      'Wordlist Size': size.toString(),
+      'Entropy (bits)': entropy,
+    };
+
+    return [
+      new BoxBuilder('Passphrase', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PassphraseBoxSource;

--- a/src/modules/boxSources/TextIndentBoxSource.ts
+++ b/src/modules/boxSources/TextIndentBoxSource.ts
@@ -1,0 +1,109 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// compute the length of the common leading-space prefix across all non-empty lines
+function commonLeadingSpaces(lines: string[]): number {
+  const nonEmpty = lines.filter((l) => l.length > 0);
+  if (nonEmpty.length === 0) return 0;
+
+  let min = Number.POSITIVE_INFINITY;
+  for (const line of nonEmpty) {
+    let count = 0;
+    while (count < line.length && line[count] === ' ') {
+      count++;
+    }
+    if (count < min) min = count;
+  }
+  return min === Number.POSITIVE_INFINITY ? 0 : min;
+}
+
+// apply indentation: positive n prepends spaces, negative n removes leading spaces
+function applyIndent(lines: string[], n: number): string[] {
+  if (n === 0) return lines;
+
+  if (n > 0) {
+    const pad = ' '.repeat(n);
+    return lines.map((line) => (line.length === 0 ? line : pad + line));
+  }
+
+  // dedent: remove up to |n| leading spaces per line
+  const remove = -n;
+  return lines.map((line) => {
+    let i = 0;
+    while (i < remove && i < line.length && line[i] === ' ') {
+      i++;
+    }
+    return line.slice(i);
+  });
+}
+
+export const TextIndentBoxSource = {
+  name: 'Indent',
+  description:
+    'Indent every line by N spaces (::indent=<n>) or dedent (::dedent / ::indent=-<n>).',
+  defaultInput: 'line one\nline two ::indent=2',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantIndent = hasOptionKeys(options, 'indent');
+    const wantDedent = hasOptionKeys(options, 'dedent');
+    if (!wantIndent && !wantDedent) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    // normalize line endings
+    const normalized = (input as string)
+      .replace(/\r\n/g, '\n')
+      .replace(/\r/g, '\n');
+    const lines = normalized.split('\n');
+
+    let amount: number;
+
+    if (wantIndent) {
+      const raw = extractOptionKeys(options, 'indent');
+      if (raw === true || raw === null) {
+        // ::indent with no value defaults to 2
+        amount = 2;
+      } else {
+        const parsed = Number.parseInt(raw as string, 10);
+        amount = Number.isNaN(parsed)
+          ? 2
+          : Math.max(-1000, Math.min(1000, parsed));
+      }
+    } else {
+      // ::dedent branch
+      const raw = extractOptionKeys(options, 'dedent');
+      if (raw === true || raw === null) {
+        // auto-dedent: remove the common leading whitespace prefix
+        amount = -commonLeadingSpaces(lines);
+      } else {
+        const parsed = Number.parseInt(raw as string, 10);
+        const fixed = Number.isNaN(parsed)
+          ? 0
+          : Math.max(0, Math.min(1000, parsed));
+        amount = -fixed;
+      }
+    }
+
+    const result = applyIndent(lines, amount).join('\n');
+
+    return [
+      new BoxBuilder('Indent', result)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default TextIndentBoxSource;

--- a/src/modules/boxSources/__test__/BusinessDaysBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BusinessDaysBoxSource.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import { BusinessDaysBoxSource } from '../BusinessDaysBoxSource';
+
+describe('BusinessDaysBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no matching option key is provided', async () => {
+      const boxes = await BusinessDaysBoxSource.generateBoxes(
+        '2025-01-01 to 2025-01-31',
+        null,
+      );
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] when an unrelated option key is provided', async () => {
+      const boxes = await BusinessDaysBoxSource.generateBoxes(
+        '2025-01-01 to 2025-01-31',
+        { qrcode: true },
+      );
+      expect(boxes).toEqual([]);
+    });
+
+    describe('Jan 2025 (23 business days, 31 calendar days, 8 weekend days)', () => {
+      // Jan 2025: weekends are 4,5,11,12,18,19,25,26 = 8 days; 31-8=23 business days
+      it('triggers with ::busdays', async () => {
+        const boxes = await BusinessDaysBoxSource.generateBoxes(
+          '2025-01-01 to 2025-01-31',
+          { busdays: true },
+        );
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Business Days']).toBe('23');
+        expect(opts['Calendar Days']).toBe('31');
+        expect(opts['Weekend Days']).toBe('8');
+        expect(opts.Start).toBe('2025-01-01');
+        expect(opts.End).toBe('2025-01-31');
+      });
+
+      it('triggers with ::businessdays', async () => {
+        const boxes = await BusinessDaysBoxSource.generateBoxes(
+          '2025-01-01 to 2025-01-31',
+          { businessdays: true },
+        );
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Business Days']).toBe('23');
+      });
+
+      it('triggers with ::workdays', async () => {
+        const boxes = await BusinessDaysBoxSource.generateBoxes(
+          '2025-01-01 to 2025-01-31',
+          { workdays: true },
+        );
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Business Days']).toBe('23');
+      });
+
+      it('accepts comma-separated dates', async () => {
+        const boxes = await BusinessDaysBoxSource.generateBoxes(
+          '2025-01-01,2025-01-31',
+          { busdays: true },
+        );
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Business Days']).toBe('23');
+      });
+    });
+
+    it('single weekday (2025-01-01 Wednesday) → Business Days 1, Calendar Days 1', async () => {
+      const boxes = await BusinessDaysBoxSource.generateBoxes(
+        '2025-01-01 to 2025-01-01',
+        { busdays: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Business Days']).toBe('1');
+      expect(opts['Calendar Days']).toBe('1');
+      expect(opts['Weekend Days']).toBe('0');
+    });
+
+    it('single weekend day (2025-01-04 Saturday) → Business Days 0', async () => {
+      const boxes = await BusinessDaysBoxSource.generateBoxes(
+        '2025-01-04 to 2025-01-04',
+        { busdays: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Business Days']).toBe('0');
+      expect(opts['Calendar Days']).toBe('1');
+      expect(opts['Weekend Days']).toBe('1');
+    });
+
+    it('full Mon-Sun week (2025-01-06 to 2025-01-12) → Business Days 5, Weekend Days 2', async () => {
+      const boxes = await BusinessDaysBoxSource.generateBoxes(
+        '2025-01-06 to 2025-01-12',
+        { busdays: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Business Days']).toBe('5');
+      expect(opts['Weekend Days']).toBe('2');
+      expect(opts['Calendar Days']).toBe('7');
+    });
+
+    it('swapped order (2025-01-31 to 2025-01-01) yields same result as forward', async () => {
+      const boxes = await BusinessDaysBoxSource.generateBoxes(
+        '2025-01-31 to 2025-01-01',
+        { busdays: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Business Days']).toBe('23');
+      expect(opts['Calendar Days']).toBe('31');
+      expect(opts.Start).toBe('2025-01-01');
+      expect(opts.End).toBe('2025-01-31');
+      expect(opts.Note).toContain('swapped');
+    });
+
+    it('invalid text input → returns an error box', async () => {
+      const boxes = await BusinessDaysBoxSource.generateBoxes('hello', {
+        busdays: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('invalid date (2025-13-01 — month 13) → returns an error box', async () => {
+      const boxes = await BusinessDaysBoxSource.generateBoxes(
+        '2025-13-01 to 2025-01-31',
+        { busdays: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('invalid date (2025-02-30 — Feb 30 does not exist) → returns an error box', async () => {
+      const boxes = await BusinessDaysBoxSource.generateBoxes(
+        '2025-02-30 to 2025-03-01',
+        { busdays: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('input exceeding length cap (>60 chars) → returns []', async () => {
+      const longInput =
+        '2025-01-01 to 2025-01-31 and some extra text to exceed 60 chars';
+      const boxes = await BusinessDaysBoxSource.generateBoxes(longInput, {
+        busdays: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CompoundInterestBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CompoundInterestBoxSource.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { CompoundInterestBoxSource } from '../CompoundInterestBoxSource';
+
+describe('CompoundInterestBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no compound option is provided', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options is null', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes(
+        '1000 5 10',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should compute monthly compounding: 1000 at 5% for 10yr → ~1647.01', async () => {
+      // 1000 * (1 + 0.05/12)^120 ≈ 1647.009...
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Future Value']).toMatch(/^1647\.0/);
+    });
+
+    it('should compute annual compounding: 1000 at 5% for 10yr → ~1628.89', async () => {
+      // 1000 * 1.05^10 ≈ 1628.894...; ::compound=1 means annual compounding
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Future Value']).toMatch(/^1628\.8/);
+    });
+
+    it('should compute annual compounding: 1000 at 10% for 1yr → 1100.00', async () => {
+      // 1000 * (1 + 0.10/1)^1 = 1100
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 10 1', {
+        compound: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Future Value']).toBe('1100.00');
+    });
+
+    it('should compute interest earned for monthly 1000/5%/10yr ≈ 647.01', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Interest Earned']).toMatch(/^647\.0/);
+    });
+
+    it('should compute EAR for 5% monthly ≈ 5.116%', async () => {
+      // (1 + 0.05/12)^12 - 1 ≈ 0.05116... → 5.116%
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Effective Annual Rate']).toMatch(/^5\.11/);
+    });
+
+    it('should return an error box for wrong argument count', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('should return an error box for negative principal', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('-100 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+
+    it('should use ::compoundinterest option key as alias', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compoundinterest: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Future Value']).toMatch(/^1647\.0/);
+    });
+
+    it('should include all required output keys', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts).toHaveProperty('Principal');
+      expect(opts).toHaveProperty('Annual Rate');
+      expect(opts).toHaveProperty('Years');
+      expect(opts).toHaveProperty('Compounds/Year');
+      expect(opts).toHaveProperty('Future Value');
+      expect(opts).toHaveProperty('Interest Earned');
+      expect(opts).toHaveProperty('Effective Annual Rate');
+    });
+
+    it('should default to 12 compounds/year when option has no numeric value', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Compounds/Year']).toBe('12');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/DataRateBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DataRateBoxSource.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { DataRateBoxSource } from '../DataRateBoxSource';
+
+describe('DataRateBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no option key is present', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array with unrelated options', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', {
+        unrelated: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert 100 Mbps correctly (bitrate → byte rates)', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.bps).toBe('100000000');
+      expect(opts.Mbps).toBe('100');
+      // 100 Mbit/s / 8 = 12.5 MB/s
+      expect(opts['MB/s']).toBe('12.5');
+      expect(opts.Kbps).toBe('100000');
+      expect(opts.Gbps).toBe('0.1');
+    });
+
+    it('should convert 1 Gbps correctly', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('1 Gbps', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mbps).toBe('1000');
+      expect(opts['MB/s']).toBe('125');
+    });
+
+    it('should convert 8 bps to 1 B/s', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('8 bps', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['B/s']).toBe('1');
+    });
+
+    it('should convert 1 MB/s (megabyte/s) to 8 Mbps', async () => {
+      // 1 MB/s = 8 Mbit/s = 8 Mbps
+      const boxes = await DataRateBoxSource.generateBoxes('1 MB/s', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mbps).toBe('8');
+    });
+
+    it('should accept ::bandwidth option key', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', {
+        bandwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('should return an error box for purely alphabetic input', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('abc', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toContain('bps');
+    });
+
+    it('should return an error box for unknown unit', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('5 foo', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toContain('mbps');
+    });
+
+    it('should produce a box named "Data Rate"', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', {
+        datarate: true,
+      });
+      expect(boxes[0].props.name).toBe('Data Rate');
+    });
+
+    it('should include the Input key showing original value and unit', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', {
+        datarate: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('100 Mbps');
+    });
+
+    it('should handle unit matching case-insensitively (mbps vs Mbps vs MBPS)', async () => {
+      const [boxLower] = await DataRateBoxSource.generateBoxes('100 mbps', {
+        datarate: true,
+      });
+      const [boxUpper] = await DataRateBoxSource.generateBoxes('100 MBPS', {
+        datarate: true,
+      });
+      const optsLower = boxLower.props.options as Record<string, string>;
+      const optsUpper = boxUpper.props.options as Record<string, string>;
+      expect(optsLower.bps).toBe(optsUpper.bps);
+    });
+
+    it('should return empty array when input exceeds 64 characters', async () => {
+      const longInput = `${'1'.repeat(60)} Mbps`;
+      const boxes = await DataRateBoxSource.generateBoxes(longInput, {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HtmlToTextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HtmlToTextBoxSource.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import { HtmlToTextBoxSource } from '../HtmlToTextBoxSource';
+
+describe('HtmlToTextBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes(
+        '<p>Hello</p>',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for an unrelated option', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('<p>Hi</p>', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with ::striptags', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('', {
+        striptags: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — tag stripping', () => {
+    it('strips tags and returns plain text via ::striptags', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes(
+        '<p>Hello <b>world</b>!</p>',
+        { striptags: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hello world!');
+    });
+
+    it('works with ::htmltotext option key', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes(
+        '<p>Hello <b>world</b>!</p>',
+        { htmltotext: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hello world!');
+    });
+
+    it('converts <br> to newline', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('a<br>b', {
+        striptags: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb');
+    });
+
+    it('converts <br/> and <br /> variants to newline', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('x<br/>y<br />z', {
+        striptags: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('x\ny\nz');
+    });
+
+    it('adds dashes for list items and separates them', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes(
+        '<ul><li>one</li><li>two</li></ul>',
+        { striptags: true },
+      );
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('- ');
+      expect(out).toContain('one');
+      expect(out).toContain('two');
+    });
+  });
+
+  describe('generateBoxes — script and style removal', () => {
+    it('removes <script> blocks entirely', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes(
+        '<script>alert(1)</script>Safe',
+        { striptags: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('Safe');
+      expect(boxes[0].props.plaintextOutput).not.toContain('alert');
+    });
+
+    it('removes <style> blocks entirely', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes(
+        '<style>.x{color:red}</style>Text',
+        { striptags: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('Text');
+      expect(boxes[0].props.plaintextOutput).not.toContain('color');
+    });
+
+    it('removes multiline <script> blocks', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes(
+        '<script>\nvar x = 1;\nvar y = 2;\n</script>Clean',
+        { striptags: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('Clean');
+    });
+  });
+
+  describe('generateBoxes — entity decoding', () => {
+    it('decodes named entities', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes(
+        '&lt;a&gt; &amp; &quot;b&quot;',
+        { striptags: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('<a> & "b"');
+    });
+
+    it('decodes &nbsp; as a space', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('a&nbsp;b', {
+        striptags: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a b');
+    });
+
+    it('decodes decimal numeric entities', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('&#65;&#66;', {
+        striptags: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+
+    it('decodes hex numeric entities', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('&#x41;&#x42;', {
+        striptags: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+
+    it('decodes mixed numeric entities', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('&#65;&#x42;', {
+        striptags: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('sets the box name to "HTML to Text"', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('<p>hi</p>', {
+        striptags: true,
+      });
+      expect(boxes[0].props.name).toBe('HTML to Text');
+    });
+
+    it('sets the correct priority', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('<p>hi</p>', {
+        striptags: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('attaches a box template (CodeBoxTemplate)', async () => {
+      const boxes = await HtmlToTextBoxSource.generateBoxes('<p>hi</p>', {
+        striptags: true,
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HtmlToTextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HtmlToTextBoxSource.test.ts
@@ -160,4 +160,18 @@ describe('HtmlToTextBoxSource', () => {
       expect(boxes[0].boxTemplate).toBeDefined();
     });
   });
+
+  describe('ReDoS safety', () => {
+    it('handles many unclosed <script> tags in linear time', async () => {
+      // many closed script blocks: an O(n^2) removal would stall; the linear
+      // scan stays fast and trailing content survives (kept under MAX_INPUT)
+      const input = `${'<script>x</script>'.repeat(5000)}safe`;
+      const start = Date.now();
+      const boxes = await HtmlToTextBoxSource.generateBoxes(input, {
+        striptags: true,
+      });
+      expect(Date.now() - start).toBeLessThan(500);
+      expect(boxes[0].props.plaintextOutput).toBe('safe');
+    });
+  });
 });

--- a/src/modules/boxSources/__test__/LoanPaymentBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LoanPaymentBoxSource.test.ts
@@ -1,0 +1,126 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { LoanPaymentBoxSource } from '../LoanPaymentBoxSource';
+
+describe('LoanPaymentBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option key is present', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes(
+        '200000 5 30',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is present', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5 30', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('computes $200k / 5% APR / 30yr → monthly payment ≈ 1073.64', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5 30', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const box = boxes[0];
+      expect(box.props.name).toBe('Loan Payment');
+      expect(box.props.priority).toBe(10);
+      expect(box.boxTemplate).toBe(KeyValueBoxTemplate);
+
+      const opts = box.props.options as Record<string, string>;
+      expect(opts['Monthly Payment']).toMatch(/^1073\.6/);
+      expect(opts['Total Paid']).toBe('386511.57');
+      expect(opts['Total Interest']).toBe('186511.57');
+      expect(opts.Payments).toBe('360');
+      expect(opts.Principal).toBe('200000.00');
+      expect(opts['Annual Rate']).toBe('5%');
+      expect(opts.Term).toBe('30 years');
+    });
+
+    it('accepts ::mortgage option key', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5 30', {
+        mortgage: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Monthly Payment']).toMatch(/^1073\.6/);
+    });
+
+    it('computes zero-interest loan: 1200 / 0% / 1yr → 100/mo', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('1200 0 1', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Monthly Payment']).toBe('100.00');
+      expect(opts['Total Paid']).toBe('1200.00');
+      expect(opts['Total Interest']).toBe('0.00');
+    });
+
+    it('computes $100k / 6% APR / 15yr → monthly payment ≈ 843.86', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('100000 6 15', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Monthly Payment']).toMatch(/^843\.8/);
+    });
+
+    it('returns an error box when arg count is wrong (too few)', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Expected input']).toBeDefined();
+    });
+
+    it('returns an error box when args are non-numeric', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('a b c', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Expected input']).toBeDefined();
+    });
+
+    it('returns an error box when principal is zero or negative', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('0 5 30', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Expected input']).toBeDefined();
+    });
+
+    it('returns an error box when years is zero or negative', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5 0', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Expected input']).toBeDefined();
+    });
+
+    it('returns [] for input exceeding 100 characters', async () => {
+      const long = `${'2'.repeat(101)} 5 30`;
+      const boxes = await LoanPaymentBoxSource.generateBoxes(long, {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('plaintext output contains key: value lines', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5 30', {
+        loan: true,
+      });
+      const plaintext = boxes[0].props.plaintextOutput;
+      expect(plaintext).toContain('Monthly Payment: 1073.6');
+      expect(plaintext).toContain('Principal: 200000.00');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/MarkdownStripBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MarkdownStripBoxSource.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from 'vitest';
+
+import { MarkdownStripBoxSource } from '../MarkdownStripBoxSource';
+
+describe('MarkdownStripBoxSource', () => {
+  describe('generateBoxes — guard conditions', () => {
+    it('returns [] with no option keys', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] with unrelated option keys', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('', {
+        stripmd: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding MAX_INPUT', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        'a'.repeat(100_001),
+        { stripmd: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — ::stripmd trigger', () => {
+    it('returns a box with correct name and priority', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', {
+        stripmd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Markdown to Text');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('uses CodeBoxTemplate', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', {
+        stripmd: true,
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+  });
+
+  describe('generateBoxes — ::mdtotext trigger', () => {
+    it('accepts mdtotext option key', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', {
+        mdtotext: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Title');
+    });
+  });
+
+  describe('heading stripping', () => {
+    it('strips h1', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('# Title', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Title');
+    });
+
+    it('strips h2 through h6', async () => {
+      for (let level = 2; level <= 6; level++) {
+        const boxes = await MarkdownStripBoxSource.generateBoxes(
+          `${'#'.repeat(level)} Heading ${level}`,
+          { stripmd: true },
+        );
+        expect(boxes[0].props.plaintextOutput).toBe(`Heading ${level}`);
+      }
+    });
+  });
+
+  describe('emphasis stripping', () => {
+    it('strips bold **text**', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('**bold**', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('bold');
+    });
+
+    it('strips bold __text__', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('__bold__', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('bold');
+    });
+
+    it('strips italic *text*', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('*italic*', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('italic');
+    });
+
+    it('strips italic _text_', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('_italic_', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('italic');
+    });
+  });
+
+  describe('inline code stripping', () => {
+    it('strips `code`', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('`code`', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('code');
+    });
+  });
+
+  describe('combined inline stripping', () => {
+    it('strips bold, italic, and code on one line', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '**bold** and *italic* and `code`',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('bold and italic and code');
+    });
+  });
+
+  describe('links and images', () => {
+    it('strips link [text](url) → text', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '[Google](https://google.com)',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('Google');
+    });
+
+    it('strips image ![alt text](img.png) → alt text', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '![alt text](img.png)',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('alt text');
+    });
+  });
+
+  describe('blockquotes', () => {
+    it('strips blockquote prefix', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('> quoted', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('quoted');
+    });
+  });
+
+  describe('list markers', () => {
+    it('normalises unordered list markers to "- "', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '- item one\n- item two',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('- item one\n- item two');
+    });
+
+    it('normalises * list markers to "- "', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '* item one\n* item two',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('- item one\n- item two');
+    });
+
+    it('strips ordered list markers', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '1. first\n2. second',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('first\nsecond');
+    });
+  });
+
+  describe('strikethrough', () => {
+    it('strips ~~text~~', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('~~gone~~', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('gone');
+    });
+  });
+
+  describe('horizontal rules', () => {
+    it('removes --- rule', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('---', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('');
+    });
+
+    it('removes *** rule', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes('***', {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('');
+    });
+  });
+
+  describe('code fences', () => {
+    it('removes fence delimiters but keeps inner content', async () => {
+      const input = '```\nconst x = 1;\n```';
+      const boxes = await MarkdownStripBoxSource.generateBoxes(input, {
+        stripmd: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('const x = 1;');
+    });
+  });
+
+  describe('multi-element document', () => {
+    it('strips heading and inline bold in a multi-line document', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '# Title\n\nSome **text**',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('Title\n\nSome text');
+    });
+
+    it('handles the defaultInput example', async () => {
+      const boxes = await MarkdownStripBoxSource.generateBoxes(
+        '# Title\n\n**bold** and *italic* and `code`',
+        { stripmd: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'Title\n\nbold and italic and code',
+      );
+    });
+  });
+
+  describe('linear regex safety', () => {
+    // a long string of asterisks must not cause catastrophic backtracking
+    it('handles a long asterisk string without hanging', () => {
+      const longAsterisks = '*'.repeat(50_000);
+      const start = Date.now();
+      // access the internal stripMarkdown indirectly via generateBoxes
+      // we only need to confirm it completes quickly (< 500 ms)
+      const result = MarkdownStripBoxSource.generateBoxes(longAsterisks, {
+        stripmd: true,
+      });
+      // the promise resolves synchronously for this pure transform, but await
+      // is not available here — we simply verify it was created fast
+      expect(Date.now() - start).toBeLessThan(500);
+      expect(result).toBeDefined();
+    });
+
+    it('handles a long underscore string without hanging', () => {
+      const longUnderscores = '_'.repeat(50_000);
+      const start = Date.now();
+      const result = MarkdownStripBoxSource.generateBoxes(longUnderscores, {
+        stripmd: true,
+      });
+      expect(Date.now() - start).toBeLessThan(500);
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PassphraseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PassphraseBoxSource.test.ts
@@ -1,0 +1,200 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { PassphraseBoxSource, WORDLIST } from '../PassphraseBoxSource';
+
+describe('PassphraseBoxSource', () => {
+  describe('generateBoxes — trigger conditions', () => {
+    it('returns [] when no option key is present', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('anything', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is present', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('anything', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers with ::passphrase option', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        passphrase: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('triggers with ::diceware alias', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        diceware: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes — default word count (4)', () => {
+    it('produces 4 words joined by hyphens', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        passphrase: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const box = boxes[0];
+      expect(box.props.name).toBe('Passphrase');
+      expect(box.props.priority).toBe(10);
+      expect(box.boxTemplate).toBe(KeyValueBoxTemplate);
+
+      const opts = box.props.options as Record<string, string>;
+      const phrase = opts.Passphrase;
+      const words = phrase.split('-');
+      expect(words).toHaveLength(4);
+      for (const word of words) {
+        expect(WORDLIST).toContain(word);
+      }
+      expect(opts.Words).toBe('4');
+    });
+  });
+
+  describe('generateBoxes — custom word count', () => {
+    it('produces 6 words when ::passphrase=6', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        passphrase: '6',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      const words = opts.Passphrase.split('-');
+      expect(words).toHaveLength(6);
+      expect(opts.Words).toBe('6');
+    });
+
+    it('clamps to 20 words when ::passphrase=99', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        passphrase: '99',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      const words = opts.Passphrase.split('-');
+      expect(words).toHaveLength(20);
+      expect(opts.Words).toBe('20');
+    });
+
+    it('clamps to 2 words when ::passphrase=1', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        passphrase: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      const words = opts.Passphrase.split('-');
+      expect(words).toHaveLength(2);
+      expect(opts.Words).toBe('2');
+    });
+  });
+
+  describe('generateBoxes — randomness', () => {
+    it('two calls produce different passphrases (overwhelmingly likely)', async () => {
+      const [a, b] = await Promise.all([
+        PassphraseBoxSource.generateBoxes('', { passphrase: true }),
+        PassphraseBoxSource.generateBoxes('', { passphrase: true }),
+      ]);
+      const phraseA = (a[0].props.options as Record<string, string>).Passphrase;
+      const phraseB = (b[0].props.options as Record<string, string>).Passphrase;
+      // probability of collision is (1/256)^4 ≈ 2e-10; treat as impossible
+      expect(phraseA).not.toBe(phraseB);
+    });
+  });
+
+  describe('generateBoxes — entropy', () => {
+    it('entropy equals count * log2(wordlistSize) for 4 words', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        passphrase: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      const size = WORDLIST.length;
+      const expected = (4 * Math.log2(size)).toFixed(1);
+      expect(opts['Entropy (bits)']).toBe(expected);
+      // for a 256-word list this is exactly '32.0'
+      if (size === 256) {
+        expect(opts['Entropy (bits)']).toBe('32.0');
+      }
+    });
+
+    it('entropy scales with word count', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        passphrase: '6',
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      const size = WORDLIST.length;
+      const expected = (6 * Math.log2(size)).toFixed(1);
+      expect(opts['Entropy (bits)']).toBe(expected);
+    });
+
+    it('Wordlist Size reflects the actual WORDLIST length', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        passphrase: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Wordlist Size']).toBe(String(WORDLIST.length));
+    });
+  });
+
+  describe('generateBoxes — all words from WORDLIST', () => {
+    it('every word in the phrase belongs to WORDLIST', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        passphrase: '10',
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      for (const word of opts.Passphrase.split('-')) {
+        expect(WORDLIST).toContain(word);
+      }
+    });
+  });
+
+  describe('generateBoxes — plaintext output', () => {
+    it('plaintext contains key: value lines', async () => {
+      const boxes = await PassphraseBoxSource.generateBoxes('', {
+        passphrase: true,
+      });
+      const plaintext = boxes[0].props.plaintextOutput;
+      expect(plaintext).toContain('Passphrase:');
+      expect(plaintext).toContain('Words: 4');
+      expect(plaintext).toContain('Entropy (bits):');
+    });
+  });
+
+  describe('generateBoxes — secure-context fallback', () => {
+    it('returns an error box when crypto.getRandomValues is unavailable', async () => {
+      const original = globalThis.crypto;
+      // @ts-expect-error — intentionally removing crypto to test the fallback
+      delete globalThis.crypto;
+
+      try {
+        const boxes = await PassphraseBoxSource.generateBoxes('', {
+          passphrase: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Error).toMatch(/secure context/i);
+      } finally {
+        globalThis.crypto = original;
+      }
+    });
+  });
+
+  describe('WORDLIST integrity', () => {
+    it('has at least 256 entries', () => {
+      expect(WORDLIST.length).toBeGreaterThanOrEqual(256);
+    });
+
+    it('has no duplicate words', () => {
+      const unique = new Set(WORDLIST);
+      expect(unique.size).toBe(WORDLIST.length);
+    });
+
+    it('all words are lowercase and non-empty', () => {
+      for (const word of WORDLIST) {
+        expect(word).toBe(word.toLowerCase());
+        expect(word.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/TextIndentBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TextIndentBoxSource.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import { TextIndentBoxSource } from '../TextIndentBoxSource';
+
+describe('TextIndentBoxSource', () => {
+  describe('guard conditions', () => {
+    it('returns [] when no option keys provided', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\nb', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option keys provided', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\nb', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('', {
+        indent: '2',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding MAX_INPUT', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes(
+        'a'.repeat(100_001),
+        {
+          indent: '2',
+        },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::indent=N (positive)', () => {
+    it('prepends N spaces to each non-empty line', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\nb', {
+        indent: '2',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('  a\n  b');
+    });
+
+    it('preserves blank lines — blank line stays blank, non-empty lines indented', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\n\nb', {
+        indent: '2',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('  a\n\n  b');
+    });
+
+    it('indents by 4 spaces on single-line input', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('x', {
+        indent: '4',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('    x');
+    });
+
+    it('defaults to 2 spaces when ::indent has no value (boolean true)', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('hello', {
+        indent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('  hello');
+    });
+  });
+
+  describe('::indent=-N (negative — dedent fixed amount)', () => {
+    it('removes up to N leading spaces from each line', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('    a\n    b', {
+        indent: '-2',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('  a\n  b');
+    });
+
+    it('does not remove more spaces than available', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('  a', {
+        indent: '-10',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a');
+    });
+  });
+
+  describe('::dedent=N (fixed dedent)', () => {
+    it('removes up to N leading spaces per line', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('    a\n      b', {
+        dedent: '4',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a\n  b');
+    });
+
+    it('does not remove non-space characters', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('  ab', {
+        dedent: '10',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('ab');
+    });
+  });
+
+  describe('::dedent (auto-dedent — no value)', () => {
+    it('removes the common leading-space prefix from all lines', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('    a\n      b', {
+        dedent: true,
+      });
+      // common prefix is 4 spaces: 'a' and '  b'
+      expect(boxes[0].props.plaintextOutput).toBe('a\n  b');
+    });
+
+    it('leaves blank lines empty after auto-dedent', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('  a\n\n  b', {
+        dedent: true,
+      });
+      // common prefix from non-empty lines is 2; blank stays blank
+      expect(boxes[0].props.plaintextOutput).toBe('a\n\nb');
+    });
+
+    it('produces no change when there is no common leading whitespace', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\n  b', {
+        dedent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a\n  b');
+    });
+  });
+
+  describe('box properties', () => {
+    it('sets box name to "Indent"', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('x', {
+        indent: '2',
+      });
+      expect(boxes[0].props.name).toBe('Indent');
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('x', {
+        indent: '2',
+      });
+      expect(boxes[0].props.priority).toBe(TextIndentBoxSource.priority);
+    });
+
+    it('uses CodeBoxTemplate', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('x', {
+        indent: '2',
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+  });
+
+  describe('CRLF normalization', () => {
+    it('normalizes CRLF to LF before indenting', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\r\nb', {
+        indent: '2',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('  a\n  b');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -2,22 +2,30 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import BusinessDaysBoxSource from './BusinessDaysBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CompoundInterestBoxSource from './CompoundInterestBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
+import DataRateBoxSource from './DataRateBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HtmlToTextBoxSource from './HtmlToTextBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LoanPaymentBoxSource from './LoanPaymentBoxSource';
+import MarkdownStripBoxSource from './MarkdownStripBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import PassphraseBoxSource from './PassphraseBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import TextIndentBoxSource from './TextIndentBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
@@ -29,22 +37,30 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  BusinessDaysBoxSource,
+  CompoundInterestBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
+  DataRateBoxSource,
   DateCalculateBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HtmlToTextBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LoanPaymentBoxSource,
+  MarkdownStripBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
+  PassphraseBoxSource,
   PasswordBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
+  TextIndentBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,


### PR DESCRIPTION
## Summary

Thirty-first exploration batch — **8 more BoxSource tools** (finance, text, converters, dates, security).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Loan Payment | `::loan` | amortizing loan monthly payment |
| Compound Interest | `::compound` | future value + effective annual rate |
| HTML to Text | `::striptags` | strip tags + decode entities |
| Markdown to Text | `::stripmd` | strip Markdown formatting |
| Data Rate | `::datarate` | bit/s ⇄ byte/s (Mbps ⇄ MB/s) |
| Business Days | `::busdays` | count weekdays between two dates |
| Passphrase | `::passphrase=<n>` | crypto-secure diceware passphrase |
| Indent | `::indent=<n>` | indent/dedent lines (auto-dedent) |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Hardening rules pre-loaded: **linear regexes** for HTML/Markdown stripping (script/style removed before tag-strip; non-greedy with fixed terminators — tested with 50k-char adversarial input for no catastrophic backtracking); **deterministic** business-days (UTC only, no `Date.now()`); **crypto-secure unbiased** passphrase sampling (256+ word list); integer-exact formatting for data-rate.
- **Verified vectors**: **$200k/5%/30yr→$1073.64/mo**; 1000/5%/10yr monthly→`1647.01`, annual→`1628.89`; `<p>Hi</p>`→`Hi` + entity decode + script removal; md heading/bold/italic/code/link strip; **100 Mbps→12.5 MB/s**, 1 MB/s→8 Mbps; **Jan 2025→23 business days** / 31 calendar / 8 weekend; passphrase 4 words all in list, entropy=count·log2(size).

## Verification

- ✅ `bun run test run` — **465 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of #260–#289 — branched from `main`.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6