### PR TITLE
feat(Braille): add Braille BoxSource

### DIFF
--- a/src/modules/boxSources/BrailleBoxSource.ts
+++ b/src/modules/boxSources/BrailleBoxSource.ts
@@ -1,0 +1,116 @@
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// grade 1 english braille: each letter maps to a unicode braille cell.
+// braille cell bitmask: dot1=1, dot2=2, dot3=4, dot4=8, dot5=16, dot6=32.
+// unicode braille block starts at U+2800; char = U+2800 + bitmask.
+const LETTER_TO_BRAILLE: ReadonlyMap<string, string> = new Map([
+  ['a', '⠁'], // dot1
+  ['b', '⠃'], // dots 1,2
+  ['c', '⠉'], // dots 1,4
+  ['d', '⠙'], // dots 1,4,5
+  ['e', '⠑'], // dots 1,5
+  ['f', '⠋'], // dots 1,2,4
+  ['g', '⠛'], // dots 1,2,4,5
+  ['h', '⠓'], // dots 1,2,5
+  ['i', '⠊'], // dots 2,4
+  ['j', '⠚'], // dots 2,4,5
+  ['k', '⠅'], // dots 1,3
+  ['l', '⠇'], // dots 1,2,3
+  ['m', '⠍'], // dots 1,3,4
+  ['n', '⠝'], // dots 1,3,4,5
+  ['o', '⠕'], // dots 1,3,5
+  ['p', '⠏'], // dots 1,2,3,4
+  ['q', '⠟'], // dots 1,2,3,4,5
+  ['r', '⠗'], // dots 1,2,3,5
+  ['s', '⠎'], // dots 2,3,4
+  ['t', '⠞'], // dots 2,3,4,5
+  ['u', '⠥'], // dots 1,3,6
+  ['v', '⠧'], // dots 1,2,3,6
+  ['w', '⠺'], // dots 2,4,5,6
+  ['x', '⠭'], // dots 1,3,4,6
+  ['y', '⠽'], // dots 1,3,4,5,6
+  ['z', '⠵'], // dots 1,3,5,6
+  [' ', '⠀'], // blank braille cell for space
+]);
+
+// reverse map built once at module load
+const BRAILLE_TO_LETTER: ReadonlyMap<string, string> = new Map(
+  Array.from(LETTER_TO_BRAILLE.entries()).map(([letter, braille]) => [
+    braille,
+    letter,
+  ]),
+);
+
+function encode(input: string): string {
+  const lower = input.toLowerCase();
+  let result = '';
+  for (const ch of lower) {
+    const braille = LETTER_TO_BRAILLE.get(ch);
+    result += braille !== undefined ? braille : ch;
+  }
+  return result;
+}
+
+function decode(input: string): string {
+  let result = '';
+  for (const ch of input) {
+    const letter = BRAILLE_TO_LETTER.get(ch);
+    result += letter !== undefined ? letter : ch;
+  }
+  return result;
+}
+
+export const BrailleBoxSource = {
+  defaultDisabled: true,
+  name: 'Braille',
+  description:
+    'Convert text to Unicode Braille (Grade 1) or decode Braille back to text. ::braille to encode, ::brailledecode to decode.',
+  defaultInput: 'hello ::braille',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'braille', 'brailleencode');
+    const wantDecode = hasOptionKeys(options, 'brailledecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      boxes.push(
+        new BoxBuilder('Braille (Encode)', encode(input))
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      boxes.push(
+        new BoxBuilder('Braille (Decode)', decode(input))
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default BrailleBoxSource;

--- a/src/modules/boxSources/__test__/BrailleBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/BrailleBoxSource.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { BrailleBoxSource } from '../BrailleBoxSource';
+
+describe('BrailleBoxSource', () => {
+  it('returns [] when no option present', async () => {
+    expect(await BrailleBoxSource.generateBoxes('abc', null)).toHaveLength(0);
+  });
+
+  it('returns [] for empty input', async () => {
+    expect(
+      await BrailleBoxSource.generateBoxes('', { braille: true }),
+    ).toHaveLength(0);
+  });
+
+  it('encodes "abc" to ⠁⠃⠉ (U+2801 U+2803 U+2809)', async () => {
+    const boxes = await BrailleBoxSource.generateBoxes('abc', {
+      braille: true,
+    });
+    const out = boxes[0].props.plaintextOutput;
+    expect(out).toBe('⠁⠃⠉');
+    const cps = [...out].map((c) => c.codePointAt(0));
+    expect(cps).toEqual([0x2801, 0x2803, 0x2809]);
+  });
+
+  it('encodes "hello" to ⠓⠑⠇⠇⠕', async () => {
+    const boxes = await BrailleBoxSource.generateBoxes('hello', {
+      braille: true,
+    });
+    expect(boxes[0].props.plaintextOutput).toBe('⠓⠑⠇⠇⠕');
+  });
+
+  it('maps a space to U+2800', async () => {
+    const boxes = await BrailleBoxSource.generateBoxes('a b', {
+      braille: true,
+    });
+    const out = boxes[0].props.plaintextOutput;
+    expect([...out][1].codePointAt(0)).toBe(0x2800);
+  });
+
+  it('decodes ⠓⠑⠇⠇⠕ back to "hello"', async () => {
+    const boxes = await BrailleBoxSource.generateBoxes('⠓⠑⠇⠇⠕', {
+      brailledecode: true,
+    });
+    expect(boxes[0].props.plaintextOutput).toBe('hello');
+  });
+
+  it('round-trips "the quick brown fox"', async () => {
+    const text = 'the quick brown fox';
+    const enc = await BrailleBoxSource.generateBoxes(text, { braille: true });
+    const encoded = enc[0].props.plaintextOutput;
+    const dec = await BrailleBoxSource.generateBoxes(encoded, {
+      brailledecode: true,
+    });
+    expect(dec[0].props.plaintextOutput).toBe(text);
+  });
+
+  it('returns 2 boxes when both options are set', async () => {
+    const boxes = await BrailleBoxSource.generateBoxes('abc', {
+      braille: true,
+      brailledecode: true,
+    });
+    expect(boxes).toHaveLength(2);
+  });
+
+  it('has the expected static metadata', () => {
+    expect(BrailleBoxSource.tag).toBe('#');
+    expect(BrailleBoxSource.kind).toBe('Encode');
+    expect(typeof BrailleBoxSource.priority).toBe('number');
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,12 +1,9 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
+import BrailleBoxSource from './BrailleBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  BrailleBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Braille (Encode)

Adds the `Braille` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `hello ::braille`

#### Options:
- `::braille`, `::brailledecode`, `::brailleencode`

#### Description:
Convert text to Unicode Braille (Grade 1) or decode Braille back to text. ::braille to encode, ::brailledecode to decode.

#### Usage Examples:
- **Input**: `hello ::braille`
- **Output Box (`Braille (Encode)`)**:
```
⠓⠑⠇⠇⠕
```
