### PR TITLE
feat(BinaryText): add Text to Binary BoxSource

### DIFF
--- a/src/modules/boxSources/BinaryTextBoxSource.ts
+++ b/src/modules/boxSources/BinaryTextBoxSource.ts
@@ -1,0 +1,96 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// converts each byte to its 8-bit binary string, joined by spaces
+function encodeTextToBinary(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  return Array.from(bytes)
+    .map((b) => b.toString(2).padStart(8, '0'))
+    .join(' ');
+}
+
+// decodes a binary string (spaces optional) back to UTF-8 text, or returns null on invalid input
+function decodeBinaryToText(input: string): string | null {
+  const stripped = input.replace(/\s/g, '');
+  if (!/^[01]+$/.test(stripped) || stripped.length % 8 !== 0) {
+    return null;
+  }
+  const bytes = new Uint8Array(stripped.length / 8);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(stripped.slice(i * 8, i * 8 + 8), 2);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+export const BinaryTextBoxSource = {
+  defaultDisabled: true,
+  name: 'Text to Binary',
+  description:
+    'Convert text to space-separated 8-bit binary (UTF-8), or binary back to text.',
+  defaultInput: 'Hi ::binary',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'binary', 'tobinary');
+    const wantDecode = hasOptionKeys(options, 'binarydecode', 'frombinary');
+
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const binary = encodeTextToBinary(input);
+      boxes.push(
+        new BoxBuilder('Text to Binary', binary)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const text = decodeBinaryToText(input);
+      if (text === null) {
+        boxes.push(
+          new BoxBuilder(
+            'Binary to Text',
+            'invalid binary: input must be a multiple of 8 bits containing only 0 and 1',
+          )
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        boxes.push(
+          new BoxBuilder('Binary to Text', text)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default BinaryTextBoxSource;

--- a/src/modules/boxSources/__test__/BinaryTextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BinaryTextBoxSource.test.ts
@@ -1,0 +1,163 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { BinaryTextBoxSource } from '../BinaryTextBoxSource';
+
+describe('BinaryTextBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('Hi', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are provided', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('Hi', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::binary', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('', {
+        binary: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::binary', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('   ', {
+        binary: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ::binary / ::tobinary', () => {
+    it('encodes "Hi" to correct binary via ::binary (H=72=01001000, i=105=01101001)', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('Hi', {
+        binary: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('01001000 01101001');
+    });
+
+    it('encodes "Hi" identically via ::tobinary', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('Hi', {
+        tobinary: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('01001000 01101001');
+    });
+
+    it('encodes "A" (65=01000001)', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('A', {
+        binary: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('01000001');
+    });
+
+    it('sets box name to "Text to Binary"', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('A', {
+        binary: true,
+      });
+      expect(boxes[0].props.name).toBe('Text to Binary');
+    });
+
+    it('uses DefaultBoxTemplate and hides expand button', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('A', {
+        binary: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('decode — ::binarydecode / ::frombinary', () => {
+    it('decodes space-separated binary "01001000 01101001" to "Hi"', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes(
+        '01001000 01101001',
+        { binarydecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('decodes contiguous binary without spaces to "Hi"', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes(
+        '0100100001101001',
+        { binarydecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('decodes via ::frombinary alias', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes(
+        '01001000 01101001',
+        { frombinary: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('sets box name to "Binary to Text"', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('01000001', {
+        binarydecode: true,
+      });
+      expect(boxes[0].props.name).toBe('Binary to Text');
+    });
+
+    it('returns error box for invalid binary containing non-0/1 digits', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('0102', {
+        binarydecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid binary/i);
+    });
+
+    it('returns error box when bit count is not a multiple of 8', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('0100100', {
+        binarydecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid binary/i);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('round-trips "Hello!" through encode then decode', async () => {
+      const encBoxes = await BinaryTextBoxSource.generateBoxes('Hello!', {
+        binary: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await BinaryTextBoxSource.generateBoxes(encoded, {
+        binarydecode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe('Hello!');
+    });
+  });
+
+  describe('both options together', () => {
+    it('returns 2 boxes when both ::binary and ::binarydecode are set', async () => {
+      const boxes = await BinaryTextBoxSource.generateBoxes('01000001', {
+        binary: true,
+        binarydecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Text to Binary');
+      expect(names).toContain('Binary to Text');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(BinaryTextBoxSource.name).toBe('Text to Binary');
+      expect(BinaryTextBoxSource.tag).toBe('#');
+      expect(BinaryTextBoxSource.kind).toBe('Encode');
+      expect(typeof BinaryTextBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -5,6 +5,7 @@ import {
   Base64DecodeBoxSource,
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
+import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
@@ -66,6 +67,7 @@ export const boxSources: BoxSource[] = [
   WordWrapBoxSource,
   A1Z26BoxSource,
   AsciiTableBoxSource,
+  BinaryTextBoxSource,
   BmiBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,


### PR DESCRIPTION
### Box Source: Text to Binary (Encode)

Adds the `Text to Binary` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `Hi ::binary`

#### Options:
- `::binary`, `::binarydecode`, `::frombinary`, `::tobinary`

#### Description:
Convert text to space-separated 8-bit binary (UTF-8), or binary back to text.

#### Usage Examples:
- **Input**: `Hi ::binary`
- **Output Box (`Text to Binary`)**:
```
01001000 01101001
```
