### PR TITLE
feat(Base91): add basE91 BoxSource

### DIFF
--- a/src/modules/boxSources/Base91BoxSource.ts
+++ b/src/modules/boxSources/Base91BoxSource.ts
@@ -1,0 +1,141 @@
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// basE91 alphabet (91 printable ASCII chars, Joachim Henke's ordering)
+const ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&()*+,./:;<=>?@[]^_`{|}~"';
+
+// precomputed reverse lookup: char → index in ALPHABET, -1 for non-members
+const DECODE_TABLE: Int8Array = (() => {
+  const table = new Int8Array(256).fill(-1);
+  for (let i = 0; i < ALPHABET.length; i++) {
+    table[ALPHABET.charCodeAt(i)] = i;
+  }
+  return table;
+})();
+
+// encodes a byte array to a basE91 string using the standard Henke algorithm
+function encodeBase91(bytes: Uint8Array): string {
+  let b = 0;
+  let n = 0;
+  const out: string[] = [];
+
+  for (const byte of bytes) {
+    b |= byte << n;
+    n += 8;
+    if (n > 13) {
+      let v = b & 8191;
+      if (v > 88) {
+        b >>= 13;
+        n -= 13;
+      } else {
+        v = b & 16383;
+        b >>= 14;
+        n -= 14;
+      }
+      out.push(ALPHABET[v % 91], ALPHABET[(v / 91) | 0]);
+    }
+  }
+
+  if (n > 0) {
+    out.push(ALPHABET[b % 91]);
+    if (n > 7 || b > 90) {
+      out.push(ALPHABET[(b / 91) | 0]);
+    }
+  }
+
+  return out.join('');
+}
+
+// decodes a basE91 string back to a byte array; non-alphabet chars are skipped per spec
+function decodeBase91(encoded: string): Uint8Array {
+  let v = -1;
+  let b = 0;
+  let n = 0;
+  const out: number[] = [];
+
+  for (let i = 0; i < encoded.length; i++) {
+    const code = encoded.charCodeAt(i);
+    // chars above the 256-entry table (e.g. CJK, emoji surrogates) are
+    // out of range → undefined, which `< 0` would NOT catch; skip explicitly
+    const d = code < 256 ? DECODE_TABLE[code] : -1;
+    if (d < 0) continue;
+
+    if (v < 0) {
+      v = d;
+    } else {
+      v += d * 91;
+      b |= v << n;
+      n += (v & 8191) > 88 ? 13 : 14;
+      do {
+        out.push(b & 255);
+        b >>= 8;
+        n -= 8;
+      } while (n > 7);
+      v = -1;
+    }
+  }
+
+  if (v >= 0) {
+    out.push((b | (v << n)) & 255);
+  }
+
+  return new Uint8Array(out);
+}
+
+export const Base91BoxSource = {
+  defaultDisabled: true,
+  name: 'basE91',
+  description: 'Encode text to basE91 or decode a basE91 string.',
+  defaultInput: 'hello ::base91',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'base91', 'base91encode');
+    const wantDecode = hasOptionKeys(options, 'base91decode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const bytes = new TextEncoder().encode(input);
+      const encoded = encodeBase91(bytes);
+      boxes.push(
+        new BoxBuilder('basE91 (Encode)', encoded)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const bytes = decodeBase91(input);
+      const decoded = new TextDecoder().decode(bytes);
+      boxes.push(
+        new BoxBuilder('basE91 (Decode)', decoded)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default Base91BoxSource;

--- a/src/modules/boxSources/__test__/Base91BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Base91BoxSource.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { Base91BoxSource } from '../Base91BoxSource';
+
+// basE91 alphabet used by the encoder — used to validate output chars
+const ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!#$%&()*+,./:;<=>?@[]^_`{|}~"';
+const ALPHABET_SET = new Set(ALPHABET);
+
+describe('Base91BoxSource', () => {
+  describe('generateBoxes — no match', () => {
+    it('should return [] when no option keys are given', async () => {
+      const boxes = await Base91BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] for empty input with ::base91', async () => {
+      const boxes = await Base91BoxSource.generateBoxes('', { base91: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] for whitespace-only input', async () => {
+      const boxes = await Base91BoxSource.generateBoxes('   ', {
+        base91: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode (::base91 / ::base91encode)', () => {
+    it('should produce a non-empty string of valid alphabet chars for "hello"', async () => {
+      const boxes = await Base91BoxSource.generateBoxes('hello', {
+        base91: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('basE91 (Encode)');
+      expect(boxes[0].props.priority).toBe(10);
+
+      const out = boxes[0].props.plaintextOutput;
+      expect(out.length).toBeGreaterThan(0);
+      for (const ch of out) {
+        expect(ALPHABET_SET.has(ch)).toBe(true);
+      }
+    });
+
+    it('should produce valid alphabet chars using ::base91encode alias', async () => {
+      const boxes = await Base91BoxSource.generateBoxes('hello', {
+        base91encode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out.length).toBeGreaterThan(0);
+      for (const ch of out) {
+        expect(ALPHABET_SET.has(ch)).toBe(true);
+      }
+    });
+  });
+
+  describe('decode (::base91decode)', () => {
+    it('should decode an encoded value back to original', async () => {
+      const encBoxes = await Base91BoxSource.generateBoxes('hello', {
+        base91: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await Base91BoxSource.generateBoxes(encoded, {
+        base91decode: true,
+      });
+      expect(decBoxes).toHaveLength(1);
+      expect(decBoxes[0].props.name).toBe('basE91 (Decode)');
+      expect(decBoxes[0].props.plaintextOutput).toBe('hello');
+    });
+  });
+
+  describe('round-trip — ASCII', () => {
+    it('should round-trip "hello world"', async () => {
+      const input = 'hello world';
+      const enc = await Base91BoxSource.generateBoxes(input, { base91: true });
+      const encoded = enc[0].props.plaintextOutput;
+      const dec = await Base91BoxSource.generateBoxes(encoded, {
+        base91decode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe(input);
+    });
+
+    it('should round-trip the quick brown fox sentence', async () => {
+      const input = 'The quick brown fox jumps over the lazy dog';
+      const enc = await Base91BoxSource.generateBoxes(input, { base91: true });
+      const encoded = enc[0].props.plaintextOutput;
+      const dec = await Base91BoxSource.generateBoxes(encoded, {
+        base91decode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe(input);
+    });
+  });
+
+  describe('round-trip — unicode', () => {
+    it('should round-trip "café 日本 😀"', async () => {
+      const input = 'café 日本 😀';
+      const enc = await Base91BoxSource.generateBoxes(input, { base91: true });
+      expect(enc).toHaveLength(1);
+      const encoded = enc[0].props.plaintextOutput;
+
+      // all output chars must be in the basE91 alphabet
+      for (const ch of encoded) {
+        expect(ALPHABET_SET.has(ch)).toBe(true);
+      }
+
+      const dec = await Base91BoxSource.generateBoxes(encoded, {
+        base91decode: true,
+      });
+      expect(dec[0].props.plaintextOutput).toBe(input);
+    });
+  });
+
+  describe('both options', () => {
+    it('should return 2 boxes when both ::base91 and ::base91decode are set', async () => {
+      // encode "hello" first to get a valid basE91 string, then use it as input
+      const encFirst = await Base91BoxSource.generateBoxes('hello', {
+        base91: true,
+      });
+      const validEncoded = encFirst[0].props.plaintextOutput;
+
+      const boxes = await Base91BoxSource.generateBoxes(validEncoded, {
+        base91: true,
+        base91decode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('basE91 (Encode)');
+      expect(boxes[1].props.name).toBe('basE91 (Decode)');
+    });
+  });
+
+  describe('lenient decode', () => {
+    it('skips out-of-range unicode chars without corrupting output (no NaN)', async () => {
+      const enc = await Base91BoxSource.generateBoxes('hi', { base91: true });
+      const valid = enc[0].props.plaintextOutput;
+      // inject CJK/emoji noise the 256-entry decode table cannot index
+      const boxes = await Base91BoxSource.generateBoxes(`${valid}日本😀`, {
+        base91decode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hi');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import Base91BoxSource from './Base91BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -83,6 +84,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  Base91BoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
   FractionBoxSource,


### PR DESCRIPTION
### Box Source: basE91 (Encode)

Adds the `basE91` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `hello ::base91`

#### Options:
- `::base91`, `::base91decode`, `::base91encode`

#### Description:
Encode text to basE91 or decode a basE91 string.

#### Usage Examples:
- **Input**: `hello ::base91`
- **Output Box (`basE91 (Encode)`)**:
```
TPwJh>A
```
