### PR TITLE
feat(Bitwise): add Bitwise BoxSource

### DIFF
--- a/src/modules/boxSources/BitwiseBoxSource.ts
+++ b/src/modules/boxSources/BitwiseBoxSource.ts
@@ -1,0 +1,221 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max shift amount to prevent absurdly large binary strings
+const MAX_SHIFT = 4096n;
+
+// formats a BigInt as decimal and hex, e.g. "8 (0x8)"
+function fmtDecHex(n: bigint): string {
+  const sign = n < 0n ? '-' : '';
+  const abs = n < 0n ? -n : n;
+  return `${sign}${abs} (${sign}0x${abs.toString(16)})`;
+}
+
+// formats a BigInt as decimal, hex, and binary
+function fmtFull(n: bigint): string {
+  const sign = n < 0n ? '-' : '';
+  const abs = n < 0n ? -n : n;
+  return `${sign}${abs} (${sign}0x${abs.toString(16)}) (${sign}0b${abs.toString(2)})`;
+}
+
+// builds the kvToPlaintext-style string from a Record for plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// parses a single operand token; accepts leading minus, decimal, 0x, 0b
+function parseOperand(token: string): bigint {
+  const t = token.trim();
+  if (t === '') {
+    throw new Error(`empty operand`);
+  }
+  // BigInt() handles decimal incl. a leading minus, but throws on negative
+  // radix literals like -0xff / -0b101, so peel the sign off those
+  if (/^-0[xXbBoO]/.test(t)) {
+    return -BigInt(t.slice(1));
+  }
+  return BigInt(t);
+}
+
+type BitwiseOp = '&' | '|' | '^' | '<<' | '>>';
+
+// applies the named operator to two BigInt values; throws for invalid shifts
+function applyOp(a: bigint, op: BitwiseOp, b: bigint): bigint {
+  switch (op) {
+    case '&':
+      return a & b;
+    case '|':
+      return a | b;
+    case '^':
+      return a ^ b;
+    case '<<':
+      if (b < 0n || b > MAX_SHIFT) {
+        throw new RangeError(
+          `shift amount ${b} out of range [0, ${MAX_SHIFT}]`,
+        );
+      }
+      return a << b;
+    case '>>':
+      if (b < 0n || b > MAX_SHIFT) {
+        throw new RangeError(
+          `shift amount ${b} out of range [0, ${MAX_SHIFT}]`,
+        );
+      }
+      return a >> b;
+  }
+}
+
+// error box shown for invalid input, explaining accepted formats
+function errorBox(priority: number, message: string): Box {
+  const kv: Record<string, string> = {
+    Error: message,
+    Formats: 'a & b  |  a | b  |  a ^ b  |  a << n  |  a >> n',
+    Literals:
+      'decimal (123), hex (0xff), binary (0b1010); leading minus allowed',
+  };
+  return new BoxBuilder('Bitwise', kvToPlaintext(kv))
+    .setOptions(kv)
+    .setTemplate(KeyValueBoxTemplate)
+    .setShowExpandButton(false)
+    .setPriority(priority)
+    .build();
+}
+
+// parses "a OP b" where OP is one of &, |, ^, <<, >>; returns null if no op found
+function parseExplicitOp(
+  s: string,
+): { a: string; op: BitwiseOp; b: string } | null {
+  // match the longest operators first (<<, >>) before single-char ones
+  const m = s.match(
+    /^([+-]?(?:0[xX][0-9a-fA-F]+|0[bB][01]+|\d+))\s*(<<|>>|[&|^])\s*([+-]?(?:0[xX][0-9a-fA-F]+|0[bB][01]+|\d+))$/,
+  );
+  if (!m) {
+    return null;
+  }
+  return { a: m[1], op: m[2] as BitwiseOp, b: m[3] };
+}
+
+// splits "a b" or "a,b" into two operand tokens; returns null if not exactly two
+function parseTwoOperands(s: string): [string, string] | null {
+  // split on comma or whitespace
+  const parts = s.split(/[\s,]+/).filter((p) => p !== '');
+  if (parts.length !== 2) {
+    return null;
+  }
+  return [parts[0], parts[1]];
+}
+
+export const BitwiseBoxSource = {
+  defaultDisabled: true,
+  name: 'Bitwise',
+  description:
+    'Bitwise AND/OR/XOR/shifts of two integers (decimal, 0x hex, or 0b binary).',
+  defaultInput: '12 & 10 ::bitwise',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'bitwise', 'bitop')) {
+      return [];
+    }
+
+    const raw = trim(input);
+    if (raw.length > 200) {
+      return [errorBox(this.priority, 'input too long (max 200 characters)')];
+    }
+
+    // try explicit operator form first: "a OP b"
+    const explicit = parseExplicitOp(raw);
+    if (explicit !== null) {
+      let a: bigint;
+      let b: bigint;
+      try {
+        a = parseOperand(explicit.a);
+        b = parseOperand(explicit.b);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return [errorBox(this.priority, `parse error: ${msg}`)];
+      }
+
+      let result: bigint;
+      try {
+        result = applyOp(a, explicit.op, b);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return [errorBox(this.priority, msg)];
+      }
+
+      const kv: Record<string, string> = {
+        Expression: `${explicit.a} ${explicit.op} ${explicit.b}`,
+        'Result (dec)': String(result),
+        'Result (hex)': `${result < 0n ? '-' : ''}0x${(result < 0n ? -result : result).toString(16)}`,
+        'Result (bin)': `${result < 0n ? '-' : ''}0b${(result < 0n ? -result : result).toString(2)}`,
+      };
+      return [
+        new BoxBuilder('Bitwise', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // try two-operand form: "a b" or "a,b" — computes all ops
+    const pair = parseTwoOperands(raw);
+    if (pair !== null) {
+      let a: bigint;
+      let b: bigint;
+      try {
+        a = parseOperand(pair[0]);
+        b = parseOperand(pair[1]);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return [errorBox(this.priority, `parse error: ${msg}`)];
+      }
+
+      const kv: Record<string, string> = {
+        A: fmtDecHex(a),
+        B: fmtDecHex(b),
+        AND: fmtDecHex(a & b),
+        OR: fmtDecHex(a | b),
+        XOR: fmtDecHex(a ^ b),
+      };
+
+      // include shifts only when b is non-negative and within cap
+      if (b >= 0n && b <= MAX_SHIFT) {
+        kv['A<<B'] = fmtFull(a << b);
+        kv['A>>B'] = fmtFull(a >> b);
+      }
+
+      return [
+        new BoxBuilder('Bitwise', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // nothing matched
+    return [
+      errorBox(
+        this.priority,
+        `cannot parse "${raw}" — expected "a OP b" or two operands`,
+      ),
+    ];
+  },
+};
+
+export default BitwiseBoxSource;

--- a/src/modules/boxSources/__test__/BitwiseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BitwiseBoxSource.test.ts
@@ -1,0 +1,197 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { BitwiseBoxSource } from '../BitwiseBoxSource';
+
+describe('BitwiseBoxSource', () => {
+  describe('negative radix literals', () => {
+    it('handles a negative hex operand (-0xff)', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('-0xff & -1', {
+        bitwise: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // -255 & -1 = -255
+      expect(opts['Result (dec)']).toBe('-255');
+    });
+  });
+
+  describe('no option key → empty array', () => {
+    it('returns [] when no option provided', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option provided', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('explicit op form', () => {
+    it('AND: 12 & 10 = 8', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('8');
+    });
+
+    it('OR: 12 | 10 = 14', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 | 10', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('14');
+    });
+
+    it('XOR: 12 ^ 10 = 6', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 ^ 10', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('6');
+    });
+
+    it('left shift: 1 << 8 = 256', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('1 << 8', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('256');
+    });
+
+    it('right shift: 256 >> 2 = 64', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('256 >> 2', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('64');
+    });
+
+    it('hex operands: 0xff & 0x0f = 15', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('0xff & 0x0f', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('15');
+      expect(opts['Result (hex)']).toBe('0xf');
+    });
+
+    it('binary operands: 0b1100 ^ 0b1010 = 6', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('0b1100 ^ 0b1010', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('6');
+    });
+
+    it('64-bit: 0xffffffffffffffff ^ 0x0 = 18446744073709551615 (no 32-bit overflow)', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes(
+        '0xffffffffffffffff ^ 0x0',
+        { bitwise: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // verifies BigInt arithmetic — a 32-bit number would overflow to -1
+      expect(opts['Result (dec)']).toBe('18446744073709551615');
+      expect(opts['Result (hex)']).toBe('0xffffffffffffffff');
+    });
+
+    it('shift too large returns error box mentioning cap', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('1 << 99999', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/4096/);
+    });
+
+    it('accepts ::bitop trigger key', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', {
+        bitop: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Result (dec)']).toBe('8');
+    });
+
+    it('expression field reflects input tokens', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', {
+        bitwise: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Expression).toContain('12');
+      expect(opts.Expression).toContain('&');
+      expect(opts.Expression).toContain('10');
+    });
+  });
+
+  describe('two-operand form', () => {
+    it('12 10 → AND=8, OR=14, XOR=6', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 10', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.AND).toContain('8');
+      expect(opts.OR).toContain('14');
+      expect(opts.XOR).toContain('6');
+    });
+
+    it('comma-separated: 12,10 → AND contains 8', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12,10', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.AND).toContain('8');
+    });
+
+    it('includes A and B keys', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 10', {
+        bitwise: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.A).toContain('12');
+      expect(opts.B).toContain('10');
+    });
+
+    it('includes shifts when b is in range', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('1 8', {
+        bitwise: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 << 8 = 256
+      expect(opts['A<<B']).toContain('256');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('non-numeric operands return an error box', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('a & b', {
+        bitwise: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('priority is set', async () => {
+      const boxes = await BitwiseBoxSource.generateBoxes('12 & 10', {
+        bitwise: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -6,6 +6,7 @@ import {
   Base64EncodeBoxSource,
 } from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
+import BitwiseBoxSource from './BitwiseBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
@@ -75,6 +76,7 @@ export const boxSources: BoxSource[] = [
   A1Z26BoxSource,
   AsciiTableBoxSource,
   BinaryTextBoxSource,
+  BitwiseBoxSource,
   BmiBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Bitwise (Calculate)

Adds the `Bitwise` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `12 & 10 ::bitwise`

#### Options:
- `::bitop`, `::bitwise`

#### Description:
Bitwise AND/OR/XOR/shifts of two integers (decimal, 0x hex, or 0b binary).

#### Usage Examples:
- **Input**: `12 & 10 ::bitwise`
- **Output Box (`Bitwise`)**:
```
Expression: 12 & 10
Result (dec): 8
Result (hex): 0x8
Result (bin): 0b1000
```
