### PR TITLE
feat(Caesar): add Caesar Cipher BoxSource

### DIFF
--- a/src/modules/boxSources/CaesarBoxSource.ts
+++ b/src/modules/boxSources/CaesarBoxSource.ts
@@ -1,0 +1,91 @@
+import { CodeBoxTemplate, DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// shift a single character by n positions within a-z or A-Z; non-letters pass through unchanged
+function shiftChar(char: string, n: number): string {
+  const code = char.charCodeAt(0);
+  if (code >= 65 && code <= 90) {
+    return String.fromCharCode(((code - 65 + ((n % 26) + 26)) % 26) + 65);
+  }
+  if (code >= 97 && code <= 122) {
+    return String.fromCharCode(((code - 97 + ((n % 26) + 26)) % 26) + 97);
+  }
+  return char;
+}
+
+function caesarShift(text: string, n: number): string {
+  return text
+    .split('')
+    .map((c) => shiftChar(c, n))
+    .join('');
+}
+
+export const CaesarBoxSource = {
+  defaultDisabled: true,
+  name: 'Caesar Cipher',
+  description:
+    'Caesar shift cipher. ::caesar=3 to shift by 3; ::caesarcrack to show all 25 shifts.',
+  defaultInput: 'Hello ::caesar=3',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const shiftVal = extractOptionKeys(options, 'caesar');
+    const wantCrack = hasOptionKeys(options, 'caesarcrack', 'caesarbrute');
+
+    if (shiftVal === null && !wantCrack) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (shiftVal !== null) {
+      // parse the shift amount; fall back to 3 when the value is missing or non-numeric
+      const n = Number.parseInt(String(shiftVal), 10);
+      const parsedShift =
+        typeof shiftVal === 'boolean' || Number.isNaN(n) ? 3 : n;
+
+      const shifted = caesarShift(input, parsedShift);
+
+      const box = new BoxBuilder('Caesar Cipher', shifted)
+        .setPriority(Priority)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .build();
+
+      boxes.push(box);
+    }
+
+    if (wantCrack) {
+      // produce all 25 non-zero shifts, one per line
+      const lines = Array.from({ length: 25 }, (_, i) => {
+        const shift = i + 1;
+        return `shift ${shift}: ${caesarShift(input, shift)}`;
+      }).join('\n');
+
+      const box = new BoxBuilder('Caesar Cipher (all shifts)', lines)
+        .setPriority(Priority)
+        .setTemplate(CodeBoxTemplate)
+        .build();
+
+      boxes.push(box);
+    }
+
+    return boxes;
+  },
+};
+
+export default CaesarBoxSource;

--- a/src/modules/boxSources/__test__/CaesarBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CaesarBoxSource.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { CaesarBoxSource } from '../CaesarBoxSource';
+
+describe('CaesarBoxSource', () => {
+  it('returns [] with no options', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] for empty input', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('', { caesar: '3' });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] for whitespace-only input', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('   ', { caesar: '3' });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('shifts Hello by 3 → Khoor', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', { caesar: '3' });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe('Khoor');
+  });
+
+  it('shifts Khoor by -3 → Hello', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Khoor', {
+      caesar: '-3',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe('Hello');
+  });
+
+  it('wraps around: xyz + 3 → abc', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('xyz', { caesar: '3' });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe('abc');
+  });
+
+  it('preserves case and punctuation: Hello, World! + 1 → Ifmmp, Xpsme!', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello, World!', {
+      caesar: '1',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe('Ifmmp, Xpsme!');
+  });
+
+  it('defaults to shift 3 when ::caesar has no numeric value', async () => {
+    // boolean true simulates ::caesar with no =value
+    const boxes = await CaesarBoxSource.generateBoxes('abc', { caesar: true });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe('def');
+  });
+
+  it('caesarcrack output contains Hello when cracking Khoor', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Khoor', {
+      caesarcrack: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.name).toBe('Caesar Cipher (all shifts)');
+    // shift 23 reverses a +3 shift (26-3=23)
+    expect(boxes[0].props.plaintextOutput).toContain('shift 23: Hello');
+  });
+
+  it('caesarcrack output contains all 25 shift lines', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('A', {
+      caesarcrack: true,
+    });
+    const lines = boxes[0].props.plaintextOutput.split('\n');
+    expect(lines).toHaveLength(25);
+    expect(lines[0]).toMatch(/^shift 1: /);
+    expect(lines[24]).toMatch(/^shift 25: /);
+  });
+
+  it('caesarbrute is accepted as an alias for caesarcrack', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', {
+      caesarbrute: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.name).toBe('Caesar Cipher (all shifts)');
+  });
+
+  it('both ::caesar=3 and ::caesarcrack returns 2 boxes, caesar first', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', {
+      caesar: '3',
+      caesarcrack: true,
+    });
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0].props.name).toBe('Caesar Cipher');
+    expect(boxes[0].props.plaintextOutput).toBe('Khoor');
+    expect(boxes[1].props.name).toBe('Caesar Cipher (all shifts)');
+  });
+
+  it('single-shift box has showExpandButton=false', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', { caesar: '3' });
+    expect(boxes[0].props.showExpandButton).toBe(false);
+  });
+
+  it('priority is set on both box types', async () => {
+    const boxes = await CaesarBoxSource.generateBoxes('Hello', {
+      caesar: '3',
+      caesarcrack: true,
+    });
+    for (const box of boxes) {
+      expect(box.props.priority).toBe(10);
+    }
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import {
 } from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
+import CaesarBoxSource from './CaesarBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -76,6 +77,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  CaesarBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,


### PR DESCRIPTION
### Box Source: Caesar Cipher (Encode)

Adds the `Caesar Cipher` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `Hello ::caesar=3`

#### Options:
- `::caesarbrute`, `::caesarcrack`

#### Description:
Caesar shift cipher. ::caesar=3 to shift by 3; ::caesarcrack to show all 25 shifts.

#### Usage Examples:
- **Input**: `Hello ::caesar=3`
- **Output Box (`Caesar Cipher`)**:
```
Khoor
```
