### PR TITLE
feat(DateCalculate): integrate relative time (Time Ago/Later) into Date Calculate Box

### DIFF
--- a/src/modules/boxSources/DateCalculateBoxSource.ts
+++ b/src/modules/boxSources/DateCalculateBoxSource.ts
@@ -1,8 +1,28 @@
 import { isString, trim } from '@functions/helper';
-import type { Box } from '@modules/Box';
-import { BoxBuilder } from '@modules/Box';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const PriorityDateCalculate = 10;
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const MONTH_MS = 30 * DAY_MS;
+const YEAR_MS = 365 * DAY_MS;
+
+type RelativeUnit = 'year' | 'month' | 'day' | 'hour' | 'minute' | 'second';
+
+function pickUnit(diffMs: number): [number, RelativeUnit] {
+  const abs = Math.abs(diffMs);
+  const sign = diffMs < 0 ? -1 : 1;
+
+  if (abs >= YEAR_MS) return [sign * Math.round(abs / YEAR_MS), 'year'];
+  if (abs >= MONTH_MS) return [sign * Math.round(abs / MONTH_MS), 'month'];
+  if (abs >= DAY_MS) return [sign * Math.round(abs / DAY_MS), 'day'];
+  if (abs >= HOUR_MS) return [sign * Math.round(abs / HOUR_MS), 'hour'];
+  if (abs >= MINUTE_MS) return [sign * Math.round(abs / MINUTE_MS), 'minute'];
+  return [sign * Math.round(abs / 1000), 'second'];
+}
 
 interface Match {
   result: string;
@@ -55,6 +75,12 @@ const parseDate = (s: string): Date => {
     const date = new Date();
     date.setDate(date.getDate() - 1);
     return date;
+  }
+  if (/^\d{10}$/.test(s)) {
+    return new Date(Number.parseInt(s, 10) * 1000);
+  }
+  if (/^\d{13}$/.test(s)) {
+    return new Date(Number.parseInt(s, 10));
   }
   return new Date(s);
 };
@@ -241,7 +267,44 @@ export const DateCalculateBoxSource = {
     return undefined;
   },
 
-  async generateBoxes(input: string): Promise<Box[]> {
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    // 1. check relative time option (Time Ago / Time Later)
+    if (
+      hasOptionKeys(options, 'relative', 'timeago', 'timelater', 'relativetime')
+    ) {
+      if (!isString(input) || trim(input).length === 0 || input.length > 100) {
+        return [];
+      }
+      const raw = trim(input);
+      const date = parseDate(raw);
+      if (Number.isNaN(date.getTime())) {
+        return [
+          new BoxBuilder('Relative Time', `Invalid date: "${raw}"`)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+      const diffMs = date.getTime() - Date.now();
+      const [value, unit] = pickUnit(diffMs);
+      const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+      const relative = rtf.format(value, unit);
+      return [
+        new BoxBuilder('Relative Time', relative)
+          .setOptions({
+            Relative: relative,
+            ISO: date.toISOString(),
+            Direction: diffMs < -500 ? 'past' : diffMs > 500 ? 'future' : 'now',
+          })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
     const match = this.checkMatch(input);
     if (!match) {
       return [];

--- a/src/modules/boxSources/__test__/DateCalculateBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DateCalculateBoxSource.test.ts
@@ -304,4 +304,38 @@ describe('DateCalculateBoxSource', () => {
       });
     });
   });
+
+  describe('Relative Time (Time Ago / Time Later)', () => {
+    it('formats a past date as relative time ago', async () => {
+      const past = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+      const boxes = await DateCalculateBoxSource.generateBoxes(past, {
+        relative: true,
+      });
+      expect(boxes.length).toBe(1);
+      expect(boxes[0].props.name).toBe('Relative Time');
+      expect(boxes[0].props.plaintextOutput).toBe('3 days ago');
+    });
+
+    it('formats a future date as relative time later', async () => {
+      const future = new Date(
+        Date.now() + 5 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const boxes = await DateCalculateBoxSource.generateBoxes(future, {
+        relative: true,
+      });
+      expect(boxes.length).toBe(1);
+      expect(boxes[0].props.name).toBe('Relative Time');
+      expect(boxes[0].props.plaintextOutput).toBe('in 5 days');
+    });
+
+    it('handles unix timestamp in seconds', async () => {
+      const pastSec = Math.floor((Date.now() - 60000) / 1000).toString();
+      const boxes = await DateCalculateBoxSource.generateBoxes(pastSec, {
+        relative: true,
+      });
+      expect(boxes.length).toBe(1);
+      expect(boxes[0].props.name).toBe('Relative Time');
+      expect(boxes[0].props.plaintextOutput).toBe('1 minute ago');
+    });
+  });
 });


### PR DESCRIPTION
### Date Calculate Box Enhancement: Relative Time (Time Ago / Time Later)

Integrates relative time formatting functionality (formerly "Time Ago" box source) directly into the existing `Date Calculate` box source as requested.

#### Details:
- **Category (Kind)**: `Time`
- **Tag**: `⏱`
- **Default Input**: `now + 7d` (original) / support `2020-01-01T00:00:00Z ::relative`

#### Usage Examples:
- **Input**: `now + 7d`
- **Output Box (`Date Calculate`)**:
```
2026-07-01T06:57:19.569Z
```
