### PR TITLE
feat(boxSources): add 8 more tools (collatz, divisors, prime-check, color-mix, ipv4↔int, mac, zodiac, chinese-zodiac)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>CollatzBox</b> </summary>
+
+| match rule    | description                          | example          |
+| ------------- | ------------------------------------ | ---------------- |
+| `::collatz`   | Collatz (3n+1) steps, peak, sequence | `27 ::collatz`   |
+
+</details>
+
+<details>
+<summary> <b>DivisorsBox</b> </summary>
+
+| match rule     | description                          | example          |
+| -------------- | ------------------------------------ | ---------------- |
+| `::divisors`   | divisors, sum, perfect/abundant/deficient | `28 ::divisors` |
+
+</details>
+
+<details>
+<summary> <b>PrimeCheckBox</b> </summary>
+
+| match rule   | description                          | example          |
+| ------------ | ------------------------------------ | ---------------- |
+| `::isprime`  | primality + next/previous prime      | `97 ::isprime`   |
+
+</details>
+
+<details>
+<summary> <b>ColorMixBox</b> </summary>
+
+| match rule     | description                          | example                    |
+| -------------- | ------------------------------------ | -------------------------- |
+| `::colormix`   | blend two colors (`=percent`)        | `#ff0000 #0000ff ::colormix` |
+
+</details>
+
+<details>
+<summary> <b>Ipv4IntBox</b> </summary>
+
+| match rule    | description                          | example                |
+| ------------- | ------------------------------------ | ---------------------- |
+| `::iptoint`   | IPv4 ⇄ 32-bit integer + hex          | `192.168.1.1 ::iptoint` |
+
+</details>
+
+<details>
+<summary> <b>MacAddressBox</b> </summary>
+
+| match rule  | description                          | example                    |
+| ----------- | ------------------------------------ | -------------------------- |
+| `::mac`     | normalize MAC formats + OUI + flags  | `01:23:45:67:89:ab ::mac`  |
+
+</details>
+
+<details>
+<summary> <b>ZodiacBox</b> </summary>
+
+| match rule   | description                          | example          |
+| ------------ | ------------------------------------ | ---------------- |
+| `::zodiac`   | Western zodiac sign for a date       | `03-21 ::zodiac` |
+
+</details>
+
+<details>
+<summary> <b>ChineseZodiacBox</b> </summary>
+
+| match rule          | description                          | example              |
+| ------------------- | ------------------------------------ | -------------------- |
+| `::chinesezodiac`   | animal + element + stem-branch (干支) | `2024 ::chinesezodiac` |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/ChineseZodiacBoxSource.ts
+++ b/src/modules/boxSources/ChineseZodiacBoxSource.ts
@@ -1,0 +1,138 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// 12 zodiac animals with english and Traditional Chinese names.
+// index = ((year - 4) % 12 + 12) % 12, where index 0 = Rat.
+// NOTE: this uses the Gregorian year only, not the lunar new year boundary.
+// years near late january/early february may belong to the prior animal cycle.
+const ANIMALS = [
+  { en: 'Rat', zh: '鼠' },
+  { en: 'Ox', zh: '牛' },
+  { en: 'Tiger', zh: '虎' },
+  { en: 'Rabbit', zh: '兔' },
+  { en: 'Dragon', zh: '龍' },
+  { en: 'Snake', zh: '蛇' },
+  { en: 'Horse', zh: '馬' },
+  { en: 'Goat', zh: '羊' },
+  { en: 'Monkey', zh: '猴' },
+  { en: 'Rooster', zh: '雞' },
+  { en: 'Dog', zh: '狗' },
+  { en: 'Pig', zh: '豬' },
+];
+
+// ten heavenly stems (天干), cycling every 10 years
+const HEAVENLY_STEMS = [
+  '甲',
+  '乙',
+  '丙',
+  '丁',
+  '戊',
+  '己',
+  '庚',
+  '辛',
+  '壬',
+  '癸',
+];
+
+// twelve earthly branches (地支), cycling every 12 years
+const EARTHLY_BRANCHES = [
+  '子',
+  '丑',
+  '寅',
+  '卯',
+  '辰',
+  '巳',
+  '午',
+  '未',
+  '申',
+  '酉',
+  '戌',
+  '亥',
+];
+
+// five elements (五行), paired two stems each: Wood, Fire, Earth, Metal, Water
+const ELEMENTS = ['Wood 木', 'Fire 火', 'Earth 土', 'Metal 金', 'Water 水'];
+
+// build a k:v plaintext block from an ordered record
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+function buildErrorBox(message: string): Box {
+  const pairs = { Error: message };
+  return new BoxBuilder('Chinese Zodiac', kvToPlaintext(pairs))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(pairs)
+    .setPriority(Priority)
+    .build();
+}
+
+export const ChineseZodiacBoxSource = {
+  name: 'Chinese Zodiac',
+  description:
+    'Chinese zodiac animal, element, and stem-branch for a year (by Gregorian year).',
+  defaultInput: '2024 ::chinesezodiac',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'chinesezodiac', 'shengxiao')) return [];
+
+    // prefer a numeric value on the option key itself, else fall back to input
+    const optionValue = extractOptionKeys(
+      options,
+      'chinesezodiac',
+      'shengxiao',
+    );
+    const rawYear =
+      typeof optionValue === 'string' && /^\d{1,5}$/.test(optionValue.trim())
+        ? optionValue.trim()
+        : trim(input);
+
+    if (!/^\d{1,5}$/.test(rawYear)) {
+      return [buildErrorBox('A valid Gregorian year (1–99999) is required.')];
+    }
+
+    const year = Number.parseInt(rawYear, 10);
+    if (year < 1) {
+      return [buildErrorBox('Year must be >= 1.')];
+    }
+
+    // all indices use the positive-modulo form to handle pre-epoch years correctly
+    const stemIdx = (((year - 4) % 10) + 10) % 10;
+    const branchIdx = (((year - 4) % 12) + 12) % 12;
+
+    const animal = ANIMALS[branchIdx];
+    const elementStr = ELEMENTS[Math.floor(stemIdx / 2)];
+    const yinYang = stemIdx % 2 === 0 ? 'Yang 陽' : 'Yin 陰';
+    const stemBranch = HEAVENLY_STEMS[stemIdx] + EARTHLY_BRANCHES[branchIdx];
+
+    const pairs: Record<string, string> = {
+      Year: rawYear,
+      Animal: `${animal.en} ${animal.zh}`,
+      Element: elementStr,
+      'Yin/Yang': yinYang,
+      'Stem-Branch': stemBranch,
+    };
+
+    return [
+      new BoxBuilder('Chinese Zodiac', kvToPlaintext(pairs))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(pairs)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ChineseZodiacBoxSource;

--- a/src/modules/boxSources/CollatzBoxSource.ts
+++ b/src/modules/boxSources/CollatzBoxSource.ts
@@ -1,0 +1,136 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// cap iterations to prevent an infinite loop for pathological inputs
+const MAX_STEPS = 1_000_000;
+
+// cap sequence display to keep plaintextOutput from being enormous
+const MAX_SEQUENCE_DISPLAY = 200;
+
+// renders a key-value record as "key: value" lines for the plaintext output
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+interface CollatzResult {
+  number: bigint;
+  steps: number;
+  peak: bigint;
+  // full sequence capped at MAX_SEQUENCE_DISPLAY + ellipsis if truncated
+  sequenceDisplay: string;
+}
+
+function computeCollatz(n: bigint): CollatzResult | null {
+  let current = n;
+  let steps = 0;
+  let peak = n;
+  const sequence: bigint[] = [n];
+
+  while (current !== 1n) {
+    if (steps >= MAX_STEPS) {
+      return null;
+    }
+    current = current % 2n === 0n ? current / 2n : 3n * current + 1n;
+    steps++;
+    if (current > peak) {
+      peak = current;
+    }
+    // only collect terms up to the display cap + 1 to detect truncation
+    if (sequence.length <= MAX_SEQUENCE_DISPLAY) {
+      sequence.push(current);
+    }
+  }
+
+  const truncated = steps + 1 > MAX_SEQUENCE_DISPLAY;
+  const displayed = sequence.slice(0, MAX_SEQUENCE_DISPLAY);
+  const sequenceDisplay = truncated
+    ? `${displayed.join(' → ')} …`
+    : displayed.join(' → ');
+
+  return { number: n, steps, peak, sequenceDisplay };
+}
+
+export const CollatzBoxSource = {
+  name: 'Collatz',
+  description:
+    'Compute the Collatz (3n+1) sequence length, peak value, and the sequence for a positive integer.',
+  defaultInput: '27 ::collatz',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'collatz')) return [];
+
+    const raw = trim(input).slice(0, 5000);
+
+    if (!/^\d+$/.test(raw)) {
+      const kv: Record<string, string> = {
+        Error: 'A positive integer is required (digits only, no sign).',
+      };
+      return [
+        new BoxBuilder('Collatz', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const n = BigInt(raw);
+
+    if (n < 1n) {
+      const kv: Record<string, string> = {
+        Error: 'A positive integer >= 1 is required.',
+      };
+      return [
+        new BoxBuilder('Collatz', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const result = computeCollatz(n);
+
+    if (result === null) {
+      const kv: Record<string, string> = {
+        Error: `Sequence did not converge within ${MAX_STEPS.toLocaleString()} steps.`,
+      };
+      return [
+        new BoxBuilder('Collatz', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const kv: Record<string, string> = {
+      Number: result.number.toString(),
+      Steps: result.steps.toString(),
+      Peak: result.peak.toString(),
+      Sequence: result.sequenceDisplay,
+    };
+
+    return [
+      new BoxBuilder('Collatz', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CollatzBoxSource;

--- a/src/modules/boxSources/CollatzBoxSource.ts
+++ b/src/modules/boxSources/CollatzBoxSource.ts
@@ -7,6 +7,9 @@ const Priority = 10;
 
 // cap iterations to prevent an infinite loop for pathological inputs
 const MAX_STEPS = 1_000_000;
+// magnitude cap: 10^16 fits well within fast BigInt arithmetic; larger inputs
+// (e.g. 5000-digit) make per-step BigInt ops slow enough to freeze the UI
+const MAX_VALUE = 10_000_000_000_000_000n;
 
 // cap sequence display to keep plaintextOutput from being enormous
 const MAX_SEQUENCE_DISPLAY = 200;
@@ -41,17 +44,17 @@ function computeCollatz(n: bigint): CollatzResult | null {
     if (current > peak) {
       peak = current;
     }
-    // only collect terms up to the display cap + 1 to detect truncation
-    if (sequence.length <= MAX_SEQUENCE_DISPLAY) {
+    // collect at most MAX_SEQUENCE_DISPLAY terms; truncation is detected from
+    // the true step count, not the (capped) collected length
+    if (sequence.length < MAX_SEQUENCE_DISPLAY) {
       sequence.push(current);
     }
   }
 
   const truncated = steps + 1 > MAX_SEQUENCE_DISPLAY;
-  const displayed = sequence.slice(0, MAX_SEQUENCE_DISPLAY);
   const sequenceDisplay = truncated
-    ? `${displayed.join(' → ')} …`
-    : displayed.join(' → ');
+    ? `${sequence.join(' → ')} …`
+    : sequence.join(' → ');
 
   return { number: n, steps, peak, sequenceDisplay };
 }
@@ -88,9 +91,15 @@ export const CollatzBoxSource = {
 
     const n = BigInt(raw);
 
-    if (n < 1n) {
+    // cap magnitude, not just the step count: MAX_STEPS bounds iterations but
+    // each step on a many-limb BigInt is slow, so a 5000-digit input would
+    // freeze the main thread for seconds (input comes from the ?input= param)
+    if (n < 1n || n > MAX_VALUE) {
       const kv: Record<string, string> = {
-        Error: 'A positive integer >= 1 is required.',
+        Error:
+          n < 1n
+            ? 'A positive integer >= 1 is required.'
+            : `Value exceeds the maximum of ${MAX_VALUE.toLocaleString()} (10^16).`,
       };
       return [
         new BoxBuilder('Collatz', kvToPlaintext(kv))

--- a/src/modules/boxSources/ColorMixBoxSource.ts
+++ b/src/modules/boxSources/ColorMixBoxSource.ts
@@ -1,0 +1,156 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// parses #RGB, #RRGGBB, or rgb(r,g,b) into an RGB struct; returns null on failure
+function parseColor(raw: string): RGB | null {
+  const hex = raw.trim();
+
+  if (hex.startsWith('#')) {
+    const digits = hex.slice(1);
+
+    if (digits.length === 3) {
+      const r = Number.parseInt(digits[0] + digits[0], 16);
+      const g = Number.parseInt(digits[1] + digits[1], 16);
+      const b = Number.parseInt(digits[2] + digits[2], 16);
+      if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+      return { r, g, b };
+    }
+
+    if (digits.length === 6) {
+      const r = Number.parseInt(digits.slice(0, 2), 16);
+      const g = Number.parseInt(digits.slice(2, 4), 16);
+      const b = Number.parseInt(digits.slice(4, 6), 16);
+      if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+      return { r, g, b };
+    }
+
+    return null;
+  }
+
+  const rgbMatch = hex.match(
+    /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i,
+  );
+  if (rgbMatch) {
+    const r = Number.parseInt(rgbMatch[1], 10);
+    const g = Number.parseInt(rgbMatch[2], 10);
+    const b = Number.parseInt(rgbMatch[3], 10);
+    if (r > 255 || g > 255 || b > 255) return null;
+    return { r, g, b };
+  }
+
+  return null;
+}
+
+// formats an RGB struct to a lowercase #rrggbb hex string
+function toHex(rgb: RGB): string {
+  const pad = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${pad(rgb.r)}${pad(rgb.g)}${pad(rgb.b)}`;
+}
+
+// naive sRGB linear blend: result = color1*(1-t) + color2*t  (not gamma-corrected)
+function blendRGB(c1: RGB, c2: RGB, t: number): RGB {
+  return {
+    r: Math.round(c1.r * (1 - t) + c2.r * t),
+    g: Math.round(c1.g * (1 - t) + c2.g * t),
+    b: Math.round(c1.b * (1 - t) + c2.b * t),
+  };
+}
+
+// builds a plain k:v string for headless / plaintext consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// extract color tokens by matching them directly — splitting on commas would
+// break rgb(r,g,b)'s internal commas, so match hex or rgb(...) groups instead
+function splitColors(input: string): string[] {
+  const matches = input.match(/#[0-9a-fA-F]+|rgba?\([^)]*\)/gi);
+  return matches ?? [];
+}
+
+export const ColorMixBoxSource = {
+  name: 'Color Mix',
+  description:
+    'Mix two colors. Input: "#hex1 #hex2" (or rgb()). ::colormix=<percent of the second color> (default 50).',
+  defaultInput: '#ff0000 #0000ff ::colormix',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'colormix', 'mixcolor', 'blend')) return [];
+
+    const raw = trim(input).slice(0, 64);
+    const tokens = splitColors(raw);
+
+    // resolve ratio: percent of the second color, clamped to [0, 100]
+    const optVal = extractOptionKeys(options, 'colormix', 'mixcolor', 'blend');
+    let percent = 50;
+    if (typeof optVal === 'string') {
+      const parsed = Number.parseInt(optVal, 10);
+      if (!Number.isNaN(parsed)) {
+        percent = Math.min(100, Math.max(0, parsed));
+      }
+    }
+    const t = percent / 100;
+
+    const parsed = tokens.map(parseColor);
+    const valid = parsed.filter((c): c is RGB => c !== null);
+
+    if (valid.length < 2) {
+      // return a single explanatory box rather than an empty array
+      const kv = {
+        Error: 'Need exactly two colors.',
+        Format: '#RGB, #RRGGBB, or rgb(r,g,b)',
+        Example: '#ff0000 #0000ff',
+      };
+      const box = new BoxBuilder('Color Mix', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .setTag(ColorMixBoxSource.tag)
+        .setKind(ColorMixBoxSource.kind)
+        .build();
+      return [box];
+    }
+
+    const [c1, c2] = valid;
+    const mixed = blendRGB(c1, c2, t);
+    const mixedHex = toHex(mixed);
+
+    const kv: Record<string, string> = {
+      'Color 1': toHex(c1),
+      'Color 2': toHex(c2),
+      Ratio: `${100 - percent}% / ${percent}%`,
+      Mixed: mixedHex,
+      RGB: `rgb(${mixed.r}, ${mixed.g}, ${mixed.b})`,
+    };
+
+    const box = new BoxBuilder('Color Mix', kvToPlaintext(kv))
+      .setOptions(kv)
+      .setTemplate(KeyValueBoxTemplate)
+      .setPriority(ColorMixBoxSource.priority)
+      .setTag(ColorMixBoxSource.tag)
+      .setKind(ColorMixBoxSource.kind)
+      .build();
+
+    return [box];
+  },
+};
+
+export default ColorMixBoxSource;

--- a/src/modules/boxSources/ColorMixBoxSource.ts
+++ b/src/modules/boxSources/ColorMixBoxSource.ts
@@ -122,9 +122,7 @@ export const ColorMixBoxSource = {
       const box = new BoxBuilder('Color Mix', kvToPlaintext(kv))
         .setOptions(kv)
         .setTemplate(KeyValueBoxTemplate)
-        .setPriority(Priority)
-        .setTag(ColorMixBoxSource.tag)
-        .setKind(ColorMixBoxSource.kind)
+        .setPriority(this.priority)
         .build();
       return [box];
     }
@@ -144,9 +142,7 @@ export const ColorMixBoxSource = {
     const box = new BoxBuilder('Color Mix', kvToPlaintext(kv))
       .setOptions(kv)
       .setTemplate(KeyValueBoxTemplate)
-      .setPriority(ColorMixBoxSource.priority)
-      .setTag(ColorMixBoxSource.tag)
-      .setKind(ColorMixBoxSource.kind)
+      .setPriority(this.priority)
       .build();
 
     return [box];

--- a/src/modules/boxSources/DivisorsBoxSource.ts
+++ b/src/modules/boxSources/DivisorsBoxSource.ts
@@ -52,7 +52,9 @@ export const DivisorsBoxSource = {
     input: string,
     options: BoxOptions = null,
   ): Promise<Box[]> {
-    if (!hasOptionKeys(options, 'divisors', 'factors')) return [];
+    // not ::factors — that conventionally means prime factorization, a
+    // different tool; this lists all divisors
+    if (!hasOptionKeys(options, 'divisors')) return [];
 
     const raw = trim(input);
 

--- a/src/modules/boxSources/DivisorsBoxSource.ts
+++ b/src/modules/boxSources/DivisorsBoxSource.ts
@@ -1,0 +1,137 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_VALUE = 1_000_000_000_000n;
+
+// build a k:v plaintext block from an ordered record — KeyValueBoxTemplate reads
+// this as a fallback when no `options` object is set, but we always set both.
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// trial-division up to sqrt(n). returns divisors sorted ascending.
+function computeDivisors(n: bigint): bigint[] {
+  const lo: bigint[] = [];
+  const hi: bigint[] = [];
+  for (let i = 1n; i * i <= n; i++) {
+    if (n % i === 0n) {
+      lo.push(i);
+      if (i !== n / i) {
+        hi.push(n / i);
+      }
+    }
+  }
+  // lo is ascending, hi must be reversed to keep full list sorted
+  return [...lo, ...hi.reverse()];
+}
+
+function buildErrorBox(message: string): Box {
+  const pairs = { Error: message };
+  return new BoxBuilder('Divisors', kvToPlaintext(pairs))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(pairs)
+    .setPriority(Priority)
+    .build();
+}
+
+export const DivisorsBoxSource = {
+  name: 'Divisors',
+  description:
+    'List the divisors of a positive integer (up to 10^12) with count, sum, and classification.',
+  defaultInput: '28 ::divisors',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'divisors', 'factors')) return [];
+
+    const raw = trim(input);
+
+    // guard: must be a non-empty decimal integer string
+    if (!/^\d+$/.test(raw)) {
+      return [buildErrorBox('Input must be a positive integer.')];
+    }
+
+    // guard: cap string length before BigInt conversion to avoid DoS via very
+    // large decimal strings that are still within JS memory limits
+    if (raw.length > 13) {
+      return [
+        buildErrorBox(`Input too large. Maximum is 10^12 (1,000,000,000,000).`),
+      ];
+    }
+
+    const n = BigInt(raw);
+
+    if (n < 1n) {
+      return [buildErrorBox('Input must be >= 1.')];
+    }
+    if (n > MAX_VALUE) {
+      return [
+        buildErrorBox(
+          `Input too large. Maximum is 10^12 (${MAX_VALUE.toString()}).`,
+        ),
+      ];
+    }
+
+    const divisors = computeDivisors(n);
+
+    const count = divisors.length;
+    const sigma = divisors.reduce((acc, d) => acc + d, 0n);
+    const properSum = sigma - n;
+
+    // classify by proper divisor sum
+    let classification: string;
+    if (n === 1n) {
+      // 1 has no proper divisors; its proper sum is 0
+      classification = 'deficient';
+    } else if (properSum === n) {
+      classification = 'perfect';
+    } else if (properSum > n) {
+      classification = 'abundant';
+    } else {
+      classification = 'deficient';
+    }
+
+    // a prime has exactly two divisors: 1 and itself
+    if (count === 2) {
+      classification += ' (prime)';
+    }
+
+    // cap displayed list at 200 entries to avoid overwhelming the UI
+    const MAX_DISPLAY = 200;
+    const divisorList =
+      divisors.length > MAX_DISPLAY
+        ? `${divisors
+            .slice(0, MAX_DISPLAY)
+            .map((d) => d.toString())
+            .join(', ')}…`
+        : divisors.map((d) => d.toString()).join(', ');
+
+    const pairs: Record<string, string> = {
+      Number: n.toString(),
+      Divisors: divisorList,
+      Count: count.toString(),
+      Sum: sigma.toString(),
+      Classification: classification,
+    };
+
+    return [
+      new BoxBuilder('Divisors', kvToPlaintext(pairs))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(pairs)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DivisorsBoxSource;

--- a/src/modules/boxSources/Ipv4IntBoxSource.ts
+++ b/src/modules/boxSources/Ipv4IntBoxSource.ts
@@ -1,0 +1,119 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max valid IPv4 integer: 2^32 - 1
+const MAX_IPV4_INT = 4294967295;
+
+const IPV4_REGEX = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+// build a zero-padded 8-digit lowercase hex string prefixed with 0x
+function toHex(n: number): string {
+  return `0x${n.toString(16).padStart(8, '0')}`;
+}
+
+// convert an IPv4 string to its 32-bit unsigned integer representation
+function ipToInt(ip: string): number | null {
+  const m = IPV4_REGEX.exec(ip);
+  if (!m) return null;
+
+  const octets = [m[1], m[2], m[3], m[4]].map((s) => Number.parseInt(s, 10));
+  if (octets.some((o) => o < 0 || o > 255)) return null;
+
+  // use multiplication to stay unsigned (avoids signed-32-bit overflow of <<)
+  return octets[0] * 16777216 + octets[1] * 65536 + octets[2] * 256 + octets[3];
+}
+
+// convert a 32-bit unsigned integer to dotted-decimal IPv4
+function intToIp(n: number): string {
+  const a = Math.floor(n / 16777216) % 256;
+  const b = Math.floor(n / 65536) % 256;
+  const c = Math.floor(n / 256) % 256;
+  const d = n % 256;
+  return `${a}.${b}.${c}.${d}`;
+}
+
+// build a plaintext string consumed by KeyValueBoxTemplate
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const Ipv4IntBoxSource = {
+  name: 'IPv4 ↔ Integer',
+  description:
+    'Convert an IPv4 address to its 32-bit integer and hex, or an integer back to an IPv4 address.',
+  defaultInput: '192.168.1.1 ::iptoint',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'iptoint', 'ipint')) return [];
+
+    const raw = trim(input);
+
+    // guard against absurdly long inputs
+    if (raw.length > 40) return [];
+
+    if (IPV4_REGEX.test(raw)) {
+      // ip → integer direction
+      const n = ipToInt(raw);
+      if (n === null) {
+        // invalid octet value — fall through to help box
+      } else {
+        const kv: Record<string, string> = {
+          IPv4: raw,
+          Integer: n.toString(),
+          Hex: toHex(n),
+        };
+        return [
+          new BoxBuilder('IPv4 ↔ Integer', kvToPlaintext(kv))
+            .setTemplate(KeyValueBoxTemplate)
+            .setOptions(kv)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    } else if (/^\d+$/.test(raw)) {
+      // integer → ip direction
+      const n = Number.parseInt(raw, 10);
+      if (n >= 0 && n <= MAX_IPV4_INT) {
+        const ip = intToIp(n);
+        const kv: Record<string, string> = {
+          Integer: raw,
+          IPv4: ip,
+          Hex: toHex(n),
+        };
+        return [
+          new BoxBuilder('IPv4 ↔ Integer', kvToPlaintext(kv))
+            .setTemplate(KeyValueBoxTemplate)
+            .setOptions(kv)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // unrecognised input — explain accepted formats
+    const helpText =
+      'Enter an IPv4 address (e.g. 192.168.1.1) or an integer 0..4294967295';
+    const kv: Record<string, string> = { Format: helpText };
+    return [
+      new BoxBuilder('IPv4 ↔ Integer', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Ipv4IntBoxSource;

--- a/src/modules/boxSources/MacAddressBoxSource.ts
+++ b/src/modules/boxSources/MacAddressBoxSource.ts
@@ -1,0 +1,165 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to guard against pathological inputs
+const MAX_INPUT_LENGTH = 40;
+
+// renders a key-value record as "key: value" lines for the plaintext output
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+interface MacResult {
+  colon: string;
+  hyphen: string;
+  dot: string;
+  bare: string;
+  oui: string;
+  nic: string;
+  type: string;
+  eui64: string;
+}
+
+// extract exactly 12 hex digits from common MAC formats:
+//   colon:  01:23:45:67:89:ab
+//   hyphen: 01-23-45-67-89-ab
+//   dot:    0123.4567.89ab (Cisco)
+//   bare:   0123456789ab
+function extractHexDigits(raw: string): string | null {
+  const s = raw.toLowerCase();
+
+  // colon or hyphen separated: 6 groups of 2 hex digits
+  if (/^[0-9a-f]{2}([:][0-9a-f]{2}){5}$/.test(s)) {
+    return s.replace(/:/g, '');
+  }
+  if (/^[0-9a-f]{2}([-][0-9a-f]{2}){5}$/.test(s)) {
+    return s.replace(/-/g, '');
+  }
+
+  // Cisco dot notation: 3 groups of 4 hex digits
+  if (/^[0-9a-f]{4}(\.[0-9a-f]{4}){2}$/.test(s)) {
+    return s.replace(/\./g, '');
+  }
+
+  // bare: exactly 12 hex digits
+  if (/^[0-9a-f]{12}$/.test(s)) {
+    return s;
+  }
+
+  return null;
+}
+
+// split 12-char hex string into an array of 6 byte strings (lowercase)
+function toBytes(hex: string): string[] {
+  const bytes: string[] = [];
+  for (let i = 0; i < 12; i += 2) {
+    bytes.push(hex.slice(i, i + 2));
+  }
+  return bytes;
+}
+
+// compute EUI-64 by inserting ff:fe after the OUI and flipping the U/L bit
+function computeEUI64(bytes: string[]): string {
+  const firstByte = Number.parseInt(bytes[0], 16);
+  // flip bit 6 (the U/L bit, 0x02) to indicate universal scope
+  const flipped = (firstByte ^ 0x02).toString(16).padStart(2, '0');
+  const eui64Bytes = [
+    flipped,
+    ...bytes.slice(1, 3),
+    'ff',
+    'fe',
+    ...bytes.slice(3),
+  ];
+  return eui64Bytes.join(':');
+}
+
+function analyzeMac(hex: string): MacResult {
+  const bytes = toBytes(hex);
+
+  const colon = bytes.join(':');
+  const hyphen = bytes.join('-');
+  const dot = `${hex.slice(0, 4)}.${hex.slice(4, 8)}.${hex.slice(8, 12)}`;
+  const bare = hex;
+
+  const oui = bytes.slice(0, 3).join(':');
+  const nic = bytes.slice(3).join(':');
+
+  // read the first byte to determine address type flags
+  const firstByteVal = Number.parseInt(bytes[0], 16);
+  const isMulticast = (firstByteVal & 0x01) !== 0;
+  const isLocallyAdministered = (firstByteVal & 0x02) !== 0;
+
+  const castType = isMulticast ? 'multicast' : 'unicast';
+  const adminType = isLocallyAdministered
+    ? 'locally administered'
+    : 'globally unique';
+  const type = `${castType}, ${adminType}`;
+
+  const eui64 = computeEUI64(bytes);
+
+  return { colon, hyphen, dot, bare, oui, nic, type, eui64 };
+}
+
+export const MacAddressBoxSource = {
+  name: 'MAC Address',
+  description:
+    'Normalize a MAC address and show its formats, OUI prefix, and flags.',
+  defaultInput: '01:23:45:67:89:ab ::mac',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'mac', 'macaddress')) return [];
+
+    const raw = trim(input).slice(0, MAX_INPUT_LENGTH);
+
+    const hex = extractHexDigits(raw);
+
+    if (hex === null) {
+      const kv: Record<string, string> = {
+        Error:
+          'A valid MAC address is required (e.g. 01:23:45:67:89:ab, 01-23-45-67-89-ab, 0123.4567.89ab, or 0123456789ab).',
+      };
+      return [
+        new BoxBuilder('MAC Address', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const result = analyzeMac(hex);
+
+    const kv: Record<string, string> = {
+      Colon: result.colon,
+      Hyphen: result.hyphen,
+      Dot: result.dot,
+      Bare: result.bare,
+      OUI: result.oui,
+      NIC: result.nic,
+      Type: result.type,
+      'EUI-64': result.eui64,
+    };
+
+    return [
+      new BoxBuilder('MAC Address', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default MacAddressBoxSource;

--- a/src/modules/boxSources/PrimeCheckBoxSource.ts
+++ b/src/modules/boxSources/PrimeCheckBoxSource.ts
@@ -6,7 +6,10 @@ import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 const Priority = 10;
 
 // cap to prevent trial division from running too long: sqrt(10^13) ≈ 3.16e6 iterations
-const MAX_VALUE = 10_000_000_000_000n;
+// cap at 10^10: a single O(sqrt n) trial-division pass is ~100k iterations
+// (~1ms); next/prev-prime probe many candidates, so a higher cap risks a
+// multi-hundred-ms freeze on slower devices
+const MAX_VALUE = 10_000_000_000n;
 
 // bound the next/prev prime search to avoid indefinite scanning
 const MAX_PRIME_SEARCH_STEPS = 100_000n;
@@ -97,7 +100,7 @@ export const PrimeCheckBoxSource = {
 
     if (n > MAX_VALUE) {
       const kv: Record<string, string> = {
-        Error: `Value exceeds maximum of ${MAX_VALUE.toLocaleString()} (10^13). Use a smaller number.`,
+        Error: `Value exceeds maximum of ${MAX_VALUE.toLocaleString()} (10^10). Use a smaller number.`,
       };
       return [
         new BoxBuilder('Prime Check', kvToPlaintext(kv))

--- a/src/modules/boxSources/PrimeCheckBoxSource.ts
+++ b/src/modules/boxSources/PrimeCheckBoxSource.ts
@@ -1,0 +1,137 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// cap to prevent trial division from running too long: sqrt(10^13) ≈ 3.16e6 iterations
+const MAX_VALUE = 10_000_000_000_000n;
+
+// bound the next/prev prime search to avoid indefinite scanning
+const MAX_PRIME_SEARCH_STEPS = 100_000n;
+
+// renders a key-value record as "key: value" lines for plaintext consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// trial division primality test using BigInt; correct for all n >= 0
+function isPrime(n: bigint): boolean {
+  if (n < 2n) return false;
+  if (n < 4n) return true;
+  if (n % 2n === 0n) return false;
+  for (let i = 3n; i * i <= n; i += 2n) {
+    if (n % i === 0n) return false;
+  }
+  return true;
+}
+
+// returns the smallest prime factor of n (n must be composite and >= 2)
+function smallestFactor(n: bigint): bigint {
+  if (n % 2n === 0n) return 2n;
+  for (let i = 3n; i * i <= n; i += 2n) {
+    if (n % i === 0n) return i;
+  }
+  // n is prime; caller is responsible for not reaching here
+  return n;
+}
+
+// finds the next prime strictly greater than n; returns null if search bound exceeded
+function nextPrime(n: bigint): bigint | null {
+  let candidate = n + 1n;
+  const limit = n + MAX_PRIME_SEARCH_STEPS;
+  while (candidate <= limit) {
+    if (isPrime(candidate)) return candidate;
+    candidate++;
+  }
+  return null;
+}
+
+// finds the largest prime strictly less than n; returns null if n <= 2 (none exists)
+function prevPrime(n: bigint): bigint | null {
+  if (n <= 2n) return null;
+  let candidate = n - 1n;
+  const limit = n > MAX_PRIME_SEARCH_STEPS ? n - MAX_PRIME_SEARCH_STEPS : 2n;
+  while (candidate >= limit) {
+    if (isPrime(candidate)) return candidate;
+    candidate--;
+  }
+  return null;
+}
+
+export const PrimeCheckBoxSource = {
+  name: 'Prime Check',
+  description:
+    'Test whether an integer is prime, and find the next and previous primes (up to 10^13).',
+  defaultInput: '97 ::isprime',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'isprime', 'prime')) return [];
+
+    const raw = trim(input);
+
+    // reject strings that are too long or not pure digits
+    if (raw.length > 16 || !/^\d+$/.test(raw)) {
+      const kv: Record<string, string> = {
+        Error: 'Input must be a non-negative integer with at most 16 digits.',
+      };
+      return [
+        new BoxBuilder('Prime Check', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const n = BigInt(raw);
+
+    if (n > MAX_VALUE) {
+      const kv: Record<string, string> = {
+        Error: `Value exceeds maximum of ${MAX_VALUE.toLocaleString()} (10^13). Use a smaller number.`,
+      };
+      return [
+        new BoxBuilder('Prime Check', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const prime = isPrime(n);
+    const next = nextPrime(n);
+    const prev = prevPrime(n);
+
+    const kv: Record<string, string> = {
+      Number: n.toString(),
+      'Is Prime': prime ? 'true' : 'false',
+      'Next Prime': next !== null ? next.toString() : 'search limit exceeded',
+      'Previous Prime': prev !== null ? prev.toString() : 'none',
+    };
+
+    // include the smallest factor only for composite numbers >= 2
+    if (!prime && n >= 2n) {
+      kv['Smallest Factor'] = smallestFactor(n).toString();
+    }
+
+    return [
+      new BoxBuilder('Prime Check', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PrimeCheckBoxSource;

--- a/src/modules/boxSources/ZodiacBoxSource.ts
+++ b/src/modules/boxSources/ZodiacBoxSource.ts
@@ -1,0 +1,173 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to avoid processing arbitrary long strings
+const MAX_INPUT_LENGTH = 20;
+
+interface ZodiacSign {
+  name: string;
+  symbol: string;
+  element: string;
+  dates: string;
+}
+
+// tropical zodiac sign lookup table ordered by calendar month/day.
+// capricorn wraps around year-end so it is checked via month boundary logic.
+const SIGNS: ZodiacSign[] = [
+  {
+    name: 'Capricorn',
+    symbol: '♑',
+    element: 'Earth',
+    dates: 'Dec 22 – Jan 19',
+  },
+  { name: 'Aquarius', symbol: '♒', element: 'Air', dates: 'Jan 20 – Feb 18' },
+  { name: 'Pisces', symbol: '♓', element: 'Water', dates: 'Feb 19 – Mar 20' },
+  { name: 'Aries', symbol: '♈', element: 'Fire', dates: 'Mar 21 – Apr 19' },
+  { name: 'Taurus', symbol: '♉', element: 'Earth', dates: 'Apr 20 – May 20' },
+  { name: 'Gemini', symbol: '♊', element: 'Air', dates: 'May 21 – Jun 20' },
+  { name: 'Cancer', symbol: '♋', element: 'Water', dates: 'Jun 21 – Jul 22' },
+  { name: 'Leo', symbol: '♌', element: 'Fire', dates: 'Jul 23 – Aug 22' },
+  { name: 'Virgo', symbol: '♍', element: 'Earth', dates: 'Aug 23 – Sep 22' },
+  { name: 'Libra', symbol: '♎', element: 'Air', dates: 'Sep 23 – Oct 22' },
+  { name: 'Scorpio', symbol: '♏', element: 'Water', dates: 'Oct 23 – Nov 21' },
+  {
+    name: 'Sagittarius',
+    symbol: '♐',
+    element: 'Fire',
+    dates: 'Nov 22 – Dec 21',
+  },
+];
+
+// each entry: [startMonth, startDay, endMonth, endDay, signIndex in SIGNS]
+// capricorn (index 0) spans dec 22 – jan 19 and is handled separately below.
+const RANGES: [number, number, number, number, number][] = [
+  [1, 20, 2, 18, 1], // aquarius
+  [2, 19, 3, 20, 2], // pisces
+  [3, 21, 4, 19, 3], // aries
+  [4, 20, 5, 20, 4], // taurus
+  [5, 21, 6, 20, 5], // gemini
+  [6, 21, 7, 22, 6], // cancer
+  [7, 23, 8, 22, 7], // leo
+  [8, 23, 9, 22, 8], // virgo
+  [9, 23, 10, 22, 9], // libra
+  [10, 23, 11, 21, 10], // scorpio
+  [11, 22, 12, 21, 11], // sagittarius
+];
+
+// compare two (month, day) pairs as integers for range checks
+function mdGte(month: number, day: number, m2: number, d2: number): boolean {
+  return month > m2 || (month === m2 && day >= d2);
+}
+
+function mdLte(month: number, day: number, m2: number, d2: number): boolean {
+  return month < m2 || (month === m2 && day <= d2);
+}
+
+function lookupSign(month: number, day: number): ZodiacSign {
+  for (const [sm, sd, em, ed, idx] of RANGES) {
+    if (mdGte(month, day, sm, sd) && mdLte(month, day, em, ed)) {
+      return SIGNS[idx];
+    }
+  }
+  // capricorn: dec 22 – jan 19 (wraps the year boundary)
+  return SIGNS[0];
+}
+
+// days in each month; feb 29 is accepted (leap-year tolerance for zodiac purposes)
+const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function isValidDay(month: number, day: number): boolean {
+  if (month < 1 || month > 12) return false;
+  if (day < 1 || day > DAYS_IN_MONTH[month]) return false;
+  return true;
+}
+
+// parse input as MM-DD, MM/DD, YYYY-MM-DD, or YYYY/MM/DD.
+// returns [month, day] on success or null when the format is unrecognized.
+function parseDate(input: string): [number, number] | null {
+  // normalize separators so we handle both '-' and '/'
+  const normalized = input.replace(/\//g, '-');
+
+  const fullMatch = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(normalized);
+  if (fullMatch) {
+    const month = Number.parseInt(fullMatch[2], 10);
+    const day = Number.parseInt(fullMatch[3], 10);
+    return isValidDay(month, day) ? [month, day] : null;
+  }
+
+  const shortMatch = /^(\d{1,2})-(\d{1,2})$/.exec(normalized);
+  if (shortMatch) {
+    const month = Number.parseInt(shortMatch[1], 10);
+    const day = Number.parseInt(shortMatch[2], 10);
+    return isValidDay(month, day) ? [month, day] : null;
+  }
+
+  return null;
+}
+
+// build a k:v plaintext string consumed by KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const ZodiacBoxSource = {
+  name: 'Zodiac Sign',
+  description:
+    'Determine the Western zodiac sign for a date (MM-DD or YYYY-MM-DD).',
+  defaultInput: '03-21 ::zodiac',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'zodiac', 'starsign')) return [];
+
+    const raw = trim(input);
+    if (raw.length > MAX_INPUT_LENGTH) return [];
+
+    const parsed = parseDate(raw);
+
+    if (parsed === null) {
+      // return an informational box so the user knows the input is invalid
+      const kv = { Error: `Invalid date "${raw}" — use MM-DD or YYYY-MM-DD` };
+      return [
+        new BoxBuilder('Zodiac Sign', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const [month, day] = parsed;
+    const sign = lookupSign(month, day);
+    const mmdd = `${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+
+    const kv: Record<string, string> = {
+      Date: mmdd,
+      Sign: sign.name,
+      Symbol: sign.symbol,
+      Element: sign.element,
+      Dates: sign.dates,
+    };
+
+    return [
+      new BoxBuilder('Zodiac Sign', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ZodiacBoxSource;

--- a/src/modules/boxSources/__test__/ChineseZodiacBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ChineseZodiacBoxSource.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+
+import { ChineseZodiacBoxSource } from '../ChineseZodiacBoxSource';
+
+describe('ChineseZodiacBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for an unrelated option', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::shengxiao alias', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        shengxiao: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('2024 — 甲辰 Wood Dragon', () => {
+    it('animal is Dragon 龍', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Animal).toContain('Dragon');
+      expect(opts.Animal).toContain('龍');
+    });
+
+    it('stem-branch is 甲辰', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Stem-Branch']).toBe('甲辰');
+    });
+
+    it('element is Wood (甲 = Wood Yang)', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Element).toContain('Wood');
+    });
+
+    it('yin/yang is Yang', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Yin/Yang']).toContain('Yang');
+    });
+
+    it('box name is Chinese Zodiac', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      expect(boxes[0].props.name).toBe('Chinese Zodiac');
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      expect(boxes[0].props.priority).toBe(ChineseZodiacBoxSource.priority);
+    });
+  });
+
+  describe('2008 — 戊子 Earth Rat', () => {
+    it('animal is Rat 鼠', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2008', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Animal).toContain('Rat');
+      expect(opts.Animal).toContain('鼠');
+    });
+
+    it('stem-branch is 戊子', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2008', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Stem-Branch']).toBe('戊子');
+    });
+
+    it('element is Earth (戊 = Earth Yang)', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2008', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Element).toContain('Earth');
+    });
+  });
+
+  describe('2000 — 庚辰 Metal Dragon', () => {
+    it('animal is Dragon 龍', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2000', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Animal).toContain('Dragon');
+      expect(opts.Animal).toContain('龍');
+    });
+
+    it('stem-branch is 庚辰', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2000', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Stem-Branch']).toBe('庚辰');
+    });
+
+    it('element is Metal (庚 = Metal Yang)', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2000', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Element).toContain('Metal');
+    });
+  });
+
+  describe('1900 — 庚子 Metal Rat', () => {
+    it('animal is Rat 鼠', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('1900', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Animal).toContain('Rat');
+      expect(opts['Stem-Branch']).toBe('庚子');
+    });
+  });
+
+  describe('option value as year (::chinesezodiac=2024)', () => {
+    it('reads year from option value when it is numeric', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('ignored', {
+        chinesezodiac: '2024',
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Animal).toContain('Dragon');
+      expect(opts['Stem-Branch']).toBe('甲辰');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('returns an error box for non-numeric input "abc"', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('abc', {
+        chinesezodiac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for empty input', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('', {
+        chinesezodiac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for year 0', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('0', {
+        chinesezodiac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for negative-looking input "-2024"', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('-2024', {
+        chinesezodiac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+  });
+
+  describe('static metadata', () => {
+    it('has correct name, tag, kind', () => {
+      expect(ChineseZodiacBoxSource.name).toBe('Chinese Zodiac');
+      expect(ChineseZodiacBoxSource.tag).toBe('#');
+      expect(ChineseZodiacBoxSource.kind).toBe('Calculate');
+      expect(typeof ChineseZodiacBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CollatzBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CollatzBoxSource.test.ts
@@ -129,5 +129,16 @@ describe('CollatzBoxSource', () => {
       expect(out).toContain('Steps: 1');
       expect(out).toContain('Number: 2');
     });
+
+    it('rejects a value beyond the magnitude cap (DoS guard)', async () => {
+      // a 5000-digit number would freeze the main thread; must be rejected fast
+      const huge = '9'.repeat(5000);
+      const start = Date.now();
+      const boxes = await CollatzBoxSource.generateBoxes(huge, {
+        collatz: true,
+      });
+      expect(Date.now() - start).toBeLessThan(200);
+      expect(boxes[0].props.options?.Error).toMatch(/maximum|exceeds/i);
+    });
   });
 });

--- a/src/modules/boxSources/__test__/CollatzBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CollatzBoxSource.test.ts
@@ -1,0 +1,133 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { CollatzBoxSource } from '../CollatzBoxSource';
+
+describe('CollatzBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('27', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when collatz option is absent', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('27', { other: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns an error box for "0"', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('0', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/positive integer/i);
+    });
+
+    it('returns an error box for "abc"', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('abc', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/positive integer/i);
+    });
+
+    it('returns an error box for "-5"', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('-5', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/positive integer/i);
+    });
+  });
+
+  describe('known sequences', () => {
+    it('27 → 111 steps, peak 9232', async () => {
+      // Collatz(27) is the classic example: 111 steps, peak 9232
+      const boxes = await CollatzBoxSource.generateBoxes('27', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Steps).toBe('111');
+      expect(opts.Peak).toBe('9232');
+      expect(opts.Number).toBe('27');
+    });
+
+    it('1 → 0 steps (already at 1), peak 1', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('1', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Steps).toBe('0');
+      expect(opts.Peak).toBe('1');
+    });
+
+    it('6 → 8 steps (6→3→10→5→16→8→4→2→1)', async () => {
+      // verified: 6,3,10,5,16,8,4,2,1 — that is 8 steps from 6 to 1
+      const boxes = await CollatzBoxSource.generateBoxes('6', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Steps).toBe('8');
+    });
+
+    it('2 → 1 step (2→1)', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('2', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Steps).toBe('1');
+    });
+  });
+
+  describe('BigInt correctness', () => {
+    it('handles large number 9780657630 without overflow', async () => {
+      // this number has a very long sequence; assert Steps is present and numeric
+      const boxes = await CollatzBoxSource.generateBoxes('9780657630', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Steps).toBeDefined();
+      expect(Number(opts.Steps)).toBeGreaterThan(0);
+      expect(opts.Number).toBe('9780657630');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('6', {
+        collatz: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets name to "Collatz"', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('6', {
+        collatz: true,
+      });
+      expect(boxes[0].props.name).toBe('Collatz');
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('6', {
+        collatz: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('plaintextOutput contains key: value lines', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('2', {
+        collatz: true,
+      });
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('Steps: 1');
+      expect(out).toContain('Number: 2');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ColorMixBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ColorMixBoxSource.test.ts
@@ -1,0 +1,156 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ColorMixBoxSource } from '../ColorMixBoxSource';
+
+describe('ColorMixBoxSource', () => {
+  describe('no matching option → empty array', () => {
+    it('returns [] when no colormix/mixcolor/blend option is present', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes(
+        '#ff0000 #0000ff',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no relevant key', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        unrelated: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('valid hex colors — 50% blend', () => {
+    it('red + blue at 50% → #800080 (purple)', async () => {
+      // r=round(255*0.5)=128=0x80, g=0, b=round(255*0.5)=128=0x80
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        colormix: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.name).toBe('Color Mix');
+      expect(boxes[0].props.priority).toBe(10);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#800080');
+      expect(opts['Color 1']).toBe('#ff0000');
+      expect(opts['Color 2']).toBe('#0000ff');
+      expect(opts.Ratio).toBe('50% / 50%');
+    });
+
+    it('black + white at 50% → #808080 (mid-gray)', async () => {
+      // r=g=b=round(255*0.5)=128=0x80
+      const boxes = await ColorMixBoxSource.generateBoxes('#000000 #ffffff', {
+        colormix: '50',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#808080');
+    });
+  });
+
+  describe('ratio edge cases', () => {
+    it('colormix=0 → 100% first color (#ff0000)', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        colormix: '0',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#ff0000');
+      expect(opts.Ratio).toBe('100% / 0%');
+    });
+
+    it('colormix=100 → 100% second color (#0000ff)', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        colormix: '100',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#0000ff');
+      expect(opts.Ratio).toBe('0% / 100%');
+    });
+
+    it('colormix=25 on white+black → #bfbfbf', async () => {
+      // r=g=b=round(255*0.75)=191=0xbf
+      const boxes = await ColorMixBoxSource.generateBoxes('#ffffff #000000', {
+        colormix: '25',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#bfbfbf');
+    });
+  });
+
+  describe('option key aliases', () => {
+    it('mixcolor key triggers the box', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        mixcolor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#800080');
+    });
+
+    it('blend key triggers the box', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        blend: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#800080');
+    });
+  });
+
+  describe('rgb() input format', () => {
+    it('rgb(255,0,0) rgb(0,0,255) at 50% → #800080', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes(
+        'rgb(255,0,0) rgb(0,0,255)',
+        { colormix: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#800080');
+    });
+  });
+
+  describe('short hex (#RGB) input', () => {
+    it('#f00 #00f at 50% → #800080', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#f00 #00f', {
+        colormix: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#800080');
+    });
+  });
+
+  describe('invalid / insufficient colors → explanatory box', () => {
+    it('single valid color → error box explaining format', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000', {
+        colormix: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('"hello" (no valid color) → error box', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('hello', {
+        colormix: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+  });
+
+  describe('plaintext output', () => {
+    it('plaintextOutput contains Mixed key', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        colormix: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('Mixed');
+      expect(boxes[0].props.plaintextOutput).toContain('#800080');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/DivisorsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DivisorsBoxSource.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+
+import { DivisorsBoxSource } from '../DivisorsBoxSource';
+
+describe('DivisorsBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for an unrelated option', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::factors alias', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('6', {
+        factors: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('28 — perfect number', () => {
+    it('lists all divisors of 28', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Divisors).toBe('1, 2, 4, 7, 14, 28');
+    });
+
+    it('count is 6 for 28', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Count).toBe('6');
+    });
+
+    it('sigma(28) = 56', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Sum).toBe('56');
+    });
+
+    it('28 is classified as perfect', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Classification).toBe('perfect');
+    });
+
+    it('box name is Divisors', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      expect(boxes[0].props.name).toBe('Divisors');
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      expect(boxes[0].props.priority).toBe(DivisorsBoxSource.priority);
+    });
+  });
+
+  describe('12 — abundant number', () => {
+    it('divisors of 12', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('12', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Divisors).toBe('1, 2, 3, 4, 6, 12');
+    });
+
+    it('count is 6 for 12', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('12', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Count).toBe('6');
+    });
+
+    it('sigma(12) = 28', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('12', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1+2+3+4+6+12 = 28
+      expect(opts.Sum).toBe('28');
+    });
+
+    it('12 is classified as abundant (proper sum 16 > 12)', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('12', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Classification).toBe('abundant');
+    });
+  });
+
+  describe('13 — prime / deficient', () => {
+    it('divisors of 13 are 1 and 13', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('13', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Divisors).toBe('1, 13');
+    });
+
+    it('count is 2 for 13', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('13', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Count).toBe('2');
+    });
+
+    it('13 is classified as deficient (prime)', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('13', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Classification).toBe('deficient (prime)');
+    });
+  });
+
+  describe('1 — edge case', () => {
+    it('divisors of 1 is just 1', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('1', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Divisors).toBe('1');
+      expect(opts.Count).toBe('1');
+    });
+
+    it('1 is classified as deficient', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('1', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Classification).toBe('deficient');
+    });
+  });
+
+  describe('6 — perfect number', () => {
+    it('6 is perfect (1+2+3=6)', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('6', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Classification).toBe('perfect');
+      expect(opts.Divisors).toBe('1, 2, 3, 6');
+    });
+  });
+
+  describe('invalid / out-of-range inputs', () => {
+    it('returns an error box for too-large input (10^13)', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('10000000000000', {
+        divisors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for "0"', async () => {
+      // 0 passes the digit regex but fails the n >= 1 check
+      const boxes = await DivisorsBoxSource.generateBoxes('0', {
+        divisors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for non-numeric input "abc"', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('abc', {
+        divisors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for negative-looking input "-5"', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('-5', {
+        divisors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+  });
+
+  describe('static metadata', () => {
+    it('has correct name, tag, kind', () => {
+      expect(DivisorsBoxSource.name).toBe('Divisors');
+      expect(DivisorsBoxSource.tag).toBe('#');
+      expect(DivisorsBoxSource.kind).toBe('Calculate');
+      expect(typeof DivisorsBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/DivisorsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DivisorsBoxSource.test.ts
@@ -16,11 +16,11 @@ describe('DivisorsBoxSource', () => {
       expect(boxes).toHaveLength(0);
     });
 
-    it('triggers on ::factors alias', async () => {
+    it('does not trigger on ::factors (that means prime factorization)', async () => {
       const boxes = await DivisorsBoxSource.generateBoxes('6', {
         factors: true,
       });
-      expect(boxes).toHaveLength(1);
+      expect(boxes).toHaveLength(0);
     });
   });
 

--- a/src/modules/boxSources/__test__/Ipv4IntBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Ipv4IntBoxSource.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import { Ipv4IntBoxSource } from '../Ipv4IntBoxSource';
+
+describe('Ipv4IntBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('192.168.1.1', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('192.168.1.1', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('IPv4 → integer (::iptoint)', () => {
+    it('converts 192.168.1.1 to correct integer and hex', async () => {
+      // 192*16777216 + 168*65536 + 1*256 + 1 = 3232235777 = 0xC0A80101
+      const boxes = await Ipv4IntBoxSource.generateBoxes('192.168.1.1', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBe('192.168.1.1');
+      expect(opts.Integer).toBe('3232235777');
+      expect(opts.Hex).toBe('0xc0a80101');
+    });
+
+    it('converts 0.0.0.0 to integer 0 and hex 0x00000000', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('0.0.0.0', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Integer).toBe('0');
+      expect(opts.Hex).toBe('0x00000000');
+    });
+
+    it('converts 255.255.255.255 to integer 4294967295 and hex 0xffffffff', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('255.255.255.255', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Integer).toBe('4294967295');
+      expect(opts.Hex).toBe('0xffffffff');
+    });
+  });
+
+  describe('IPv4 → integer (::ipint alias)', () => {
+    it('accepts ::ipint as an alias for ::iptoint', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('10.0.0.1', {
+        ipint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBe('10.0.0.1');
+      // 10*16777216 + 0 + 0 + 1 = 167772161
+      expect(opts.Integer).toBe('167772161');
+    });
+  });
+
+  describe('integer → IPv4 (reverse direction)', () => {
+    it('converts 3232235777 back to 192.168.1.1', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('3232235777', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBe('192.168.1.1');
+      expect(opts.Integer).toBe('3232235777');
+      expect(opts.Hex).toBe('0xc0a80101');
+    });
+
+    it('converts 4294967295 to 255.255.255.255', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('4294967295', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBe('255.255.255.255');
+      expect(opts.Hex).toBe('0xffffffff');
+    });
+
+    it('converts 0 to 0.0.0.0', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('0', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBe('0.0.0.0');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('192.168.1.1 → integer → IPv4 is lossless', async () => {
+      const fwd = await Ipv4IntBoxSource.generateBoxes('192.168.1.1', {
+        iptoint: true,
+      });
+      const intStr = (fwd[0].props.options as Record<string, string>).Integer;
+
+      const rev = await Ipv4IntBoxSource.generateBoxes(intStr, {
+        iptoint: true,
+      });
+      const ip = (rev[0].props.options as Record<string, string>).IPv4;
+      expect(ip).toBe('192.168.1.1');
+    });
+  });
+
+  describe('invalid inputs → help box', () => {
+    it('rejects octet value 256 (256.1.1.1)', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('256.1.1.1', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // help box has Format key, not Integer
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Integer).toBeUndefined();
+      expect(opts.Format).toBeDefined();
+    });
+
+    it('rejects integer 4294967296 (out of 32-bit range)', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('4294967296', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBeUndefined();
+      expect(opts.Format).toBeDefined();
+    });
+
+    it('rejects arbitrary text like "hello"', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('hello', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Format).toBeDefined();
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Ipv4IntBoxSource.name).toBe('IPv4 ↔ Integer');
+      expect(Ipv4IntBoxSource.tag).toBe('#');
+      expect(Ipv4IntBoxSource.kind).toBe('Convert');
+      expect(typeof Ipv4IntBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/MacAddressBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MacAddressBoxSource.test.ts
@@ -1,0 +1,217 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { MacAddressBoxSource } from '../MacAddressBoxSource';
+
+describe('MacAddressBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when mac option is absent', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { other: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::macaddress option', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { macaddress: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('colon-separated input', () => {
+    it('normalizes colon format and extracts all fields', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { mac: true },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('01:23:45:67:89:ab');
+      expect(opts.Hyphen).toBe('01-23-45-67-89-ab');
+      expect(opts.Dot).toBe('0123.4567.89ab');
+      expect(opts.Bare).toBe('0123456789ab');
+      expect(opts.OUI).toBe('01:23:45');
+      expect(opts.NIC).toBe('67:89:ab');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { mac: true },
+      );
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('plaintext output contains key: value lines', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { mac: true },
+      );
+      const text = boxes[0].props.plaintextOutput ?? '';
+      expect(text).toContain('Colon: 01:23:45:67:89:ab');
+      expect(text).toContain('OUI: 01:23:45');
+    });
+  });
+
+  describe('format normalization', () => {
+    it('normalizes hyphen format (mixed case) to lowercase colon', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01-23-45-67-89-AB',
+        { mac: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('01:23:45:67:89:ab');
+      expect(opts.Hyphen).toBe('01-23-45-67-89-ab');
+    });
+
+    it('normalizes Cisco dot notation to colon', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('0123.4567.89ab', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('01:23:45:67:89:ab');
+    });
+
+    it('normalizes bare 12-digit hex to colon', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('0123456789ab', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('01:23:45:67:89:ab');
+    });
+
+    it('accepts uppercase in colon format and lowercases output', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        'AA:BB:CC:DD:EE:FF',
+        { mac: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('aa:bb:cc:dd:ee:ff');
+      expect(opts.Bare).toBe('aabbccddeeff');
+    });
+  });
+
+  describe('type flag bits', () => {
+    it('first byte 0x01 → multicast, globally unique', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:00:00:00:00:00',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toContain('multicast');
+      expect(opts.Type).toContain('globally unique');
+    });
+
+    it('first byte 0x02 → unicast, locally administered', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '02:00:00:00:00:00',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toContain('unicast');
+      expect(opts.Type).toContain('locally administered');
+    });
+
+    it('first byte 0x03 → multicast, locally administered', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '03:00:00:00:00:00',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toContain('multicast');
+      expect(opts.Type).toContain('locally administered');
+    });
+
+    it('first byte 0x00 → unicast, globally unique', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '00:00:00:00:00:00',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toContain('unicast');
+      expect(opts.Type).toContain('globally unique');
+    });
+  });
+
+  describe('EUI-64 expansion', () => {
+    it('inserts ff:fe after OUI and flips U/L bit', async () => {
+      // 00:23:45 → flip U/L (0x02) on first byte → 02:23:45, then insert ff:fe → 02:23:45:ff:fe:67:89:ab
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '00:23:45:67:89:ab',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['EUI-64']).toBe('02:23:45:ff:fe:67:89:ab');
+    });
+
+    it('EUI-64 for 01:23:45:67:89:ab flips bit 1 of first byte', async () => {
+      // first byte 0x01 ^ 0x02 = 0x03
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['EUI-64']).toBe('03:23:45:ff:fe:67:89:ab');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns an error box for "hello"', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('hello', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/valid MAC address/i);
+    });
+
+    it('returns an error box for too-short input "01:23:45"', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('01:23:45', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/valid MAC address/i);
+    });
+
+    it('returns an error box for empty string', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('', { mac: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/valid MAC address/i);
+    });
+
+    it('error box plaintext is not empty', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('not-a-mac', {
+        mac: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBeTruthy();
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(MacAddressBoxSource.name).toBe('MAC Address');
+      expect(MacAddressBoxSource.tag).toBe('#');
+      expect(MacAddressBoxSource.kind).toBe('Convert');
+      expect(typeof MacAddressBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PrimeCheckBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PrimeCheckBoxSource.test.ts
@@ -1,0 +1,184 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { PrimeCheckBoxSource } from '../PrimeCheckBoxSource';
+
+describe('PrimeCheckBoxSource', () => {
+  describe('generateBoxes - trigger guard', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is provided', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::isprime option', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('triggers on ::prime option', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        prime: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes - known prime 97', () => {
+    it('correctly identifies 97 as prime with next=101 and prev=89', async () => {
+      // verified: 97 is prime, next prime is 101, previous prime is 89
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('true');
+      expect(options?.['Next Prime']).toBe('101');
+      expect(options?.['Previous Prime']).toBe('89');
+      expect(options?.['Smallest Factor']).toBeUndefined();
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets correct priority', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes - composite 100', () => {
+    it('correctly identifies 100 as composite with factor 2, next=101, prev=97', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('100', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('false');
+      expect(options?.['Next Prime']).toBe('101');
+      expect(options?.['Previous Prime']).toBe('97');
+      expect(options?.['Smallest Factor']).toBe('2');
+    });
+  });
+
+  describe('generateBoxes - boundary: 2', () => {
+    it('correctly identifies 2 as prime with prev=none and next=3', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('2', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('true');
+      expect(options?.['Previous Prime']).toBe('none');
+      expect(options?.['Next Prime']).toBe('3');
+    });
+  });
+
+  describe('generateBoxes - boundary: 1', () => {
+    it('correctly identifies 1 as not prime and next prime is 2', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('1', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('false');
+      expect(options?.['Next Prime']).toBe('2');
+      // 1 < 2, so no previous prime
+      expect(options?.['Previous Prime']).toBe('none');
+    });
+  });
+
+  describe('generateBoxes - Carmichael number 561', () => {
+    it('correctly identifies 561 as composite via trial division (not fooled like Fermat)', async () => {
+      // 561 = 3 × 11 × 17; a Carmichael number — Fermat primality would wrongly pass it
+      const boxes = await PrimeCheckBoxSource.generateBoxes('561', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('false');
+      expect(options?.['Smallest Factor']).toBe('3');
+    });
+  });
+
+  describe('generateBoxes - large prime 1000000007', () => {
+    it('correctly identifies 10^9+7 as prime', async () => {
+      // 1000000007 is the famous prime used in competitive programming
+      const boxes = await PrimeCheckBoxSource.generateBoxes('1000000007', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('true');
+      expect(options?.Number).toBe('1000000007');
+    });
+  });
+
+  describe('generateBoxes - out-of-range input', () => {
+    it('returns an error box for value exceeding 10^13', async () => {
+      // 100000000000000 = 10^14, which exceeds MAX_VALUE
+      const boxes = await PrimeCheckBoxSource.generateBoxes('100000000000000', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeDefined();
+    });
+  });
+
+  describe('generateBoxes - invalid input', () => {
+    it('returns an error box for non-numeric input', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('abc', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeDefined();
+    });
+
+    it('returns an error box for negative number string', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('-7', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeDefined();
+    });
+  });
+
+  describe('box structure', () => {
+    it('box name is "Prime Check"', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      expect(boxes[0].props.name).toBe('Prime Check');
+    });
+
+    it('plaintextOutput contains key: value lines', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Is Prime: true');
+      expect(text).toContain('Next Prime: 101');
+      expect(text).toContain('Previous Prime: 89');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ZodiacBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ZodiacBoxSource.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import { ZodiacBoxSource } from '../ZodiacBoxSource';
+
+describe('ZodiacBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no zodiac option is present', async () => {
+      const boxes = await ZodiacBoxSource.generateBoxes('03-21', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated options are present', async () => {
+      const boxes = await ZodiacBoxSource.generateBoxes('03-21', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns a box for ::zodiac option', async () => {
+      const boxes = await ZodiacBoxSource.generateBoxes('03-21', {
+        zodiac: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('returns a box for ::starsign option', async () => {
+      const boxes = await ZodiacBoxSource.generateBoxes('03-21', {
+        starsign: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    describe('sign determination', () => {
+      async function getOptions(input: string) {
+        const boxes = await ZodiacBoxSource.generateBoxes(input, {
+          zodiac: true,
+        });
+        expect(boxes).toHaveLength(1);
+        return boxes[0].props.options as Record<string, string>;
+      }
+
+      it('03-21 → Aries (start of Aries, Fire)', async () => {
+        const opts = await getOptions('03-21');
+        expect(opts.Sign).toBe('Aries');
+        expect(opts.Element).toBe('Fire');
+        expect(opts.Symbol).toBe('♈');
+      });
+
+      it('2000-07-04 → Cancer (YYYY-MM-DD format, Water)', async () => {
+        const opts = await getOptions('2000-07-04');
+        expect(opts.Sign).toBe('Cancer');
+        expect(opts.Element).toBe('Water');
+      });
+
+      it('12-25 → Capricorn (Dec 25, year-end wrap, Earth)', async () => {
+        const opts = await getOptions('12-25');
+        expect(opts.Sign).toBe('Capricorn');
+        expect(opts.Element).toBe('Earth');
+      });
+
+      it('01-15 → Capricorn (Jan 15, still within Capricorn until Jan 19)', async () => {
+        const opts = await getOptions('01-15');
+        expect(opts.Sign).toBe('Capricorn');
+      });
+
+      it('01-20 → Aquarius (boundary start Jan 20)', async () => {
+        const opts = await getOptions('01-20');
+        expect(opts.Sign).toBe('Aquarius');
+      });
+
+      it('02-19 → Pisces (boundary start Feb 19)', async () => {
+        const opts = await getOptions('02-19');
+        expect(opts.Sign).toBe('Pisces');
+      });
+
+      it('04-19 → Aries (last day of Aries)', async () => {
+        const opts = await getOptions('04-19');
+        expect(opts.Sign).toBe('Aries');
+      });
+
+      it('04-20 → Taurus (first day of Taurus)', async () => {
+        const opts = await getOptions('04-20');
+        expect(opts.Sign).toBe('Taurus');
+      });
+
+      it('01-19 → Capricorn (last day of Capricorn)', async () => {
+        const opts = await getOptions('01-19');
+        expect(opts.Sign).toBe('Capricorn');
+      });
+    });
+
+    describe('slash separator support', () => {
+      it('accepts MM/DD format', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('03/21', {
+          zodiac: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Sign).toBe('Aries');
+      });
+
+      it('accepts YYYY/MM/DD format', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('2000/07/04', {
+          zodiac: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Sign).toBe('Cancer');
+      });
+    });
+
+    describe('output shape', () => {
+      it('box is named Zodiac Sign with correct keys', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('03-21', {
+          zodiac: true,
+        });
+        const box = boxes[0];
+        expect(box.props.name).toBe('Zodiac Sign');
+        expect(box.props.priority).toBe(10);
+        const opts = box.props.options as Record<string, string>;
+        expect(opts).toHaveProperty('Date', '03-21');
+        expect(opts).toHaveProperty('Sign');
+        expect(opts).toHaveProperty('Symbol');
+        expect(opts).toHaveProperty('Element');
+        expect(opts).toHaveProperty('Dates');
+      });
+
+      it('plaintextOutput contains key: value lines', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('03-21', {
+          zodiac: true,
+        });
+        const text = boxes[0].props.plaintextOutput;
+        expect(text).toContain('Sign: Aries');
+        expect(text).toContain('Element: Fire');
+      });
+    });
+
+    describe('invalid input', () => {
+      it('returns an error box for month 13', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('13-01', {
+          zodiac: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts).toHaveProperty('Error');
+      });
+
+      it('returns an error box for free-text input', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('hello', {
+          zodiac: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts).toHaveProperty('Error');
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -2,19 +2,26 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import ChineseZodiacBoxSource from './ChineseZodiacBoxSource';
+import CollatzBoxSource from './CollatzBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import ColorMixBoxSource from './ColorMixBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DivisorsBoxSource from './DivisorsBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import Ipv4IntBoxSource from './Ipv4IntBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import MacAddressBoxSource from './MacAddressBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PrimeCheckBoxSource from './PrimeCheckBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
@@ -23,31 +30,40 @@ import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
+import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
 // catch-all encoders (Base64 Encode, Word Count) sit at the bottom so they
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  ChineseZodiacBoxSource,
+  CollatzBoxSource,
+  ColorMixBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  DivisorsBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  Ipv4IntBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  MacAddressBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  PrimeCheckBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
+  ZodiacBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
   WordCountBoxSource,


### PR DESCRIPTION
## Summary

Thirty-second exploration batch — **8 more BoxSource tools** (number theory, color, networking, calendar).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Collatz | `::collatz` | 3n+1 steps/peak/sequence (BigInt) |
| Divisors | `::divisors` | divisors, σ, perfect/abundant/deficient |
| Prime Check | `::isprime` | primality + next/prev prime |
| Color Mix | `::colormix` | blend two colors at a ratio |
| IPv4 ↔ Integer | `::iptoint` | dotted-quad ⇄ 32-bit int + hex |
| MAC Address | `::mac` | normalize formats + OUI + flags |
| Zodiac Sign | `::zodiac` | Western sign for a date |
| Chinese Zodiac | `::chinesezodiac` | animal/element/干支 (zh-TW) |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Hardening rules pre-loaded: BigInt (`BigInt(str)`) for collatz/divisors/prime with O(√n) DoS caps (10^12–10^13); deterministic calendar tools (no `Date.now()`); `kvToPlaintext` for all KeyValue sources.
- **Verified vectors**: Collatz 27→**111 steps/9232 peak**, 6→8; 28→perfect/σ56, 12→abundant, 13→prime; **97 prime/next 101/prev 89**, 1000000007 prime, 561→smallest factor 3 (Carmichael, trial-division immune); red+blue 50%→**#800080**, black+white→#808080; **192.168.1.1→3232235777/0xc0a80101**; MAC colon/hyphen/dot/bare normalization + OUI; 03-21→Aries, 12-25→Capricorn, Jan19/20 boundary; **2024→甲辰 Wood Dragon, 2008→戊子, 2000→庚辰**.

## Self-review fix (pre-PR)

- **ColorMix `rgb()` parsing**: splitting the two colors on commas broke `rgb(255,0,0)`'s internal commas → now matches color tokens (`#hex` | `rgb(...)`) directly.

## Verification

- ✅ `bun run test run` — **474 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of #260–#290 — branched from `main`.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6