### PR TITLE
feat(AspectRatio): add Aspect Ratio BoxSource

### DIFF
--- a/src/modules/boxSources/AspectRatioBoxSource.ts
+++ b/src/modules/boxSources/AspectRatioBoxSource.ts
@@ -1,0 +1,82 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// common aspect ratio names keyed by simplified ratio string
+const CommonRatios: Record<string, string> = {
+  '16:9': '16:9 Widescreen',
+  '4:3': '4:3 Standard',
+  '21:9': '21:9 Ultrawide',
+  '1:1': '1:1 Square',
+  '3:2': '3:2 Classic',
+  '16:10': '16:10 Widescreen',
+};
+
+function gcd(a: number, b: number): number {
+  while (b !== 0) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+export const AspectRatioBoxSource = {
+  defaultDisabled: true,
+  name: 'Aspect Ratio',
+  description:
+    'Simplify width x height into an aspect ratio (e.g. 1920x1080 → 16:9).',
+  defaultInput: '1920x1080 ::ratio',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ratio', 'aspect')) return [];
+
+    const match = trim(input).match(/^(\d+)\s*[x:×]\s*(\d+)$/i);
+    if (!match) return [];
+
+    const w = Number.parseInt(match[1], 10);
+    const h = Number.parseInt(match[2], 10);
+    if (w <= 0 || h <= 0) return [];
+
+    const divisor = gcd(w, h);
+    const rw = w / divisor;
+    const rh = h / divisor;
+    const ratioStr = `${rw}:${rh}`;
+
+    // round to 4 significant digits and strip trailing zeros
+    const decimal = Number((w / h).toPrecision(4)).toString();
+
+    const kvOptions: Record<string, string> = {
+      Ratio: ratioStr,
+      Decimal: decimal,
+    };
+
+    const commonName = CommonRatios[ratioStr];
+    if (commonName) {
+      kvOptions.Common = commonName;
+    }
+
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Aspect Ratio', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default AspectRatioBoxSource;

--- a/src/modules/boxSources/__test__/AspectRatioBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AspectRatioBoxSource.test.ts
@@ -1,0 +1,144 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { AspectRatioBoxSource } from '../AspectRatioBoxSource';
+
+describe('AspectRatioBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are provided', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('happy path — ::ratio trigger', () => {
+    it('simplifies 1920x1080 to 16:9', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '16:9' });
+    });
+
+    it('accepts colon separator (1280:720) and gives 16:9', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1280:720', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '16:9' });
+    });
+
+    it('simplifies 1024x768 to 4:3', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1024x768', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '4:3' });
+    });
+
+    it('simplifies 500x500 to 1:1', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('500x500', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '1:1' });
+    });
+  });
+
+  describe('happy path — ::aspect trigger', () => {
+    it('also triggers on ::aspect option', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        aspect: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '16:9' });
+    });
+  });
+
+  describe('common name', () => {
+    it('includes Common name for 16:9', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        ratio: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Common: '16:9 Widescreen',
+      });
+    });
+
+    it('omits Common key for non-standard ratios', async () => {
+      // 700x300 simplifies to 7:3, which is not in the common-ratio table
+      const boxes = await AspectRatioBoxSource.generateBoxes('700x300', {
+        ratio: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Ratio: '7:3' });
+      expect(boxes[0].props.options).not.toHaveProperty('Common');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('abc', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when height is zero (1920x0)', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x0', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when width is zero (0x1080)', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('0x1080', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('', {
+        ratio: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('box structure', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        ratio: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority from source constant', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        ratio: true,
+      });
+      expect(boxes[0].props.priority).toBe(AspectRatioBoxSource.priority);
+    });
+
+    it('sets box name to Aspect Ratio', async () => {
+      const boxes = await AspectRatioBoxSource.generateBoxes('1920x1080', {
+        ratio: true,
+      });
+      expect(boxes[0].props.name).toBe('Aspect Ratio');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(AspectRatioBoxSource.name).toBe('Aspect Ratio');
+      expect(AspectRatioBoxSource.tag).toBe('#');
+      expect(AspectRatioBoxSource.kind).toBe('Convert');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import AspectRatioBoxSource from './AspectRatioBoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -83,6 +84,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  AspectRatioBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
   FractionBoxSource,


### PR DESCRIPTION
### Box Source: Aspect Ratio (Convert)

Adds the `Aspect Ratio` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1920x1080 ::ratio`

#### Options:
- `::aspect`, `::ratio`

#### Description:
Simplify width x height into an aspect ratio (e.g. 1920x1080 → 16:9).

#### Usage Examples:
- **Input**: `1920x1080 ::ratio`
- **Output Box (`Aspect Ratio`)**:
```
Ratio: 16:9
Decimal: 1.778
Common: 16:9 Widescreen
```
