### PR TITLE
feat(AngleConvert): add Angle Convert BoxSource

### DIFF
--- a/src/modules/boxSources/AngleConvertBoxSource.ts
+++ b/src/modules/boxSources/AngleConvertBoxSource.ts
@@ -1,0 +1,149 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// maps all accepted unit spellings to a canonical unit name
+const unitAliases: Record<string, string> = {
+  deg: 'deg',
+  degree: 'deg',
+  degrees: 'deg',
+  '°': 'deg',
+  rad: 'rad',
+  radian: 'rad',
+  radians: 'rad',
+  grad: 'grad',
+  gradian: 'grad',
+  gradians: 'grad',
+  gon: 'grad',
+  turn: 'turn',
+  turns: 'turn',
+  rev: 'turn',
+};
+
+// converts a value in the given canonical unit to degrees
+function toDegrees(value: number, unit: string): number {
+  switch (unit) {
+    case 'deg':
+      return value;
+    case 'rad':
+      return value * (180 / Math.PI);
+    case 'grad':
+      return value * 0.9;
+    case 'turn':
+      return value * 360;
+    default:
+      return value;
+  }
+}
+
+// formats a number to ~6 significant figures and strips trailing zeros
+function formatSigFigs(n: number): string {
+  // toPrecision(7) gives 7 sig figs; we use 7 to keep the 6th digit accurate
+  const formatted = n.toPrecision(7);
+  // remove trailing zeros after decimal point
+  if (formatted.includes('.')) {
+    return formatted.replace(/\.?0+$/, '');
+  }
+  return formatted;
+}
+
+const INPUT_MAX_LEN = 64;
+const UNIT_REGEX = /^(-?\d+(?:\.\d+)?)\s*([a-z°]+)$/i;
+const VALID_UNITS = Object.keys(unitAliases).join(', ');
+
+export const AngleConvertBoxSource = {
+  defaultDisabled: true,
+  name: 'Angle Convert',
+  description:
+    'Convert an angle between degrees, radians, gradians, and turns. e.g. "180 deg ::angle".',
+  defaultInput: '180 deg ::angle',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'angle')) return [];
+
+    const trimmed = trim(input).slice(0, INPUT_MAX_LEN);
+    const match = UNIT_REGEX.exec(trimmed);
+
+    if (!match) {
+      // invalid format — return an informational box
+      const errorContent = `Input: ${trimmed}
+Error: unable to parse input
+Format: <number> <unit>
+Units: ${VALID_UNITS}`;
+      return [
+        new BoxBuilder('Angle Convert', errorContent)
+          .setOptions({
+            Input: trimmed,
+            Error: 'unable to parse input',
+            Format: '<number> <unit>',
+            Units: VALID_UNITS,
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const rawUnit = match[2].toLowerCase();
+    const canonicalUnit = unitAliases[rawUnit];
+
+    if (!canonicalUnit) {
+      const errorContent = `Input: ${trimmed}
+Error: unrecognized unit "${match[2]}"
+Units: ${VALID_UNITS}`;
+      return [
+        new BoxBuilder('Angle Convert', errorContent)
+          .setOptions({
+            Input: trimmed,
+            Error: `unrecognized unit "${match[2]}"`,
+            Units: VALID_UNITS,
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const degrees = toDegrees(value, canonicalUnit);
+    const radians = degrees * (Math.PI / 180);
+    const gradians = degrees / 0.9;
+    const turns = degrees / 360;
+
+    const degreesStr = formatSigFigs(degrees);
+    const radiansStr = formatSigFigs(radians);
+    const gradiansStr = formatSigFigs(gradians);
+    const turnsStr = formatSigFigs(turns);
+
+    const content = `Input: ${trimmed}
+Degrees: ${degreesStr}
+Radians: ${radiansStr}
+Gradians: ${gradiansStr}
+Turns: ${turnsStr}`;
+
+    return [
+      new BoxBuilder('Angle Convert', content)
+        .setOptions({
+          Input: trimmed,
+          Degrees: degreesStr,
+          Radians: radiansStr,
+          Gradians: gradiansStr,
+          Turns: turnsStr,
+        })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default AngleConvertBoxSource;

--- a/src/modules/boxSources/__test__/AngleConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AngleConvertBoxSource.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { AngleConvertBoxSource } from '../AngleConvertBoxSource';
+
+describe('AngleConvertBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when ::angle option is not present', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('180 deg', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options object has no angle key', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('180 deg', {
+        foo: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert 180 deg → π rad, 200 grad, 0.5 turn', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('180 deg', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('180');
+      expect(opts.Radians).toBe('3.141593');
+      expect(opts.Gradians).toBe('200');
+      expect(opts.Turns).toBe('0.5');
+    });
+
+    it('should convert 1 turn → 360 deg, ~6.283185 rad, 400 grad', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('1 turn', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('360');
+      expect(opts.Radians).toBe('6.283185');
+      expect(opts.Gradians).toBe('400');
+      expect(opts.Turns).toBe('1');
+    });
+
+    it('should convert 100 grad → 90 deg', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('100 grad', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('90');
+    });
+
+    it('should convert 1.5708 rad → ~90 deg', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('1.5708 rad', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1.5708 rad is approximately 90 degrees (within floating-point tolerance)
+      expect(Number.parseFloat(opts.Degrees)).toBeCloseTo(90, 3);
+    });
+
+    it('should handle the ° symbol: 90° → ~1.570796 rad', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('90°', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('90');
+      expect(opts.Radians).toBe('1.570796');
+    });
+
+    it('should return an error box for non-numeric input "abc"', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('abc', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // error box must mention valid units
+      expect(opts.Units).toBeDefined();
+      expect(opts.Units.length).toBeGreaterThan(0);
+    });
+
+    it('should return an error box for unrecognized unit "5 parsecs"', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('5 parsecs', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Units).toBeDefined();
+      expect(opts.Units.length).toBeGreaterThan(0);
+    });
+
+    it('should accept unit alias "degrees"', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('360 degrees', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('360');
+      expect(opts.Turns).toBe('1');
+    });
+
+    it('should accept unit alias "radians"', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('1 radians', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(opts.Degrees)).toBeCloseTo(57.29578, 3);
+    });
+
+    it('should handle negative angles', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('-90 deg', {
+        angle: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Degrees).toBe('-90');
+      expect(opts.Turns).toBe('-0.25');
+    });
+
+    it('should set box name to "Angle Convert"', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('180 deg', {
+        angle: true,
+      });
+
+      expect(boxes[0].props.name).toBe('Angle Convert');
+    });
+
+    it('should set priority to the module priority', async () => {
+      const boxes = await AngleConvertBoxSource.generateBoxes('180 deg', {
+        angle: true,
+      });
+
+      expect(boxes[0].props.priority).toBe(AngleConvertBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,5 +1,6 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
+import AngleConvertBoxSource from './AngleConvertBoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
 import {
   Base64DecodeBoxSource,
@@ -73,6 +74,7 @@ export const boxSources: BoxSource[] = [
   Base64EncodeBoxSource,
   WordWrapBoxSource,
   A1Z26BoxSource,
+  AngleConvertBoxSource,
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,


### PR DESCRIPTION
### Box Source: Angle Convert (Convert)

Adds the `Angle Convert` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `180 deg ::angle`

#### Options:
- `::angle`

#### Description:
Convert an angle between degrees, radians, gradians, and turns. e.g.

#### Usage Examples:
- **Input**: `180 deg ::angle`
- **Output Box (`Angle Convert`)**:
```
Input: 180 deg
Degrees: 180
Radians: 3.141593
Gradians: 200
Turns: 0.5
```
