### PR TITLE
feat(CharFrequency): add Character Frequency BoxSource

### DIFF
--- a/src/modules/boxSources/CharFrequencyBoxSource.ts
+++ b/src/modules/boxSources/CharFrequencyBoxSource.ts
@@ -1,0 +1,94 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+// maximum rows shown to bound output size
+const MAX_DISPLAY_ROWS = 100;
+
+// visible token labels for whitespace/control characters
+function charToken(char: string): string {
+  if (char === ' ') return 'SPACE';
+  if (char === '\t') return 'TAB';
+  if (char === '\n') return 'LF';
+  if (char === '\r') return 'CR';
+  return char;
+}
+
+export const CharFrequencyBoxSource = {
+  defaultDisabled: true,
+  name: 'Character Frequency',
+  description: 'Count how often each character appears in the text.',
+  defaultInput: 'hello world ::charfreq',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'charfreq', 'charfrequency')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    // build frequency map keyed by code point to avoid prototype pollution;
+    // for..of iterates by Unicode code point, so surrogate pairs count as 1
+    const freq = new Map<string, number>();
+    let totalChars = 0;
+    for (const char of input) {
+      freq.set(char, (freq.get(char) ?? 0) + 1);
+      totalChars++;
+    }
+
+    const uniqueChars = freq.size;
+
+    // sort by count desc, then by code point asc for ties
+    const sorted = [...freq.entries()].sort(
+      ([charA, countA], [charB, countB]) => {
+        if (countB !== countA) return countB - countA;
+        const cpA = charA.codePointAt(0) ?? 0;
+        const cpB = charB.codePointAt(0) ?? 0;
+        return cpA - cpB;
+      },
+    );
+
+    const truncated = sorted.length > MAX_DISPLAY_ROWS;
+    const displayed = truncated ? sorted.slice(0, MAX_DISPLAY_ROWS) : sorted;
+
+    // summary entries come first; character entries follow
+    const kvOptions: Record<string, string> = {
+      'Total Characters': String(totalChars),
+      'Unique Characters': String(uniqueChars),
+    };
+    for (const [char, count] of displayed) {
+      kvOptions[charToken(char)] = String(count);
+    }
+    if (truncated) {
+      kvOptions['(truncated)'] =
+        `showing top ${MAX_DISPLAY_ROWS} of ${sorted.length} unique chars`;
+    }
+
+    // build plaintext as a readable key:value list for headless / TUI use
+    const plaintextLines = Object.entries(kvOptions).map(
+      ([k, v]) => `${k}: ${v}`,
+    );
+    const plaintextOutput = plaintextLines.join('\n');
+
+    return [
+      new BoxBuilder('Character Frequency', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CharFrequencyBoxSource;

--- a/src/modules/boxSources/__test__/CharFrequencyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CharFrequencyBoxSource.test.ts
@@ -1,0 +1,144 @@
+import { CharFrequencyBoxSource } from '@modules/boxSources/CharFrequencyBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('CharFrequencyBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option key is present', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('   ', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('counts characters correctly for "hello"', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('hello', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Characters']).toBe('5');
+      expect(opts['Unique Characters']).toBe('4');
+      expect(opts.l).toBe('2');
+      expect(opts.h).toBe('1');
+      expect(opts.e).toBe('1');
+      expect(opts.o).toBe('1');
+    });
+
+    it('counts characters correctly for "aaa"', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('aaa', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Characters']).toBe('3');
+      expect(opts['Unique Characters']).toBe('1');
+      expect(opts.a).toBe('3');
+    });
+
+    it('counts characters correctly for "hello world" including SPACE token', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('hello world', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Characters']).toBe('11');
+      expect(opts.l).toBe('3');
+      expect(opts.o).toBe('2');
+      expect(opts.SPACE).toBe('1');
+    });
+
+    it('counts emoji as single code points', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('😀😀', {
+        charfreq: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // for..of counts code points, so '😀😀' = 2 code points, not 4 UTF-16 units
+      expect(opts['Total Characters']).toBe('2');
+      expect(opts['Unique Characters']).toBe('1');
+      expect(opts['😀']).toBe('2');
+    });
+
+    it('accepts ::charfrequency as an alias', async () => {
+      const boxes = await CharFrequencyBoxSource.generateBoxes('hi', {
+        charfrequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('handles "__proto__" input without prototype pollution', async () => {
+      const proto = Object.prototype;
+      const beforeKeys = Object.getOwnPropertyNames(proto);
+
+      const boxes = await CharFrequencyBoxSource.generateBoxes('__proto__', {
+        charfreq: true,
+      });
+
+      // must not crash and must return a valid box
+      expect(boxes).toHaveLength(1);
+
+      // prototype must be unmodified
+      const afterKeys = Object.getOwnPropertyNames(proto);
+      expect(afterKeys).toEqual(beforeKeys);
+
+      // '__proto__' = _ _ p r o t o _ _ → 4 underscores, 2 o, 1 each p/r/t
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts._).toBe('4');
+      expect(opts.o).toBe('2');
+      expect(opts.p).toBe('1');
+      expect(opts.r).toBe('1');
+      expect(opts.t).toBe('1');
+    });
+
+    it('box name is "Character Frequency" and template is KeyValueBoxTemplate', async () => {
+      const { KeyValueBoxTemplate } = await import('@components/BoxTemplate');
+      const boxes = await CharFrequencyBoxSource.generateBoxes('abc', {
+        charfreq: true,
+      });
+      expect(boxes[0].props.name).toBe('Character Frequency');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('sorts by count desc then code point asc', async () => {
+      // 'b' x3, 'a' x2, 'c' x1 — after that for ties 'a'(97) before 'c'(99)
+      const boxes = await CharFrequencyBoxSource.generateBoxes('bbbaacc', {
+        charfreq: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      const keys = Object.keys(opts).filter(
+        (k) => !['Total Characters', 'Unique Characters'].includes(k),
+      );
+      // expected order: b(3), a(2), c(2) — 'a'(97) before 'c'(99) for the tie
+      expect(keys).toEqual(['b', 'a', 'c']);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has correct static properties', () => {
+      expect(CharFrequencyBoxSource.name).toBe('Character Frequency');
+      expect(CharFrequencyBoxSource.tag).toBe('#');
+      expect(CharFrequencyBoxSource.kind).toBe('Calculate');
+      expect(CharFrequencyBoxSource.priority).toBe(10);
+      expect(CharFrequencyBoxSource.defaultInput).toBe(
+        'hello world ::charfreq',
+      );
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import {
 } from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
+import CharFrequencyBoxSource from './CharFrequencyBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  CharFrequencyBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Character Frequency (Calculate)

Adds the `Character Frequency` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `hello world ::charfreq`

#### Options:
- `::charfreq`, `::charfrequency`

#### Description:
Count how often each character appears in the text.

#### Usage Examples:
- **Input**: `hello world ::charfreq`
- **Output Box (`Character Frequency`)**:
```
Total Characters: 11
Unique Characters: 8
l: 3
o: 2
SPACE: 1
d: 1
e: 1
h: 1
r: 1
w: 1
```
