### PR TITLE
feat(BaconCipher): add Bacon Cipher BoxSource

### DIFF
--- a/src/modules/boxSources/BaconCipherBoxSource.ts
+++ b/src/modules/boxSources/BaconCipherBoxSource.ts
@@ -1,0 +1,94 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// maps each letter index (0=A … 25=Z) to its 5-char a/b code (0→'a', 1→'b')
+const ENCODE_TABLE: string[] = Array.from({ length: 26 }, (_, i) =>
+  i.toString(2).padStart(5, '0').replace(/0/g, 'a').replace(/1/g, 'b'),
+);
+
+// reverse lookup: a/b code → letter
+const DECODE_TABLE: Record<string, string> = Object.fromEntries(
+  ENCODE_TABLE.map((code, i) => [code, String.fromCharCode(65 + i)]),
+);
+
+function encodeBacon(input: string): string {
+  return input
+    .toUpperCase()
+    .split('')
+    .filter((ch) => ch >= 'A' && ch <= 'Z')
+    .map((ch) => ENCODE_TABLE[ch.charCodeAt(0) - 65])
+    .join(' ');
+}
+
+function decodeBacon(input: string): string {
+  // keep only a/b so stray characters don't misalign the 5-char groups
+  const normalized = input.toLowerCase().replace(/[^ab]/g, '');
+  const groups: string[] = [];
+  for (let i = 0; i + 5 <= normalized.length; i += 5) {
+    groups.push(normalized.slice(i, i + 5));
+  }
+  return groups
+    .map((g) => {
+      // skip groups with chars other than a/b
+      if (!/^[ab]{5}$/.test(g)) return '';
+      return (DECODE_TABLE[g] ?? '').toLowerCase();
+    })
+    .join('');
+}
+
+export const BaconCipherBoxSource = {
+  defaultDisabled: true,
+  name: 'Bacon Cipher',
+  description:
+    "Encode text to Bacon's cipher (5-letter A/B groups) or decode it back.",
+  defaultInput: 'hello ::bacon',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'bacon', 'baconencode');
+    const wantDecode = hasOptionKeys(options, 'bacondecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      boxes.push(
+        new BoxBuilder('Bacon Cipher (Encode)', encodeBacon(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      boxes.push(
+        new BoxBuilder('Bacon Cipher (Decode)', decodeBacon(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default BaconCipherBoxSource;

--- a/src/modules/boxSources/__test__/BaconCipherBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BaconCipherBoxSource.test.ts
@@ -1,0 +1,159 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { BaconCipherBoxSource } from '../BaconCipherBoxSource';
+
+describe('BaconCipherBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(BaconCipherBoxSource.name).toBe('Bacon Cipher');
+      expect(BaconCipherBoxSource.tag).toBe('#');
+      expect(BaconCipherBoxSource.kind).toBe('Encode');
+      expect(typeof BaconCipherBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is empty string with ::bacon', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('', {
+        bacon: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is whitespace only', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('   ', {
+        bacon: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — individual letters', () => {
+    // A = index 0 = 00000 in 5-bit binary → 'aaaaa'
+    it("encodes 'A' to 'aaaaa'", async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('A', {
+        bacon: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('aaaaa');
+    });
+
+    // B = index 1 = 00001 → 'aaaab'
+    it("encodes 'B' to 'aaaab'", async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('B', {
+        bacon: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('aaaab');
+    });
+
+    // Z = index 25 = 11001 in 5-bit binary → 'bbaab'
+    it("encodes 'Z' to 'bbaab'", async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('Z', {
+        bacon: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('bbaab');
+    });
+  });
+
+  describe('encode — word', () => {
+    // H=7=00111→'aabbb', E=4=00100→'aabaa', L=11=01011→'ababb', O=14=01110→'abbba'
+    it("encodes 'hello' to correct 5-char groups separated by spaces", async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('hello', {
+        bacon: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'aabbb aabaa ababb ababb abbba',
+      );
+      expect(boxes[0].props.name).toBe('Bacon Cipher (Encode)');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('drops non-letter characters during encode', async () => {
+      // "A B" → 'aaaaa aaaab' (space in input dropped, codes space-separated)
+      const boxes = await BaconCipherBoxSource.generateBoxes('A B', {
+        bacon: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('aaaaa aaaab');
+    });
+  });
+
+  describe('decode', () => {
+    it("decodes 'aabbb aabaa ababb ababb abbba' to 'hello'", async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes(
+        'aabbb aabaa ababb ababb abbba',
+        { bacondecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+      expect(boxes[0].props.name).toBe('Bacon Cipher (Decode)');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('decode is case-insensitive for the a/b input', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('AAAAA', {
+        bacondecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a');
+    });
+
+    it('ignores incomplete trailing group', async () => {
+      // 'aaaaa' + 'aa' (incomplete) → 'a'
+      const boxes = await BaconCipherBoxSource.generateBoxes('aaaaaa a', {
+        bacondecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encode then decode returns the original letters lowercased', async () => {
+      const word = 'WORLD';
+      const encoded = await BaconCipherBoxSource.generateBoxes(word, {
+        bacon: true,
+      });
+      const encodedText = encoded[0].props.plaintextOutput;
+
+      const decoded = await BaconCipherBoxSource.generateBoxes(encodedText, {
+        bacondecode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe(word.toLowerCase());
+    });
+  });
+
+  describe('both options', () => {
+    it('returns 2 boxes when both ::bacon and ::bacondecode are set', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('hello', {
+        bacon: true,
+        bacondecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Bacon Cipher (Encode)');
+      expect(names).toContain('Bacon Cipher (Decode)');
+    });
+  });
+
+  describe('::baconencode alias', () => {
+    it('responds to ::baconencode the same as ::bacon', async () => {
+      const boxes = await BaconCipherBoxSource.generateBoxes('A', {
+        baconencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('aaaaa');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import BaconCipherBoxSource from './BaconCipherBoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -74,6 +75,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  BaconCipherBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
   FrequencyBoxSource,


### PR DESCRIPTION
### Box Source: Bacon Cipher (Encode)

Adds the `Bacon Cipher` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `hello ::bacon`

#### Options:
- `::bacon`, `::bacondecode`, `::baconencode`

#### Description:
Encode text to Bacon

#### Usage Examples:
- **Input**: `hello ::bacon`
- **Output Box (`Bacon Cipher (Encode)`)**:
```
aabbb aabaa ababb ababb abbba
```
