### PR TITLE
feat(Autokey): add Autokey Cipher BoxSource

### DIFF
--- a/src/modules/boxSources/AutokeyBoxSource.ts
+++ b/src/modules/boxSources/AutokeyBoxSource.ts
@@ -1,0 +1,179 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+const USAGE_ENCRYPT =
+  'Usage: ::autokey=KEY — key must contain at least one letter.';
+const USAGE_DECRYPT =
+  'Usage: ::autokeydecode=KEY — key must contain at least one letter.';
+
+// extracts only the letter characters from a string, uppercased
+function extractLetters(s: string): string {
+  return s
+    .toUpperCase()
+    .split('')
+    .filter((c) => c >= 'A' && c <= 'Z')
+    .join('');
+}
+
+// autokey encrypt: keystream = key letters + plaintext letters
+function autokeyEncrypt(plaintext: string, keyLetters: string): string {
+  // build the full keystream from key letters followed by plaintext letters
+  const plaintextLetters = extractLetters(plaintext);
+  const keystream = keyLetters + plaintextLetters;
+
+  let ki = 0; // index into keystream
+  const result: string[] = [];
+
+  for (const ch of plaintext) {
+    const upper = ch.toUpperCase();
+    if (upper >= 'A' && upper <= 'Z') {
+      const p = upper.charCodeAt(0) - 65;
+      const k = keystream.charCodeAt(ki) - 65;
+      const c = (p + k) % 26;
+      const encChar = String.fromCharCode(65 + c);
+      result.push(ch === ch.toUpperCase() ? encChar : encChar.toLowerCase());
+      ki++;
+    } else {
+      result.push(ch);
+    }
+  }
+
+  return result.join('');
+}
+
+// autokey decrypt: keystream starts as key letters; each recovered plaintext
+// letter is appended to extend the keystream
+function autokeyDecrypt(ciphertext: string, keyLetters: string): string {
+  // keystream grows dynamically — start with key letters
+  const keystream: number[] = keyLetters
+    .split('')
+    .map((c) => c.charCodeAt(0) - 65);
+
+  let ki = 0;
+  const result: string[] = [];
+
+  for (const ch of ciphertext) {
+    const upper = ch.toUpperCase();
+    if (upper >= 'A' && upper <= 'Z') {
+      const c = upper.charCodeAt(0) - 65;
+      const k = keystream[ki];
+      const p = (((c - k) % 26) + 26) % 26;
+      const decChar = String.fromCharCode(65 + p);
+      result.push(ch === ch.toUpperCase() ? decChar : decChar.toLowerCase());
+      // extend keystream with the recovered plaintext letter
+      keystream.push(p);
+      ki++;
+    } else {
+      result.push(ch);
+    }
+  }
+
+  return result.join('');
+}
+
+function buildUsageBox(name: string, usage: string, priority: number): Box {
+  return new BoxBuilder(name, usage)
+    .setTemplate(DefaultBoxTemplate)
+    .setShowExpandButton(false)
+    .setPriority(priority)
+    .build();
+}
+
+export const AutokeyBoxSource = {
+  defaultDisabled: true,
+  name: 'Autokey Cipher',
+  description:
+    'Vigenere autokey cipher (the message extends the key). ::autokey=KEY to encrypt, ::autokeydecode=KEY to decrypt.',
+  defaultInput: 'ATTACKATDAWN ::autokey=QUEENLY',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const encKey = extractOptionKeys(options, 'autokey', 'autokeyencode');
+    const decKey = extractOptionKeys(options, 'autokeydecode');
+
+    if (encKey === null && decKey === null) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (encKey !== null) {
+      // bare ::autokey without a value is boolean true — show usage
+      if (typeof encKey !== 'string') {
+        boxes.push(
+          buildUsageBox(
+            'Autokey Cipher (Encrypt)',
+            USAGE_ENCRYPT,
+            this.priority,
+          ),
+        );
+      } else {
+        const keyLetters = extractLetters(encKey);
+        if (keyLetters.length === 0) {
+          boxes.push(
+            buildUsageBox(
+              'Autokey Cipher (Encrypt)',
+              USAGE_ENCRYPT,
+              this.priority,
+            ),
+          );
+        } else {
+          const ciphertext = autokeyEncrypt(input, keyLetters);
+          boxes.push(
+            new BoxBuilder('Autokey Cipher (Encrypt)', ciphertext)
+              .setTemplate(DefaultBoxTemplate)
+              .setShowExpandButton(false)
+              .setPriority(this.priority)
+              .build(),
+          );
+        }
+      }
+    }
+
+    if (decKey !== null) {
+      if (typeof decKey !== 'string') {
+        boxes.push(
+          buildUsageBox(
+            'Autokey Cipher (Decrypt)',
+            USAGE_DECRYPT,
+            this.priority,
+          ),
+        );
+      } else {
+        const keyLetters = extractLetters(decKey);
+        if (keyLetters.length === 0) {
+          boxes.push(
+            buildUsageBox(
+              'Autokey Cipher (Decrypt)',
+              USAGE_DECRYPT,
+              this.priority,
+            ),
+          );
+        } else {
+          const plaintext = autokeyDecrypt(input, keyLetters);
+          boxes.push(
+            new BoxBuilder('Autokey Cipher (Decrypt)', plaintext)
+              .setTemplate(DefaultBoxTemplate)
+              .setShowExpandButton(false)
+              .setPriority(this.priority)
+              .build(),
+          );
+        }
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default AutokeyBoxSource;

--- a/src/modules/boxSources/__test__/AutokeyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/AutokeyBoxSource.test.ts
@@ -1,0 +1,160 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { AutokeyBoxSource } from '../AutokeyBoxSource';
+
+describe('AutokeyBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(AutokeyBoxSource.name).toBe('Autokey Cipher');
+      expect(AutokeyBoxSource.tag).toBe('#');
+      expect(AutokeyBoxSource.kind).toBe('Encode');
+      expect(typeof AutokeyBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await AutokeyBoxSource.generateBoxes('ATTACKATDAWN', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await AutokeyBoxSource.generateBoxes('ATTACKATDAWN', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const boxes = await AutokeyBoxSource.generateBoxes('', {
+        autokey: 'QUEENLY',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - encrypt canonical Wikipedia vector', () => {
+    // plaintext ATTACKATDAWN, key QUEENLY
+    // keystream = QUEENLY + ATTACKATDAWN = QUEENLYATTACKDAWN...
+    // first 12: Q U E E N L Y A T T A C
+    // A+Q=Q, T+U=N, T+E=X, A+E=E, C+N=P, K+L=V, A+Y=Y, T+A=T, D+T=W, A+T=T, W+A=W, N+C=P
+    // ciphertext: QNXEPVYTWTWP
+    it('encrypts ATTACKATDAWN with key QUEENLY to QNXEPVYTWTWP', async () => {
+      const boxes = await AutokeyBoxSource.generateBoxes('ATTACKATDAWN', {
+        autokey: 'QUEENLY',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Autokey Cipher (Encrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('QNXEPVYTWTWP');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('generateBoxes - decrypt canonical Wikipedia vector', () => {
+    it('decrypts QNXEPVYTWTWP with key QUEENLY to ATTACKATDAWN', async () => {
+      const boxes = await AutokeyBoxSource.generateBoxes('QNXEPVYTWTWP', {
+        autokeydecode: 'QUEENLY',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Autokey Cipher (Decrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('ATTACKATDAWN');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('generateBoxes - case preservation and round-trip with punctuation', () => {
+    it('round-trips "Hello, World!" with key KEY', async () => {
+      const original = 'Hello, World!';
+      const encBoxes = await AutokeyBoxSource.generateBoxes(original, {
+        autokey: 'KEY',
+      });
+      expect(encBoxes).toHaveLength(1);
+      const ciphertext = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await AutokeyBoxSource.generateBoxes(ciphertext, {
+        autokeydecode: 'KEY',
+      });
+      expect(decBoxes).toHaveLength(1);
+      // punctuation and spaces pass through unchanged; letters round-trip
+      expect(decBoxes[0].props.plaintextOutput).toBe(original);
+    });
+
+    it('preserves non-letter characters in position', async () => {
+      // comma and space must appear at indices 5 and 6 of "Hello, World!"
+      const encBoxes = await AutokeyBoxSource.generateBoxes('Hello, World!', {
+        autokey: 'KEY',
+      });
+      const cipher = encBoxes[0].props.plaintextOutput;
+      expect(cipher[5]).toBe(',');
+      expect(cipher[6]).toBe(' ');
+      expect(cipher[12]).toBe('!');
+    });
+  });
+
+  describe('generateBoxes - bare option (no key value) → usage box', () => {
+    it('returns usage box when ::autokey is bare boolean true', async () => {
+      const boxes = await AutokeyBoxSource.generateBoxes('ATTACKATDAWN', {
+        autokey: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Autokey Cipher (Encrypt)');
+      // usage box contains instructions, not ciphertext
+      expect(boxes[0].props.plaintextOutput).toMatch(/usage/i);
+    });
+
+    it('returns usage box when ::autokeydecode is bare boolean true', async () => {
+      const boxes = await AutokeyBoxSource.generateBoxes('QNXEPVYTWTWP', {
+        autokeydecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Autokey Cipher (Decrypt)');
+      expect(boxes[0].props.plaintextOutput).toMatch(/usage/i);
+    });
+  });
+
+  describe('generateBoxes - key with no letters → usage box', () => {
+    it('returns usage box when key contains only digits', async () => {
+      const boxes = await AutokeyBoxSource.generateBoxes('ATTACKATDAWN', {
+        autokey: '123',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/usage/i);
+    });
+
+    it('returns usage box for decrypt when key contains only digits', async () => {
+      const boxes = await AutokeyBoxSource.generateBoxes('QNXEPVYTWTWP', {
+        autokeydecode: '456',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/usage/i);
+    });
+  });
+
+  describe('generateBoxes - both options → 2 boxes', () => {
+    it('returns encrypt box then decrypt box when both options are set', async () => {
+      const boxes = await AutokeyBoxSource.generateBoxes('ATTACKATDAWN', {
+        autokey: 'QUEENLY',
+        autokeydecode: 'QUEENLY',
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Autokey Cipher (Encrypt)');
+      expect(boxes[1].props.name).toBe('Autokey Cipher (Decrypt)');
+    });
+  });
+
+  describe('generateBoxes - autokeyencode alias', () => {
+    it('::autokeyencode=KEY works identically to ::autokey=KEY', async () => {
+      const via_autokey = await AutokeyBoxSource.generateBoxes('ATTACKATDAWN', {
+        autokey: 'QUEENLY',
+      });
+      const via_autokeyencode = await AutokeyBoxSource.generateBoxes(
+        'ATTACKATDAWN',
+        { autokeyencode: 'QUEENLY' },
+      );
+      expect(via_autokeyencode[0].props.plaintextOutput).toBe(
+        via_autokey[0].props.plaintextOutput,
+      );
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import AutokeyBoxSource from './AutokeyBoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -74,6 +75,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  AutokeyBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
   FrequencyBoxSource,


### PR DESCRIPTION
### Box Source: Autokey Cipher (Encode)

Adds the `Autokey Cipher` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `ATTACKATDAWN ::autokey=QUEENLY`

#### Options:
- None

#### Description:
Vigenere autokey cipher (the message extends the key). ::autokey=KEY to encrypt, ::autokeydecode=KEY to decrypt.

#### Usage Examples:
- **Input**: `ATTACKATDAWN ::autokey=QUEENLY`
- **Output Box (`Autokey Cipher (Encrypt)`)**:
```
QNXEPVYTWTWP
```
