### PR TITLE
feat(boxSources): add 8 more tools (fraction, unaccent, leetspeak, pct-change, volume, jsonl, properties, bifid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,78 @@ full design and roadmap, and
 
 </details>
 
+<details>
+<summary> <b>FractionBox</b> </summary>
+
+| match rule     | description                          | example            |
+| -------------- | ------------------------------------ | ------------------ |
+| `::fraction`   | decimal ⇄ simplified fraction        | `0.75 ::fraction`  |
+
+</details>
+
+<details>
+<summary> <b>UnaccentBox</b> </summary>
+
+| match rule     | description                          | example                  |
+| -------------- | ------------------------------------ | ------------------------ |
+| `::unaccent`   | strip diacritics (café → cafe)       | `Crème brûlée ::unaccent` |
+
+</details>
+
+<details>
+<summary> <b>LeetSpeakBox</b> </summary>
+
+| match rule  | description                          | example         |
+| ----------- | ------------------------------------ | --------------- |
+| `::leet`    | text ⇄ leetspeak (`::leetdecode`)    | `leet ::leet`   |
+
+</details>
+
+<details>
+<summary> <b>PercentChangeBox</b> </summary>
+
+| match rule      | description                          | example                |
+| --------------- | ------------------------------------ | ---------------------- |
+| `::pctchange`   | percentage change between two numbers | `120 to 150 ::pctchange` |
+
+</details>
+
+<details>
+<summary> <b>VolumeConvertBox</b> </summary>
+
+| match rule       | description                          | example                |
+| ---------------- | ------------------------------------ | ---------------------- |
+| `::cubicvolume`  | m³/L/mL/ft³/gallon conversion        | `1 m3 ::cubicvolume`   |
+
+</details>
+
+<details>
+<summary> <b>JsonlBox</b> </summary>
+
+| match rule  | description                          | example                      |
+| ----------- | ------------------------------------ | ---------------------------- |
+| `::jsonl`   | JSON array ⇄ JSONL (one per line)    | `[{"a":1},{"a":2}] ::jsonl`  |
+
+</details>
+
+<details>
+<summary> <b>PropertiesBox</b> </summary>
+
+| match rule       | description                          | example                       |
+| ---------------- | ------------------------------------ | ----------------------------- |
+| `::properties`   | Java .properties ⇄ JSON              | `a=1`<br>`b=2` `::properties`  |
+
+</details>
+
+<details>
+<summary> <b>BifidBox</b> </summary>
+
+| match rule  | description                          | example               |
+| ----------- | ------------------------------------ | --------------------- |
+| `::bifid`   | Bifid cipher (5×5 Polybius, I/J)     | `FLEEATONCE ::bifid`  |
+
+</details>
+
 ## Development ⛑️
 
 It is recommended to use Node.js version 22.x

--- a/src/modules/boxSources/BifidBoxSource.ts
+++ b/src/modules/boxSources/BifidBoxSource.ts
@@ -1,0 +1,122 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// 5x5 polybius square, row-major, I/J merged (no J)
+const SQUARE = 'ABCDEFGHIKLMNOPQRSTUVWXYZ';
+
+// precompute char→index lookup for O(1) access
+const CHAR_TO_IDX = new Map<string, number>(
+  Array.from(SQUARE).map((ch, i) => [ch, i]),
+);
+
+/** normalizes plaintext: uppercase, J→I, keep only A-Z letters */
+function preprocess(input: string): string {
+  return input
+    .toUpperCase()
+    .replace(/J/g, 'I')
+    .replace(/[^A-Z]/g, '');
+}
+
+/** enciphers a preprocessed (letters-only, no J) string using period-less Bifid */
+function bifidEncode(plain: string): string {
+  const n = plain.length;
+  const rows: number[] = [];
+  const cols: number[] = [];
+
+  for (let i = 0; i < n; i++) {
+    const idx = CHAR_TO_IDX.get(plain[i]) ?? 0;
+    rows.push(Math.floor(idx / 5));
+    cols.push(idx % 5);
+  }
+
+  // concatenate rows then cols, then read back in pairs
+  const combined = [...rows, ...cols];
+  let result = '';
+  for (let i = 0; i < n; i++) {
+    result += SQUARE[combined[2 * i] * 5 + combined[2 * i + 1]];
+  }
+  return result;
+}
+
+/** deciphers a Bifid ciphertext (period-less, same square) */
+function bifidDecode(cipher: string): string {
+  const n = cipher.length;
+  // flatten cipher coords into a 2N sequence: r0,c0,r1,c1,...
+  const flat: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const idx = CHAR_TO_IDX.get(cipher[i]) ?? 0;
+    flat.push(Math.floor(idx / 5));
+    flat.push(idx % 5);
+  }
+
+  // first half = original rows, second half = original cols
+  const rows = flat.slice(0, n);
+  const cols = flat.slice(n);
+
+  let result = '';
+  for (let i = 0; i < n; i++) {
+    result += SQUARE[rows[i] * 5 + cols[i]];
+  }
+  return result;
+}
+
+export const BifidBoxSource = {
+  name: 'Bifid Cipher',
+  description:
+    'Bifid cipher (5x5 Polybius, I/J merged). ::bifid to encrypt, ::bifiddecode to decrypt.',
+  defaultInput: 'FLEEATONCE ::bifid',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'bifid', 'bifidencode');
+    const wantDecode = hasOptionKeys(options, 'bifiddecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const normalized = preprocess(input);
+    if (normalized.length === 0) return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const ciphertext = bifidEncode(normalized);
+      boxes.push(
+        new BoxBuilder('Bifid Cipher (Encrypt)', ciphertext)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(Priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const plaintext = bifidDecode(normalized);
+      boxes.push(
+        new BoxBuilder('Bifid Cipher (Decrypt)', plaintext)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(Priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default BifidBoxSource;

--- a/src/modules/boxSources/FractionBoxSource.ts
+++ b/src/modules/boxSources/FractionBoxSource.ts
@@ -1,0 +1,175 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// euclid gcd for non-negative bigints
+function gcd(a: bigint, b: bigint): bigint {
+  while (b !== 0n) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+interface FractionResult {
+  numerator: bigint;
+  denominator: bigint;
+}
+
+// reduces a fraction to lowest terms; denominator is always positive
+function reduce(num: bigint, den: bigint): FractionResult {
+  if (den < 0n) {
+    num = -num;
+    den = -den;
+  }
+  const g = gcd(num < 0n ? -num : num, den);
+  return { numerator: num / g, denominator: den / g };
+}
+
+// formats a fraction string, e.g. '3/4' or '-1/2'
+function fractionStr(num: bigint, den: bigint): string {
+  if (den === 1n) return `${num}`;
+  return `${num}/${den}`;
+}
+
+// formats mixed number, e.g. '1 1/4' for 5/4; returns undefined if |num| < den
+function mixedStr(num: bigint, den: bigint): string | null {
+  const absNum = num < 0n ? -num : num;
+  if (absNum <= den) return null;
+  const whole = num / den;
+  const rem = num < 0n ? -(-num % den) : num % den;
+  if (rem === 0n) return `${whole}`;
+  return `${whole} ${rem < 0n ? -rem : rem}/${den}`;
+}
+
+// builds the plaintext kv string for KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// max input length to prevent abuse
+const MAX_INPUT_LENGTH = 64;
+
+const FRACTION_RE = /^(-?\d+)\s*\/\s*(\d+)$/;
+const DECIMAL_RE = /^-?\d+(\.\d+)?$/;
+
+export const FractionBoxSource = {
+  name: 'Fraction',
+  description:
+    'Convert a decimal to a simplified fraction, or a fraction (a/b) to a decimal.',
+  defaultInput: '0.75 ::fraction',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'fraction', 'tofraction')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT_LENGTH) return [];
+
+    // fraction a/b → decimal
+    const fracMatch = FRACTION_RE.exec(raw);
+    if (fracMatch) {
+      const num = BigInt(fracMatch[1]);
+      const den = BigInt(fracMatch[2]);
+
+      if (den === 0n) {
+        const kv = { Error: 'denominator cannot be zero' };
+        return [
+          new BoxBuilder('Fraction', kvToPlaintext(kv))
+            .setTemplate(KeyValueBoxTemplate)
+            .setOptions(kv)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      const { numerator: sNum, denominator: sDen } = reduce(num, den);
+      const simplified = fractionStr(sNum, sDen);
+
+      // compute decimal — use Number since we need a floating-point result
+      const decimalVal = Number(num) / Number(den);
+      // show up to 6 significant decimal places, trim trailing zeros
+      const decimalStr = Number.isInteger(decimalVal)
+        ? String(decimalVal)
+        : decimalVal.toFixed(6).replace(/\.?0+$/, '');
+
+      const kv: Record<string, string> = {
+        Fraction: simplified,
+        Decimal: decimalStr,
+      };
+      return [
+        new BoxBuilder('Fraction', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // decimal → fraction
+    const decMatch = DECIMAL_RE.exec(raw);
+    if (decMatch) {
+      const dotIndex = raw.indexOf('.');
+      const decimalPlaces = dotIndex === -1 ? 0 : raw.length - dotIndex - 1;
+
+      const denominator = 10n ** BigInt(decimalPlaces);
+      // parse the number as an integer by removing the dot
+      const intStr = raw.replace('.', '');
+      const numerator = BigInt(intStr);
+
+      const { numerator: sNum, denominator: sDen } = reduce(
+        numerator,
+        denominator,
+      );
+      const fracResult = fractionStr(sNum, sDen);
+      const mixed = mixedStr(sNum, sDen);
+
+      // recompute the decimal for display
+      const decimalVal = Number.parseFloat(raw);
+      const decimalStr = Number.isInteger(decimalVal)
+        ? String(decimalVal)
+        : raw;
+
+      const kv: Record<string, string> = {
+        Decimal: decimalStr,
+        Fraction: fracResult,
+      };
+      if (mixed !== null) {
+        kv.Mixed = mixed;
+      }
+
+      return [
+        new BoxBuilder('Fraction', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // unrecognized format — show usage hint
+    const kv = {
+      Usage: 'Enter a decimal like 0.75 or a fraction like 3/4',
+    };
+    return [
+      new BoxBuilder('Fraction', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FractionBoxSource;

--- a/src/modules/boxSources/JsonlBoxSource.ts
+++ b/src/modules/boxSources/JsonlBoxSource.ts
@@ -44,6 +44,7 @@ export const JsonlBoxSource = {
     if (input.length > MAX_INPUT) return [];
 
     const trimmed = trim(input);
+    if (!trimmed) return [];
 
     // array → jsonl direction
     if (trimmed.startsWith('[')) {

--- a/src/modules/boxSources/JsonlBoxSource.ts
+++ b/src/modules/boxSources/JsonlBoxSource.ts
@@ -1,0 +1,109 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// converts a JSON array to JSONL (one compact JSON element per line)
+function arrayToJsonl(arr: unknown[]): string {
+  return arr.map((item) => JSON.stringify(item)).join('\n');
+}
+
+// converts JSONL lines to a pretty-printed JSON array; throws on invalid lines
+function jsonlToArray(input: string): unknown[] {
+  const lines = input
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  return lines.map((line, idx) => {
+    try {
+      return JSON.parse(line);
+    } catch {
+      throw new Error(`line ${idx + 1}: ${JSON.stringify(line)}`);
+    }
+  });
+}
+
+export const JsonlBoxSource = {
+  name: 'JSONL',
+  description:
+    'Convert a JSON array to JSONL (one object per line) or JSONL back to a JSON array. ::jsonl',
+  defaultInput: '[{"a":1},{"a":2}] ::jsonl',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonl', 'ndjson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    // array → jsonl direction
+    if (trimmed.startsWith('[')) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        return [
+          new BoxBuilder('JSONL', `Parse error: invalid JSON array`)
+            .setTemplate(CodeBoxTemplate)
+            .setOptions({ language: 'json' })
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      if (!Array.isArray(parsed)) {
+        return [
+          new BoxBuilder('JSONL', 'Parse error: input is not a JSON array')
+            .setTemplate(CodeBoxTemplate)
+            .setOptions({ language: 'json' })
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      const output = arrayToJsonl(parsed);
+      return [
+        new BoxBuilder('JSONL', output)
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'json' })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // jsonl → array direction
+    let arr: unknown[];
+    try {
+      arr = jsonlToArray(trimmed);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return [
+        new BoxBuilder('JSONL', `Parse error: ${msg}`)
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'json' })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const output = JSON.stringify(arr, null, 2);
+    return [
+      new BoxBuilder('JSONL', output)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'json' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonlBoxSource;

--- a/src/modules/boxSources/LeetSpeakBoxSource.ts
+++ b/src/modules/boxSources/LeetSpeakBoxSource.ts
@@ -1,0 +1,94 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// basic leet substitutions — encode direction (letter → digit/symbol)
+const TO_LEET: Record<string, string> = {
+  a: '4',
+  b: '8',
+  e: '3',
+  g: '6',
+  i: '1',
+  l: '1',
+  o: '0',
+  s: '5',
+  t: '7',
+  z: '2',
+};
+
+// reverse map — digit → letter. '1' is ambiguous (both 'l' and 'i' encode to '1');
+// we pick 'i' as the canonical decode target and document the loss.
+const FROM_LEET: Record<string, string> = Object.fromEntries(
+  Object.entries(TO_LEET)
+    // iterate in insertion order; 'i' appears after 'l' so it wins the '1' slot
+    .map(([letter, digit]) => [digit, letter]),
+);
+
+function encode(input: string): string {
+  return input
+    .toLowerCase()
+    .split('')
+    .map((ch) => TO_LEET[ch] ?? ch)
+    .join('');
+}
+
+function decode(input: string): string {
+  return input
+    .split('')
+    .map((ch) => FROM_LEET[ch] ?? ch)
+    .join('');
+}
+
+export const LeetSpeakBoxSource = {
+  name: 'Leetspeak',
+  description:
+    'Convert text to leetspeak (h4ck3r) or decode it back. ::leet to encode, ::leetdecode to decode.',
+  defaultInput: 'leet ::leet',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'leet', 'leetspeak', '1337');
+    const wantDecode = hasOptionKeys(options, 'leetdecode', 'unleet');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      boxes.push(
+        new BoxBuilder('Leetspeak (Encode)', encode(input))
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      // decode is approximate — '1' maps to 'i' (not 'l'); other ambiguities may apply
+      boxes.push(
+        new BoxBuilder('Leetspeak (Decode)', decode(input))
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default LeetSpeakBoxSource;

--- a/src/modules/boxSources/LeetSpeakBoxSource.ts
+++ b/src/modules/boxSources/LeetSpeakBoxSource.ts
@@ -20,12 +20,10 @@ const TO_LEET: Record<string, string> = {
   z: '2',
 };
 
-// reverse map — digit → letter. '1' is ambiguous (both 'l' and 'i' encode to '1');
-// we pick 'i' as the canonical decode target and document the loss.
+// reverse map — digit → letter. '1' is ambiguous (both 'i' and 'l' encode to '1');
+// 'l' wins because it is defined after 'i' in TO_LEET and overwrites it here.
 const FROM_LEET: Record<string, string> = Object.fromEntries(
-  Object.entries(TO_LEET)
-    // iterate in insertion order; 'i' appears after 'l' so it wins the '1' slot
-    .map(([letter, digit]) => [digit, letter]),
+  Object.entries(TO_LEET).map(([letter, digit]) => [digit, letter]),
 );
 
 function encode(input: string): string {
@@ -78,7 +76,7 @@ export const LeetSpeakBoxSource = {
     }
 
     if (wantDecode) {
-      // decode is approximate — '1' maps to 'i' (not 'l'); other ambiguities may apply
+      // decode is approximate — '1' maps to 'l' (not 'i'); other ambiguities may apply
       boxes.push(
         new BoxBuilder('Leetspeak (Decode)', decode(input))
           .setTemplate(CodeBoxTemplate)

--- a/src/modules/boxSources/MetricVolumeBoxSource.ts
+++ b/src/modules/boxSources/MetricVolumeBoxSource.ts
@@ -1,0 +1,129 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit aliases (normalized) → liters
+const TO_L: Record<string, number> = {
+  l: 1,
+  ml: 0.001,
+  cl: 0.01,
+  dl: 0.1,
+  kl: 1000,
+  m3: 1000,
+  cm3: 0.001,
+  mm3: 1e-6,
+  dm3: 1,
+  ft3: 28.316846592,
+  in3: 0.016387064,
+  yd3: 764.554857984,
+  usgal: 3.785411784,
+  gal: 3.785411784,
+  impgal: 4.54609,
+  usqt: 0.946352946,
+  uspt: 0.473176473,
+};
+
+const SUPPORTED_UNITS = Object.keys(TO_L).join(', ');
+
+// max input length to prevent abuse
+const MAX_INPUT_LENGTH = 64;
+
+// formats the value as an integer string when exact, or 6-decimal trimmed float
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// builds the plaintext kv string for KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// normalizes a unit string: lowercase, ³→3, ^3→3, collapse whitespace
+function normalizeUnit(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/³/g, '3')
+    .replace(/\^3/g, '3')
+    .replace(/\s+/g, '');
+}
+
+export const MetricVolumeBoxSource = {
+  name: 'Volume Convert',
+  description: 'Convert a volume between m³, L, mL, ft³, gallons, and more.',
+  defaultInput: '1 m3 ::cubicvolume',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cubicvolume', 'volumeconvert')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT_LENGTH) return [];
+
+    // expect "<number> <unit>", split on first whitespace boundary
+    const spaceIdx = raw.search(/\s+/);
+    if (spaceIdx === -1) {
+      return [buildErrorBox()];
+    }
+
+    const numStr = raw.slice(0, spaceIdx);
+    const unitRaw = raw.slice(spaceIdx).trim();
+
+    const value = Number.parseFloat(numStr);
+    if (Number.isNaN(value)) {
+      return [buildErrorBox()];
+    }
+
+    const unit = normalizeUnit(unitRaw);
+    const factor = TO_L[unit];
+    if (factor === undefined) {
+      return [buildErrorBox()];
+    }
+
+    const liters = value * factor;
+
+    const kv: Record<string, string> = {
+      Input: `${formatValue(value)} ${unitRaw}`,
+      L: formatValue(liters),
+      mL: formatValue(liters * 1000),
+      'm³': formatValue(liters / 1000),
+      'cm³': formatValue(liters * 1000),
+      'ft³': formatValue(liters / 28.316846592),
+      'in³': formatValue(liters / 0.016387064),
+      'US gal': formatValue(liters / 3.785411784),
+      'imp gal': formatValue(liters / 4.54609),
+    };
+
+    return [
+      new BoxBuilder('Volume Convert', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+function buildErrorBox(): Box {
+  const kv = {
+    Error: 'Invalid input. Expected: <number> <unit>',
+    Supported: SUPPORTED_UNITS,
+  };
+  return new BoxBuilder('Volume Convert', kvToPlaintext(kv))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(kv)
+    .setPriority(Priority)
+    .build();
+}
+
+export default MetricVolumeBoxSource;

--- a/src/modules/boxSources/PercentChangeBoxSource.ts
+++ b/src/modules/boxSources/PercentChangeBoxSource.ts
@@ -1,0 +1,116 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to prevent abuse
+const MAX_INPUT_LENGTH = 100;
+
+// builds the plaintext kv string for KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// formats a number to at most 4 decimal places, stripping trailing zeros
+function formatNumber(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(4).replace(/\.?0+$/, '');
+}
+
+interface ParsedPair {
+  a: number;
+  b: number;
+}
+
+// parses two numbers from input separated by ' to ', comma, or whitespace
+function parsePair(raw: string): ParsedPair | null {
+  // split on ' to ', comma, or one-or-more whitespace characters
+  const parts = raw
+    .split(/\s+to\s+|,\s*|\s+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  if (parts.length !== 2) return null;
+
+  const a = Number.parseFloat(parts[0]);
+  const b = Number.parseFloat(parts[1]);
+
+  if (Number.isNaN(a) || Number.isNaN(b)) return null;
+
+  return { a, b };
+}
+
+export const PercentChangeBoxSource = {
+  name: 'Percent Change',
+  description:
+    'Percentage change between two numbers. Input: "<from> to <to>" or "<from> <to>".',
+  defaultInput: '120 to 150 ::pctchange',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'pctchange', 'percentchange')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT_LENGTH) return [];
+
+    const pair = parsePair(raw);
+
+    if (pair === null) {
+      const kv = {
+        Usage: 'Enter two numbers: "120 to 150", "120,150", or "120 150"',
+      };
+      return [
+        new BoxBuilder('Percent Change', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { a, b } = pair;
+
+    const change = b - a;
+
+    const percentChange = a === 0 ? null : ((b - a) / a) * 100;
+
+    const direction =
+      change > 0 ? 'increase' : change < 0 ? 'decrease' : 'no change';
+
+    const kv: Record<string, string> = {
+      From: formatNumber(a),
+      To: formatNumber(b),
+      Change: formatNumber(change),
+      'Percent Change':
+        percentChange === null
+          ? 'undefined (from is 0)'
+          : formatNumber(percentChange),
+      Direction: direction,
+      ...(a !== 0
+        ? {
+            Ratio: formatNumber(b / a),
+            Of: `${formatNumber((b / a) * 100)}%`,
+          }
+        : {}),
+    };
+
+    return [
+      new BoxBuilder('Percent Change', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PercentChangeBoxSource;

--- a/src/modules/boxSources/PropertiesBoxSource.ts
+++ b/src/modules/boxSources/PropertiesBoxSource.ts
@@ -1,0 +1,160 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// keys that would allow prototype pollution if set on a plain object
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+// unescape minimal backslash sequences from .properties values
+function unescapeValue(raw: string): string {
+  return raw
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t')
+    .replace(/\\\\/g, '\\')
+    .replace(/\\=/g, '=');
+}
+
+// parse a .properties file into a null-prototype flat object
+function parseProperties(text: string): Record<string, string> {
+  const result = Object.create(null) as Record<string, string>;
+
+  for (const line of text.split('\n')) {
+    const stripped = line.trimStart();
+
+    // skip blank lines and comments
+    if (!stripped || stripped[0] === '#' || stripped[0] === '!') continue;
+
+    // split on first =, :, or whitespace acting as separator
+    const eqIdx = stripped.search(/[=:\s]/);
+    if (eqIdx === -1) {
+      // key with no value
+      const key = stripped.trim();
+      if (!FORBIDDEN_KEYS.has(key)) {
+        result[key] = '';
+      }
+      continue;
+    }
+
+    const key = stripped.slice(0, eqIdx).trim();
+    if (FORBIDDEN_KEYS.has(key)) continue;
+
+    // consume the separator character itself
+    const afterSep = stripped.slice(eqIdx);
+    // strip the separator and any surrounding whitespace
+    const value = afterSep.replace(/^[=:\s]\s*/, '');
+    result[key] = unescapeValue(value.trimEnd());
+  }
+
+  return result;
+}
+
+// serialize a flat record to .properties format
+function stringifyProperties(obj: Record<string, unknown>): string {
+  return Object.keys(obj)
+    .filter((key) => !FORBIDDEN_KEYS.has(key) && Object.hasOwn(obj, key))
+    .map((key) => {
+      const raw = obj[key];
+      const value = typeof raw === 'string' ? raw : JSON.stringify(raw);
+      return `${key}=${value}`;
+    })
+    .join('\n');
+}
+
+export const PropertiesBoxSource = {
+  name: 'Properties / JSON',
+  description:
+    'Convert a Java .properties file to JSON, or a flat JSON object to .properties.',
+  defaultInput: 'server.host=localhost\nserver.port=8080 ::properties',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'properties', 'propertiesjson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    if (!trimmed) return [];
+
+    const boxes: Box[] = [];
+
+    // direction: JSON → properties when input looks like a JSON object
+    if (trimmed.startsWith('{')) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        boxes.push(
+          new BoxBuilder(
+            'JSON → Properties',
+            `Parse error: input starts with '{' but is not valid JSON`,
+          )
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        );
+        return boxes;
+      }
+
+      if (
+        parsed === null ||
+        typeof parsed !== 'object' ||
+        Array.isArray(parsed)
+      ) {
+        boxes.push(
+          new BoxBuilder(
+            'JSON → Properties',
+            'Error: expected a JSON object (not an array or primitive)',
+          )
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        );
+        return boxes;
+      }
+
+      const output = stringifyProperties(parsed as Record<string, unknown>);
+      boxes.push(
+        new BoxBuilder('JSON → Properties', output)
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+      return boxes;
+    }
+
+    // default direction: properties → JSON
+    try {
+      const obj = parseProperties(trimmed);
+      const output = JSON.stringify(obj, null, 2);
+      boxes.push(
+        new BoxBuilder('Properties → JSON', output)
+          .setOptions({ language: 'json' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    } catch (e) {
+      boxes.push(
+        new BoxBuilder(
+          'Properties → JSON',
+          `Parse error: ${e instanceof Error ? e.message : String(e)}`,
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default PropertiesBoxSource;

--- a/src/modules/boxSources/UnaccentBoxSource.ts
+++ b/src/modules/boxSources/UnaccentBoxSource.ts
@@ -1,0 +1,76 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// characters that NFD decomposition does not handle — mapped to their ASCII equivalents
+const SPECIAL_CHAR_MAP: Record<string, string> = {
+  ø: 'o',
+  Ø: 'O',
+  ß: 'ss',
+  æ: 'ae',
+  Æ: 'AE',
+  œ: 'oe',
+  Œ: 'OE',
+  đ: 'd',
+  Đ: 'D',
+  ł: 'l',
+  Ł: 'L',
+  ð: 'd',
+  þ: 'th',
+};
+
+const SPECIAL_CHAR_REGEX = new RegExp(
+  `[${Object.keys(SPECIAL_CHAR_MAP).join('')}]`,
+  'g',
+);
+
+// strips combining diacritical marks (U+0300–U+036F) after NFD normalization,
+// then substitutes characters NFD cannot decompose
+function removeAccents(input: string): string {
+  const nfdStripped = input.normalize('NFD').replace(/[̀-ͯ]/g, '');
+  return nfdStripped.replace(
+    SPECIAL_CHAR_REGEX,
+    (ch) => SPECIAL_CHAR_MAP[ch] ?? ch,
+  );
+}
+
+export const UnaccentBoxSource = {
+  name: 'Remove Accents',
+  description:
+    'Strip diacritics/accents from text (café → cafe). ::unaccent or ::deburr.',
+  defaultInput: 'Crème brûlée ::unaccent',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'unaccent', 'deburr', 'removeaccents')) {
+      return [];
+    }
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    ) {
+      return [];
+    }
+
+    const result = removeAccents(input);
+    return [
+      new BoxBuilder('Remove Accents', result)
+        .setTemplate(CodeBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UnaccentBoxSource;

--- a/src/modules/boxSources/__test__/BifidBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BifidBoxSource.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+
+import { BifidBoxSource } from '../BifidBoxSource';
+
+// all test vectors use the standard square ABCDEFGHIKLMNOPQRSTUVWXYZ (no J)
+// note: the Wikipedia "FLEEATONCE → UAEOLWRINS" example uses the keyword square
+// BGWKZQPNDSIOAXEFCLUMTHYVR — it does NOT apply to the standard alphabet square.
+// with the standard square the correct encode of FLEEATONCE is HADNAAZDSP.
+//
+// trace for FLEEATONCE with standard square:
+//   F(1,0) L(2,0) E(0,4) E(0,4) A(0,0) T(3,3) O(2,3) N(2,2) C(0,2) E(0,4)
+//   R=[1,2,0,0,0,3,2,2,0,0]  C=[0,0,4,4,0,3,3,2,2,4]
+//   combined=[1,2,0,0,0,3,2,2,0,0, 0,0,4,4,0,3,3,2,2,4]
+//   pairs→ (1,2)H (0,0)A (0,3)D (2,2)N (0,0)A (0,0)A (4,4)Z (0,3)D (3,2)S (2,4)P
+//   → HADNAAZDSP
+
+describe('BifidBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('FLEEATONCE', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is empty object', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('FLEEATONCE', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::bifid', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('', { bifid: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('   ', { bifid: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for non-letter input (all digits/punctuation stripped to empty)', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('123!@#', {
+        bifid: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ::bifid', () => {
+    it('encodes FLEEATONCE to HADNAAZDSP with standard square', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('FLEEATONCE', {
+        bifid: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Bifid Cipher (Encrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('HADNAAZDSP');
+    });
+
+    it('::bifidencode is an alias for ::bifid', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('FLEEATONCE', {
+        bifidencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('HADNAAZDSP');
+    });
+  });
+
+  describe('decode — ::bifiddecode', () => {
+    it('decodes HADNAAZDSP back to FLEEATONCE', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('HADNAAZDSP', {
+        bifiddecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Bifid Cipher (Decrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('FLEEATONCE');
+    });
+  });
+
+  describe('J→I substitution (lossy)', () => {
+    it('treats J as I before enciphering', async () => {
+      // J is preprocessed to I, so JUMP → IUMP then enciphered
+      const encBoxes = await BifidBoxSource.generateBoxes('JUMP', {
+        bifid: true,
+      });
+      const iumpBoxes = await BifidBoxSource.generateBoxes('IUMP', {
+        bifid: true,
+      });
+      expect(encBoxes[0].props.plaintextOutput).toBe(
+        iumpBoxes[0].props.plaintextOutput,
+      );
+    });
+
+    it('decode round-trip of JUMP recovers IUMP, not JUMP (J→I is lossy)', async () => {
+      const enc = await BifidBoxSource.generateBoxes('JUMP', { bifid: true });
+      const ciphertext = enc[0].props.plaintextOutput;
+      const dec = await BifidBoxSource.generateBoxes(ciphertext, {
+        bifiddecode: true,
+      });
+      // J became I permanently during preprocessing
+      expect(dec[0].props.plaintextOutput).toBe('IUMP');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encode then decode recovers DEFENDTHEEAST from DEFENDTHEEAST', async () => {
+      // input "DEFENDtheEAST" → letters only → DEFENDTHEEAST
+      const enc = await BifidBoxSource.generateBoxes('DEFENDtheEAST', {
+        bifid: true,
+      });
+      const ciphertext = enc[0].props.plaintextOutput;
+      expect(ciphertext).toHaveLength(13); // DEFENDTHEEAST is 13 letters
+
+      const dec = await BifidBoxSource.generateBoxes(ciphertext, {
+        bifiddecode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe('DEFENDTHEEAST');
+    });
+
+    it('spaces and punctuation are stripped before enciphering', async () => {
+      // "DEFEND THE EAST" strips to same 12 letters as "DEFENDTHEEAST"
+      const withSpaces = await BifidBoxSource.generateBoxes('DEFEND THE EAST', {
+        bifid: true,
+      });
+      const withoutSpaces = await BifidBoxSource.generateBoxes(
+        'DEFENDTHEEAST',
+        {
+          bifid: true,
+        },
+      );
+      expect(withSpaces[0].props.plaintextOutput).toBe(
+        withoutSpaces[0].props.plaintextOutput,
+      );
+    });
+  });
+
+  describe('both options → two boxes', () => {
+    it('returns encode box and decode box when both ::bifid and ::bifiddecode are set', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('FLEEATONCE', {
+        bifid: true,
+        bifiddecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Bifid Cipher (Encrypt)');
+      expect(names).toContain('Bifid Cipher (Decrypt)');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('showExpandButton is false', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('HELLO', {
+        bifid: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await BifidBoxSource.generateBoxes('HELLO', {
+        bifid: true,
+      });
+      expect(boxes[0].props.priority).toBe(BifidBoxSource.priority);
+    });
+  });
+
+  describe('static metadata', () => {
+    it('has expected name, tag, kind, priority', () => {
+      expect(BifidBoxSource.name).toBe('Bifid Cipher');
+      expect(BifidBoxSource.tag).toBe('#');
+      expect(BifidBoxSource.kind).toBe('Encode');
+      expect(typeof BifidBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/FractionBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FractionBoxSource.test.ts
@@ -1,0 +1,164 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { FractionBoxSource } from '../FractionBoxSource';
+
+describe('FractionBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no option is provided', async () => {
+      const boxes = await FractionBoxSource.generateBoxes('0.75', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await FractionBoxSource.generateBoxes('0.75', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('decimal → fraction', () => {
+      it('converts 0.75 to 3/4', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.75', {
+          fraction: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.name).toBe('Fraction');
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+        expect(boxes[0].props.options?.Fraction).toBe('3/4');
+        expect(boxes[0].props.options?.Decimal).toBe('0.75');
+      });
+
+      it('converts 0.5 to 1/2', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.5', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('1/2');
+      });
+
+      it('converts 0.333 exactly to 333/1000 (not 1/3)', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.333', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('333/1000');
+      });
+
+      it('converts 0.1 to 1/10', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.1', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('1/10');
+      });
+
+      it('converts 1.25 to 5/4 with mixed 1 1/4', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('1.25', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('5/4');
+        expect(boxes[0].props.options?.Mixed).toBe('1 1/4');
+      });
+
+      it('converts integer 2 to 2 (denominator 1 collapses)', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('2', {
+          fraction: true,
+        });
+        // 2/1 simplifies — denominator 1 means we just show the number
+        expect(boxes[0].props.options?.Fraction).toBe('2');
+      });
+
+      it('converts 0 to 0', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('0');
+      });
+
+      it('converts negative -0.5 to -1/2', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('-0.5', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('-1/2');
+      });
+
+      it('works with ::tofraction option key', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.75', {
+          tofraction: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Fraction).toBe('3/4');
+      });
+
+      it('does not include Mixed key when fraction is proper (< 1)', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.75', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Mixed).toBeUndefined();
+      });
+    });
+
+    describe('fraction a/b → decimal', () => {
+      it('converts 3/4 to decimal 0.75', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('3/4', {
+          fraction: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Fraction).toBe('3/4');
+        expect(boxes[0].props.options?.Decimal).toBe('0.75');
+      });
+
+      it('simplifies 6/8 to 3/4 and decimal 0.75', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('6/8', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('3/4');
+        expect(boxes[0].props.options?.Decimal).toBe('0.75');
+      });
+
+      it('converts 1/3 to a rounded decimal', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('1/3', {
+          fraction: true,
+        });
+        const decimal = boxes[0].props.options?.Decimal;
+        expect(decimal).toBeDefined();
+        // should start with 0.333
+        expect(String(decimal)).toMatch(/^0\.333/);
+      });
+
+      it('returns error box for division by zero (5/0)', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('5/0', {
+          fraction: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Error).toBeDefined();
+      });
+    });
+
+    describe('invalid / unknown input', () => {
+      it('returns a usage hint box for unrecognized input', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('hello', {
+          fraction: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Usage).toBeDefined();
+      });
+    });
+
+    describe('box metadata', () => {
+      it('sets priority correctly', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.75', {
+          fraction: true,
+        });
+        expect(boxes[0].props.priority).toBe(10);
+      });
+
+      it('sets plaintextOutput as k:v lines', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.75', {
+          fraction: true,
+        });
+        const text = boxes[0].props.plaintextOutput;
+        expect(text).toContain('Decimal: 0.75');
+        expect(text).toContain('Fraction: 3/4');
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/JsonlBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonlBoxSource.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonlBoxSource } from '../JsonlBoxSource';
+
+describe('JsonlBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no option is provided', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1}]', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when unrelated option is provided', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1}]', {
+        yaml: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert JSON array to JSONL (compact, one per line)', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1},{"a":2}]', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('{"a":1}\n{"a":2}');
+    });
+
+    it('should convert JSON array to JSONL via ::ndjson option', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1},{"a":2}]', {
+        ndjson: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('{"a":1}\n{"a":2}');
+    });
+
+    it('should convert JSONL to pretty-printed JSON array', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('{"a":1}\n{"a":2}', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual([{ a: 1 }, { a: 2 }]);
+    });
+
+    it('should skip blank lines when converting JSONL to array', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('{"a":1}\n\n{"a":2}\n', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toHaveLength(2);
+      expect(parsed).toEqual([{ a: 1 }, { a: 2 }]);
+    });
+
+    it('should handle scalar values in array → JSONL', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[1,2,3]', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1\n2\n3');
+    });
+
+    it('should handle scalar JSONL → array', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('1\n2\n3', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual([1, 2, 3]);
+    });
+
+    it('should return error box for invalid JSON array input', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[bad', { jsonl: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/parse error/i);
+    });
+
+    it('should return error box mentioning the failing line number for invalid JSONL', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('{"a":1}\n{bad', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/line 2/i);
+    });
+
+    it('should preserve data through array → jsonl → array round-trip', async () => {
+      const original = [
+        { x: 1, y: 'hello' },
+        { x: 2, y: 'world' },
+      ];
+      const input = JSON.stringify(original);
+
+      // array → jsonl
+      const jsonlBoxes = await JsonlBoxSource.generateBoxes(input, {
+        jsonl: true,
+      });
+      expect(jsonlBoxes).toHaveLength(1);
+      const jsonlOutput = jsonlBoxes[0].props.plaintextOutput;
+
+      // jsonl → array
+      const arrayBoxes = await JsonlBoxSource.generateBoxes(jsonlOutput, {
+        jsonl: true,
+      });
+      expect(arrayBoxes).toHaveLength(1);
+      const roundTripped = JSON.parse(arrayBoxes[0].props.plaintextOutput);
+      expect(roundTripped).toEqual(original);
+    });
+
+    it('should use CodeBoxTemplate with language set to json', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1}]', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.language).toBe('json');
+    });
+
+    it('should set priority on the box', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1}]', {
+        jsonl: true,
+      });
+      expect(boxes[0].props.priority).toBe(JsonlBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/LeetSpeakBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LeetSpeakBoxSource.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import { LeetSpeakBoxSource } from '../LeetSpeakBoxSource';
+
+describe('LeetSpeakBoxSource', () => {
+  describe('no matching option', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty input', () => {
+    it('returns [] for empty string with ::leet', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('', { leet: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::leet', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('   ', {
+        leet: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ::leet', () => {
+    // l→1, e→3, e→3, t→7
+    it('encodes "leet" → "1337"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Leetspeak (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('1337');
+    });
+
+    // h passes through, a→4, c passes through, k passes through, e→3, r passes through
+    it('encodes "hacker" → "h4ck3r"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('hacker', {
+        leet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('h4ck3r');
+    });
+
+    // e→3, l→1, i→1, t→7, e→3
+    it('encodes "elite" → "31173" (both l and i map to 1)', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('elite', {
+        leet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('31173');
+    });
+
+    it('preserves non-letter characters: "a b!" → "4 8!"', async () => {
+      // a→4, space passes through, b→8, !  passes through
+      const boxes = await LeetSpeakBoxSource.generateBoxes('a b!', {
+        leet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('4 8!');
+    });
+
+    it('accepts ::leetspeak alias', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leetspeak: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('1337');
+    });
+
+    it('accepts ::1337 alias', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        '1337': true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('1337');
+    });
+
+    it('priority is set on the box', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+      });
+      expect(boxes[0].props.priority).toBe(LeetSpeakBoxSource.priority);
+    });
+  });
+
+  describe('decode — ::leetdecode', () => {
+    // 1→i (ambiguous; 'i' is the canonical choice), 3→e, 3→e, 7→t
+    it('decodes "1337" → "leet"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('1337', {
+        leetdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Leetspeak (Decode)');
+      // '1' maps to 'l' (l overwrites i in the reverse map) — documented approximation
+      expect(boxes[0].props.plaintextOutput).toBe('leet');
+    });
+
+    it('decodes "h4ck3r" → "hacker"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('h4ck3r', {
+        leetdecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hacker');
+    });
+
+    it('accepts ::unleet alias', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('h4ck3r', {
+        unleet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hacker');
+    });
+  });
+
+  describe('both encode and decode options', () => {
+    it('returns 2 boxes when both ::leet and ::leetdecode are set', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+        leetdecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Leetspeak (Encode)');
+      expect(names).toContain('Leetspeak (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LeetSpeakBoxSource.name).toBe('Leetspeak');
+      expect(LeetSpeakBoxSource.tag).toBe('#');
+      expect(LeetSpeakBoxSource.kind).toBe('Transform');
+      expect(typeof LeetSpeakBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/MetricVolumeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MetricVolumeBoxSource.test.ts
@@ -1,0 +1,145 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { MetricVolumeBoxSource } from '../MetricVolumeBoxSource';
+
+describe('MetricVolumeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are provided', async () => {
+      const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::volumeconvert option key', async () => {
+      const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+        volumeconvert: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    describe('1 m³ = 1000 L', () => {
+      it('converts 1 m3 to 1000 L', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+          cubicvolume: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.name).toBe('Volume Convert');
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+        expect(boxes[0].props.options?.L).toBe('1000');
+      });
+
+      it('converts 1 m3 to 1000000 mL', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+          cubicvolume: true,
+        });
+        expect(boxes[0].props.options?.mL).toBe('1000000');
+      });
+
+      it('converts 1 m3 to 1000000 cm³', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+          cubicvolume: true,
+        });
+        expect(boxes[0].props.options?.['cm³']).toBe('1000000');
+      });
+    });
+
+    describe('1 L conversions', () => {
+      it('converts 1 L to 1000 mL', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 l', {
+          cubicvolume: true,
+        });
+        expect(boxes[0].props.options?.mL).toBe('1000');
+      });
+
+      it('converts 1 L to 0.001 m³', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 l', {
+          cubicvolume: true,
+        });
+        expect(boxes[0].props.options?.['m³']).toBe('0.001');
+      });
+    });
+
+    describe('1 ft³ ≈ 28.316847 L', () => {
+      it('converts 1 ft3 and L starts with 28.31684', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 ft3', {
+          cubicvolume: true,
+        });
+        const l = boxes[0].props.options?.L;
+        expect(String(l)).toMatch(/^28\.31684/);
+      });
+    });
+
+    describe('1 usgal ≈ 3.785412 L', () => {
+      it('converts 1 usgal and L starts with 3.78541', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 usgal', {
+          cubicvolume: true,
+        });
+        const l = boxes[0].props.options?.L;
+        expect(String(l)).toMatch(/^3\.78541/);
+      });
+    });
+
+    describe('superscript ³ support', () => {
+      it('converts "1 m³" (unicode superscript) to 1000 L', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m³', {
+          cubicvolume: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.L).toBe('1000');
+      });
+    });
+
+    describe('1 impgal ≈ 4.54609 L', () => {
+      it('converts 1 impgal and L equals 4.54609', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 impgal', {
+          cubicvolume: true,
+        });
+        const l = boxes[0].props.options?.L;
+        expect(String(l)).toMatch(/^4\.54609/);
+      });
+    });
+
+    describe('invalid input', () => {
+      it('returns an error box for bare "abc"', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('abc', {
+          cubicvolume: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Error).toBeDefined();
+      });
+
+      it('returns an error box for "5 foo" (unknown unit)', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('5 foo', {
+          cubicvolume: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Error).toBeDefined();
+      });
+    });
+
+    describe('box metadata', () => {
+      it('sets priority to 10', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+          cubicvolume: true,
+        });
+        expect(boxes[0].props.priority).toBe(10);
+      });
+
+      it('sets plaintextOutput as k:v lines', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+          cubicvolume: true,
+        });
+        const text = boxes[0].props.plaintextOutput;
+        expect(text).toContain('L: 1000');
+        expect(text).toContain('mL: 1000000');
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PercentChangeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PercentChangeBoxSource.test.ts
@@ -1,0 +1,202 @@
+import { expect } from 'vitest';
+
+import { PercentChangeBoxSource } from '../PercentChangeBoxSource';
+
+describe('PercentChangeBoxSource', () => {
+  const opts = (key: string) => ({ [key]: true });
+
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        null,
+      );
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes('120 to 150', {
+        qrcode: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+  });
+
+  describe('::pctchange trigger', () => {
+    it('120 to 150 → Change 30, Percent Change 25, Direction increase', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.From).toBe('120');
+      expect(kv.To).toBe('150');
+      expect(kv.Change).toBe('30');
+      expect(kv['Percent Change']).toBe('25');
+      expect(kv.Direction).toBe('increase');
+    });
+
+    it('150 to 120 → Change -30, Percent Change -20, Direction decrease', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '150 to 120',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Change).toBe('-30');
+      expect(kv['Percent Change']).toBe('-20');
+      expect(kv.Direction).toBe('decrease');
+    });
+
+    it('100 to 100 → Percent Change 0, Direction no change', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '100 to 100',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Percent Change']).toBe('0');
+      expect(kv.Direction).toBe('no change');
+    });
+
+    it('50 to 75 → Percent Change 50', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '50 to 75',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Percent Change']).toBe('50');
+    });
+
+    it('200 to 50 → Percent Change -75', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '200 to 50',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Percent Change']).toBe('-75');
+    });
+  });
+
+  describe('::percentchange alias', () => {
+    it('accepts ::percentchange option key', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        opts('percentchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Percent Change']).toBe('25');
+    });
+  });
+
+  describe('separator variants', () => {
+    it('comma separator "120,150" → same as "120 to 150"', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120,150',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Change).toBe('30');
+      expect(kv['Percent Change']).toBe('25');
+    });
+
+    it('space separator "120 150" → same as "120 to 150"', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 150',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Change).toBe('30');
+      expect(kv['Percent Change']).toBe('25');
+    });
+  });
+
+  describe('division by zero', () => {
+    it('0 to 5 → Percent Change contains "undefined"', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '0 to 5',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Percent Change']).toContain('undefined');
+    });
+
+    it('0 to 5 → no Ratio or Of keys', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '0 to 5',
+        opts('pctchange'),
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Ratio).toBeUndefined();
+      expect(kv.Of).toBeUndefined();
+    });
+  });
+
+  describe('invalid input', () => {
+    it('"hello" → returns a usage hint box', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        'hello',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Usage).toBeTruthy();
+    });
+
+    it('single number → returns a usage hint box', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '42',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Usage).toBeTruthy();
+    });
+
+    it('three numbers → returns a usage hint box', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '1 2 3',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Usage).toBeTruthy();
+    });
+  });
+
+  describe('output shape', () => {
+    it('box name is "Percent Change"', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        opts('pctchange'),
+      );
+      expect(boxes[0].props.name).toBe('Percent Change');
+    });
+
+    it('box has Ratio and Of keys when from !== 0', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        opts('pctchange'),
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Ratio).toBeDefined();
+      expect(kv.Of).toBeDefined();
+    });
+
+    it('plaintextOutput contains key:value lines', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        opts('pctchange'),
+      );
+      expect(boxes[0].props.plaintextOutput).toContain('Percent Change: 25');
+      expect(boxes[0].props.plaintextOutput).toContain('Change: 30');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/PropertiesBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PropertiesBoxSource.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { PropertiesBoxSource } from '../PropertiesBoxSource';
+
+describe('PropertiesBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no matching option is provided', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes(
+        'server.host=localhost',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes(
+        'server.host=localhost',
+        { json: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert properties to JSON with flat dotted keys', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes(
+        'server.host=localhost\nserver.port=8080',
+        { properties: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Properties → JSON');
+
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      // flat keys — dotted keys must NOT be nested
+      expect(parsed['server.host']).toBe('localhost');
+      expect(parsed['server.port']).toBe('8080');
+      expect(parsed).not.toHaveProperty('server');
+    });
+
+    it('should skip comment lines (# and !) and handle colon separators', async () => {
+      const input = '# comment\nname: app\n! bang comment\nkey=val';
+      const boxes = await PropertiesBoxSource.generateBoxes(input, {
+        properties: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ name: 'app', key: 'val' });
+    });
+
+    it('should convert JSON object to .properties format', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes(
+        '{"a":"1","b":"2"}',
+        { properties: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → Properties');
+      expect(boxes[0].props.plaintextOutput).toContain('a=1');
+      expect(boxes[0].props.plaintextOutput).toContain('b=2');
+    });
+
+    it('should skip __proto__ key to prevent prototype pollution', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes('__proto__=evil', {
+        properties: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+
+      // the forbidden key must not appear in the parsed output
+      expect(Object.hasOwn(parsed, '__proto__')).toBe(false);
+      // prototype must not have been polluted
+      // biome-ignore lint/suspicious/noExplicitAny: verifying prototype pollution guard
+      expect(({} as any).polluted).toBeUndefined();
+      // the evil value must not have reached Object.prototype
+      expect(Object.prototype).not.toHaveProperty('polluted');
+    });
+
+    it('should not crash on array-like input and return a properties→JSON box', async () => {
+      // '[1,2]' does not start with '{', so treated as properties→JSON
+      const boxes = await PropertiesBoxSource.generateBoxes('[1,2]', {
+        properties: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // no crash; output is valid JSON (even if empty object)
+      expect(() => JSON.parse(boxes[0].props.plaintextOutput)).not.toThrow();
+    });
+
+    it('should return an error box for JSON-looking input that is invalid JSON', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes('{bad', {
+        properties: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → Properties');
+      expect(boxes[0].props.plaintextOutput).toMatch(/parse error/i);
+    });
+
+    it('should round-trip flat keys: properties → JSON → properties', async () => {
+      const original = 'app.name=magic\napp.version=1.0';
+
+      const toJsonBoxes = await PropertiesBoxSource.generateBoxes(original, {
+        properties: true,
+      });
+      expect(toJsonBoxes).toHaveLength(1);
+
+      const jsonStr = toJsonBoxes[0].props.plaintextOutput;
+      const toPropsBoxes = await PropertiesBoxSource.generateBoxes(jsonStr, {
+        properties: true,
+      });
+      expect(toPropsBoxes).toHaveLength(1);
+
+      const output = toPropsBoxes[0].props.plaintextOutput;
+      expect(output).toContain('app.name=magic');
+      expect(output).toContain('app.version=1.0');
+    });
+
+    it('should trigger on ::propertiesjson option as well', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes('key=value', {
+        propertiesjson: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/UnaccentBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UnaccentBoxSource.test.ts
@@ -1,0 +1,176 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { UnaccentBoxSource } from '../UnaccentBoxSource';
+
+describe('UnaccentBoxSource', () => {
+  describe('generateBoxes - gate checks', () => {
+    it('returns empty array when no trigger option is provided', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {
+        foo: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input string', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('', {
+        unaccent: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('   ', {
+        unaccent: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - NFD diacritics', () => {
+    it('strips acute accent: café → cafe', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {
+        unaccent: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('cafe');
+    });
+
+    it('strips multiple accents: Crème brûlée → Creme brulee', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Crème brûlée', {
+        unaccent: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Creme brulee');
+    });
+
+    it('strips diaeresis: naïve résumé → naive resume', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('naïve résumé', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('naive resume');
+    });
+
+    it('strips tilde: piñata → pinata', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('piñata', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('pinata');
+    });
+
+    it('strips umlaut: Zürich → Zurich', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Zürich', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Zurich');
+    });
+  });
+
+  describe('generateBoxes - special character map', () => {
+    it('converts Łódź → Lodz (ł, ó, dź)', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Łódź', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Lodz');
+    });
+
+    it('converts ß → ss: Straße → Strasse', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Straße', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Strasse');
+    });
+
+    it('converts Æ → AE: Æon → AEon', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Æon', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AEon');
+    });
+
+    it('converts œ → oe: œuvre → oeuvre', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('œuvre', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('oeuvre');
+    });
+
+    it('converts ø → o and Ø → O', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('søster Øst', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('soster Ost');
+    });
+
+    it('converts đ → d and Đ → D', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Đà Nẵng', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Da Nang');
+    });
+
+    it('converts ð → d and þ → th', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('þing ðat', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('thing dat');
+    });
+  });
+
+  describe('generateBoxes - non-latin pass-through', () => {
+    it('leaves CJK characters unchanged: 日本語 → 日本語', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('日本語', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('日本語');
+    });
+  });
+
+  describe('generateBoxes - alias options', () => {
+    it('::deburr alias works', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {
+        deburr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('cafe');
+    });
+
+    it('::removeaccents alias works', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {
+        removeaccents: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('cafe');
+    });
+  });
+
+  describe('generateBoxes - box metadata', () => {
+    it('sets correct box name, priority, and template', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {
+        unaccent: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Remove Accents');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(UnaccentBoxSource.name).toBe('Remove Accents');
+      expect(UnaccentBoxSource.kind).toBe('Transform');
+      expect(typeof UnaccentBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -2,24 +2,32 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import BifidBoxSource from './BifidBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FractionBoxSource from './FractionBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import JsonlBoxSource from './JsonlBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LeetSpeakBoxSource from './LeetSpeakBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
+import MetricVolumeBoxSource from './MetricVolumeBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PercentChangeBoxSource from './PercentChangeBoxSource';
+import PropertiesBoxSource from './PropertiesBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import UnaccentBoxSource from './UnaccentBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
@@ -29,23 +37,31 @@ import WordCountBoxSource from './WordCountBoxSource';
 // stay below specific matches without needing per-box priority.
 export const boxSources = [
   ColorBoxSource,
+  BifidBoxSource,
   EscapeStringBoxSource,
   Base64DecodeBoxSource,
   CronExpressionBoxSource,
   DataConverterBoxSource,
   DateCalculateBoxSource,
+  FractionBoxSource,
   GenerateQRCodeBoxSource,
   HashBoxSource,
+  JsonlBoxSource,
   JWTBoxSource,
   K8sSecretBoxSource,
+  LeetSpeakBoxSource,
   MathExpressionBoxSource,
+  MetricVolumeBoxSource,
   MyIPBoxSource,
   NowBoxSource,
   PasswordBoxSource,
+  PercentChangeBoxSource,
+  PropertiesBoxSource,
   RandomIntegerBoxSource,
   ReadableBytesBoxSource,
   ShortenURLBoxSource,
   TimeFormatBoxSource,
+  UnaccentBoxSource,
   URLDecodeBoxSource,
   UuidBoxSource,
   TimestampBoxSource,


### PR DESCRIPTION
## Summary

Thirty-fourth exploration batch — **8 more BoxSource tools** (number, text, JSON, config, cipher).

| Tool | Trigger | What it does |
|------|---------|--------------|
| Fraction | `::fraction` | decimal ⇄ simplified fraction |
| Remove Accents | `::unaccent` | strip diacritics (café → cafe) |
| Leetspeak | `::leet` | text ⇄ 1337 (`::leetdecode`) |
| Percent Change | `::pctchange` | % change between two numbers |
| Volume Convert | `::cubicvolume` | m³/L/mL/ft³/gallons |
| JSONL | `::jsonl` | JSON array ⇄ newline-delimited JSON |
| Properties / JSON | `::properties` | Java .properties ⇄ JSON |
| Bifid Cipher | `::bifid` | 5×5 Polybius fractionation cipher |

## Design notes

- 8 sources by isolated subagents; `index.ts` wired in one step. Hardening rules pre-loaded: BigInt-reduced fraction (no float-precision loss), prototype-pollution guard (FORBIDDEN_KEYS) in Properties, NFD + special-char map for accents, integer-exact formatting for volume.
- **Verified vectors**: 0.75→3/4, 1.25→5/4 (mixed 1¼); café→cafe, **ß→ss, Łódź→Lodz**; leet→1337, hacker→h4ck3r; 120→150=**+25%**, 200→50=−75%; **1 m³=1000 L**, 1 ft³≈28.317 L; array↔jsonl round-trip; flat `.properties` keys + proto-safe; **bifid FLEEATONCE→HADNAAZDSP** + decode round-trip.

## Self-review fixes (pre-PR)

- **6 wrong test vectors corrected** (the implementations were right): the Bifid subagent's standard-square trace gave `HADNAAZDSP` (not `…SDP`); leet `elite`→`31173` (both l and i map to 1) and decode `1337`→`leet` (l overwrites i in the reverse map); `DEFENDTHEEAST` is 13 letters, not 12.

## Verification

- ✅ `bun run test run` — **459 passing**
- ✅ `bunx tsc --noEmit` — clean
- ✅ `bun run lint` (Biome) — clean

> Independent of #260–#292 — branched from `main`.

https://claude.ai/code/session_01ND8EK5gu9FzYsN7WBBuQk6