### PR TITLE
feat(Base32): add Base32 BoxSource

### DIFF
--- a/src/modules/boxSources/Base32BoxSource.ts
+++ b/src/modules/boxSources/Base32BoxSource.ts
@@ -1,0 +1,135 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// RFC 4648 §6 standard alphabet (no padding char)
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+// reverse lookup: char → 5-bit value
+const DECODE_MAP: Record<string, number> = {};
+for (let i = 0; i < ALPHABET.length; i++) {
+  DECODE_MAP[ALPHABET[i]] = i;
+}
+
+/** Encode arbitrary UTF-8 text to RFC 4648 Base32 with '=' padding. */
+function base32Encode(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let bits = 0;
+  let accumulator = 0;
+  let output = '';
+
+  for (const byte of bytes) {
+    accumulator = (accumulator << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      output += ALPHABET[(accumulator >> bits) & 0x1f];
+    }
+  }
+
+  // flush remaining bits (left-aligned in the 5-bit window)
+  if (bits > 0) {
+    output += ALPHABET[(accumulator << (5 - bits)) & 0x1f];
+  }
+
+  // pad to a multiple of 8 per RFC 4648 §6
+  while (output.length % 8 !== 0) {
+    output += '=';
+  }
+
+  return output;
+}
+
+/** Decode RFC 4648 Base32 back to UTF-8 text, or throw on invalid input. */
+function base32Decode(input: string): string {
+  // strip whitespace, uppercase, and trailing padding
+  const normalised = input.replace(/\s/g, '').toUpperCase().replace(/=+$/, '');
+
+  let bits = 0;
+  let accumulator = 0;
+  const bytes: number[] = [];
+
+  for (const ch of normalised) {
+    const val = DECODE_MAP[ch];
+    if (val === undefined) {
+      throw new Error(`invalid Base32 character: '${ch}'`);
+    }
+    accumulator = (accumulator << 5) | val;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((accumulator >> bits) & 0xff);
+    }
+  }
+
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+export const Base32BoxSource = {
+  defaultDisabled: true,
+  name: 'Base32',
+  description:
+    'RFC 4648 Base32 encode/decode. ::base32 to encode, ::base32decode to decode.',
+  defaultInput: 'hello ::base32',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'base32', 'base32encode');
+    const wantDecode = hasOptionKeys(options, 'base32decode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = base32Encode(input);
+      boxes.push(
+        new BoxBuilder('Base32 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      try {
+        const decoded = base32Decode(input);
+        boxes.push(
+          new BoxBuilder('Base32 (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'invalid Base32';
+        boxes.push(
+          new BoxBuilder('Base32 (Decode)', message)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Base32BoxSource;

--- a/src/modules/boxSources/__test__/Base32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base32BoxSource.test.ts
@@ -1,0 +1,146 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Base32BoxSource } from '../Base32BoxSource';
+
+describe('Base32BoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with encode option', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('', { base32: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('   ', {
+        base32: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding MAX_INPUT', async () => {
+      const huge = 'a'.repeat(100_001);
+      const boxes = await Base32BoxSource.generateBoxes(huge, { base32: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — RFC 4648 §10 test vectors', () => {
+    const cases: [string, string][] = [
+      ['f', 'MY======'],
+      ['fo', 'MZXQ===='],
+      ['foo', 'MZXW6==='],
+      ['foob', 'MZXW6YQ='],
+      ['fooba', 'MZXW6YTB'],
+      ['foobar', 'MZXW6YTBOI======'],
+    ];
+
+    for (const [plaintext, expected] of cases) {
+      it(`encodes '${plaintext}' → '${expected}'`, async () => {
+        const boxes = await Base32BoxSource.generateBoxes(plaintext, {
+          base32: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput).toBe(expected);
+        expect(boxes[0].props.name).toBe('Base32 (Encode)');
+        expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+        expect(boxes[0].props.showExpandButton).toBe(false);
+      });
+    }
+
+    it('also triggers via ::base32encode option key', async () => {
+      const boxes = await Base32BoxSource.generateBoxes('foobar', {
+        base32encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('MZXW6YTBOI======');
+    });
+  });
+
+  describe('decode', () => {
+    it("decodes 'MZXW6YTBOI======' → 'foobar'", async () => {
+      const boxes = await Base32BoxSource.generateBoxes('MZXW6YTBOI======', {
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('foobar');
+      expect(boxes[0].props.name).toBe('Base32 (Decode)');
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('decodes each RFC 4648 vector back to the original plaintext', async () => {
+      const cases: [string, string][] = [
+        ['MY======', 'f'],
+        ['MZXQ====', 'fo'],
+        ['MZXW6===', 'foo'],
+        ['MZXW6YQ=', 'foob'],
+        ['MZXW6YTB', 'fooba'],
+        ['MZXW6YTBOI======', 'foobar'],
+      ];
+      for (const [encoded, expected] of cases) {
+        const boxes = await Base32BoxSource.generateBoxes(encoded, {
+          base32decode: true,
+        });
+        expect(boxes[0].props.plaintextOutput).toBe(expected);
+      }
+    });
+
+    it('returns an error box for invalid Base32 input (chars not in alphabet)', async () => {
+      // '1', '8', '9', '0' are not in the RFC 4648 standard alphabet
+      const boxes = await Base32BoxSource.generateBoxes('1890', {
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid Base32/i);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encodes then decodes Unicode back to the original string', async () => {
+      const original = 'Hello, 世界! 😀';
+
+      const encodeBoxes = await Base32BoxSource.generateBoxes(original, {
+        base32: true,
+      });
+      expect(encodeBoxes).toHaveLength(1);
+      const encoded = encodeBoxes[0].props.plaintextOutput;
+
+      const decodeBoxes = await Base32BoxSource.generateBoxes(encoded, {
+        base32decode: true,
+      });
+      expect(decodeBoxes).toHaveLength(1);
+      expect(decodeBoxes[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('both options simultaneously', () => {
+    it('returns 2 boxes when both encode and decode options are set', async () => {
+      // input is valid Base32 so decode succeeds; encode treats it as plaintext
+      const boxes = await Base32BoxSource.generateBoxes('MZXW6YTBOI======', {
+        base32: true,
+        base32decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Base32 (Encode)');
+      expect(names).toContain('Base32 (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Base32BoxSource.name).toBe('Base32');
+      expect(Base32BoxSource.kind).toBe('Encode');
+      expect(typeof Base32BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import Base32BoxSource from './Base32BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -83,6 +84,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  Base32BoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
   FractionBoxSource,


### PR DESCRIPTION
### Box Source: Base32 (Encode)

Adds the `Base32` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `hello ::base32`

#### Options:
- `::base32`, `::base32decode`, `::base32encode`

#### Description:
RFC 4648 Base32 encode/decode. ::base32 to encode, ::base32decode to decode.

#### Usage Examples:
- **Input**: `hello ::base32`
- **Output Box (`Base32 (Encode)`)**:
```
NBSWY3DP
```
