### PR TITLE
feat(CaseConverter): add Case Converter BoxSource

### DIFF
--- a/src/modules/boxSources/CaseConverterBoxSource.ts
+++ b/src/modules/boxSources/CaseConverterBoxSource.ts
@@ -1,0 +1,106 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// split input into lowercase tokens by whitespace, separators, and camelCase/PascalCase boundaries
+function tokenize(input: string): string[] {
+  // insert a space before every uppercase letter that follows a lowercase letter or digit (camelCase boundary)
+  const expanded = input
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    // split an acronym from a following word (XMLParser → XML Parser); the
+    // fixed-width lookahead avoids the catastrophic backtracking that
+    // `([A-Z]+)([A-Z][a-z])` exhibits on long uppercase runs (ReDoS)
+    .replace(/([A-Z])(?=[A-Z][a-z])/g, '$1 ');
+
+  return expanded
+    .split(/[\s\-_.]+/)
+    .map((t) => t.toLowerCase())
+    .filter((t) => t.length > 0);
+}
+
+function capitalize(word: string): string {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+function toCamelCase(tokens: string[]): string {
+  return tokens.map((t, i) => (i === 0 ? t : capitalize(t))).join('');
+}
+
+function toPascalCase(tokens: string[]): string {
+  return tokens.map(capitalize).join('');
+}
+
+function toSnakeCase(tokens: string[]): string {
+  return tokens.join('_');
+}
+
+function toKebabCase(tokens: string[]): string {
+  return tokens.join('-');
+}
+
+function toConstantCase(tokens: string[]): string {
+  return tokens.map((t) => t.toUpperCase()).join('_');
+}
+
+function toDotCase(tokens: string[]): string {
+  return tokens.join('.');
+}
+
+function toTitleCase(tokens: string[]): string {
+  return tokens.map(capitalize).join(' ');
+}
+
+function toSentenceCase(tokens: string[]): string {
+  return tokens.map((t, i) => (i === 0 ? capitalize(t) : t)).join(' ');
+}
+
+export const CaseConverterBoxSource = {
+  defaultDisabled: true,
+  name: 'Case Converter',
+  description:
+    'Convert text between camelCase, snake_case, kebab-case, PascalCase, CONSTANT_CASE, dot.case, Title Case and Sentence case.',
+  defaultInput: 'hello world foo bar ::case',
+  tag: 'Aa',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    // gate on ::case option so this never intercepts unrelated inputs
+    if (!hasOptionKeys(options, 'case')) return [];
+    if (!isString(input) || trim(input).length === 0) return [];
+
+    const tokens = tokenize(trim(input));
+    if (tokens.length === 0) return [];
+
+    const output: Record<string, string> = {
+      camelCase: toCamelCase(tokens),
+      PascalCase: toPascalCase(tokens),
+      snake_case: toSnakeCase(tokens),
+      'kebab-case': toKebabCase(tokens),
+      CONSTANT_CASE: toConstantCase(tokens),
+      'dot.case': toDotCase(tokens),
+      'Title Case': toTitleCase(tokens),
+      'Sentence case': toSentenceCase(tokens),
+    };
+
+    const content = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Case Converter', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CaseConverterBoxSource;

--- a/src/modules/boxSources/__test__/CaseConverterBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CaseConverterBoxSource.test.ts
@@ -1,0 +1,123 @@
+import { CaseConverterBoxSource } from '@modules/boxSources/CaseConverterBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('CaseConverterBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::case option is absent', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes(
+        'hello world',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with ::case option', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes('   ', {
+        case: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes('', {
+        case: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts multi-word space-separated input to all cases', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes('hello world', {
+        case: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+
+      expect(opts.camelCase).toBe('helloWorld');
+      expect(opts.PascalCase).toBe('HelloWorld');
+      expect(opts.snake_case).toBe('hello_world');
+      expect(opts['kebab-case']).toBe('hello-world');
+      expect(opts.CONSTANT_CASE).toBe('HELLO_WORLD');
+      expect(opts['dot.case']).toBe('hello.world');
+      expect(opts['Title Case']).toBe('Hello World');
+      expect(opts['Sentence case']).toBe('Hello world');
+    });
+
+    it('tokenizes camelCase input correctly', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes('fooBarBaz', {
+        case: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+
+      expect(opts.camelCase).toBe('fooBarBaz');
+      expect(opts.PascalCase).toBe('FooBarBaz');
+      expect(opts.snake_case).toBe('foo_bar_baz');
+      expect(opts['kebab-case']).toBe('foo-bar-baz');
+      expect(opts.CONSTANT_CASE).toBe('FOO_BAR_BAZ');
+      expect(opts['dot.case']).toBe('foo.bar.baz');
+      expect(opts['Title Case']).toBe('Foo Bar Baz');
+      expect(opts['Sentence case']).toBe('Foo bar baz');
+    });
+
+    it('tokenizes mixed separators (hyphens and underscores)', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes(
+        'hello-world_foo',
+        { case: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+
+      expect(opts.snake_case).toBe('hello_world_foo');
+      expect(opts['kebab-case']).toBe('hello-world-foo');
+      expect(opts.CONSTANT_CASE).toBe('HELLO_WORLD_FOO');
+    });
+
+    it('splits acronym boundaries (XMLParser, myHTTPSClient)', async () => {
+      const xml = await CaseConverterBoxSource.generateBoxes('XMLParser', {
+        case: true,
+      });
+      expect((xml[0].props.options as Record<string, string>).camelCase).toBe(
+        'xmlParser',
+      );
+
+      const https = await CaseConverterBoxSource.generateBoxes(
+        'myHTTPSClient',
+        {
+          case: true,
+        },
+      );
+      expect((https[0].props.options as Record<string, string>).camelCase).toBe(
+        'myHttpsClient',
+      );
+    });
+
+    it('tokenizes a long uppercase run in linear time (ReDoS guard)', async () => {
+      // the old /([A-Z]+)([A-Z][a-z])/g regex took ~7s on 100k uppercase chars;
+      // the lookahead form is linear, so this resolves well under the test timeout
+      const boxes = await CaseConverterBoxSource.generateBoxes(
+        `${'A'.repeat(100_000)}b`,
+        { case: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('plaintextOutput lists all conversions as key: value lines', async () => {
+      const boxes = await CaseConverterBoxSource.generateBoxes('hello world', {
+        case: true,
+      });
+
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('camelCase: helloWorld');
+      expect(text).toContain('PascalCase: HelloWorld');
+      expect(text).toContain('snake_case: hello_world');
+      expect(text).toContain('kebab-case: hello-world');
+      expect(text).toContain('CONSTANT_CASE: HELLO_WORLD');
+      expect(text).toContain('dot.case: hello.world');
+      expect(text).toContain('Title Case: Hello World');
+      expect(text).toContain('Sentence case: Hello world');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import {
 } from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
+import CaseConverterBoxSource from './CaseConverterBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  CaseConverterBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Case Converter (Convert)

Adds the `Case Converter` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `Aa`
- **Default Input**: `hello world foo bar ::case`

#### Options:
- `::case`

#### Description:
Convert text between camelCase, snake_case, kebab-case, PascalCase, CONSTANT_CASE, dot.case, Title Case and Sentence case.

#### Usage Examples:
- **Input**: `hello world foo bar ::case`
- **Output Box (`Case Converter`)**:
```
camelCase: helloWorldFooBar
PascalCase: HelloWorldFooBar
snake_case: hello_world_foo_bar
kebab-case: hello-world-foo-bar
CONSTANT_CASE: HELLO_WORLD_FOO_BAR
dot.case: hello.world.foo.bar
Title Case: Hello World Foo Bar
Sentence case: Hello world foo bar
```
