### PR TITLE
feat(Base58): add Base58 BoxSource

### DIFF
--- a/src/modules/boxSources/Base58BoxSource.ts
+++ b/src/modules/boxSources/Base58BoxSource.ts
@@ -1,0 +1,144 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+// base58 long-division is O(n²); base58 is meant for small blobs (keys, hashes,
+// addresses), so a low cap keeps worst-case work sub-millisecond
+const MAX_INPUT = 1_024;
+
+// bitcoin alphabet: excludes 0, O, I, l to avoid visual ambiguity
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+// precompute decode map for O(1) char lookup
+const ALPHABET_MAP: Record<string, number> = {};
+for (let i = 0; i < ALPHABET.length; i++) {
+  ALPHABET_MAP[ALPHABET[i]] = i;
+}
+
+// encodes a byte array to base58 string using long division
+function base58EncodeBytes(bytes: Uint8Array): string {
+  let leadingZeros = 0;
+  for (const b of bytes) {
+    if (b !== 0) break;
+    leadingZeros++;
+  }
+
+  // working copy excluding leading zero bytes; an all-zero input leaves this
+  // empty so the loop never runs and we return only the '1' padding (otherwise
+  // the division emits a spurious extra '1' and breaks the round-trip)
+  const digits = Array.from(bytes.subarray(leadingZeros));
+  let result = '';
+
+  while (digits.length > 0) {
+    let carry = 0;
+    const next: number[] = [];
+    for (const byte of digits) {
+      carry = carry * 256 + byte;
+      const quotient = Math.floor(carry / 58);
+      carry = carry % 58;
+      if (next.length > 0 || quotient > 0) {
+        next.push(quotient);
+      }
+    }
+    result = ALPHABET[carry] + result;
+    digits.length = 0;
+    for (const v of next) digits.push(v);
+  }
+
+  return '1'.repeat(leadingZeros) + result;
+}
+
+// decodes a base58 string to a byte array; returns null on invalid input
+function base58DecodeBytes(input: string): Uint8Array | null {
+  let leadingZeros = 0;
+  for (const ch of input) {
+    if (ch !== '1') break;
+    leadingZeros++;
+  }
+
+  // mutable working copy; each element is a base-58 digit value
+  const digits: number[] = [];
+  for (const ch of input.slice(leadingZeros)) {
+    const value = ALPHABET_MAP[ch];
+    if (value === undefined) return null;
+
+    let carry = value;
+    for (let i = digits.length - 1; i >= 0; i--) {
+      carry += digits[i] * 58;
+      digits[i] = carry % 256;
+      carry = Math.floor(carry / 256);
+    }
+    while (carry > 0) {
+      digits.unshift(carry % 256);
+      carry = Math.floor(carry / 256);
+    }
+  }
+
+  const result = new Uint8Array(leadingZeros + digits.length);
+  for (let i = 0; i < digits.length; i++) {
+    result[leadingZeros + i] = digits[i];
+  }
+  return result;
+}
+
+export const Base58BoxSource = {
+  defaultDisabled: true,
+  name: 'Base58',
+  description:
+    'Encode text to Base58 (Bitcoin alphabet) or decode Base58 back to text.',
+  defaultInput: 'Hello World! ::base58',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'base58', 'base58encode');
+    const wantDecode = hasOptionKeys(options, 'base58decode');
+    if (!wantEncode && !wantDecode) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const bytes = new TextEncoder().encode(input);
+      const encoded = base58EncodeBytes(bytes);
+      boxes.push(
+        new BoxBuilder('Base58 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const bytes = base58DecodeBytes(input);
+      if (bytes === null) {
+        boxes.push(
+          new BoxBuilder('Base58 (Decode)', 'invalid Base58 input')
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        const decoded = new TextDecoder().decode(bytes);
+        boxes.push(
+          new BoxBuilder('Base58 (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Base58BoxSource;

--- a/src/modules/boxSources/__test__/Base58BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base58BoxSource.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import { Base58BoxSource } from '../Base58BoxSource';
+
+describe('Base58BoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Base58BoxSource.name).toBe('Base58');
+      expect(Base58BoxSource.tag).toBe('#');
+      expect(Base58BoxSource.kind).toBe('Encode');
+      expect(typeof Base58BoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('Hello World!', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('Hello World!', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - encode known vector', () => {
+    it('encodes "Hello World!" to canonical base58', async () => {
+      // canonical vector: base58(ASCII bytes of "Hello World!")
+      const boxes = await Base58BoxSource.generateBoxes('Hello World!', {
+        base58: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base58 (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('2NEpo7TZRRrLZSi2U');
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('accepts ::base58encode option alias', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('Hello World!', {
+        base58encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('2NEpo7TZRRrLZSi2U');
+    });
+  });
+
+  describe('generateBoxes - decode', () => {
+    it('decodes "2NEpo7TZRRrLZSi2U" back to "Hello World!"', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('2NEpo7TZRRrLZSi2U', {
+        base58decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base58 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('Hello World!');
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('returns invalid box for forbidden chars (0, O, I, l)', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('0OIl', {
+        base58decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base58 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('invalid Base58 input');
+    });
+  });
+
+  describe('generateBoxes - round-trip', () => {
+    it('decode(encode("Hello World!")) === "Hello World!"', async () => {
+      const encBoxes = await Base58BoxSource.generateBoxes('Hello World!', {
+        base58: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Base58BoxSource.generateBoxes(encoded, {
+        base58decode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe('Hello World!');
+    });
+
+    it('decode(encode("foobar")) === "foobar"', async () => {
+      const encBoxes = await Base58BoxSource.generateBoxes('foobar', {
+        base58: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Base58BoxSource.generateBoxes(encoded, {
+        base58decode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe('foobar');
+    });
+  });
+
+  describe('generateBoxes - leading zero bytes', () => {
+    const NUL = String.fromCharCode(0);
+
+    it('encodes a single NUL byte to exactly "1" and round-trips', async () => {
+      const enc = await Base58BoxSource.generateBoxes(NUL, { base58: true });
+      expect(enc[0].props.plaintextOutput).toBe('1');
+
+      const dec = await Base58BoxSource.generateBoxes('1', {
+        base58decode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe(NUL);
+    });
+
+    it('preserves a leading NUL before a printable byte', async () => {
+      const enc = await Base58BoxSource.generateBoxes(`${NUL}A`, {
+        base58: true,
+      });
+      const encoded = enc[0].props.plaintextOutput;
+      expect(encoded.startsWith('1')).toBe(true);
+      const dec = await Base58BoxSource.generateBoxes(encoded, {
+        base58decode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe(`${NUL}A`);
+    });
+  });
+
+  describe('generateBoxes - both options', () => {
+    it('returns 2 boxes when both encode and decode options are set', async () => {
+      const boxes = await Base58BoxSource.generateBoxes('Hello World!', {
+        base58: true,
+        base58decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Base58 (Encode)');
+      expect(names).toContain('Base58 (Decode)');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import Base58BoxSource from './Base58BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -83,6 +84,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  Base58BoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
   FractionBoxSource,


### PR DESCRIPTION
### Box Source: Base58 (Encode)

Adds the `Base58` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `Hello World! ::base58`

#### Options:
- `::base58`, `::base58decode`, `::base58encode`

#### Description:
Encode text to Base58 (Bitcoin alphabet) or decode Base58 back to text.

#### Usage Examples:
- **Input**: `Hello World! ::base58`
- **Output Box (`Base58 (Encode)`)**:
```
2NEpo7TZRRrLZSi2U
```
