### PR TITLE
feat(Base85): add Base85 BoxSource

### DIFF
--- a/src/modules/boxSources/Base85BoxSource.ts
+++ b/src/modules/boxSources/Base85BoxSource.ts
@@ -1,0 +1,155 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// encodes UTF-8 bytes to Ascii85 (no <~ ~> delimiters, z-shorthand for zero groups)
+function encodeAscii85(input: string): string {
+  const bytes = [...new TextEncoder().encode(input)];
+  let out = '';
+
+  for (let i = 0; i < bytes.length; i += 4) {
+    const group = bytes.slice(i, i + 4);
+    const partialLen = group.length;
+    while (group.length < 4) group.push(0);
+
+    const val =
+      group[0] * 16_777_216 + group[1] * 65_536 + group[2] * 256 + group[3];
+
+    if (partialLen === 4 && val === 0) {
+      out += 'z';
+    } else {
+      const chars = new Array<string>(5);
+      let v = val;
+      for (let j = 4; j >= 0; j--) {
+        chars[j] = String.fromCharCode((v % 85) + 33);
+        v = Math.floor(v / 85);
+      }
+      // for a partial group, keep only (partialLen + 1) chars
+      out += chars.slice(0, partialLen + 1).join('');
+    }
+  }
+
+  return out;
+}
+
+// decodes Ascii85 back to a UTF-8 string; returns null on invalid input
+function decodeAscii85(input: string): string | null {
+  const s = input.replace(/\s/g, '');
+  const bytes: number[] = [];
+
+  let i = 0;
+  while (i < s.length) {
+    if (s[i] === 'z') {
+      bytes.push(0, 0, 0, 0);
+      i++;
+      continue;
+    }
+
+    const group = s.slice(i, i + 5);
+    i += group.length;
+    const partialLen = group.length;
+
+    // a partial group must have at least 2 chars
+    if (partialLen === 1) return null;
+
+    // validate all chars are in range '!' (33) to 'u' (117)
+    for (const ch of group) {
+      const code = ch.charCodeAt(0);
+      if (code < 33 || code > 117) return null;
+    }
+
+    // pad partial group with 'u' (84 + 33 = 117) to reach 5 chars
+    let padded = group;
+    while (padded.length < 5) padded += 'u';
+
+    // accumulate base-85 value
+    let val = 0;
+    for (let j = 0; j < 5; j++) {
+      val = val * 85 + (padded.charCodeAt(j) - 33);
+    }
+
+    // clamp to uint32 range (overflow means invalid input)
+    if (val > 0xffffffff) return null;
+
+    const b0 = (val >>> 24) & 0xff;
+    const b1 = (val >>> 16) & 0xff;
+    const b2 = (val >>> 8) & 0xff;
+    const b3 = val & 0xff;
+
+    // for a full group emit 4 bytes; for a partial group (n chars) emit n-1 bytes
+    const emit = [b0, b1, b2, b3].slice(0, partialLen - 1);
+    bytes.push(...emit);
+  }
+
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+export const Base85BoxSource = {
+  defaultDisabled: true,
+  name: 'Base85',
+  description:
+    'Encode text to Ascii85 (Base85) or decode Ascii85 back to text.',
+  defaultInput: 'hello ::base85',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(
+      options,
+      'base85',
+      'base85encode',
+      'ascii85',
+    );
+    const wantDecode = hasOptionKeys(options, 'base85decode');
+    if (!wantEncode && !wantDecode) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = encodeAscii85(input);
+      boxes.push(
+        new BoxBuilder('Base85 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decodeAscii85(input);
+      if (decoded === null) {
+        boxes.push(
+          new BoxBuilder(
+            'Base85 (Decode)',
+            'Invalid Ascii85 input: contains out-of-range characters.',
+          )
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        boxes.push(
+          new BoxBuilder('Base85 (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default Base85BoxSource;

--- a/src/modules/boxSources/__test__/Base85BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base85BoxSource.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import { Base85BoxSource } from '../Base85BoxSource';
+
+describe('Base85BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - invalid decode', () => {
+    it('rejects a single-char group (invalid Ascii85 length)', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('A', {
+        base85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+  });
+
+  describe('generateBoxes - encode (::base85)', () => {
+    it('returns one encode box for ::base85 option', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('hello', {
+        base85: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base85 (Encode)');
+    });
+
+    it('known vector: "Man " encodes to "9jqo^"', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('Man ', {
+        base85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('9jqo^');
+    });
+
+    it('all-zero group (4 NUL bytes) encodes to single "z"', async () => {
+      const input = String.fromCharCode(0).repeat(4);
+      const boxes = await Base85BoxSource.generateBoxes(input, {
+        base85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('z');
+    });
+
+    it('encodes "hello" to the correct Ascii85 string', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('hello', {
+        base85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('BOu!rDZ');
+    });
+
+    it('encodes "foobar" correctly', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('foobar', {
+        base85: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AoDTs@<)');
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('hello', {
+        base85: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('generateBoxes - encode aliases', () => {
+    it('responds to ::ascii85 option', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('hello', {
+        ascii85: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base85 (Encode)');
+    });
+
+    it('responds to ::base85encode option', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('hello', {
+        base85encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base85 (Encode)');
+    });
+  });
+
+  describe('generateBoxes - decode (::base85decode)', () => {
+    it('decodes "BOu!rDZ" back to "hello"', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('BOu!rDZ', {
+        base85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base85 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decodes "9jqo^" back to "Man "', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('9jqo^', {
+        base85decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Man ');
+    });
+
+    it('decodes z shorthand (single "z") back to 4 NUL bytes', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('z', {
+        base85decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe(
+        String.fromCharCode(0).repeat(4),
+      );
+    });
+
+    it('invalid char "v" produces an invalid-input box', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('BOu!vDZ', {
+        base85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Base85 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+
+    it('invalid char "~" produces an invalid-input box', async () => {
+      const boxes = await Base85BoxSource.generateBoxes('~invalid~', {
+        base85decode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+  });
+
+  describe('generateBoxes - round-trip', () => {
+    it('decode(encode("hello")) === "hello"', async () => {
+      const encoded = (
+        await Base85BoxSource.generateBoxes('hello', { base85: true })
+      )[0].props.plaintextOutput;
+      const decoded = (
+        await Base85BoxSource.generateBoxes(encoded, { base85decode: true })
+      )[0].props.plaintextOutput;
+      expect(decoded).toBe('hello');
+    });
+
+    it('decode(encode("foobar")) === "foobar"', async () => {
+      const encoded = (
+        await Base85BoxSource.generateBoxes('foobar', { base85: true })
+      )[0].props.plaintextOutput;
+      const decoded = (
+        await Base85BoxSource.generateBoxes(encoded, { base85decode: true })
+      )[0].props.plaintextOutput;
+      expect(decoded).toBe('foobar');
+    });
+  });
+
+  describe('generateBoxes - both options together', () => {
+    it('returns 2 boxes when both base85 and base85decode are set', async () => {
+      // encode "hello" first, then pass encoded as input with both options
+      const encoded = 'BOu!rDZ'; // known encoding of "hello"
+      const boxes = await Base85BoxSource.generateBoxes(encoded, {
+        base85: true,
+        base85decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Base85 (Encode)');
+      expect(names).toContain('Base85 (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Base85BoxSource.name).toBe('Base85');
+      expect(Base85BoxSource.tag).toBe('#');
+      expect(Base85BoxSource.kind).toBe('Encode');
+      expect(typeof Base85BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import Base85BoxSource from './Base85BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -83,6 +84,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  Base85BoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
   FractionBoxSource,


### PR DESCRIPTION
### Box Source: Base85 (Encode)

Adds the `Base85` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `hello ::base85`

#### Options:
- `::`, `::ascii85`, `::base85`, `::base85decode`, `::base85encode`

#### Description:
Encode text to Ascii85 (Base85) or decode Ascii85 back to text.

#### Usage Examples:
- **Input**: `hello ::base85`
- **Output Box (`Base85 (Encode)`)**:
```
BOu!rDZ
```
