### PR TITLE
feat(Adler32): add Adler-32 BoxSource

### DIFF
--- a/src/modules/boxSources/Adler32BoxSource.ts
+++ b/src/modules/boxSources/Adler32BoxSource.ts
@@ -1,0 +1,57 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 20;
+const MAX_INPUT = 100_000;
+// adler-32 modulus (largest prime < 2^16)
+const MOD_ADLER = 65521;
+
+// compute adler-32 checksum over the utf-8 encoding of `str`
+function computeAdler32(str: string): number {
+  const bytes = new TextEncoder().encode(str);
+  let a = 1;
+  let b = 0;
+  for (const byte of bytes) {
+    a = (a + byte) % MOD_ADLER;
+    b = (b + a) % MOD_ADLER;
+  }
+  return ((b << 16) | a) >>> 0;
+}
+
+export const Adler32BoxSource = {
+  defaultDisabled: true,
+  name: 'Adler-32',
+  description: 'Compute the Adler-32 checksum of the input text.',
+  defaultInput: 'Wikipedia ::adler32',
+  tag: '#',
+  kind: 'Hash',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'adler32', 'adler')) return [];
+    if (input.length === 0 || input.length > MAX_INPUT) return [];
+
+    const checksum = computeAdler32(input);
+    const hex = checksum.toString(16).padStart(8, '0');
+    const decimal = checksum.toString(10);
+
+    const output: Record<string, string> = {
+      Hex: hex,
+      Decimal: decimal,
+    };
+
+    return [
+      new BoxBuilder('Adler-32', `Hex: ${hex}\nDecimal: ${decimal}`)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Adler32BoxSource;

--- a/src/modules/boxSources/__test__/Adler32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Adler32BoxSource.test.ts
@@ -1,0 +1,96 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Adler32BoxSource } from '../Adler32BoxSource';
+
+describe('Adler32BoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Adler32BoxSource.name).toBe('Adler-32');
+      expect(Adler32BoxSource.tag).toBe('#');
+      expect(Adler32BoxSource.kind).toBe('Hash');
+      expect(typeof Adler32BoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - option gate', () => {
+    it('returns empty array when no option provided', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('', { adler32: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - canonical vector: Wikipedia', () => {
+    it('produces correct Decimal and Hex for "Wikipedia" via ::adler32', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {
+        adler32: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // canonical adler-32 of 'Wikipedia' is 0x11E60398 = 300286872
+      expect(opts.Decimal).toBe('300286872');
+      expect(opts.Hex).toBe('11e60398');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {
+        adler32: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets the box name to Adler-32', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {
+        adler32: true,
+      });
+      expect(boxes[0].props.name).toBe('Adler-32');
+    });
+  });
+
+  describe('generateBoxes - canonical vector: "a"', () => {
+    it('produces correct checksum for single character "a"', async () => {
+      // utf-8 byte 97 → a=98, b=98 → (98<<16|98) = 6422626 = 0x00620062
+      const boxes = await Adler32BoxSource.generateBoxes('a', {
+        adler32: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('6422626');
+      expect(opts.Hex).toBe('00620062');
+    });
+  });
+
+  describe('generateBoxes - ::adler alias', () => {
+    it('::adler alias triggers the same computation as ::adler32', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {
+        adler: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('300286872');
+      expect(opts.Hex).toBe('11e60398');
+    });
+  });
+
+  describe('generateBoxes - priority', () => {
+    it('sets priority on the box', async () => {
+      const boxes = await Adler32BoxSource.generateBoxes('Wikipedia', {
+        adler32: true,
+      });
+      expect(boxes[0].props.priority).toBe(Adler32BoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,5 +1,6 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
+import Adler32BoxSource from './Adler32BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
 import {
   Base64DecodeBoxSource,
@@ -82,6 +83,7 @@ export const boxSources: BoxSource[] = [
   Base64EncodeBoxSource,
   WordWrapBoxSource,
   A1Z26BoxSource,
+  Adler32BoxSource,
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,


### PR DESCRIPTION
### Box Source: Adler-32 (Hash)

Adds the `Adler-32` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Hash`
- **Tag**: `#`
- **Default Input**: `Wikipedia ::adler32`

#### Options:
- `::adler`, `::adler32`

#### Description:
Compute the Adler-32 checksum of the input text.

#### Usage Examples:
- **Input**: `Wikipedia ::adler32`
- **Output Box (`Adler-32`)**:
```
Hex: 11e60398
Decimal: 300286872
```
