### PR TITLE
feat(Ascii85): add Ascii85 BoxSource

### DIFF
--- a/src/modules/boxSources/Ascii85BoxSource.ts
+++ b/src/modules/boxSources/Ascii85BoxSource.ts
@@ -1,0 +1,179 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// encodes raw bytes to Ascii85 (Adobe variant without <~ ~> framing)
+function encodeAscii85(bytes: Uint8Array): string {
+  const out: string[] = [];
+
+  for (let i = 0; i < bytes.length; i += 4) {
+    const remaining = bytes.length - i;
+    const chunkLen = Math.min(4, remaining);
+
+    // pack up to 4 bytes into a uint32 (big-endian), padding with 0
+    let val =
+      (((bytes[i] ?? 0) << 24) |
+        ((bytes[i + 1] ?? 0) << 16) |
+        ((bytes[i + 2] ?? 0) << 8) |
+        (bytes[i + 3] ?? 0)) >>>
+      0;
+
+    // special case: 4 zero bytes → single 'z'
+    if (chunkLen === 4 && val === 0) {
+      out.push('z');
+      continue;
+    }
+
+    // encode into 5 base-85 digits
+    const digits: number[] = new Array(5);
+    for (let d = 4; d >= 0; d--) {
+      digits[d] = val % 85;
+      val = Math.floor(val / 85);
+    }
+
+    // for a partial chunk of n bytes, output n+1 chars
+    const outLen = chunkLen + 1;
+    for (let d = 0; d < outLen; d++) {
+      out.push(String.fromCharCode(digits[d] + 33));
+    }
+  }
+
+  return out.join('');
+}
+
+// decodes Ascii85 string (Adobe variant without <~ ~> framing) to raw bytes
+function decodeAscii85(encoded: string): Uint8Array | Error {
+  // strip all whitespace characters
+  const stripped = encoded.replace(/\s/g, '');
+
+  const out: number[] = [];
+  let i = 0;
+
+  while (i < stripped.length) {
+    const ch = stripped[i];
+
+    // 'z' expands to 4 zero bytes
+    if (ch === 'z') {
+      out.push(0, 0, 0, 0);
+      i++;
+      continue;
+    }
+
+    // collect up to 5 chars for a group
+    const groupChars: number[] = [];
+    for (let g = 0; g < 5 && i + g < stripped.length; g++) {
+      const c = stripped.charCodeAt(i + g);
+      // valid range is '!' (33) to 'u' (117), but 'z' (122) handled above
+      if (c < 33 || c > 117) {
+        return new Error(`invalid Ascii85 character: '${stripped[i + g]}'`);
+      }
+      groupChars.push(c - 33);
+    }
+
+    const groupLen = groupChars.length;
+    i += groupLen;
+
+    if (groupLen === 1) {
+      // a single trailing char is not a valid Ascii85 group
+      return new Error('invalid Ascii85: trailing single character');
+    }
+
+    // pad the group to 5 with 84 ('u') and decode
+    while (groupChars.length < 5) {
+      groupChars.push(84);
+    }
+
+    let val =
+      (groupChars[0] * 85 ** 4 +
+        groupChars[1] * 85 ** 3 +
+        groupChars[2] * 85 ** 2 +
+        groupChars[3] * 85 +
+        groupChars[4]) >>>
+      0;
+
+    // for n input chars, emit n-1 bytes
+    const byteCount = groupLen - 1;
+    const bytes: number[] = new Array(4);
+    for (let b = 3; b >= 0; b--) {
+      bytes[b] = val & 0xff;
+      val = (val >>> 8) >>> 0;
+    }
+    for (let b = 0; b < byteCount; b++) {
+      out.push(bytes[b]);
+    }
+  }
+
+  return new Uint8Array(out);
+}
+
+export const Ascii85BoxSource = {
+  defaultDisabled: true,
+  name: 'Ascii85',
+  description:
+    'Ascii85 (base85) encode/decode. ::ascii85 to encode, ::ascii85decode to decode.',
+  defaultInput: 'hello ::ascii85',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'ascii85', 'base85', 'a85');
+    const wantDecode = hasOptionKeys(options, 'ascii85decode', 'a85decode');
+
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const bytes = new TextEncoder().encode(input);
+      const encoded = encodeAscii85(bytes);
+      boxes.push(
+        new BoxBuilder('Ascii85 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const result = decodeAscii85(input);
+
+      if (result instanceof Error) {
+        boxes.push(
+          new BoxBuilder('Ascii85 (Decode)', `Error: ${result.message}`)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        const decoded = new TextDecoder().decode(result);
+        boxes.push(
+          new BoxBuilder('Ascii85 (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Ascii85BoxSource;

--- a/src/modules/boxSources/__test__/Ascii85BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Ascii85BoxSource.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { Ascii85BoxSource } from '../Ascii85BoxSource';
+
+describe('Ascii85BoxSource', () => {
+  describe('generateBoxes — no match', () => {
+    it('returns [] when no option key is present', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is empty string', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is only whitespace', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('   ', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ::ascii85 / ::base85 / ::a85', () => {
+    it('encodes "Man " → "9jqo^" (canonical Wikipedia example)', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Ascii85 (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('9jqo^');
+    });
+
+    it('accepts ::base85 as an alias', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        base85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('9jqo^');
+    });
+
+    it('accepts ::a85 as an alias', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        a85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('9jqo^');
+    });
+
+    it('encodes 4 null bytes using the "z" shortcut', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('\x00\x00\x00\x00', {
+        ascii85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('z');
+    });
+
+    it('round-trips "The quick brown fox"', async () => {
+      const input = 'The quick brown fox';
+      const encBoxes = await Ascii85BoxSource.generateBoxes(input, {
+        ascii85: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Ascii85BoxSource.generateBoxes(encoded, {
+        ascii85decode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe(input);
+    });
+
+    it('round-trips unicode string "héllo 世界"', async () => {
+      const input = 'héllo 世界';
+      const encBoxes = await Ascii85BoxSource.generateBoxes(input, {
+        ascii85: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Ascii85BoxSource.generateBoxes(encoded, {
+        ascii85decode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe(input);
+    });
+
+    it('round-trips "sure." (5-byte partial group)', async () => {
+      const input = 'sure.';
+      const encBoxes = await Ascii85BoxSource.generateBoxes(input, {
+        ascii85: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Ascii85BoxSource.generateBoxes(encoded, {
+        ascii85decode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe(input);
+    });
+  });
+
+  describe('decode — ::ascii85decode / ::a85decode', () => {
+    it('decodes "9jqo^" → "Man "', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('9jqo^', {
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Ascii85 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('Man ');
+    });
+
+    it('accepts ::a85decode as an alias', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('9jqo^', {
+        a85decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Man ');
+    });
+
+    it('decodes "z" → 4 null bytes', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('z', {
+        ascii85decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('\x00\x00\x00\x00');
+    });
+
+    it('returns an error box for invalid characters', async () => {
+      // '~' is outside the valid '!'..'u' range
+      const boxes = await Ascii85BoxSource.generateBoxes('v~', {
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/^Error:/);
+    });
+  });
+
+  describe('both encode and decode options', () => {
+    it('returns 2 boxes when both ::ascii85 and ::ascii85decode are set', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        ascii85: true,
+        ascii85decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Ascii85 (Encode)');
+      expect(names).toContain('Ascii85 (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('sets showExpandButton to false', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        ascii85: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('sets priority from BoxSource.priority', async () => {
+      const boxes = await Ascii85BoxSource.generateBoxes('Man ', {
+        ascii85: true,
+      });
+      expect(boxes[0].props.priority).toBe(Ascii85BoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,5 +1,6 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
+import Ascii85BoxSource from './Ascii85BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
 import {
   Base64DecodeBoxSource,
@@ -82,6 +83,7 @@ export const boxSources: BoxSource[] = [
   Base64EncodeBoxSource,
   WordWrapBoxSource,
   A1Z26BoxSource,
+  Ascii85BoxSource,
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,


### PR DESCRIPTION
### Box Source: Ascii85 (Encode)

Adds the `Ascii85` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `hello ::ascii85`

#### Options:
- `::a85`, `::a85decode`, `::ascii85`, `::ascii85decode`, `::base85`

#### Description:
Ascii85 (base85) encode/decode. ::ascii85 to encode, ::ascii85decode to decode.

#### Usage Examples:
- **Input**: `hello ::ascii85`
- **Output Box (`Ascii85 (Encode)`)**:
```
BOu!rDZ
```
