### PR TITLE
feat(AreaConvert): add Area Convert BoxSource

### DIFF
--- a/src/modules/boxSources/AreaConvertBoxSource.ts
+++ b/src/modules/boxSources/AreaConvertBoxSource.ts
@@ -1,0 +1,137 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit (normalized) -> square meters
+const TO_M2: Record<string, number> = {
+  m2: 1,
+  km2: 1e6,
+  cm2: 1e-4,
+  mm2: 1e-6,
+  ft2: 0.09290304,
+  in2: 0.00064516,
+  yd2: 0.83612736,
+  acre: 4046.8564224,
+  hectare: 10000,
+  ha: 10000,
+  mi2: 2589988.110336,
+};
+
+// output units with display labels, in display order
+const OUTPUT_UNITS: { key: string; label: string }[] = [
+  { key: 'm2', label: 'm²' },
+  { key: 'km2', label: 'km²' },
+  { key: 'cm2', label: 'cm²' },
+  { key: 'ft2', label: 'ft²' },
+  { key: 'in2', label: 'in²' },
+  { key: 'yd2', label: 'yd²' },
+  { key: 'acre', label: 'acre' },
+  { key: 'hectare', label: 'hectare' },
+  { key: 'mi2', label: 'mile²' },
+];
+
+// normalize a raw unit string into a key for TO_M2 lookup
+function normalizeUnit(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/\^2/g, '2')
+    .replace(/²/g, '2')
+    .replace(/\s+/g, '');
+}
+
+// format as integer when exact, otherwise 6 decimal places stripped of trailing zeros
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// build a plaintext k:v block for the KeyValueBoxTemplate
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// list of supported unit names for error messages
+const SUPPORTED_UNITS = Object.keys(TO_M2).join(', ');
+
+export const AreaConvertBoxSource = {
+  defaultDisabled: true,
+  name: 'Area Convert',
+  description: 'Convert an area between m², km², ft², acre, hectare, and more.',
+  defaultInput: '1 acre ::area',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'area')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > 64) return [];
+
+    // parse "<number> <unit>" with optional whitespace
+    const match = raw.match(/^(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s+(.+)$/);
+    if (!match) {
+      return [
+        new BoxBuilder(
+          'Area Convert',
+          `Format: "<number> <unit>"\nSupported units: ${SUPPORTED_UNITS}`,
+        )
+          .setOptions({
+            Error: 'invalid format',
+            Format: '<number> <unit>',
+            'Supported units': SUPPORTED_UNITS,
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitKey = normalizeUnit(match[2]);
+
+    if (!(unitKey in TO_M2)) {
+      return [
+        new BoxBuilder(
+          'Area Convert',
+          `Unknown unit "${match[2]}"\nSupported units: ${SUPPORTED_UNITS}`,
+        )
+          .setOptions({
+            Error: `unknown unit "${match[2]}"`,
+            'Supported units': SUPPORTED_UNITS,
+          })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const valueInM2 = value * TO_M2[unitKey];
+
+    const kvPairs: Record<string, string> = {
+      Input: `${formatValue(value)} ${match[2]}`,
+    };
+    for (const { key, label } of OUTPUT_UNITS) {
+      const converted = valueInM2 / TO_M2[key];
+      kvPairs[label] = formatValue(converted);
+    }
+
+    return [
+      new BoxBuilder('Area Convert', kvToPlaintext(kvPairs))
+        .setOptions(kvPairs)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default AreaConvertBoxSource;

--- a/src/modules/boxSources/__test__/AreaConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AreaConvertBoxSource.test.ts
@@ -1,0 +1,123 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { AreaConvertBoxSource } from '../AreaConvertBoxSource';
+
+describe('AreaConvertBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] when no options are provided', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 acre', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 acre', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('1 acre conversions', () => {
+    it('converts 1 acre to m², ft², and hectare correctly', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 acre', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Area Convert');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.priority).toBe(10);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 acre = 4046.8564224 m² → 6dp → 4046.856422
+      expect(opts['m²']).toBe('4046.856422');
+      // 1 acre = 43560 ft² exactly
+      expect(opts['ft²']).toBe('43560');
+      // 1 acre ≈ 0.404686 hectare
+      expect(opts.hectare).toBe('0.404686');
+    });
+  });
+
+  describe('1 hectare conversions', () => {
+    it('converts 1 hectare to m² and acre correctly', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 hectare', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 hectare = exactly 10000 m²
+      expect(opts['m²']).toBe('10000');
+      // 1 hectare ≈ 2.471054 acres
+      expect(opts.acre).toBe('2.471054');
+    });
+  });
+
+  describe('1 km2 conversions', () => {
+    it('converts 1 km2 to m² and hectare correctly', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 km2', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['m²']).toBe('1000000');
+      expect(opts.hectare).toBe('100');
+    });
+  });
+
+  describe('unit notation variants', () => {
+    it('accepts m^2 notation', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('5 m^2', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['m²']).toBe('5');
+    });
+
+    it('accepts m² superscript notation', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('5 m²', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['m²']).toBe('5');
+    });
+  });
+
+  describe('1 mi2 conversions', () => {
+    it('converts 1 mi2 to exactly 640 acres', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('1 mi2', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 square mile = exactly 640 acres
+      expect(opts.acre).toBe('640');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns an error box for unparseable input', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('abc', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toBeDefined();
+      expect(opts['Supported units']).toContain('acre');
+    });
+
+    it('returns an error box for unknown unit', async () => {
+      const boxes = await AreaConvertBoxSource.generateBoxes('5 foo', {
+        area: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toBeDefined();
+      expect(opts['Supported units']).toContain('acre');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,5 +1,6 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
+import AreaConvertBoxSource from './AreaConvertBoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
 import {
   Base64DecodeBoxSource,
@@ -73,6 +74,7 @@ export const boxSources: BoxSource[] = [
   Base64EncodeBoxSource,
   WordWrapBoxSource,
   A1Z26BoxSource,
+  AreaConvertBoxSource,
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,


### PR DESCRIPTION
### Box Source: Area Convert (Convert)

Adds the `Area Convert` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1 acre ::area`

#### Options:
- `::area`

#### Description:
Convert an area between m², km², ft², acre, hectare, and more.

#### Usage Examples:
- **Input**: `1 acre ::area`
- **Output Box (`Area Convert`)**:
```
Input: 1 acre
m²: 4046.856422
km²: 0.004047
cm²: 40468564.224
ft²: 43560
in²: 6272640
yd²: 4840
acre: 1
hectare: 0.404686
mile²: 0.001563
```
