### PR TITLE
feat(ByteSwap): add Byte Swap BoxSource

### DIFF
--- a/src/modules/boxSources/ByteSwapBoxSource.ts
+++ b/src/modules/boxSources/ByteSwapBoxSource.ts
@@ -1,0 +1,113 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// size thresholds (in bytes) for which we emit integer interpretations
+const WORD_SIZES = new Set([2, 4, 8]);
+
+/** build a `key: value` plaintext string from an ordered entries list */
+function kvToPlaintext(entries: [string, string][]): string {
+  return entries.map(([k, v]) => `${k}: ${v}`).join('\n');
+}
+
+/** swap byte order of a lowercase hex string that has an even number of digits */
+function swapBytes(hex: string): string {
+  const bytes: string[] = [];
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes.push(hex.slice(i, i + 2));
+  }
+  return bytes.reverse().join('');
+}
+
+export const ByteSwapBoxSource = {
+  defaultDisabled: true,
+  name: 'Byte Swap',
+  description:
+    'Swap the byte order (endianness) of a hex value. ::byteswap or ::endian.',
+  defaultInput: '0x12345678 ::byteswap',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'byteswap', 'endian')) return [];
+
+    if (input.length > MAX_INPUT) return [];
+
+    const raw = trim(input);
+
+    // strip optional 0x / 0X prefix
+    const stripped =
+      raw.startsWith('0x') || raw.startsWith('0X') ? raw.slice(2) : raw;
+
+    const hex = stripped.toLowerCase();
+
+    // validate: must be pure hex digits
+    if (!/^[0-9a-f]+$/.test(hex)) {
+      const entries: [string, string][] = [
+        ['Error', 'Input must be a valid hex value (digits 0-9 and a-f).'],
+      ];
+      return [
+        new BoxBuilder('Byte Swap', kvToPlaintext(entries))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(Object.fromEntries(entries))
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // must have an even number of digits to represent whole bytes
+    if (hex.length % 2 !== 0) {
+      const entries: [string, string][] = [
+        [
+          'Error',
+          'A hex value with an even number of digits is required (each byte is 2 hex digits).',
+        ],
+      ];
+      return [
+        new BoxBuilder('Byte Swap', kvToPlaintext(entries))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(Object.fromEntries(entries))
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const swapped = swapBytes(hex);
+    const byteCount = hex.length / 2;
+
+    const entries: [string, string][] = [
+      ['Input', `0x${hex}`],
+      ['Swapped', `0x${swapped}`],
+      ['Bytes', String(byteCount)],
+    ];
+
+    // for 2, 4, or 8-byte values add big-endian / little-endian decimal views
+    if (WORD_SIZES.has(byteCount)) {
+      // interpret the original bytes as big-endian unsigned integer
+      const beValue = BigInt(`0x${hex}`);
+      // interpret the swapped bytes as big-endian unsigned integer (== LE of original)
+      const leValue = BigInt(`0x${swapped}`);
+
+      entries.push(['As BE', String(beValue)]);
+      entries.push(['As LE', String(leValue)]);
+    }
+
+    return [
+      new BoxBuilder('Byte Swap', kvToPlaintext(entries))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(Object.fromEntries(entries))
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ByteSwapBoxSource;

--- a/src/modules/boxSources/__test__/ByteSwapBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ByteSwapBoxSource.test.ts
@@ -1,0 +1,144 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ByteSwapBoxSource } from '../ByteSwapBoxSource';
+
+describe('ByteSwapBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(ByteSwapBoxSource.name).toBe('Byte Swap');
+      expect(ByteSwapBoxSource.tag).toBe('#');
+      expect(ByteSwapBoxSource.kind).toBe('Convert');
+      expect(typeof ByteSwapBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - trigger guard', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::byteswap trigger', () => {
+    it('swaps 0x12345678 to 0x78563412', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', {
+        byteswap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('0x12345678');
+      expect(opts.Swapped).toBe('0x78563412');
+      expect(opts.Bytes).toBe('4');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', {
+        byteswap: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority from ByteSwapBoxSource.priority', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', {
+        byteswap: true,
+      });
+      expect(boxes[0].props.priority).toBe(ByteSwapBoxSource.priority);
+    });
+  });
+
+  describe('generateBoxes - ::endian alias', () => {
+    it('works with ::endian option', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x12345678', {
+        endian: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Swapped).toBe('0x78563412');
+    });
+  });
+
+  describe('generateBoxes - input without 0x prefix', () => {
+    it('accepts hex without 0x prefix and normalizes output', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('deadbeef', {
+        byteswap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('0xdeadbeef');
+      expect(opts.Swapped).toBe('0xefbeadde');
+    });
+  });
+
+  describe('generateBoxes - 2-byte big-endian / little-endian', () => {
+    it('0x00ff → Swapped 0xff00, As BE 255, As LE 65280', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x00ff', {
+        byteswap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('0x00ff');
+      expect(opts.Swapped).toBe('0xff00');
+      expect(opts.Bytes).toBe('2');
+      expect(opts['As BE']).toBe('255');
+      expect(opts['As LE']).toBe('65280');
+    });
+  });
+
+  describe('generateBoxes - 8-byte round-trip', () => {
+    it('swapping twice returns the original value', async () => {
+      const original = '0x0102030405060708';
+      const firstPass = await ByteSwapBoxSource.generateBoxes(original, {
+        byteswap: true,
+      });
+      const swappedHex = (firstPass[0].props.options as Record<string, string>)
+        .Swapped;
+
+      const secondPass = await ByteSwapBoxSource.generateBoxes(swappedHex, {
+        byteswap: true,
+      });
+      const roundTripped = (
+        secondPass[0].props.options as Record<string, string>
+      ).Swapped;
+
+      // strip leading 0x before comparing to original lowercase hex
+      expect(roundTripped).toBe('0x0102030405060708');
+    });
+  });
+
+  describe('generateBoxes - error cases', () => {
+    it('odd-length hex returns an error box mentioning even number of digits', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0xabc', {
+        byteswap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/even number of digits/i);
+    });
+
+    it('invalid characters return an error box mentioning hex', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('xyz', {
+        byteswap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/hex/i);
+    });
+  });
+
+  describe('generateBoxes - plaintextOutput', () => {
+    it('plaintext output contains key: value pairs', async () => {
+      const boxes = await ByteSwapBoxSource.generateBoxes('0x1234', {
+        byteswap: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Input: 0x1234');
+      expect(text).toContain('Swapped: 0x3412');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,12 +1,9 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
+import ByteSwapBoxSource from './ByteSwapBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  ByteSwapBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Byte Swap (Convert)

Adds the `Byte Swap` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `0x12345678 ::byteswap`

#### Options:
- `::byteswap`, `::endian`

#### Description:
Swap the byte order (endianness) of a hex value. ::byteswap or ::endian.

#### Usage Examples:
- **Input**: `0x12345678 ::byteswap`
- **Output Box (`Byte Swap`)**:
```
Input: 0x12345678
Swapped: 0x78563412
Bytes: 4
As BE: 305419896
As LE: 2018915346
```
