### PR TITLE
feat(ChineseZodiac): add Chinese Zodiac BoxSource

### DIFF
--- a/src/modules/boxSources/ChineseZodiacBoxSource.ts
+++ b/src/modules/boxSources/ChineseZodiacBoxSource.ts
@@ -1,0 +1,139 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// 12 zodiac animals with english and Traditional Chinese names.
+// index = ((year - 4) % 12 + 12) % 12, where index 0 = Rat.
+// NOTE: this uses the Gregorian year only, not the lunar new year boundary.
+// years near late january/early february may belong to the prior animal cycle.
+const ANIMALS = [
+  { en: 'Rat', zh: '鼠' },
+  { en: 'Ox', zh: '牛' },
+  { en: 'Tiger', zh: '虎' },
+  { en: 'Rabbit', zh: '兔' },
+  { en: 'Dragon', zh: '龍' },
+  { en: 'Snake', zh: '蛇' },
+  { en: 'Horse', zh: '馬' },
+  { en: 'Goat', zh: '羊' },
+  { en: 'Monkey', zh: '猴' },
+  { en: 'Rooster', zh: '雞' },
+  { en: 'Dog', zh: '狗' },
+  { en: 'Pig', zh: '豬' },
+];
+
+// ten heavenly stems (天干), cycling every 10 years
+const HEAVENLY_STEMS = [
+  '甲',
+  '乙',
+  '丙',
+  '丁',
+  '戊',
+  '己',
+  '庚',
+  '辛',
+  '壬',
+  '癸',
+];
+
+// twelve earthly branches (地支), cycling every 12 years
+const EARTHLY_BRANCHES = [
+  '子',
+  '丑',
+  '寅',
+  '卯',
+  '辰',
+  '巳',
+  '午',
+  '未',
+  '申',
+  '酉',
+  '戌',
+  '亥',
+];
+
+// five elements (五行), paired two stems each: Wood, Fire, Earth, Metal, Water
+const ELEMENTS = ['Wood 木', 'Fire 火', 'Earth 土', 'Metal 金', 'Water 水'];
+
+// build a k:v plaintext block from an ordered record
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+function buildErrorBox(message: string): Box {
+  const pairs = { Error: message };
+  return new BoxBuilder('Chinese Zodiac', kvToPlaintext(pairs))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(pairs)
+    .setPriority(Priority)
+    .build();
+}
+
+export const ChineseZodiacBoxSource = {
+  defaultDisabled: true,
+  name: 'Chinese Zodiac',
+  description:
+    'Chinese zodiac animal, element, and stem-branch for a year (by Gregorian year).',
+  defaultInput: '2024 ::chinesezodiac',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'chinesezodiac', 'shengxiao')) return [];
+
+    // prefer a numeric value on the option key itself, else fall back to input
+    const optionValue = extractOptionKeys(
+      options,
+      'chinesezodiac',
+      'shengxiao',
+    );
+    const rawYear =
+      typeof optionValue === 'string' && /^\d{1,5}$/.test(optionValue.trim())
+        ? optionValue.trim()
+        : trim(input);
+
+    if (!/^\d{1,5}$/.test(rawYear)) {
+      return [buildErrorBox('A valid Gregorian year (1–99999) is required.')];
+    }
+
+    const year = Number.parseInt(rawYear, 10);
+    if (year < 1) {
+      return [buildErrorBox('Year must be >= 1.')];
+    }
+
+    // all indices use the positive-modulo form to handle pre-epoch years correctly
+    const stemIdx = (((year - 4) % 10) + 10) % 10;
+    const branchIdx = (((year - 4) % 12) + 12) % 12;
+
+    const animal = ANIMALS[branchIdx];
+    const elementStr = ELEMENTS[Math.floor(stemIdx / 2)];
+    const yinYang = stemIdx % 2 === 0 ? 'Yang 陽' : 'Yin 陰';
+    const stemBranch = HEAVENLY_STEMS[stemIdx] + EARTHLY_BRANCHES[branchIdx];
+
+    const pairs: Record<string, string> = {
+      Year: rawYear,
+      Animal: `${animal.en} ${animal.zh}`,
+      Element: elementStr,
+      'Yin/Yang': yinYang,
+      'Stem-Branch': stemBranch,
+    };
+
+    return [
+      new BoxBuilder('Chinese Zodiac', kvToPlaintext(pairs))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(pairs)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ChineseZodiacBoxSource;

--- a/src/modules/boxSources/__test__/ChineseZodiacBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ChineseZodiacBoxSource.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+
+import { ChineseZodiacBoxSource } from '../ChineseZodiacBoxSource';
+
+describe('ChineseZodiacBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for an unrelated option', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::shengxiao alias', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        shengxiao: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('2024 — 甲辰 Wood Dragon', () => {
+    it('animal is Dragon 龍', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Animal).toContain('Dragon');
+      expect(opts.Animal).toContain('龍');
+    });
+
+    it('stem-branch is 甲辰', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Stem-Branch']).toBe('甲辰');
+    });
+
+    it('element is Wood (甲 = Wood Yang)', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Element).toContain('Wood');
+    });
+
+    it('yin/yang is Yang', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Yin/Yang']).toContain('Yang');
+    });
+
+    it('box name is Chinese Zodiac', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      expect(boxes[0].props.name).toBe('Chinese Zodiac');
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2024', {
+        chinesezodiac: true,
+      });
+      expect(boxes[0].props.priority).toBe(ChineseZodiacBoxSource.priority);
+    });
+  });
+
+  describe('2008 — 戊子 Earth Rat', () => {
+    it('animal is Rat 鼠', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2008', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Animal).toContain('Rat');
+      expect(opts.Animal).toContain('鼠');
+    });
+
+    it('stem-branch is 戊子', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2008', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Stem-Branch']).toBe('戊子');
+    });
+
+    it('element is Earth (戊 = Earth Yang)', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2008', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Element).toContain('Earth');
+    });
+  });
+
+  describe('2000 — 庚辰 Metal Dragon', () => {
+    it('animal is Dragon 龍', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2000', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Animal).toContain('Dragon');
+      expect(opts.Animal).toContain('龍');
+    });
+
+    it('stem-branch is 庚辰', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2000', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Stem-Branch']).toBe('庚辰');
+    });
+
+    it('element is Metal (庚 = Metal Yang)', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('2000', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Element).toContain('Metal');
+    });
+  });
+
+  describe('1900 — 庚子 Metal Rat', () => {
+    it('animal is Rat 鼠', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('1900', {
+        chinesezodiac: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Animal).toContain('Rat');
+      expect(opts['Stem-Branch']).toBe('庚子');
+    });
+  });
+
+  describe('option value as year (::chinesezodiac=2024)', () => {
+    it('reads year from option value when it is numeric', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('ignored', {
+        chinesezodiac: '2024',
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Animal).toContain('Dragon');
+      expect(opts['Stem-Branch']).toBe('甲辰');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('returns an error box for non-numeric input "abc"', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('abc', {
+        chinesezodiac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for empty input', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('', {
+        chinesezodiac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for year 0', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('0', {
+        chinesezodiac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for negative-looking input "-2024"', async () => {
+      const boxes = await ChineseZodiacBoxSource.generateBoxes('-2024', {
+        chinesezodiac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+  });
+
+  describe('static metadata', () => {
+    it('has correct name, tag, kind', () => {
+      expect(ChineseZodiacBoxSource.name).toBe('Chinese Zodiac');
+      expect(ChineseZodiacBoxSource.tag).toBe('#');
+      expect(ChineseZodiacBoxSource.kind).toBe('Calculate');
+      expect(typeof ChineseZodiacBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import {
 } from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
+import ChineseZodiacBoxSource from './ChineseZodiacBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -76,6 +77,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  ChineseZodiacBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,


### PR DESCRIPTION
### Box Source: Chinese Zodiac (Calculate)

Adds the `Chinese Zodiac` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `2024 ::chinesezodiac`

#### Options:
- `::chinesezodiac`, `::shengxiao`

#### Description:
Chinese zodiac animal, element, and stem-branch for a year (by Gregorian year).

#### Usage Examples:
- **Input**: `2024 ::chinesezodiac`
- **Output Box (`Chinese Zodiac`)**:
```
Year: 2024
Animal: Dragon 龍
Element: Wood 木
Yin/Yang: Yang 陽
Stem-Branch: 甲辰
```
