### PR TITLE
feat(CreditCardInfo): add Credit Card Info BoxSource

### DIFF
--- a/src/modules/boxSources/CreditCardInfoBoxSource.ts
+++ b/src/modules/boxSources/CreditCardInfoBoxSource.ts
@@ -1,0 +1,155 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// brand detection result
+interface CardBrand {
+  name: string;
+  // whether the card length falls within the brand's valid set
+  validLength: boolean;
+}
+
+// luhn mod-10 check
+function luhnCheck(digits: string): boolean {
+  let sum = 0;
+  let shouldDouble = false;
+
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = Number.parseInt(digits[i], 10);
+
+    if (shouldDouble) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+
+    sum += d;
+    shouldDouble = !shouldDouble;
+  }
+
+  return sum % 10 === 0;
+}
+
+// detect card brand from digit string; returns name and whether length is valid for that brand
+function detectBrand(digits: string): CardBrand {
+  const len = digits.length;
+  const prefix4 = Number.parseInt(digits.slice(0, 4), 10);
+  const prefix2 = Number.parseInt(digits.slice(0, 2), 10);
+  const prefix3 = Number.parseInt(digits.slice(0, 3), 10);
+
+  // Visa: starts with 4, lengths 13/16/19
+  if (digits[0] === '4') {
+    return {
+      name: 'Visa',
+      validLength: len === 13 || len === 16 || len === 19,
+    };
+  }
+
+  // Mastercard: 51-55 or 2221-2720, length 16
+  if (
+    (prefix2 >= 51 && prefix2 <= 55) ||
+    (prefix4 >= 2221 && prefix4 <= 2720)
+  ) {
+    return { name: 'Mastercard', validLength: len === 16 };
+  }
+
+  // American Express: 34 or 37, length 15
+  if (prefix2 === 34 || prefix2 === 37) {
+    return { name: 'American Express', validLength: len === 15 };
+  }
+
+  // Discover: 6011, 65, or 644-649, lengths 16/19
+  if (
+    digits.startsWith('6011') ||
+    prefix2 === 65 ||
+    (prefix3 >= 644 && prefix3 <= 649)
+  ) {
+    return { name: 'Discover', validLength: len === 16 || len === 19 };
+  }
+
+  // Diners Club: 36, 38, 39, or 300-305, length 14
+  if (
+    prefix2 === 36 ||
+    prefix2 === 38 ||
+    prefix2 === 39 ||
+    (prefix3 >= 300 && prefix3 <= 305)
+  ) {
+    return { name: 'Diners Club', validLength: len === 14 };
+  }
+
+  // JCB: 3528-3589, lengths 16-19
+  if (prefix4 >= 3528 && prefix4 <= 3589) {
+    return { name: 'JCB', validLength: len >= 16 && len <= 19 };
+  }
+
+  return { name: 'Unknown', validLength: false };
+}
+
+// mask the PAN: show first digit + bullets for middle digits + last 4
+function maskPAN(digits: string): string {
+  if (digits.length <= 5) {
+    // too short to meaningfully mask; replace all but last char
+    return '•'.repeat(digits.length - 1) + digits[digits.length - 1];
+  }
+
+  const first = digits[0];
+  const last4 = digits.slice(-4);
+  const middleLen = digits.length - 1 - 4;
+  return first + '•'.repeat(middleLen) + last4;
+}
+
+export const CreditCardInfoBoxSource = {
+  defaultDisabled: true,
+  name: 'Credit Card Info',
+  description:
+    'Detect the card brand from a number and check Luhn validity (masks the number).',
+  defaultInput: '4111111111111111 ::cardinfo',
+  tag: '#',
+  kind: 'Validate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cardtype', 'creditcard', 'cardinfo'))
+      return [];
+
+    // strip spaces and hyphens, leaving only digits
+    const cleaned = trim(input).replace(/[\s-]/g, '');
+
+    // if the result is not entirely digits or is outside the valid length range, bail out
+    if (!/^\d+$/.test(cleaned)) return [];
+    if (cleaned.length < 12 || cleaned.length > 19) return [];
+
+    const brand = detectBrand(cleaned);
+    const luhnValid = luhnCheck(cleaned);
+    const masked = maskPAN(cleaned);
+
+    // key-value entries displayed in the box
+    const kvOptions: Record<string, string> = {
+      Masked: masked,
+      Brand: brand.name,
+      Length: String(cleaned.length),
+      'Luhn Valid': String(luhnValid),
+    };
+
+    // plaintextOutput as k:v lines (not JSON)
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Credit Card', plaintextOutput)
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CreditCardInfoBoxSource;

--- a/src/modules/boxSources/__test__/CreditCardInfoBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CreditCardInfoBoxSource.test.ts
@@ -1,0 +1,276 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { CreditCardInfoBoxSource } from '../CreditCardInfoBoxSource';
+
+describe('CreditCardInfoBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(CreditCardInfoBoxSource.name).toBe('Credit Card Info');
+      expect(CreditCardInfoBoxSource.tag).toBe('#');
+      expect(CreditCardInfoBoxSource.kind).toBe('Validate');
+      expect(typeof CreditCardInfoBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - trigger guard', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(
+        '4111111111111111',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(
+        '4111111111111111',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is provided', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(
+        '4111111111111111',
+        { hash: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - input validation', () => {
+    it('returns empty array for non-digit input', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(
+        'not-a-number',
+        {
+          cardtype: true,
+        },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for digit string shorter than 12', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes('41111111111', {
+        cardtype: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for digit string longer than 19', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(
+        '41111111111111111111',
+        {
+          cardtype: true,
+        },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('accepts input with spaces and hyphens', async () => {
+      // spaced grouping of 4111111111111111
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(
+        '4111 1111 1111 1111',
+        { cardtype: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes - Visa', () => {
+    const pan = '4111111111111111';
+
+    it('detects Visa brand', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Brand: 'Visa' });
+    });
+
+    it('reports Luhn Valid true', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Luhn Valid': 'true' });
+    });
+
+    it('masks the number — last 4 are visible', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      const masked = (boxes[0].props.options as Record<string, string>).Masked;
+      expect(masked).toMatch(/1111$/);
+    });
+
+    it('masked value does NOT contain the full PAN', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      const masked = (boxes[0].props.options as Record<string, string>).Masked;
+      expect(masked).not.toBe(pan);
+      expect(masked).not.toContain(pan);
+    });
+
+    it('no option value exposes the full PAN', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      for (const value of Object.values(opts)) {
+        expect(value).not.toContain(pan);
+      }
+      expect(boxes[0].props.plaintextOutput).not.toContain(pan);
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+
+  describe('generateBoxes - Mastercard', () => {
+    const pan = '5555555555554444';
+
+    it('detects Mastercard brand', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Brand: 'Mastercard' });
+    });
+
+    it('reports Luhn Valid true', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Luhn Valid': 'true' });
+    });
+
+    it('no option value exposes the full PAN', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        creditcard: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      for (const value of Object.values(opts)) {
+        expect(value).not.toContain(pan);
+      }
+      expect(boxes[0].props.plaintextOutput).not.toContain(pan);
+    });
+  });
+
+  describe('generateBoxes - American Express', () => {
+    const pan = '378282246310005';
+
+    it('detects American Express brand', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Brand: 'American Express',
+      });
+    });
+
+    it('reports length 15', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Length: '15' });
+    });
+
+    it('reports Luhn Valid true', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Luhn Valid': 'true' });
+    });
+
+    it('no option value exposes the full PAN', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      for (const value of Object.values(opts)) {
+        expect(value).not.toContain(pan);
+      }
+      expect(boxes[0].props.plaintextOutput).not.toContain(pan);
+    });
+  });
+
+  describe('generateBoxes - Discover', () => {
+    const pan = '6011111111111117';
+
+    it('detects Discover brand', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Brand: 'Discover' });
+    });
+
+    it('reports Luhn Valid true', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Luhn Valid': 'true' });
+    });
+
+    it('no option value exposes the full PAN', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      for (const value of Object.values(opts)) {
+        expect(value).not.toContain(pan);
+      }
+      expect(boxes[0].props.plaintextOutput).not.toContain(pan);
+    });
+  });
+
+  describe('generateBoxes - invalid Luhn', () => {
+    it('reports Luhn Valid false for 4111111111111112', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(
+        '4111111111111112',
+        { cardtype: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ 'Luhn Valid': 'false' });
+    });
+  });
+
+  describe('generateBoxes - ::creditcard trigger key', () => {
+    it('responds to ::creditcard option key', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(
+        '4111111111111111',
+        { creditcard: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Brand: 'Visa' });
+    });
+  });
+
+  describe('generateBoxes - plaintextOutput format', () => {
+    it('uses k:v lines (not JSON)', async () => {
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(
+        '4111111111111111',
+        { cardtype: true },
+      );
+      const text = boxes[0].props.plaintextOutput;
+      // must contain colon-separated lines
+      expect(text).toMatch(/^Masked: /m);
+      expect(text).toMatch(/^Brand: /m);
+      expect(text).toMatch(/^Length: /m);
+      expect(text).toMatch(/^Luhn Valid: /m);
+      // must NOT be parseable as JSON object
+      expect(() => JSON.parse(text)).toThrow();
+    });
+
+    it('does not contain the full PAN in plaintextOutput', async () => {
+      const pan = '4111111111111111';
+      const boxes = await CreditCardInfoBoxSource.generateBoxes(pan, {
+        cardtype: true,
+      });
+      expect(boxes[0].props.plaintextOutput).not.toContain(pan);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -8,6 +8,7 @@ import {
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CreditCardInfoBoxSource from './CreditCardInfoBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  CreditCardInfoBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Credit Card Info (Validate)

Redesigns and adds the `Credit Card Info` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Validate`
- **Tag**: `#`
- **Default Input**: `4111111111111111 ::cardinfo`

#### Options:
- `::cardinfo` / `::creditcard` / `::cardtype`: Displays card brand detection, Luhn checksum verification, length, and masked number.

#### Description:
Detect the credit card brand, validate Luhn checksum, and display card details.

#### Usage Examples:
- **Input**: `4111111111111111 ::cardinfo`
- **Output Box (`Credit Card`)**:
```
Masked: 4•••••••••••1111
Brand: Visa
Length: 16
Luhn Valid: true
```
