### PR TITLE
feat(Base62): add Base62 BoxSource

### DIFF
--- a/src/modules/boxSources/Base62BoxSource.ts
+++ b/src/modules/boxSources/Base62BoxSource.ts
@@ -1,0 +1,110 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// standard base62 alphabet: digits, uppercase, then lowercase
+const ALPHABET =
+  '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const BASE = 62n;
+
+// build reverse lookup once at module init
+const CHAR_TO_INDEX = new Map<string, bigint>(
+  [...ALPHABET].map((ch, i) => [ch, BigInt(i)]),
+);
+
+function encodeBase62(n: bigint): string {
+  if (n === 0n) return '0';
+  let result = '';
+  let value = n;
+  while (value > 0n) {
+    result = ALPHABET[Number(value % BASE)] + result;
+    value /= BASE;
+  }
+  return result;
+}
+
+function decodeBase62(s: string): bigint {
+  let value = 0n;
+  for (const ch of s) {
+    const digit = CHAR_TO_INDEX.get(ch);
+    if (digit === undefined) throw new Error(`invalid base62 char: ${ch}`);
+    value = value * BASE + digit;
+  }
+  return value;
+}
+
+export const Base62BoxSource = {
+  defaultDisabled: true,
+  name: 'Base62',
+  description:
+    'Encode a non-negative integer to Base62, or decode a Base62 string to a number.',
+  defaultInput: '123456789 ::base62',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'base62', 'base62encode');
+    const wantDecode = hasOptionKeys(options, 'base62decode');
+    if (!wantEncode && !wantDecode) return [];
+
+    // cap input length to avoid DoS on huge strings
+    const raw = trim(input).slice(0, 5000);
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      if (!/^\d+$/.test(raw)) {
+        boxes.push(
+          new BoxBuilder(
+            'Base62',
+            'Invalid input: a non-negative integer is required for encoding.',
+          )
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        const decimal = BigInt(raw);
+        const encoded = encodeBase62(decimal);
+        boxes.push(
+          new BoxBuilder('Base62', `Decimal: ${raw}\nBase62: ${encoded}`)
+            .setOptions({ Decimal: raw, Base62: encoded })
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    if (wantDecode) {
+      if (!/^[0-9A-Za-z]+$/.test(raw)) {
+        boxes.push(
+          new BoxBuilder(
+            'Base62',
+            'Invalid input: only base62 characters (0–9, A–Z, a–z) are allowed.',
+          )
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        const decoded = decodeBase62(raw);
+        boxes.push(
+          new BoxBuilder('Base62', `Base62: ${raw}\nDecimal: ${decoded}`)
+            .setOptions({ Base62: raw, Decimal: decoded.toString() })
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Base62BoxSource;

--- a/src/modules/boxSources/__test__/Base62BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base62BoxSource.test.ts
@@ -1,0 +1,169 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Base62BoxSource } from '../Base62BoxSource';
+
+describe('Base62BoxSource', () => {
+  describe('no option keys → empty array', () => {
+    it('returns [] when no base62 option is provided', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('123456789', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] with unrelated options', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('123456789', {
+        foo: 'bar',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode', () => {
+    it('encodes 0 to "0"', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('0', { base62: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Decimal: '0',
+        Base62: '0',
+      });
+    });
+
+    it('encodes 61 to "z" (last single-char value)', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('61', { base62: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Decimal: '61',
+        Base62: 'z',
+      });
+    });
+
+    it('encodes 62 to "10"', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('62', { base62: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Decimal: '62',
+        Base62: '10',
+      });
+    });
+
+    it('encodes 123456789 and round-trips back', async () => {
+      const encBoxes = await Base62BoxSource.generateBoxes('123456789', {
+        base62: true,
+      });
+      expect(encBoxes).toHaveLength(1);
+      const encoded = encBoxes[0].props.options?.Base62 as string;
+      expect(encoded).toBeTruthy();
+
+      const decBoxes = await Base62BoxSource.generateBoxes(encoded, {
+        base62decode: true,
+      });
+      expect(decBoxes).toHaveLength(1);
+      expect(decBoxes[0].props.options).toMatchObject({ Decimal: '123456789' });
+    });
+
+    it('uses KeyValueBoxTemplate for valid encode', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('62', { base62: true });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('returns error box for non-digit encode input', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('abc', {
+        base62: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/non-negative integer/i);
+    });
+
+    it('accepts ::base62encode option alias', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('62', {
+        base62encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Base62: '10' });
+    });
+  });
+
+  describe('decode', () => {
+    it('decodes "10" to 62', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('10', {
+        base62decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Base62: '10',
+        Decimal: '62',
+      });
+    });
+
+    it('decodes "z" to 61', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('z', {
+        base62decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Base62: 'z',
+        Decimal: '61',
+      });
+    });
+
+    it('uses KeyValueBoxTemplate for valid decode', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('10', {
+        base62decode: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('returns error box for invalid base62 chars', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('!!', {
+        base62decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+  });
+
+  describe('BigInt round-trip for value > Number.MAX_SAFE_INTEGER', () => {
+    // 9007199254740993 = 2^53 + 1, which Number.parseInt would lose precision on
+    it('encodes and decodes 9007199254740993 exactly', async () => {
+      const input = '9007199254740993';
+      const encBoxes = await Base62BoxSource.generateBoxes(input, {
+        base62: true,
+      });
+      expect(encBoxes).toHaveLength(1);
+      const encoded = encBoxes[0].props.options?.Base62 as string;
+
+      const decBoxes = await Base62BoxSource.generateBoxes(encoded, {
+        base62decode: true,
+      });
+      expect(decBoxes).toHaveLength(1);
+      expect(decBoxes[0].props.options?.Decimal).toBe(input);
+    });
+  });
+
+  describe('both options → two boxes', () => {
+    it('produces encode box then decode box when both options set', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('62', {
+        base62: true,
+        base62decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      // first box is encode result
+      expect(boxes[0].props.options).toMatchObject({
+        Decimal: '62',
+        Base62: '10',
+      });
+      // second box is decode result: '62' as base62 = 6*62 + 2 = 374
+      expect(boxes[1].props.options).toMatchObject({
+        Base62: '62',
+        Decimal: '374',
+      });
+    });
+  });
+
+  describe('priority', () => {
+    it('sets priority to 10', async () => {
+      const boxes = await Base62BoxSource.generateBoxes('1', { base62: true });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import Base62BoxSource from './Base62BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -83,6 +84,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  Base62BoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
   FractionBoxSource,


### PR DESCRIPTION
### Box Source: Base62 (Convert)

Adds the `Base62` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `123456789 ::base62`

#### Options:
- `::base62`, `::base62decode`, `::base62encode`

#### Description:
Encode a non-negative integer to Base62, or decode a Base62 string to a number.

#### Usage Examples:
- **Input**: `123456789 ::base62`
- **Output Box (`Base62`)**:
```
Decimal: 123456789
Base62: 8M0kX
```
