### PR TITLE
feat(Beaufort): add Beaufort Cipher BoxSource

### DIFF
--- a/src/modules/boxSources/BeaufortBoxSource.ts
+++ b/src/modules/boxSources/BeaufortBoxSource.ts
@@ -1,0 +1,78 @@
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// strips non-alpha chars from the key and uppercases, returning null when nothing remains
+function normalizeKey(raw: string): string | null {
+  const letters = raw.replace(/[^a-zA-Z]/g, '').toUpperCase();
+  return letters.length > 0 ? letters : null;
+}
+
+// beaufort cipher: C[i] = (key[i] - plain[i]) mod 26.
+// non-letter characters in the plaintext are passed through unchanged
+// and do NOT advance the key index. output letters are uppercase.
+function beaufort(text: string, key: string): string {
+  let ki = 0;
+  let result = '';
+  for (const ch of text) {
+    const code = ch.toUpperCase().charCodeAt(0);
+    if (code >= 65 && code <= 90) {
+      const p = code - 65;
+      const k = key.charCodeAt(ki % key.length) - 65;
+      result += String.fromCharCode(((k - p + 26) % 26) + 65);
+      ki++;
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+export const BeaufortBoxSource = {
+  defaultDisabled: true,
+  name: 'Beaufort Cipher',
+  description:
+    'Beaufort cipher (self-reciprocal): C[i] = (key[i] - plain[i]) mod 26. ::beaufort=key.',
+  defaultInput: 'DEFEND ::beaufort=FORTIFICATION',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const rawKey = extractOptionKeys(options, 'beaufort');
+    if (rawKey === null) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT) {
+      return [];
+    }
+
+    // a bare `::beaufort` (no `=key`) yields the boolean `true`, not a key;
+    // only a string option value can be a cipher key
+    const key = typeof rawKey === 'string' ? normalizeKey(rawKey) : null;
+    if (key === null) {
+      // the option was missing a value or contained no alphabetic characters
+      const box = new BoxBuilder(
+        'Beaufort Cipher',
+        'Provide an alphabetic key, e.g. ::beaufort=FORTIFICATION',
+      )
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    const output = beaufort(input, key);
+    const box = new BoxBuilder('Beaufort Cipher', output)
+      .setShowExpandButton(false)
+      .setPriority(this.priority)
+      .build();
+    return [box];
+  },
+};
+
+export default BeaufortBoxSource;

--- a/src/modules/boxSources/__test__/BeaufortBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BeaufortBoxSource.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { BeaufortBoxSource } from '../BeaufortBoxSource';
+
+describe('BeaufortBoxSource', () => {
+  describe('no match', () => {
+    it('returns [] when ::beaufort option is absent', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes('DEFEND', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with ::beaufort key', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes('', {
+        beaufort: 'FORTIFICATION',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('canonical Beaufort vector', () => {
+    // reference: https://en.wikipedia.org/wiki/Beaufort_cipher
+    it('DEFENDTHEEASTWALLOFTHECASTLE + FORTIFICATION → CKMPVCPVWPIWUJOGIUAPVWRIWUUK', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes(
+        'DEFENDTHEEASTWALLOFTHECASTLE',
+        { beaufort: 'FORTIFICATION' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'CKMPVCPVWPIWUJOGIUAPVWRIWUUK',
+      );
+    });
+  });
+
+  describe('self-reciprocity', () => {
+    it('applying beaufort twice with the same key recovers the plaintext', async () => {
+      const plain = 'HELLOWORLD';
+      const key = 'SECRET';
+
+      const enc = await BeaufortBoxSource.generateBoxes(plain, {
+        beaufort: key,
+      });
+      expect(enc).toHaveLength(1);
+      const cipher = enc[0].props.plaintextOutput;
+
+      const dec = await BeaufortBoxSource.generateBoxes(cipher, {
+        beaufort: key,
+      });
+      expect(dec).toHaveLength(1);
+      expect(dec[0].props.plaintextOutput).toBe(plain);
+    });
+  });
+
+  describe('non-letters pass through', () => {
+    it('preserves spaces and punctuation in place without advancing key index', async () => {
+      // 'HI, THERE' — letters H I T H E R E are enciphered; ', ' and ' ' pass through.
+      // key ALPHA: A(0) L(11) P(15) H(7) A(0)...
+      // H(7) → (A(0)-7+26)%26=19=T
+      // I(8) → (L(11)-8+26)%26=3=D
+      // T(19) → (P(15)-19+26)%26=22=W
+      // H(7) → (H(7)-7+26)%26=0=A
+      // E(4) → (A(0)-4+26)%26=22=W
+      // R(17) → repeat key from pos5→A(0): (A(0)-17+26)%26=9=J
+      // E(4) → (L(11)-4)%26=7=H
+      const boxes = await BeaufortBoxSource.generateBoxes('HI, THERE', {
+        beaufort: 'ALPHA',
+      });
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      // 'HI, THERE' has a comma at index 2 and a single space at index 3;
+      // index 5 is the letter 'H' and is enciphered, not preserved
+      expect(out[2]).toBe(',');
+      expect(out[3]).toBe(' ');
+      // total length unchanged
+      expect(out).toHaveLength('HI, THERE'.length);
+    });
+  });
+
+  describe('invalid key', () => {
+    it('returns a single box explaining the key requirement when key has no letters', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes('HELLO', {
+        beaufort: '123',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/alphabetic/i);
+    });
+  });
+
+  describe('box properties', () => {
+    it('box is named "Beaufort Cipher" and has expand button hidden', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes('DEFEND', {
+        beaufort: 'KEY',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Beaufort Cipher');
+      expect(boxes[0].props.showExpandButton).toBe(false);
+      expect(boxes[0].props.priority).toBe(10);
+      // headless template — web layer supplies DefaultBoxTemplate
+      expect(boxes[0].boxTemplate).toBeUndefined();
+    });
+
+    it('a bare ::beaufort (no =key) returns a usage box, not a "TRUE" cipher', async () => {
+      const boxes = await BeaufortBoxSource.generateBoxes('HELLO', {
+        beaufort: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/alphabetic key/i);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import BeaufortBoxSource from './BeaufortBoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -74,6 +75,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  BeaufortBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
   FrequencyBoxSource,


### PR DESCRIPTION
### Box Source: Beaufort Cipher (Encode)

Adds the `Beaufort Cipher` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `DEFEND ::beaufort=FORTIFICATION`

#### Options:
- None

#### Description:
Beaufort cipher (self-reciprocal): C[i] = (key[i] - plain[i]) mod 26. ::beaufort=key.

#### Usage Examples:
- **Input**: `DEFEND ::beaufort=FORTIFICATION`
- **Output Box (`Beaufort Cipher`)**:
```
CKMPVC
```
