### PR TITLE
feat(boxSources): add 8 more tools (haversine, excel-column, json-pick, port-lookup, nato, leap-year, frequency, reverse-text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>HaversineBox</b> </summary>
+
+| match rule      | description                          | example                              |
+| --------------- | ------------------------------------ | ------------------------------------ |
+| `::haversine`   | great-circle distance between coords | `40.7,-74 to 51.5,-0.1 ::haversine`  |
+
+</details>
+
+<details>
+<summary> <b>SpreadsheetColumnBox</b> </summary>
+
+| match rule     | description                          | example          |
+| -------------- | ------------------------------------ | ---------------- |
+| `::excelcol`   | column letter ⇄ number (A=1, AA=27)  | `AB ::excelcol`  |
+
+</details>
+
+<details>
+<summary> <b>JsonPickBox</b> </summary>
+
+| match rule         | description                          | example                       |
+| ------------------ | ------------------------------------ | ----------------------------- |
+| `::jsonpick=a,b`   | pick/omit top-level JSON keys (`::jsonomit`) | `{"a":1,"b":2} ::jsonpick=a` |
+
+</details>
+
+<details>
+<summary> <b>PortLookupBox</b> </summary>
+
+| match rule  | description                          | example       |
+| ----------- | ------------------------------------ | ------------- |
+| `::port`    | well-known port ⇄ service name       | `443 ::port`  |
+
+</details>
+
+<details>
+<summary> <b>NatoPhoneticBox</b> </summary>
+
+| match rule  | description                          | example          |
+| ----------- | ------------------------------------ | ---------------- |
+| `::nato`    | NATO phonetic spelling (`::natodecode`) | `ABC ::nato`  |
+
+</details>
+
+<details>
+<summary> <b>LeapYearBox</b> </summary>
+
+| match rule    | description                          | example            |
+| ------------- | ------------------------------------ | ------------------ |
+| `::leapyear`  | leap-year check + reason + nearby    | `2024 ::leapyear`  |
+
+</details>
+
+<details>
+<summary> <b>FrequencyConvertBox</b> </summary>
+
+| match rule    | description                          | example              |
+| ------------- | ------------------------------------ | -------------------- |
+| `::frequency` | Hz/kHz/MHz/GHz + period              | `2.4 GHz ::frequency` |
+
+</details>
+
+<details>
+<summary> <b>ReverseTextBox</b> </summary>
+
+| match rule   | description                          | example                |
+| ------------ | ------------------------------------ | ---------------------- |
+| `::reverse`  | reverse chars/words/lines (emoji-safe) | `hello ::reverse`    |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/ExcelColumnBoxSource.ts
+++ b/src/modules/boxSources/ExcelColumnBoxSource.ts
@@ -7,13 +7,16 @@ const Priority = 10;
 
 // max column number supported (roughly 3-letter ZZZ = 18278; allow generous cap)
 const MAX_COL_NUMBER = 1_000_000_000;
-const MAX_COL_LETTERS_LEN = 16;
+// 11 'Z's = 3.8e15 < Number.MAX_SAFE_INTEGER (9e15); 12+ would overflow to an
+// imprecise float and stop round-tripping, so cap the letter length here
+const MAX_COL_LETTERS_LEN = 11;
 
 // bijective base-26: A=1 … Z=26, AA=27, AB=28, ZZ=702, AAA=703
 function lettersToNumber(letters: string): number {
+  const upper = letters.toUpperCase();
   let num = 0;
-  for (let i = 0; i < letters.length; i++) {
-    num = num * 26 + (letters.toUpperCase().charCodeAt(i) - 64);
+  for (let i = 0; i < upper.length; i++) {
+    num = num * 26 + (upper.charCodeAt(i) - 64);
   }
   return num;
 }

--- a/src/modules/boxSources/ExcelColumnBoxSource.ts
+++ b/src/modules/boxSources/ExcelColumnBoxSource.ts
@@ -1,0 +1,112 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max column number supported (roughly 3-letter ZZZ = 18278; allow generous cap)
+const MAX_COL_NUMBER = 1_000_000_000;
+const MAX_COL_LETTERS_LEN = 16;
+
+// bijective base-26: A=1 … Z=26, AA=27, AB=28, ZZ=702, AAA=703
+function lettersToNumber(letters: string): number {
+  let num = 0;
+  for (let i = 0; i < letters.length; i++) {
+    num = num * 26 + (letters.toUpperCase().charCodeAt(i) - 64);
+  }
+  return num;
+}
+
+// inverse of bijective base-26
+function numberToLetters(n: number): string {
+  let result = '';
+  let remaining = n;
+  while (remaining > 0) {
+    const rem = (remaining - 1) % 26;
+    result = String.fromCharCode(65 + rem) + result;
+    remaining = Math.floor((remaining - 1) / 26);
+  }
+  return result;
+}
+
+// build plaintext output "Column: AB\nNumber: 28" for kvToPlaintext
+function kvToPlaintext(column: string, number: number): string {
+  return `Column: ${column}\nNumber: ${number}`;
+}
+
+export const ExcelColumnBoxSource = {
+  name: 'Spreadsheet Column',
+  description:
+    'Convert a spreadsheet column letter to its number and back (A=1, AA=27).',
+  defaultInput: 'AB ::excelcol',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'excelcol', 'spreadsheetcol')) return [];
+
+    const trimmed = trim(input);
+
+    if (/^[A-Za-z]+$/.test(trimmed)) {
+      // guard against absurdly long letter strings
+      if (trimmed.length > MAX_COL_LETTERS_LEN) return [];
+
+      const column = trimmed.toUpperCase();
+      const number = lettersToNumber(column);
+      return [
+        new BoxBuilder('Spreadsheet Column', kvToPlaintext(column, number))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Column: column, Number: String(number) })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (/^\d+$/.test(trimmed)) {
+      const n = Number.parseInt(trimmed, 10);
+      if (n < 1 || n > MAX_COL_NUMBER) {
+        return [
+          new BoxBuilder(
+            'Spreadsheet Column',
+            'Number out of range (must be 1 – 1,000,000,000).',
+          )
+            .setTemplate(KeyValueBoxTemplate)
+            .setOptions({
+              Column: '',
+              Number: 'out of range',
+            })
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      const column = numberToLetters(n);
+      return [
+        new BoxBuilder('Spreadsheet Column', kvToPlaintext(column, n))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Column: column, Number: String(n) })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // mixed or unrecognised input — return an explanatory box
+    return [
+      new BoxBuilder(
+        'Spreadsheet Column',
+        'Enter column letters (e.g. AB) or a column number.',
+      )
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions({ Column: '', Number: '' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ExcelColumnBoxSource;

--- a/src/modules/boxSources/FrequencyConvertBoxSource.ts
+++ b/src/modules/boxSources/FrequencyConvertBoxSource.ts
@@ -1,0 +1,125 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit (normalized) -> hertz
+const TO_HZ: Record<string, number> = {
+  hz: 1,
+  khz: 1e3,
+  mhz: 1e6,
+  ghz: 1e9,
+  thz: 1e12,
+};
+
+const BOX_NAME = 'Frequency Convert';
+
+const FORMAT_ERROR_MSG =
+  'Invalid input. Expected format: <number> <unit>\n' +
+  'Supported units: Hz, kHz, MHz, GHz, THz\n' +
+  'Example: 2.4 GHz';
+
+/** renders key-value record as plaintext for headless consumers */
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+/**
+ * formats a frequency/period number with integer-exact display when possible,
+ * 6-decimal fixed notation for normal ranges, or exponential for extremes.
+ */
+function fmtNum(n: number): string {
+  if (n === 0) return '0';
+  const abs = Math.abs(n);
+  if (abs >= 1e15 || abs < 1e-4) {
+    return n.toExponential(6);
+  }
+  // use integer if it rounds exactly
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(6).replace(/\.?0+$/, '');
+}
+
+export const FrequencyConvertBoxSource = {
+  name: 'Frequency Convert',
+  description:
+    'Convert a frequency between Hz, kHz, MHz, GHz, THz and its period.',
+  defaultInput: '2.4 GHz ::frequency',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'frequency', 'freq')) return [];
+
+    const raw = trim(input);
+    if (raw.length > 64) {
+      // prose message → leave the template undefined (DefaultBoxTemplate)
+      // so it renders; a KeyValue template with no options would show blank
+      return [
+        new BoxBuilder(BOX_NAME, FORMAT_ERROR_MSG)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // parse "<number> <unit>", allowing scientific notation in the number
+    const match = raw.match(
+      /^([+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?)\s+(\S+)$/,
+    );
+    if (!match) {
+      return [
+        new BoxBuilder(BOX_NAME, FORMAT_ERROR_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitKey = match[2].toLowerCase();
+
+    if (Number.isNaN(value) || !(unitKey in TO_HZ)) {
+      return [
+        new BoxBuilder(BOX_NAME, FORMAT_ERROR_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const hz = value * TO_HZ[unitKey];
+
+    // period is only meaningful for positive frequency
+    const periodSec = hz > 0 ? 1 / hz : null;
+
+    const kv: Record<string, string> = {
+      Input: `${value} ${match[2]}`,
+      Hz: fmtNum(hz),
+      kHz: fmtNum(hz / 1e3),
+      MHz: fmtNum(hz / 1e6),
+      GHz: fmtNum(hz / 1e9),
+      THz: fmtNum(hz / 1e12),
+    };
+
+    if (periodSec !== null) {
+      kv.Period = `${fmtNum(periodSec)} s`;
+    }
+
+    return [
+      new BoxBuilder(BOX_NAME, kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FrequencyConvertBoxSource;

--- a/src/modules/boxSources/HaversineBoxSource.ts
+++ b/src/modules/boxSources/HaversineBoxSource.ts
@@ -1,0 +1,152 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// mean earth radius per IUGG
+const EARTH_RADIUS_KM = 6371.0088;
+const KM_TO_MILES = 0.621371;
+const KM_TO_NM = 1 / 1.852;
+
+// coordinate separators: ' to ', ';', '|'
+const PAIR_SEP = /\s+to\s+|;|\|/i;
+
+interface Coord {
+  lat: number;
+  lng: number;
+}
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+/** formats a display string for the coordinate */
+function formatCoord(c: Coord): string {
+  return `${c.lat}, ${c.lng}`;
+}
+
+/** parses "lat,lng" and validates ranges; returns null if invalid */
+function parseCoord(s: string): Coord | null {
+  const parts = s.split(',');
+  if (parts.length !== 2) return null;
+  const lat = Number.parseFloat(parts[0].trim());
+  const lng = Number.parseFloat(parts[1].trim());
+  if (Number.isNaN(lat) || Number.isNaN(lng)) return null;
+  if (lat < -90 || lat > 90) return null;
+  if (lng < -180 || lng > 180) return null;
+  return { lat, lng };
+}
+
+/** haversine great-circle distance in km */
+function haversineKm(a: Coord, b: Coord): number {
+  const φ1 = toRad(a.lat);
+  const φ2 = toRad(b.lat);
+  const dφ = toRad(b.lat - a.lat);
+  const dλ = toRad(b.lng - a.lng);
+  const sinDφ = Math.sin(dφ / 2);
+  const sinDλ = Math.sin(dλ / 2);
+  const val = sinDφ * sinDφ + Math.cos(φ1) * Math.cos(φ2) * sinDλ * sinDλ;
+  const c = 2 * Math.atan2(Math.sqrt(val), Math.sqrt(1 - val));
+  return EARTH_RADIUS_KM * c;
+}
+
+/** initial bearing (forward azimuth) in degrees 0..360 */
+function initialBearing(a: Coord, b: Coord): number {
+  const φ1 = toRad(a.lat);
+  const φ2 = toRad(b.lat);
+  const dλ = toRad(b.lng - a.lng);
+  const y = Math.sin(dλ) * Math.cos(φ2);
+  const x =
+    Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(dλ);
+  return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+}
+
+/** renders key-value record as plaintext for headless consumers */
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+const FORMAT_ERROR_BOX_NAME = 'Distance';
+const FORMAT_ERROR_MSG =
+  'Invalid input. Expected format: lat1,lng1 to lat2,lng2\n' +
+  'Latitude must be -90..90, longitude must be -180..180.';
+
+export const HaversineBoxSource = {
+  name: 'Distance',
+  description:
+    'Great-circle distance between two coordinates. Input: "lat1,lng1 to lat2,lng2".',
+  defaultInput: '40.7128,-74.0060 to 51.5074,-0.1278 ::haversine',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'haversine', 'distance')) return [];
+
+    const raw = trim(input);
+    if (raw.length > 100) {
+      return [
+        new BoxBuilder(FORMAT_ERROR_BOX_NAME, FORMAT_ERROR_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const parts = raw.split(PAIR_SEP);
+    if (parts.length !== 2) {
+      return [
+        new BoxBuilder(FORMAT_ERROR_BOX_NAME, FORMAT_ERROR_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const coordA = parseCoord(parts[0]);
+    const coordB = parseCoord(parts[1]);
+
+    if (!coordA || !coordB) {
+      return [
+        new BoxBuilder(FORMAT_ERROR_BOX_NAME, FORMAT_ERROR_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const km = haversineKm(coordA, coordB);
+    const miles = km * KM_TO_MILES;
+    const nm = km * KM_TO_NM;
+    const bearing = initialBearing(coordA, coordB);
+
+    // integer-exact for zero distance; otherwise 3 decimals
+    const fmtDist = (n: number): string => (n === 0 ? '0' : n.toFixed(3));
+
+    const kv: Record<string, string> = {
+      From: formatCoord(coordA),
+      To: formatCoord(coordB),
+      Kilometers: fmtDist(km),
+      Miles: fmtDist(miles),
+      'Nautical Miles': fmtDist(nm),
+      'Initial Bearing': `${bearing.toFixed(1)}°`,
+    };
+
+    return [
+      new BoxBuilder(FORMAT_ERROR_BOX_NAME, kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HaversineBoxSource;

--- a/src/modules/boxSources/JsonPickBoxSource.ts
+++ b/src/modules/boxSources/JsonPickBoxSource.ts
@@ -27,8 +27,9 @@ export const JsonPickBoxSource = {
     if (pick === null && omit === null) return [];
     if (input.length > MAX_INPUT) return [];
 
-    // bare flag (boolean true, no value) → show usage hint
-    if (pick === true || omit === true) {
+    // show usage only when NEITHER flag carries a usable key list — a bare
+    // ::jsonomit alongside ::jsonpick=a,b must not suppress the pick
+    if (typeof pick !== 'string' && typeof omit !== 'string') {
       const flag = pick === true ? '::jsonpick' : '::jsonomit';
       return [
         new BoxBuilder(

--- a/src/modules/boxSources/JsonPickBoxSource.ts
+++ b/src/modules/boxSources/JsonPickBoxSource.ts
@@ -1,0 +1,133 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+// keys that must never be read or written to prevent prototype pollution
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export const JsonPickBoxSource = {
+  name: 'JSON Pick',
+  description:
+    'Pick or omit top-level keys from a JSON object. ::jsonpick=a,b or ::jsonomit=a,b.',
+  defaultInput: '{"a":1,"b":2,"c":3} ::jsonpick=a,c',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const pick = extractOptionKeys(options, 'jsonpick');
+    const omit = extractOptionKeys(options, 'jsonomit');
+
+    if (pick === null && omit === null) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // bare flag (boolean true, no value) → show usage hint
+    if (pick === true || omit === true) {
+      const flag = pick === true ? '::jsonpick' : '::jsonomit';
+      return [
+        new BoxBuilder(
+          'JSON Pick',
+          `Usage: provide a comma-separated key list, e.g. ${flag}=a,b,c`,
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'json' })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // parse input as a JSON object
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trim(input));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return [
+        new BoxBuilder('JSON Pick', `JSON parse error: ${msg}`)
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'json' })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      return [
+        new BoxBuilder(
+          'JSON Pick',
+          'Input must be a JSON object (not an array or scalar).',
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'json' })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const source = parsed as Record<string, unknown>;
+    const result: Record<string, unknown> = Object.create(null);
+
+    if (typeof pick === 'string') {
+      // pick mode: include only listed keys that exist as own enumerable properties,
+      // using the original object's key order for determinism
+      const requested = new Set(
+        pick
+          .split(',')
+          .map((k) => k.trim())
+          .filter((k) => k.length > 0 && !FORBIDDEN_KEYS.has(k)),
+      );
+      for (const key of Object.keys(source)) {
+        if (
+          requested.has(key) &&
+          Object.hasOwn(source, key) &&
+          !FORBIDDEN_KEYS.has(key)
+        ) {
+          result[key] = source[key];
+        }
+      }
+    } else if (typeof omit === 'string') {
+      // omit mode: include all own keys except the listed ones
+      const excluded = new Set(
+        omit
+          .split(',')
+          .map((k) => k.trim())
+          .filter((k) => k.length > 0),
+      );
+      for (const key of Object.keys(source)) {
+        if (
+          !excluded.has(key) &&
+          Object.hasOwn(source, key) &&
+          !FORBIDDEN_KEYS.has(key)
+        ) {
+          result[key] = source[key];
+        }
+      }
+    }
+
+    // convert to a plain object so JSON.stringify uses the normal prototype
+    const output = JSON.stringify(Object.assign({}, result), null, 2);
+
+    return [
+      new BoxBuilder('JSON Pick', output)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'json' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonPickBoxSource;

--- a/src/modules/boxSources/LeapYearBoxSource.ts
+++ b/src/modules/boxSources/LeapYearBoxSource.ts
@@ -1,0 +1,103 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+const BOX_NAME = 'Leap Year';
+const YEAR_RE = /^\d{1,7}$/;
+
+/** returns true when the given year satisfies the Gregorian leap year rule */
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+/** human-readable explanation of the leap-year rule that applied */
+function leapReason(year: number): string {
+  if (year % 400 === 0) return `${year}: divisible by 400 → leap`;
+  if (year % 100 === 0)
+    return `${year}: divisible by 100 but not 400 → not leap`;
+  if (year % 4 === 0) return `${year}: divisible by 4, not by 100 → leap`;
+  return `${year}: not divisible by 4 → not leap`;
+}
+
+/** finds the nearest leap year strictly greater than the given year */
+function nextLeap(year: number): number {
+  let y = year + 1;
+  while (!isLeapYear(y)) y++;
+  return y;
+}
+
+/** finds the nearest leap year strictly less than the given year */
+function prevLeap(year: number): number {
+  let y = year - 1;
+  while (!isLeapYear(y)) y--;
+  return y;
+}
+
+/** renders a key-value record as plaintext for headless consumers */
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+const INVALID_BOX_MSG =
+  'Invalid input. Expected a numeric year (1–7 digits), e.g. 2024 ::leapyear';
+
+export const LeapYearBoxSource = {
+  name: 'Leap Year',
+  description:
+    'Check whether a year is a leap year (Gregorian), with the reason and nearby leap years.',
+  defaultInput: '2024 ::leapyear',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'leapyear', 'isleap')) return [];
+
+    // prefer a numeric option value (e.g. ::leapyear=2024), else fall back to input
+    const optVal = extractOptionKeys(options, 'leapyear', 'isleap');
+    const raw =
+      typeof optVal === 'string' && YEAR_RE.test(optVal.trim())
+        ? optVal.trim()
+        : trim(input);
+
+    if (!YEAR_RE.test(raw)) {
+      return [
+        new BoxBuilder(BOX_NAME, INVALID_BOX_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const year = Number.parseInt(raw, 10);
+    const leap = isLeapYear(year);
+
+    const kv: Record<string, string> = {
+      Year: String(year),
+      'Leap Year': String(leap),
+      Reason: leapReason(year),
+      'Days in Year': leap ? '366' : '365',
+      'February Days': leap ? '29' : '28',
+      'Next Leap Year': String(nextLeap(year)),
+      'Previous Leap Year': String(prevLeap(year)),
+    };
+
+    return [
+      new BoxBuilder(BOX_NAME, kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LeapYearBoxSource;

--- a/src/modules/boxSources/LeapYearBoxSource.ts
+++ b/src/modules/boxSources/LeapYearBoxSource.ts
@@ -6,7 +6,9 @@ import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
 const Priority = 10;
 
 const BOX_NAME = 'Leap Year';
-const YEAR_RE = /^\d{1,7}$/;
+// require year >= 1 (no leading zeros, no year 0 — which JS would treat as a
+// leap year and report a nonsensical negative "previous leap year")
+const YEAR_RE = /^[1-9]\d{0,6}$/;
 
 /** returns true when the given year satisfies the Gregorian leap year rule */
 function isLeapYear(year: number): boolean {
@@ -87,7 +89,8 @@ export const LeapYearBoxSource = {
       'Days in Year': leap ? '366' : '365',
       'February Days': leap ? '29' : '28',
       'Next Leap Year': String(nextLeap(year)),
-      'Previous Leap Year': String(prevLeap(year)),
+      // the first Gregorian leap year is 4 AD; nothing earlier to report
+      'Previous Leap Year': year > 4 ? String(prevLeap(year)) : 'none',
     };
 
     return [

--- a/src/modules/boxSources/NatoPhoneticBoxSource.ts
+++ b/src/modules/boxSources/NatoPhoneticBoxSource.ts
@@ -1,0 +1,138 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 10_000;
+
+const NATO: Record<string, string> = {
+  a: 'Alfa',
+  b: 'Bravo',
+  c: 'Charlie',
+  d: 'Delta',
+  e: 'Echo',
+  f: 'Foxtrot',
+  g: 'Golf',
+  h: 'Hotel',
+  i: 'India',
+  j: 'Juliett',
+  k: 'Kilo',
+  l: 'Lima',
+  m: 'Mike',
+  n: 'November',
+  o: 'Oscar',
+  p: 'Papa',
+  q: 'Quebec',
+  r: 'Romeo',
+  s: 'Sierra',
+  t: 'Tango',
+  u: 'Uniform',
+  v: 'Victor',
+  w: 'Whiskey',
+  x: 'X-ray',
+  y: 'Yankee',
+  z: 'Zulu',
+  '0': 'Zero',
+  '1': 'One',
+  '2': 'Two',
+  '3': 'Three',
+  '4': 'Four',
+  '5': 'Five',
+  '6': 'Six',
+  '7': 'Seven',
+  '8': 'Eight',
+  '9': 'Nine',
+};
+
+// reverse map: lowercase nato word → original char (uppercase letter or digit)
+const NATO_REVERSE: Record<string, string> = Object.fromEntries(
+  Object.entries(NATO).map(([char, word]) => [
+    word.toLowerCase(),
+    char === char.toUpperCase() ? char : char.toUpperCase(),
+  ]),
+);
+
+function encodeNato(input: string): string {
+  const tokens: string[] = [];
+  for (const ch of input) {
+    const lower = ch.toLowerCase();
+    if (lower === ' ') {
+      tokens.push('(space)');
+    } else if (NATO[lower] !== undefined) {
+      tokens.push(NATO[lower]);
+    } else {
+      tokens.push(ch);
+    }
+  }
+  return tokens.join(' ');
+}
+
+function decodeNato(input: string): string {
+  const tokens = input.trim().split(/\s+/);
+  const result: string[] = [];
+  for (const token of tokens) {
+    const lower = token.toLowerCase();
+    if (lower === '(space)') {
+      result.push(' ');
+    } else if (NATO_REVERSE[lower] !== undefined) {
+      result.push(NATO_REVERSE[lower]);
+    } else {
+      result.push(token);
+    }
+  }
+  return result.join('');
+}
+
+export const NatoPhoneticBoxSource = {
+  name: 'NATO Phonetic',
+  description:
+    'Spell text in the NATO phonetic alphabet (Alfa Bravo Charlie). ::nato to encode, ::natodecode to decode.',
+  defaultInput: 'ABC ::nato',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'nato', 'natoencode', 'phonetic');
+    const wantDecode = hasOptionKeys(options, 'natodecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = encodeNato(input);
+      boxes.push(
+        new BoxBuilder('NATO Phonetic (Encode)', encoded)
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decodeNato(input);
+      boxes.push(
+        new BoxBuilder('NATO Phonetic (Decode)', decoded)
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default NatoPhoneticBoxSource;

--- a/src/modules/boxSources/PortLookupBoxSource.ts
+++ b/src/modules/boxSources/PortLookupBoxSource.ts
@@ -1,0 +1,155 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// curated well-known ports (IANA / common). number -> {service, description}
+const PORTS: Record<number, { name: string; desc: string }> = {
+  20: { name: 'FTP-DATA', desc: 'File Transfer (data)' },
+  21: { name: 'FTP', desc: 'File Transfer (control)' },
+  22: { name: 'SSH', desc: 'Secure Shell' },
+  23: { name: 'Telnet', desc: 'Telnet' },
+  25: { name: 'SMTP', desc: 'Simple Mail Transfer' },
+  53: { name: 'DNS', desc: 'Domain Name System' },
+  67: { name: 'DHCP', desc: 'DHCP server' },
+  68: { name: 'DHCP', desc: 'DHCP client' },
+  80: { name: 'HTTP', desc: 'Hypertext Transfer' },
+  110: { name: 'POP3', desc: 'Post Office Protocol v3' },
+  123: { name: 'NTP', desc: 'Network Time Protocol' },
+  143: { name: 'IMAP', desc: 'Internet Message Access' },
+  161: { name: 'SNMP', desc: 'Simple Network Management' },
+  389: { name: 'LDAP', desc: 'Lightweight Directory Access' },
+  443: { name: 'HTTPS', desc: 'HTTP over TLS' },
+  445: { name: 'SMB', desc: 'Microsoft-DS / SMB' },
+  465: { name: 'SMTPS', desc: 'SMTP over TLS' },
+  587: { name: 'SMTP', desc: 'Mail submission' },
+  636: { name: 'LDAPS', desc: 'LDAP over TLS' },
+  993: { name: 'IMAPS', desc: 'IMAP over TLS' },
+  995: { name: 'POP3S', desc: 'POP3 over TLS' },
+  1433: { name: 'MSSQL', desc: 'Microsoft SQL Server' },
+  1521: { name: 'Oracle', desc: 'Oracle database' },
+  3306: { name: 'MySQL', desc: 'MySQL database' },
+  3389: { name: 'RDP', desc: 'Remote Desktop' },
+  5432: { name: 'PostgreSQL', desc: 'PostgreSQL database' },
+  5672: { name: 'AMQP', desc: 'RabbitMQ / AMQP' },
+  6379: { name: 'Redis', desc: 'Redis' },
+  8080: { name: 'HTTP-alt', desc: 'HTTP alternate' },
+  8443: { name: 'HTTPS-alt', desc: 'HTTPS alternate' },
+  9200: { name: 'Elasticsearch', desc: 'Elasticsearch' },
+  27017: { name: 'MongoDB', desc: 'MongoDB' },
+};
+
+// returns the IANA range label for a valid port number
+function portRange(n: number): string {
+  if (n <= 1023) return 'well-known';
+  if (n <= 49151) return 'registered';
+  return 'dynamic/private';
+}
+
+// builds the plaintext k:v representation used by KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const PortLookupBoxSource = {
+  name: 'Port Lookup',
+  description: 'Look up a well-known port number or service name. ::port',
+  defaultInput: '443 ::port',
+  tag: '#',
+  kind: 'Decode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'port', 'portlookup')) return [];
+
+    const query = trim(input).slice(0, 32);
+
+    if (/^\d+$/.test(query)) {
+      // number → service lookup
+      const n = Number.parseInt(query, 10);
+
+      if (n < 0 || n > 65535) {
+        const kv: Record<string, string> = {
+          Port: query,
+          Service: 'invalid — out of range (0–65535)',
+          Description: '',
+          Range: 'n/a',
+        };
+        return [
+          new BoxBuilder('Port Lookup', kvToPlaintext(kv))
+            .setTemplate(KeyValueBoxTemplate)
+            .setOptions(kv)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      const entry = PORTS[n];
+      const range = portRange(n);
+
+      const kv: Record<string, string> = entry
+        ? {
+            Port: String(n),
+            Service: entry.name,
+            Description: entry.desc,
+            Range: range,
+          }
+        : {
+            Port: String(n),
+            Service: 'unassigned / not a well-known port',
+            Description: '',
+            Range: range,
+          };
+
+      return [
+        new BoxBuilder('Port Lookup', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // name → port(s) lookup (case-insensitive)
+    const needle = query.toLowerCase();
+    const matches = Object.entries(PORTS)
+      .filter(([, v]) => v.name.toLowerCase() === needle)
+      .map(([port]) => port);
+
+    if (matches.length > 0) {
+      const kv: Record<string, string> = {
+        Service: query,
+        'Port(s)': matches.join(', '),
+      };
+      return [
+        new BoxBuilder('Port Lookup', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // no match found — return an informational box
+    const kv: Record<string, string> = {
+      Service: query,
+      'Port(s)': 'no match in well-known port table',
+    };
+    return [
+      new BoxBuilder('Port Lookup', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PortLookupBoxSource;

--- a/src/modules/boxSources/ReverseTextBoxSource.ts
+++ b/src/modules/boxSources/ReverseTextBoxSource.ts
@@ -1,0 +1,62 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// reverse a string by unicode code points so multi-byte chars (emoji, etc.) stay intact
+function reverseChars(str: string): string {
+  return [...str].reverse().join('');
+}
+
+// reverse word order; multiple whitespace runs collapse to a single space
+function reverseWords(str: string): string {
+  return str.split(/\s+/).reverse().join(' ');
+}
+
+// reverse line order; normalize CRLF to LF first
+function reverseLines(str: string): string {
+  return str.replace(/\r\n/g, '\n').split('\n').reverse().join('\n');
+}
+
+export const ReverseTextBoxSource = {
+  name: 'Reverse Text',
+  description:
+    'Reverse text by characters (default), words (::reverse=words), or lines (::reverse=lines).',
+  defaultInput: 'hello world ::reverse',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'reverse')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const mode = extractOptionKeys(options, 'reverse');
+
+    let output: string;
+    if (mode === 'words') {
+      output = reverseWords(input);
+    } else if (mode === 'lines') {
+      output = reverseLines(input);
+    } else {
+      // default: chars (handles true/empty/'chars'/any other value)
+      output = reverseChars(input);
+    }
+
+    const box = new BoxBuilder('Reverse Text', output)
+      .setTemplate(CodeBoxTemplate)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default ReverseTextBoxSource;

--- a/src/modules/boxSources/ReverseTextBoxSource.ts
+++ b/src/modules/boxSources/ReverseTextBoxSource.ts
@@ -6,8 +6,17 @@ import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
 const Priority = 10;
 const MAX_INPUT = 100_000;
 
-// reverse a string by unicode code points so multi-byte chars (emoji, etc.) stay intact
+// reverse a string by grapheme cluster so emoji with modifiers/ZWJ/flags
+// (e.g. 👍🏽, 🇺🇸) stay intact; fall back to code-point reversal if the
+// Intl.Segmenter API is unavailable (still safe for simple emoji like 😀)
 function reverseChars(str: string): string {
+  if (typeof Intl?.Segmenter === 'function') {
+    const segmenter = new Intl.Segmenter();
+    return [...segmenter.segment(str)]
+      .map((s) => s.segment)
+      .reverse()
+      .join('');
+  }
   return [...str].reverse().join('');
 }
 

--- a/src/modules/boxSources/__test__/ExcelColumnBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ExcelColumnBoxSource.test.ts
@@ -1,0 +1,207 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ExcelColumnBoxSource } from '../ExcelColumnBoxSource';
+
+describe('ExcelColumnBoxSource', () => {
+  describe('no option → empty array', () => {
+    it('returns [] when options is null', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when no matching option key is present', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('letters → number (bijective base-26)', () => {
+    it('A → 1', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('A', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Number).toBe('1');
+      expect(boxes[0].props.options?.Column).toBe('A');
+    });
+
+    it('Z → 26', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('Z', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('26');
+    });
+
+    // AB = 1*26 + 2 = 28
+    it('AB → 28', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Number).toBe('28');
+      expect(boxes[0].props.options?.Column).toBe('AB');
+    });
+
+    // AA = 1*26 + 1 = 27
+    it('AA → 27', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AA', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('27');
+    });
+
+    // ZZ = 26*26 + 26 = 702
+    it('ZZ → 702', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('ZZ', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('702');
+    });
+
+    // AAA = 26^2 + 26 + 1 = 703
+    it('AAA → 703', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AAA', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('703');
+    });
+
+    // Excel's last column XFD → 16384
+    it('XFD → 16384 (Excel max column)', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('XFD', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('16384');
+    });
+
+    it('lowercase ab is treated case-insensitively → 28', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('ab', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('28');
+      // column is always uppercased in output
+      expect(boxes[0].props.options?.Column).toBe('AB');
+    });
+  });
+
+  describe('number → letters (reverse lookup)', () => {
+    it('28 → AB', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('28', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Column).toBe('AB');
+      expect(boxes[0].props.options?.Number).toBe('28');
+    });
+
+    it('1 → A', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('1', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Column).toBe('A');
+    });
+
+    it('27 → AA', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('27', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Column).toBe('AA');
+    });
+
+    it('702 → ZZ', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('702', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Column).toBe('ZZ');
+    });
+
+    it('16384 → XFD', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('16384', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Column).toBe('XFD');
+    });
+  });
+
+  describe('round-trip AB → 28 → AB', () => {
+    it('letters→number→letters stays consistent', async () => {
+      const fwd = await ExcelColumnBoxSource.generateBoxes('AB', {
+        excelcol: true,
+      });
+      const num = fwd[0].props.options?.Number as string;
+      const rev = await ExcelColumnBoxSource.generateBoxes(num, {
+        excelcol: true,
+      });
+      expect(rev[0].props.options?.Column).toBe('AB');
+    });
+  });
+
+  describe('alternate option key ::spreadsheetcol', () => {
+    it('accepts spreadsheetcol option', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        spreadsheetcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Number).toBe('28');
+    });
+  });
+
+  describe('invalid / mixed inputs → explanatory box', () => {
+    it('A1 (mixed) returns explanatory box, not empty', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('A1', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/enter column/i);
+    });
+
+    it('"hello world" (space) returns explanatory box', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('hello world', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/enter column/i);
+    });
+
+    it('0 returns out-of-range box', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('0', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Number).toBe('out of range');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        excelcol: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is Spreadsheet Column', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.name).toBe('Spreadsheet Column');
+    });
+
+    it('priority is set', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('source metadata', () => {
+      expect(ExcelColumnBoxSource.name).toBe('Spreadsheet Column');
+      expect(ExcelColumnBoxSource.tag).toBe('#');
+      expect(ExcelColumnBoxSource.kind).toBe('Convert');
+      expect(ExcelColumnBoxSource.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/FrequencyConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FrequencyConvertBoxSource.test.ts
@@ -1,0 +1,244 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { FrequencyConvertBoxSource } from '../FrequencyConvertBoxSource';
+
+describe('FrequencyConvertBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(FrequencyConvertBoxSource.name).toBe('Frequency Convert');
+      expect(FrequencyConvertBoxSource.tag).toBe('#');
+      expect(FrequencyConvertBoxSource.kind).toBe('Convert');
+      expect(FrequencyConvertBoxSource.priority).toBe(10);
+    });
+  });
+
+  describe('option gate', () => {
+    it('returns [] when options is null', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes(
+        '2.4 GHz',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes(
+        '2.4 GHz',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('activates on ::frequency option', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('activates on ::freq option', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('2.4 GHz → Hz / MHz / GHz', () => {
+    it('Hz is 2400000000', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      // 2.4 GHz = 2.4e9 Hz exactly
+      expect(Number.parseFloat(kv.Hz)).toBe(2_400_000_000);
+    });
+
+    it('MHz is 2400', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      // 2.4 GHz = 2400 MHz
+      expect(Number.parseFloat(kv.MHz)).toBe(2400);
+    });
+
+    it('GHz is 2.4', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.GHz)).toBeCloseTo(2.4, 9);
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is Frequency Convert', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      expect(boxes[0].props.name).toBe('Frequency Convert');
+    });
+
+    it('priority is set to 10', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('kv options contain all expected keys', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv).toHaveProperty('Input');
+      expect(kv).toHaveProperty('Hz');
+      expect(kv).toHaveProperty('kHz');
+      expect(kv).toHaveProperty('MHz');
+      expect(kv).toHaveProperty('GHz');
+      expect(kv).toHaveProperty('THz');
+      expect(kv).toHaveProperty('Period');
+    });
+  });
+
+  describe('1 kHz → Hz / Period', () => {
+    it('Hz is 1000', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('1 kHz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.Hz)).toBe(1000);
+    });
+
+    it('Period is approximately 0.001 s (1 ms)', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('1 kHz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      // period should contain "0.001 s"
+      const periodVal = Number.parseFloat(kv.Period);
+      expect(periodVal).toBeCloseTo(0.001, 9);
+    });
+  });
+
+  describe('1 Hz', () => {
+    it('Period is 1 s', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('1 Hz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      const periodVal = Number.parseFloat(kv.Period);
+      expect(periodVal).toBe(1);
+    });
+
+    it('Hz is 1', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('1 Hz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.Hz)).toBe(1);
+    });
+  });
+
+  describe('440 Hz', () => {
+    it('kHz is 0.44', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('440 Hz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.kHz)).toBeCloseTo(0.44, 9);
+    });
+  });
+
+  describe('1000000 Hz', () => {
+    it('MHz is 1', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes(
+        '1000000 Hz',
+        {
+          frequency: true,
+        },
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.MHz)).toBe(1);
+    });
+
+    it('kHz is 1000', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes(
+        '1000000 Hz',
+        {
+          frequency: true,
+        },
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.kHz)).toBe(1000);
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('returns an error box for "abc"', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('abc', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box for "5 foo" (unknown unit)', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('5 foo', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box for input exceeding 64 chars', async () => {
+      const long = `${'1'.repeat(70)} GHz`;
+      const boxes = await FrequencyConvertBoxSource.generateBoxes(long, {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+  });
+
+  describe('plaintext output', () => {
+    it('plaintextOutput contains key: value lines', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toMatch(/Hz:/);
+      expect(text).toMatch(/MHz:/);
+      expect(text).toMatch(/GHz:/);
+      expect(text).toMatch(/Period:/);
+    });
+  });
+
+  describe('case-insensitive unit parsing', () => {
+    it('accepts "ghz" lowercase', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('1 ghz', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.Hz)).toBe(1e9);
+    });
+
+    it('accepts "MHZ" uppercase', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('100 MHZ', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.Hz)).toBe(1e8);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/HaversineBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HaversineBoxSource.test.ts
@@ -1,0 +1,229 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { HaversineBoxSource } from '../HaversineBoxSource';
+
+describe('HaversineBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HaversineBoxSource.name).toBe('Distance');
+      expect(HaversineBoxSource.tag).toBe('#');
+      expect(HaversineBoxSource.kind).toBe('Calculate');
+      expect(HaversineBoxSource.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes - option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('activates on ::haversine option', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('activates on ::distance option', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { distance: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes - NYC to London', () => {
+    it('Kilometers is approximately 5570 km', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      expect(km).toBeGreaterThan(5560);
+      expect(km).toBeLessThan(5580);
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is Distance', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      expect(boxes[0].props.name).toBe('Distance');
+    });
+
+    it('priority is set', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('Miles ≈ km * 0.621371', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      const miles = Number.parseFloat(kv.Miles);
+      expect(miles).toBeCloseTo(km * 0.621371, 2);
+    });
+
+    it('kv options contain all expected keys', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv).toHaveProperty('From');
+      expect(kv).toHaveProperty('To');
+      expect(kv).toHaveProperty('Kilometers');
+      expect(kv).toHaveProperty('Miles');
+      expect(kv).toHaveProperty('Nautical Miles');
+      expect(kv).toHaveProperty('Initial Bearing');
+    });
+  });
+
+  describe('generateBoxes - same point (0,0 to 0,0)', () => {
+    it('Kilometers is 0', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0 to 0,0', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Kilometers).toBe('0');
+    });
+  });
+
+  describe('generateBoxes - equator quarter (0,0 to 0,90)', () => {
+    it('Kilometers ≈ 10018.75 (quarter circumference)', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0 to 0,90', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      expect(km).toBeGreaterThan(10000);
+      expect(km).toBeLessThan(10040);
+    });
+  });
+
+  describe('generateBoxes - equator half (0,0 to 0,180)', () => {
+    it('Kilometers ≈ 20037.5 (half circumference)', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0 to 0,180', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      // half circumference: 2 * pi * R / 2 = pi * 6371.0088 ≈ 20015
+      expect(km).toBeGreaterThan(20000);
+      expect(km).toBeLessThan(20060);
+    });
+  });
+
+  describe('generateBoxes - alternate separators', () => {
+    it('accepts semicolon separator', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0;0,90', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      expect(km).toBeGreaterThan(10000);
+    });
+
+    it('accepts pipe separator', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0|0,90', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      expect(km).toBeGreaterThan(10000);
+    });
+  });
+
+  describe('generateBoxes - invalid inputs', () => {
+    it('returns an error box for "hello"', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('hello', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box for bad lat (91,0 to 0,0)', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('91,0 to 0,0', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box for bad lng (0,0 to 0,181)', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0 to 0,181', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box when only one pair is given', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('40.7128,-74.0060', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box for input exceeding 100 chars', async () => {
+      const long = `${'0,0'.repeat(20)} to 0,0`;
+      const boxes = await HaversineBoxSource.generateBoxes(long, {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+  });
+
+  describe('generateBoxes - plaintext output', () => {
+    it('plaintextOutput contains key: value lines', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toMatch(/Kilometers:/);
+      expect(text).toMatch(/Miles:/);
+      expect(text).toMatch(/Nautical Miles:/);
+      expect(text).toMatch(/Initial Bearing:/);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JsonPickBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonPickBoxSource.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonPickBoxSource } from '../JsonPickBoxSource';
+
+describe('JsonPickBoxSource', () => {
+  describe('trigger guard', () => {
+    it('returns [] when neither jsonpick nor jsonomit is provided', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('pick mode', () => {
+    it('picks listed keys and omits the rest', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes(
+        '{"a":1,"b":2,"c":3}',
+        { jsonpick: 'a,c' },
+      );
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: 1, c: 3 });
+      // b must not appear
+      expect(Object.hasOwn(result, 'b')).toBe(false);
+    });
+
+    it('preserves original key order from the source object', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes(
+        '{"a":1,"b":2,"c":3}',
+        { jsonpick: 'c,a' },
+      );
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      // order follows the original object (a before c), not the requested order
+      expect(Object.keys(result)).toEqual(['a', 'c']);
+    });
+
+    it('silently skips a requested key that does not exist in the source', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', {
+        jsonpick: 'a,z',
+      });
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: 1 });
+      expect(Object.hasOwn(result, 'z')).toBe(false);
+    });
+
+    it('preserves nested values unchanged', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes(
+        '{"a":{"x":1},"b":2}',
+        { jsonpick: 'a' },
+      );
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: { x: 1 } });
+    });
+  });
+
+  describe('omit mode', () => {
+    it('omits listed keys and retains the rest', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes(
+        '{"a":1,"b":2,"c":3}',
+        { jsonomit: 'b' },
+      );
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: 1, c: 3 });
+    });
+  });
+
+  describe('prototype safety', () => {
+    it('does not pollute Object.prototype when __proto__ is in the pick list', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', {
+        jsonpick: '__proto__,a',
+      });
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      // a is included, __proto__ is not an own key on the result
+      expect(result).toEqual({ a: 1 });
+      expect(Object.hasOwn(result, '__proto__')).toBe(false);
+      // prototype must not have been polluted
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+  });
+
+  describe('bare flag (usage hint)', () => {
+    it('returns a usage box when ::jsonpick is a bare boolean', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', {
+        jsonpick: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/usage/i);
+    });
+
+    it('returns a usage box when ::jsonomit is a bare boolean', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', {
+        jsonomit: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/usage/i);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns an error box for invalid JSON', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{bad', {
+        jsonpick: 'a',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/parse error/i);
+    });
+
+    it('returns an error box when input is a JSON array', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('[1,2]', {
+        jsonpick: 'a',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/object/i);
+    });
+
+    it('returns an error box when input is a JSON scalar', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('"hello"', {
+        jsonpick: 'a',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/object/i);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(JsonPickBoxSource.name).toBe('JSON Pick');
+      expect(JsonPickBoxSource.tag).toBe('#');
+      expect(JsonPickBoxSource.kind).toBe('Transform');
+      expect(typeof JsonPickBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LeapYearBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LeapYearBoxSource.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+
+import { LeapYearBoxSource } from '../LeapYearBoxSource';
+
+describe('LeapYearBoxSource', () => {
+  describe('no option → empty array', () => {
+    it('returns [] when options is null', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options has no leapyear/isleap key', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('2024 — divisible by 4, not by 100 → leap', () => {
+    it('returns one box', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        leapyear: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('Leap Year is true', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['Leap Year']).toBe('true');
+    });
+
+    it('February Days is 29', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['February Days']).toBe('29');
+    });
+
+    it('Days in Year is 366', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['Days in Year']).toBe('366');
+    });
+
+    it('Reason mentions "divisible by 4" and "not by 100"', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        leapyear: true,
+      });
+      const reason = boxes[0].props.options?.Reason as string;
+      expect(reason).toMatch(/divisible by 4/i);
+      expect(reason).toMatch(/not by 100|not.*100/i);
+    });
+
+    it('Next Leap Year is 2028', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['Next Leap Year']).toBe('2028');
+    });
+
+    it('Previous Leap Year is 2020', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['Previous Leap Year']).toBe('2020');
+    });
+  });
+
+  describe('1900 — divisible by 100 but not 400 → not leap', () => {
+    it('Leap Year is false', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('1900', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['Leap Year']).toBe('false');
+    });
+
+    it('February Days is 28', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('1900', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['February Days']).toBe('28');
+    });
+
+    it('Days in Year is 365', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('1900', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['Days in Year']).toBe('365');
+    });
+
+    it('Reason mentions divisible by 100 but not 400', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('1900', {
+        leapyear: true,
+      });
+      const reason = boxes[0].props.options?.Reason as string;
+      expect(reason).toMatch(/100/);
+      expect(reason).toMatch(/not.*400|400.*not/i);
+    });
+
+    it('Next Leap Year is 1904', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('1900', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['Next Leap Year']).toBe('1904');
+    });
+
+    it('Previous Leap Year is 1896', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('1900', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['Previous Leap Year']).toBe('1896');
+    });
+  });
+
+  describe('2000 — divisible by 400 → leap', () => {
+    it('Leap Year is true', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2000', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['Leap Year']).toBe('true');
+    });
+
+    it('February Days is 29', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2000', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['February Days']).toBe('29');
+    });
+
+    it('Reason mentions divisible by 400', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2000', {
+        leapyear: true,
+      });
+      const reason = boxes[0].props.options?.Reason as string;
+      expect(reason).toMatch(/400/);
+    });
+  });
+
+  describe('2023 — not divisible by 4 → not leap', () => {
+    it('Leap Year is false', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2023', {
+        leapyear: true,
+      });
+      expect(boxes[0].props.options?.['Leap Year']).toBe('false');
+    });
+
+    it('Reason mentions not divisible by 4', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2023', {
+        leapyear: true,
+      });
+      const reason = boxes[0].props.options?.Reason as string;
+      expect(reason).toMatch(/not divisible by 4/i);
+    });
+  });
+
+  describe('::isleap alias', () => {
+    it('accepts isleap option key', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        isleap: true,
+      });
+      expect(boxes[0].props.options?.['Leap Year']).toBe('true');
+    });
+  });
+
+  describe('option value as year (::leapyear=2024)', () => {
+    it('uses the option value when it is a numeric string', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('', {
+        leapyear: '2024',
+      });
+      expect(boxes[0].props.options?.['Leap Year']).toBe('true');
+      expect(boxes[0].props.options?.['February Days']).toBe('29');
+    });
+
+    it('uses option value 1900 even when input is different', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        leapyear: '1900',
+      });
+      expect(boxes[0].props.options?.['Leap Year']).toBe('false');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns a box (not empty) for non-numeric input', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('abc', {
+        leapyear: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('returns a box for empty input', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('', {
+        leapyear: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('returns a box for input with spaces only', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('   ', {
+        leapyear: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('plaintext output', () => {
+    it('contains all expected keys in plaintext output', async () => {
+      const boxes = await LeapYearBoxSource.generateBoxes('2024', {
+        leapyear: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Year:');
+      expect(text).toContain('Leap Year:');
+      expect(text).toContain('Reason:');
+      expect(text).toContain('Days in Year:');
+      expect(text).toContain('February Days:');
+      expect(text).toContain('Next Leap Year:');
+      expect(text).toContain('Previous Leap Year:');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LeapYearBoxSource.name).toBe('Leap Year');
+      expect(LeapYearBoxSource.tag).toBe('#');
+      expect(LeapYearBoxSource.kind).toBe('Calculate');
+      expect(typeof LeapYearBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/NatoPhoneticBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NatoPhoneticBoxSource.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { NatoPhoneticBoxSource } from '../NatoPhoneticBoxSource';
+
+describe('NatoPhoneticBoxSource', () => {
+  describe('generateBoxes — no match cases', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('ABC');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::nato', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::nato', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('   ', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes(
+        'A'.repeat(10_001),
+        { nato: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ::nato', () => {
+    it('encodes ABC to Alfa Bravo Charlie', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('ABC', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('NATO Phonetic (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa Bravo Charlie');
+    });
+
+    it('encodes SOS to Sierra Oscar Sierra', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('SOS', {
+        nato: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Sierra Oscar Sierra');
+    });
+
+    it('encodes digit string A1 to Alfa One', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('A1', {
+        nato: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa One');
+    });
+
+    it('encodes lowercase abc same as uppercase', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('abc', {
+        nato: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa Bravo Charlie');
+    });
+
+    it('encodes via ::natoencode alias', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('SOS', {
+        natoencode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Sierra Oscar Sierra');
+    });
+
+    it('encodes via ::phonetic alias', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('SOS', {
+        phonetic: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Sierra Oscar Sierra');
+    });
+
+    it('sets priority and showExpandButton correctly', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('A', {
+        nato: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('decode — ::natodecode', () => {
+    it('decodes Alfa Bravo Charlie to ABC', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes(
+        'Alfa Bravo Charlie',
+        {
+          natodecode: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('NATO Phonetic (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('ABC');
+    });
+
+    it('decodes case-insensitively (alfa bravo → AB)', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('alfa bravo', {
+        natodecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+
+    it('keeps unrecognized tokens as-is', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes(
+        'Alfa UNKNOWN Charlie',
+        {
+          natodecode: true,
+        },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('AUNKNOWNC');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('HELLO round-trips through encode then decode', async () => {
+      const encoded = await NatoPhoneticBoxSource.generateBoxes('HELLO', {
+        nato: true,
+      });
+      const encodedText = encoded[0].props.plaintextOutput;
+
+      const decoded = await NatoPhoneticBoxSource.generateBoxes(encodedText, {
+        natodecode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe('HELLO');
+    });
+  });
+
+  describe('both options — returns 2 boxes', () => {
+    it('produces encode box and decode box when both options present', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('Alfa', {
+        nato: true,
+        natodecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('NATO Phonetic (Encode)');
+      expect(boxes[1].props.name).toBe('NATO Phonetic (Decode)');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PortLookupBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PortLookupBoxSource.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import { PortLookupBoxSource } from '../PortLookupBoxSource';
+
+describe('PortLookupBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('number → service lookup', () => {
+    it('443 resolves to HTTPS with TLS in description and well-known range', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toBe('HTTPS');
+      expect(opts.Description).toMatch(/TLS/i);
+      expect(opts.Range).toBe('well-known');
+      expect(opts.Port).toBe('443');
+    });
+
+    it('80 resolves to HTTP', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('80', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toBe('HTTP');
+      expect(opts.Range).toBe('well-known');
+    });
+
+    it('22 resolves to SSH', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('22', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toBe('SSH');
+    });
+
+    it('::portlookup alias also triggers lookup', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('22', {
+        portlookup: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toBe('SSH');
+    });
+
+    it('valid but unassigned port 12345 returns unassigned service and registered range', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('12345', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toMatch(/unassigned/i);
+      expect(opts.Range).toBe('registered');
+    });
+
+    it('out-of-range port 70000 returns an invalid box', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('70000', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toMatch(/invalid|out of range/i);
+    });
+
+    it('dynamic/private range port 50000 shows correct range', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('50000', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Range).toBe('dynamic/private');
+    });
+  });
+
+  describe('name → port(s) lookup', () => {
+    it('"https" resolves to port 443', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('https', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Port(s)']).toContain('443');
+    });
+
+    it('"http" resolves to port 80', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('http', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Port(s)']).toContain('80');
+    });
+
+    it('"HTTPS" is case-insensitive and resolves to 443', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('HTTPS', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Port(s)']).toContain('443');
+    });
+
+    it('"hello!" returns a no-match box', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('hello!', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Port(s)']).toMatch(/no match/i);
+    });
+  });
+
+  describe('box structure', () => {
+    it('box is named "Port Lookup"', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', {
+        port: true,
+      });
+      expect(boxes[0].props.name).toBe('Port Lookup');
+    });
+
+    it('plaintextOutput contains key:value pairs', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', {
+        port: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('Service: HTTPS');
+    });
+
+    it('boxTemplate is set (KeyValueBoxTemplate)', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', {
+        port: true,
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(PortLookupBoxSource.name).toBe('Port Lookup');
+      expect(PortLookupBoxSource.tag).toBe('#');
+      expect(PortLookupBoxSource.kind).toBe('Decode');
+      expect(typeof PortLookupBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ReverseTextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ReverseTextBoxSource.test.ts
@@ -1,0 +1,131 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ReverseTextBoxSource } from '../ReverseTextBoxSource';
+
+describe('ReverseTextBoxSource', () => {
+  describe('trigger conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('hello', {
+        qr: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('', {
+        reverse: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('chars mode (default)', () => {
+    it('reverses ascii string by characters', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('hello', {
+        reverse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('olleh');
+    });
+
+    it('reverses mixed string with spaces', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('abc 123', {
+        reverse: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('321 cba');
+    });
+
+    it('reverses unicode precomposed char correctly (é as one code point)', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('café', {
+        reverse: true,
+      });
+      // é (U+00E9) is a single precomposed code point; must stay intact
+      expect(boxes[0].props.plaintextOutput).toBe('éfac');
+    });
+
+    it('is code-point safe: emoji stays intact (a😀b → b😀a)', async () => {
+      // verify the invariant the test depends on
+      expect([...'a😀b'].reverse().join('')).toBe('b😀a');
+
+      const boxes = await ReverseTextBoxSource.generateBoxes('a😀b', {
+        reverse: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('b😀a');
+    });
+
+    it('is code-point safe: skin-tone emoji (👍🏽) stays intact', async () => {
+      const input = '👍🏽';
+      const boxes = await ReverseTextBoxSource.generateBoxes(input, {
+        reverse: true,
+      });
+      // reversed by code point — the pair should still round-trip cleanly
+      expect(boxes[0].props.plaintextOutput).toBe(
+        [...input].reverse().join(''),
+      );
+    });
+
+    it('uses CodeBoxTemplate', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('hello', {
+        reverse: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+
+    it('sets the box name to "Reverse Text"', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('hello', {
+        reverse: true,
+      });
+      expect(boxes[0].props.name).toBe('Reverse Text');
+    });
+  });
+
+  describe('words mode', () => {
+    it('reverses word order', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes(
+        'hello world foo',
+        { reverse: 'words' },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('foo world hello');
+    });
+
+    it('collapses multiple spaces between words', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('a  b   c', {
+        reverse: 'words',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('c b a');
+    });
+  });
+
+  describe('lines mode', () => {
+    it('reverses line order', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes(
+        'line1\nline2\nline3',
+        { reverse: 'lines' },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('line3\nline2\nline1');
+    });
+
+    it('normalizes CRLF before reversing lines', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('a\r\nb\r\nc', {
+        reverse: 'lines',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('c\nb\na');
+    });
+  });
+
+  describe('input length guard', () => {
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const huge = 'x'.repeat(100_001);
+      const boxes = await ReverseTextBoxSource.generateBoxes(huge, {
+        reverse: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ReverseTextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ReverseTextBoxSource.test.ts
@@ -59,15 +59,21 @@ describe('ReverseTextBoxSource', () => {
       expect(boxes[0].props.plaintextOutput).toBe('b😀a');
     });
 
-    it('is code-point safe: skin-tone emoji (👍🏽) stays intact', async () => {
+    it('is grapheme-safe: skin-tone emoji (👍🏽) stays intact', async () => {
       const input = '👍🏽';
       const boxes = await ReverseTextBoxSource.generateBoxes(input, {
         reverse: true,
       });
-      // reversed by code point — the pair should still round-trip cleanly
-      expect(boxes[0].props.plaintextOutput).toBe(
-        [...input].reverse().join(''),
-      );
+      // a single grapheme cluster reverses to itself (not split into base +
+      // modifier) thanks to Intl.Segmenter
+      expect(boxes[0].props.plaintextOutput).toBe('👍🏽');
+    });
+
+    it('reverses multiple grapheme clusters as whole units', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('a👍🏽b', {
+        reverse: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('b👍🏽a');
     });
 
     it('uses CodeBoxTemplate', async () => {

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,16 +7,24 @@ import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import ExcelColumnBoxSource from './ExcelColumnBoxSource';
+import FrequencyConvertBoxSource from './FrequencyConvertBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HaversineBoxSource from './HaversineBoxSource';
+import JsonPickBoxSource from './JsonPickBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LeapYearBoxSource from './LeapYearBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
+import NatoPhoneticBoxSource from './NatoPhoneticBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PortLookupBoxSource from './PortLookupBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import ReverseTextBoxSource from './ReverseTextBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
@@ -34,16 +42,24 @@ export const boxSources = [
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  ExcelColumnBoxSource,
+  FrequencyConvertBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  HaversineBoxSource,
+  JsonPickBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LeapYearBoxSource,
   MathExpressionBoxSource,
   MyIPBoxSource,
+  NatoPhoneticBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  PortLookupBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
+  ReverseTextBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
   URLDecodeBoxSource,


### PR DESCRIPTION
## Summary

Thirty-third exploration batch — **8 more BoxSource tools** (geo, spreadsheet, JSON, networking, text, calendar).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Distance | `::haversine` | great-circle distance between two coords |
| Spreadsheet Column | `::excelcol` | column letter ⇄ number (A=1, AA=27) |
| JSON Pick | `::jsonpick=a,b` | pick/omit top-level keys (`::jsonomit`) |
| Port Lookup | `::port` | well-known port ⇄ service name |
| NATO Phonetic | `::nato` | phonetic spelling (`::natodecode`) |
| Leap Year | `::leapyear` | leap check + reason + next/prev |
| Frequency Convert | `::frequency` | Hz/kHz/MHz/GHz + period |
| Reverse Text | `::reverse` | chars/words/lines (code-point safe) |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Hardening rules pre-loaded: prototype-pollution guard (FORBIDDEN_KEYS + `Object.hasOwn`) in JsonPick, code-point reversal for emoji safety, deterministic Leap Year (no `Date.now()`), `kvToPlaintext` for KeyValue sources.
- **Verified vectors**: **NYC–London ≈ 5570 km**, quarter-circumference ≈ 10007 km; **AB→28, ZZ→702, XFD→16384**; jsonpick `{a,c}` + `__proto__` not pollutable; **443→HTTPS, 22→SSH**, name `https`→443; ABC→`Alfa Bravo Charlie`; 2024 leap/1900 not/2000 leap, next/prev 2028/2020; 2.4 GHz→2.4e9 Hz/2400 MHz; `hello`→`olleh`, **`a😀b`→`b😀a` (emoji intact)**.

## Self-review fix (pre-PR)

- Frequency `>64-char` test had an off-by-one (60+4=64, not >64) → bumped to 70; and its over-length error box used a KeyValue template with no options (blank web render) → dropped the template so the message shows.

## Verification

- ✅ `bun run test run` — **491 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of #260–#291 — branched from `main`.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6