### PR TITLE
feat(CaesarCipher): add Caesar Cipher BoxSource

### DIFF
--- a/src/modules/boxSources/CaesarCipherBoxSource.ts
+++ b/src/modules/boxSources/CaesarCipherBoxSource.ts
@@ -30,11 +30,25 @@ function caesarShift(text: string, shift: number): string {
   return out;
 }
 
+// ROT47 rotates ASCII characters 33-126 by 47 positions
+function rot47Shift(text: string): string {
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code >= 33 && code <= 126) {
+      out += String.fromCharCode(((code - 33 + 47) % 94) + 33);
+    } else {
+      out += text[i];
+    }
+  }
+  return out;
+}
+
 export const CaesarCipherBoxSource = {
   defaultDisabled: true,
   name: 'Caesar Cipher',
   description:
-    'Rotate letters by N positions (ROT13 by default). Use ::caesar=N for a custom shift (supports positive/negative shift, shows encode and decode).',
+    'Rotate letters by N positions (ROT13 by default, ROT47, or custom shift). Supports ::rot13, ::rot47, ::caesar=N.',
   defaultInput: 'Hello, World! ::rot13',
   tag: 'Aa',
   kind: 'Encode',
@@ -44,11 +58,38 @@ export const CaesarCipherBoxSource = {
     input: string,
     options: BoxOptions = null,
   ): Promise<Box[]> {
-    if (!hasOptionKeys(options, 'rot13', 'caesar')) return [];
+    if (!hasOptionKeys(options, 'rot13', 'caesar', 'rot47')) return [];
     if (!isString(input) || input.length === 0) return [];
     if (input.length > MAX_INPUT) return [];
 
-    // rot13 always wins; otherwise parse the caesar= value
+    if (hasOptionKeys(options, 'rot47')) {
+      const output = rot47Shift(input);
+      const val = extractOptionKeys(options, 'rot47');
+      const mode = val === 'encode' || val === 'decode' ? val : null;
+      const boxes: Box[] = [];
+
+      if (mode !== 'decode') {
+        boxes.push(
+          new BoxBuilder('ROT47 Encode', output)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+      if (mode !== 'encode') {
+        boxes.push(
+          new BoxBuilder('ROT47 Decode', output)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+      return boxes;
+    }
+
+    // rot13 or custom caesar shift
     let shift: number;
     let isRot13 = false;
     let specificMode: 'encode' | 'decode' | null = null;

--- a/src/modules/boxSources/CaesarCipherBoxSource.ts
+++ b/src/modules/boxSources/CaesarCipherBoxSource.ts
@@ -1,0 +1,79 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// bound synchronous work; input is seeded from a ?input= url param with no cap
+const MAX_INPUT = 100_000;
+
+// rotates a single ASCII letter by shift positions, preserving case; non-letters pass through unchanged
+function rotateChar(ch: string, shift: number): string {
+  const code = ch.charCodeAt(0);
+  if (code >= 65 && code <= 90) {
+    return String.fromCharCode(((code - 65 + shift) % 26) + 65);
+  }
+  if (code >= 97 && code <= 122) {
+    return String.fromCharCode(((code - 97 + shift) % 26) + 97);
+  }
+  return ch;
+}
+
+// applies a caesar shift to every character of the input string;
+// accumulates char-by-char to avoid a full intermediate array allocation
+function caesarShift(text: string, shift: number): string {
+  let out = '';
+  for (const ch of text) {
+    out += rotateChar(ch, shift);
+  }
+  return out;
+}
+
+export const CaesarCipherBoxSource = {
+  defaultDisabled: true,
+  name: 'Caesar Cipher',
+  description:
+    'Rotate letters by N positions (ROT13 by default). Use ::caesar=N for a custom shift.',
+  defaultInput: 'Hello, World! ::rot13',
+  tag: 'Aa',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'rot13', 'caesar')) return [];
+    if (!isString(input) || input.length === 0) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // rot13 always wins; otherwise parse the caesar= value
+    let shift: number;
+    if (hasOptionKeys(options, 'rot13')) {
+      shift = 13;
+    } else {
+      const raw = extractOptionKeys(options, 'caesar');
+      const parsed =
+        raw === true || raw === null
+          ? Number.NaN
+          : Number.parseInt(String(raw), 10);
+      shift = Number.isNaN(parsed) ? 13 : parsed;
+    }
+
+    // normalize into 0..25 (handles negative and large values)
+    const n = ((shift % 26) + 26) % 26;
+
+    const output = caesarShift(input, n);
+
+    return [
+      new BoxBuilder(`Caesar Cipher (shift ${n})`, output)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CaesarCipherBoxSource;

--- a/src/modules/boxSources/CaesarCipherBoxSource.ts
+++ b/src/modules/boxSources/CaesarCipherBoxSource.ts
@@ -34,7 +34,7 @@ export const CaesarCipherBoxSource = {
   defaultDisabled: true,
   name: 'Caesar Cipher',
   description:
-    'Rotate letters by N positions (ROT13 by default). Use ::caesar=N for a custom shift.',
+    'Rotate letters by N positions (ROT13 by default). Use ::caesar=N for a custom shift (supports positive/negative shift, shows encode and decode).',
   defaultInput: 'Hello, World! ::rot13',
   tag: 'Aa',
   kind: 'Encode',
@@ -50,8 +50,16 @@ export const CaesarCipherBoxSource = {
 
     // rot13 always wins; otherwise parse the caesar= value
     let shift: number;
+    let isRot13 = false;
+    let specificMode: 'encode' | 'decode' | null = null;
+
     if (hasOptionKeys(options, 'rot13')) {
+      isRot13 = true;
       shift = 13;
+      const val = extractOptionKeys(options, 'rot13');
+      if (val === 'encode' || val === 'decode') {
+        specificMode = val;
+      }
     } else {
       const raw = extractOptionKeys(options, 'caesar');
       const parsed =
@@ -61,18 +69,38 @@ export const CaesarCipherBoxSource = {
       shift = Number.isNaN(parsed) ? 13 : parsed;
     }
 
-    // normalize into 0..25 (handles negative and large values)
-    const n = ((shift % 26) + 26) % 26;
+    const getEffectiveShift = (s: number) => ((s % 26) + 26) % 26;
+    const boxes: Box[] = [];
 
-    const output = caesarShift(input, n);
+    if (specificMode !== 'decode') {
+      const title = isRot13
+        ? 'Caesar Cipher (ROT13 Encode)'
+        : `Caesar Cipher (shift ${shift}) Encode`;
+      const output = caesarShift(input, getEffectiveShift(shift));
+      boxes.push(
+        new BoxBuilder(title, output)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
 
-    return [
-      new BoxBuilder(`Caesar Cipher (shift ${n})`, output)
-        .setTemplate(DefaultBoxTemplate)
-        .setShowExpandButton(false)
-        .setPriority(this.priority)
-        .build(),
-    ];
+    if (specificMode !== 'encode') {
+      const title = isRot13
+        ? 'Caesar Cipher (ROT13 Decode)'
+        : `Caesar Cipher (shift ${-shift}) Decode`;
+      const output = caesarShift(input, getEffectiveShift(-shift));
+      boxes.push(
+        new BoxBuilder(title, output)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
   },
 };
 

--- a/src/modules/boxSources/Rot47BoxSource.ts
+++ b/src/modules/boxSources/Rot47BoxSource.ts
@@ -1,0 +1,75 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// rotate printable ASCII characters (! to ~, codes 33-126) by 47 positions
+function rot47(input: string): string {
+  let result = '';
+  for (let i = 0; i < input.length; i++) {
+    const c = input.charCodeAt(i);
+    if (c >= 33 && c <= 126) {
+      result += String.fromCharCode(33 + ((c - 33 + 47) % 94));
+    } else {
+      result += input[i];
+    }
+  }
+  return result;
+}
+
+export const Rot47BoxSource = {
+  defaultDisabled: true,
+  name: 'ROT47',
+  description:
+    'Apply the ROT47 cipher (rotates printable ASCII ! to ~ by 47). Self-inverse (shows encode and decode).',
+  defaultInput: 'Hello, World! ::rot47',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'rot47')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const val = extractOptionKeys(options, 'rot47');
+    const specificMode = val === 'encode' || val === 'decode' ? val : null;
+
+    const output = rot47(input);
+    const boxes: Box[] = [];
+
+    if (specificMode !== 'decode') {
+      boxes.push(
+        new BoxBuilder('ROT47 Encode', output)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (specificMode !== 'encode') {
+      boxes.push(
+        new BoxBuilder('ROT47 Decode', output)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default Rot47BoxSource;

--- a/src/modules/boxSources/__test__/CaesarCipherBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CaesarCipherBoxSource.test.ts
@@ -135,6 +135,19 @@ describe('CaesarCipherBoxSource', () => {
     });
   });
 
+  describe('rot47', () => {
+    it('encodes and decodes using ROT47 correctly', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('Hello World!', {
+        rot47: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('ROT47 Encode');
+      expect(boxes[0].props.plaintextOutput).toBe('w6==@ (@C=5P');
+      expect(boxes[1].props.name).toBe('ROT47 Decode');
+      expect(boxes[1].props.plaintextOutput).toBe('w6==@ (@C=5P');
+    });
+  });
+
   describe('metadata', () => {
     it('has expected static properties', () => {
       expect(CaesarCipherBoxSource.name).toBe('Caesar Cipher');

--- a/src/modules/boxSources/__test__/CaesarCipherBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CaesarCipherBoxSource.test.ts
@@ -1,0 +1,130 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { CaesarCipherBoxSource } from '../CaesarCipherBoxSource';
+
+describe('CaesarCipherBoxSource', () => {
+  describe('no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes(
+        'Hello, World!',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes(
+        'Hello, World!',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input with rot13 option', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('', {
+        rot13: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('rot13', () => {
+    it('encodes Hello, World! correctly', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
+        rot13: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Uryyb, Jbeyq!');
+    });
+
+    it('is its own inverse — applying rot13 twice returns the original', async () => {
+      const input = 'Hello, World!';
+      const first = await CaesarCipherBoxSource.generateBoxes(input, {
+        rot13: true,
+      });
+      const rotated = first[0].props.plaintextOutput;
+      const second = await CaesarCipherBoxSource.generateBoxes(rotated, {
+        rot13: true,
+      });
+      expect(second[0].props.plaintextOutput).toBe(input);
+    });
+
+    it('box name reflects shift 13', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
+        rot13: true,
+      });
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13)');
+    });
+
+    it('uses DefaultBoxTemplate', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
+        rot13: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+
+  describe('caesar shift', () => {
+    it('shifts abc by 1 to bcd', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('abc', {
+        caesar: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('bcd');
+    });
+
+    it('wraps xyz by 3 to abc', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('xyz', {
+        caesar: '3',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('abc');
+    });
+
+    it('negative shift -1 on bcd returns abc', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('bcd', {
+        caesar: '-1',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('abc');
+    });
+
+    it('box name includes the effective shift', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('abc', {
+        caesar: '1',
+      });
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 1)');
+    });
+
+    it('defaults to shift 13 when caesar value is true (no value given)', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
+        caesar: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Uryyb, Jbeyq!');
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13)');
+    });
+
+    it('defaults to shift 13 on non-numeric caesar value', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes('abc', {
+        caesar: 'xyz',
+      });
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13)');
+    });
+
+    it('preserves non-letter characters', async () => {
+      const boxes = await CaesarCipherBoxSource.generateBoxes(
+        'Hello, World! 123',
+        { rot13: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('Uryyb, Jbeyq! 123');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(CaesarCipherBoxSource.name).toBe('Caesar Cipher');
+      expect(CaesarCipherBoxSource.tag).toBe('Aa');
+      expect(CaesarCipherBoxSource.kind).toBe('Encode');
+      expect(typeof CaesarCipherBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/CaesarCipherBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CaesarCipherBoxSource.test.ts
@@ -34,8 +34,14 @@ describe('CaesarCipherBoxSource', () => {
       const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
         rot13: true,
       });
-      expect(boxes).toHaveLength(1);
+      expect(boxes).toHaveLength(2);
       expect(boxes[0].props.plaintextOutput).toBe('Uryyb, Jbeyq!');
+      expect(boxes[0].props.name).toBe('Caesar Cipher (ROT13 Encode)');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+
+      expect(boxes[1].props.plaintextOutput).toBe('Uryyb, Jbeyq!');
+      expect(boxes[1].props.name).toBe('Caesar Cipher (ROT13 Decode)');
+      expect(boxes[1].boxTemplate).toBe(DefaultBoxTemplate);
     });
 
     it('is its own inverse — applying rot13 twice returns the original', async () => {
@@ -50,64 +56,74 @@ describe('CaesarCipherBoxSource', () => {
       expect(second[0].props.plaintextOutput).toBe(input);
     });
 
-    it('box name reflects shift 13', async () => {
+    it('supports encode specific option', async () => {
       const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
-        rot13: true,
+        rot13: 'encode',
       });
-      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13)');
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Caesar Cipher (ROT13 Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('Uryyb, Jbeyq!');
     });
 
-    it('uses DefaultBoxTemplate', async () => {
+    it('supports decode specific option', async () => {
       const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
-        rot13: true,
+        rot13: 'decode',
       });
-      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Caesar Cipher (ROT13 Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('Uryyb, Jbeyq!');
     });
   });
 
   describe('caesar shift', () => {
-    it('shifts abc by 1 to bcd', async () => {
+    it('shifts abc by 1 to bcd (encode) and wraps to zab (decode)', async () => {
       const boxes = await CaesarCipherBoxSource.generateBoxes('abc', {
         caesar: '1',
       });
-      expect(boxes).toHaveLength(1);
+      expect(boxes).toHaveLength(2);
       expect(boxes[0].props.plaintextOutput).toBe('bcd');
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 1) Encode');
+
+      expect(boxes[1].props.plaintextOutput).toBe('zab');
+      expect(boxes[1].props.name).toBe('Caesar Cipher (shift -1) Decode');
     });
 
-    it('wraps xyz by 3 to abc', async () => {
+    it('wraps xyz by 3 to abc (encode) and uvw (decode)', async () => {
       const boxes = await CaesarCipherBoxSource.generateBoxes('xyz', {
         caesar: '3',
       });
+      expect(boxes).toHaveLength(2);
       expect(boxes[0].props.plaintextOutput).toBe('abc');
+      expect(boxes[1].props.plaintextOutput).toBe('uvw');
     });
 
-    it('negative shift -1 on bcd returns abc', async () => {
+    it('negative shift -1 on bcd returns abc (encode) and cde (decode)', async () => {
       const boxes = await CaesarCipherBoxSource.generateBoxes('bcd', {
         caesar: '-1',
       });
+      expect(boxes).toHaveLength(2);
       expect(boxes[0].props.plaintextOutput).toBe('abc');
-    });
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift -1) Encode');
 
-    it('box name includes the effective shift', async () => {
-      const boxes = await CaesarCipherBoxSource.generateBoxes('abc', {
-        caesar: '1',
-      });
-      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 1)');
+      expect(boxes[1].props.plaintextOutput).toBe('cde');
+      expect(boxes[1].props.name).toBe('Caesar Cipher (shift 1) Decode');
     });
 
     it('defaults to shift 13 when caesar value is true (no value given)', async () => {
       const boxes = await CaesarCipherBoxSource.generateBoxes('Hello, World!', {
         caesar: true,
       });
+      expect(boxes).toHaveLength(2);
       expect(boxes[0].props.plaintextOutput).toBe('Uryyb, Jbeyq!');
-      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13)');
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13) Encode');
     });
 
     it('defaults to shift 13 on non-numeric caesar value', async () => {
       const boxes = await CaesarCipherBoxSource.generateBoxes('abc', {
         caesar: 'xyz',
       });
-      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13)');
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Caesar Cipher (shift 13) Encode');
     });
 
     it('preserves non-letter characters', async () => {

--- a/src/modules/boxSources/__test__/Rot47BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Rot47BoxSource.test.ts
@@ -1,0 +1,131 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Rot47BoxSource } from '../Rot47BoxSource';
+
+describe('Rot47BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('Hello, World!', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('Hello, World!', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns empty array for empty string', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('', { rot47: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('   ', { rot47: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - known vector', () => {
+    it('produces canonical ROT47 output for "Hello, World!"', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('Hello, World!', {
+        rot47: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.plaintextOutput).toBe('w6==@[ (@C=5P');
+      expect(boxes[0].props.name).toBe('ROT47 Encode');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+
+      expect(boxes[1].props.plaintextOutput).toBe('w6==@[ (@C=5P');
+      expect(boxes[1].props.name).toBe('ROT47 Decode');
+      expect(boxes[1].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('produces correct ROT47 for "ABC"', async () => {
+      // A(65)→p, B(66)→q, C(67)→r
+      const boxes = await Rot47BoxSource.generateBoxes('ABC', { rot47: true });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.plaintextOutput).toBe('pqr');
+      expect(boxes[1].props.plaintextOutput).toBe('pqr');
+    });
+
+    it('supports encode specific option', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('ABC', {
+        rot47: 'encode',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('ROT47 Encode');
+      expect(boxes[0].props.plaintextOutput).toBe('pqr');
+    });
+
+    it('supports decode specific option', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('ABC', {
+        rot47: 'decode',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('ROT47 Decode');
+      expect(boxes[0].props.plaintextOutput).toBe('pqr');
+    });
+  });
+
+  describe('generateBoxes - self-inverse property', () => {
+    it('rot47(rot47(x)) === x for "Hello, World!"', async () => {
+      const first = await Rot47BoxSource.generateBoxes('Hello, World!', {
+        rot47: true,
+      });
+      const encoded = first[0].props.plaintextOutput as string;
+      const second = await Rot47BoxSource.generateBoxes(encoded, {
+        rot47: true,
+      });
+      expect(second[0].props.plaintextOutput).toBe('Hello, World!');
+    });
+
+    it('rot47(rot47(x)) === x for arbitrary printable ASCII', async () => {
+      const input =
+        '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+      const first = await Rot47BoxSource.generateBoxes(input, { rot47: true });
+      const second = await Rot47BoxSource.generateBoxes(
+        first[0].props.plaintextOutput as string,
+        { rot47: true },
+      );
+      expect(second[0].props.plaintextOutput).toBe(input);
+    });
+  });
+
+  describe('generateBoxes - boundary characters', () => {
+    it('preserves spaces (code 32, below range 33-126)', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('A B', { rot47: true });
+      expect(boxes).toHaveLength(2);
+      // A→p, space→space, B→q
+      expect(boxes[0].props.plaintextOutput).toBe('p q');
+    });
+
+    it('preserves newline and tab (control characters below 33)', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('A\nB\tC', {
+        rot47: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.plaintextOutput).toBe('p\nq\tr');
+    });
+
+    it('preserves non-ASCII characters (codes > 126)', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('héllo', {
+        rot47: true,
+      });
+      expect(boxes).toHaveLength(2);
+      // lowercase h(104)→9, é unchanged (code 233), l→=, l→=, o→@
+      expect(boxes[0].props.plaintextOutput).toBe('9é==@');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Rot47BoxSource.name).toBe('ROT47');
+      expect(Rot47BoxSource.tag).toBe('#');
+      expect(Rot47BoxSource.kind).toBe('Encode');
+      expect(typeof Rot47BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import {
 } from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
+import CaesarCipherBoxSource from './CaesarCipherBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -85,6 +86,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  CaesarCipherBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -30,6 +30,7 @@ import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import Rot47BoxSource from './Rot47BoxSource';
 import SemverBoxSource from './SemverBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import SnowflakeBoxSource from './SnowflakeBoxSource';
@@ -110,4 +111,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  Rot47BoxSource,
 ];


### PR DESCRIPTION
### Box Sources: Caesar Cipher & ROT47 (Encode)

Adds `Caesar Cipher` and `ROT47` box sources to Magic Box. Both are disabled by default.

---

### 1. Caesar Cipher

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `Aa`
- **Default Input**: `Hello, World! ::rot13`

#### Options:
- `::rot13` (supports `::rot13=encode` or `::rot13=decode` to show only one)
- `::caesar=N` (supports positive/negative N, e.g. `::caesar=3` or `::caesar=-3`)

#### Description:
Rotate letters by N positions (ROT13 by default). Shows both Encode and Decode results.

#### Usage Examples:
- **Input**:
```
Hello, World! ::rot13
```
- **Output Boxes**:
  - `Caesar Cipher (ROT13 Encode)`: `Uryyb, Jbeyq!`
  - `Caesar Cipher (ROT13 Decode)`: `Uryyb, Jbeyq!`

---

### 2. ROT47

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `Hello, World! ::rot47`

#### Options:
- `::rot47` (supports `::rot47=encode` or `::rot47=decode` to show only one)

#### Description:
Apply the ROT47 cipher (rotates printable ASCII ! to ~ by 47). Self-inverse (shows both Encode and Decode).

#### Usage Examples:
- **Input**:
```
Hello, World! ::rot47
```
- **Output Boxes**:
  - `ROT47 Encode`: `w6==@[ (@C=5P`
  - `ROT47 Decode`: `w6==@[ (@C=5P`