### PR TITLE
feat(Atbash): add Atbash BoxSource

### DIFF
--- a/src/modules/boxSources/AtbashBoxSource.ts
+++ b/src/modules/boxSources/AtbashBoxSource.ts
@@ -1,0 +1,60 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// apply the atbash substitution: A↔Z, B↔Y, ...; non-alpha chars pass through unchanged
+function applyAtbash(input: string): string {
+  let result = '';
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code >= 65 && code <= 90) {
+      // uppercase A-Z
+      result += String.fromCharCode(90 - (code - 65));
+    } else if (code >= 97 && code <= 122) {
+      // lowercase a-z
+      result += String.fromCharCode(122 - (code - 97));
+    } else {
+      result += input[i];
+    }
+  }
+  return result;
+}
+
+export const AtbashBoxSource = {
+  defaultDisabled: true,
+  name: 'Atbash',
+  description: 'Apply the Atbash cipher (A↔Z, B↔Y, ...). Self-inverse.',
+  defaultInput: 'hello ::atbash',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'atbash')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const output = applyAtbash(input);
+
+    const box = new BoxBuilder('Atbash', output)
+      .setTemplate(DefaultBoxTemplate)
+      .setShowExpandButton(false)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default AtbashBoxSource;

--- a/src/modules/boxSources/__test__/AtbashBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AtbashBoxSource.test.ts
@@ -1,0 +1,107 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { AtbashBoxSource } from '../AtbashBoxSource';
+
+describe('AtbashBoxSource', () => {
+  describe('generateBoxes - gate conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no atbash key', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::atbash', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('', { atbash: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::atbash', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('   ', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - cipher correctness', () => {
+    it('transforms "hello" to "svool"', async () => {
+      // h→s, e→v, l→o, l→o, o→l
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('svool');
+    });
+
+    it('transforms "ABC" to "ZYX"', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('ABC', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ZYX');
+    });
+
+    it('preserves case and punctuation: "Hello, World!" → "Svool, Dliow!"', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('Hello, World!', {
+        atbash: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Svool, Dliow!');
+    });
+
+    it('is self-inverse: atbash(atbash(x)) === x', async () => {
+      const original = 'The quick brown fox jumps over the lazy dog.';
+      const once = await AtbashBoxSource.generateBoxes(original, {
+        atbash: true,
+      });
+      const twice = await AtbashBoxSource.generateBoxes(
+        once[0].props.plaintextOutput,
+        { atbash: true },
+      );
+      expect(twice[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('generateBoxes - box properties', () => {
+    it('sets name to "Atbash"', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {
+        atbash: true,
+      });
+      expect(boxes[0].props.name).toBe('Atbash');
+    });
+
+    it('uses DefaultBoxTemplate', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {
+        atbash: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('sets showExpandButton to false', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {
+        atbash: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await AtbashBoxSource.generateBoxes('hello', {
+        atbash: true,
+      });
+      expect(boxes[0].props.priority).toBe(AtbashBoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(AtbashBoxSource.name).toBe('Atbash');
+      expect(AtbashBoxSource.kind).toBe('Encode');
+      expect(typeof AtbashBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import AtbashBoxSource from './AtbashBoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -74,6 +75,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  AtbashBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
   FrequencyBoxSource,


### PR DESCRIPTION
### Box Source: Atbash (Encode)

Adds the `Atbash` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `hello ::atbash`

#### Options:
- `::atbash`

#### Description:
Apply the Atbash cipher (A↔Z, B↔Y, ...). Self-inverse.

#### Usage Examples:
- **Input**: `hello ::atbash`
- **Output Box (`Atbash`)**:
```
svool
```
