### PR TITLE
feat(Chmod): add chmod BoxSource

### DIFF
--- a/src/modules/boxSources/ChmodBoxSource.ts
+++ b/src/modules/boxSources/ChmodBoxSource.ts
@@ -1,0 +1,180 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// render key/value pairs as `k: v` lines for the headless/TUI plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// octal digit → rwx triplet string
+function octalDigitToRwx(digit: number): string {
+  const r = digit & 4 ? 'r' : '-';
+  const w = digit & 2 ? 'w' : '-';
+  const x = digit & 1 ? 'x' : '-';
+  return `${r}${w}${x}`;
+}
+
+// build symbolic string from 3-digit octal value (user/group/other)
+// if special != 0: bit 4=setuid (user x→s/S), bit 2=setgid (group x→s/S), bit 1=sticky (other x→t/T)
+function octalToSymbolic(octalStr: string): string {
+  let special = 0;
+  let digits: string;
+
+  if (octalStr.length === 4) {
+    special = Number.parseInt(octalStr[0], 8);
+    digits = octalStr.slice(1);
+  } else {
+    digits = octalStr;
+  }
+
+  const u = Number.parseInt(digits[0], 8);
+  const g = Number.parseInt(digits[1], 8);
+  const o = Number.parseInt(digits[2], 8);
+
+  let userRwx = octalDigitToRwx(u);
+  let groupRwx = octalDigitToRwx(g);
+  let otherRwx = octalDigitToRwx(o);
+
+  if (special & 4) {
+    // setuid: replace user x with 's' (x set) or 'S' (x not set)
+    userRwx = userRwx.slice(0, 2) + (u & 1 ? 's' : 'S');
+  }
+  if (special & 2) {
+    // setgid: replace group x with 's'/'S'
+    groupRwx = groupRwx.slice(0, 2) + (g & 1 ? 's' : 'S');
+  }
+  if (special & 1) {
+    // sticky: replace other x with 't'/'T'
+    otherRwx = otherRwx.slice(0, 2) + (o & 1 ? 't' : 'T');
+  }
+
+  return `${userRwx}${groupRwx}${otherRwx}`;
+}
+
+// human-readable description of a single rwx triplet
+function rwxDescription(rwx: string, label: string): string {
+  const parts: string[] = [];
+  if (rwx[0] === 'r') parts.push('read');
+  if (rwx[1] === 'w') parts.push('write');
+  const x = rwx[2];
+  if (x === 'x' || x === 's' || x === 't') parts.push('execute');
+  if (x === 's' || x === 'S') parts.push('setuid/setgid');
+  if (x === 't' || x === 'T') parts.push('sticky');
+  return parts.length > 0
+    ? `${label}: ${parts.join(', ')}`
+    : `${label}: no permissions`;
+}
+
+// build description string from symbolic (9 chars, after stripping file-type prefix)
+function symbolicDescription(sym: string): string {
+  const user = rwxDescription(sym.slice(0, 3), 'user');
+  const group = rwxDescription(sym.slice(3, 6), 'group');
+  const other = rwxDescription(sym.slice(6, 9), 'other');
+  return `${user}; ${group}; ${other}`;
+}
+
+// symbolic 9-char string → octal string (3 or 4 digits)
+function symbolicToOctal(sym: string): string {
+  let special = 0;
+
+  // compute each triad's base value (r=4, w=2, x=1)
+  function triadValue(triad: string): number {
+    let v = 0;
+    if (triad[0] === 'r') v += 4;
+    if (triad[1] === 'w') v += 2;
+    const x = triad[2];
+    if (x === 'x' || x === 's' || x === 't') v += 1;
+    return v;
+  }
+
+  const u = triadValue(sym.slice(0, 3));
+  const g = triadValue(sym.slice(3, 6));
+  const o = triadValue(sym.slice(6, 9));
+
+  // accumulate special bits from symbolic chars
+  const ux = sym[2];
+  const gx = sym[5];
+  const ox = sym[8];
+  if (ux === 's' || ux === 'S') special |= 4;
+  if (gx === 's' || gx === 'S') special |= 2;
+  if (ox === 't' || ox === 'T') special |= 1;
+
+  const base = `${u}${g}${o}`;
+  return special > 0 ? `${special}${base}` : base;
+}
+
+export const ChmodBoxSource = {
+  defaultDisabled: true,
+  name: 'chmod',
+  description:
+    'Convert Unix permissions between octal (755) and symbolic (rwxr-xr-x).',
+  defaultInput: '755 ::chmod',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'chmod', 'permissions')) return [];
+
+    const raw = trim(input).slice(0, 20);
+
+    // octal input: 3 or 4 octal digits
+    if (/^[0-7]{3,4}$/.test(raw)) {
+      const symbolic = octalToSymbolic(raw);
+      const description = symbolicDescription(symbolic);
+      const kv = { Octal: raw, Symbolic: symbolic, Description: description };
+      return [
+        new BoxBuilder('chmod', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // symbolic input: 9 or 10 chars (optional leading file-type char)
+    if (/^[-rwxsStTdlcbp]{9,10}$/.test(raw)) {
+      // strip leading file-type character if present (e.g. 'd' in 'drwxr-xr-x')
+      const sym9 = raw.length === 10 ? raw.slice(1) : raw;
+
+      // validate that sym9 is a proper 9-char permission string
+      if (!/^[-rwxsStT]{9}$/.test(sym9)) {
+        return [invalidFormatBox(this.priority)];
+      }
+
+      const octal = symbolicToOctal(sym9);
+      const description = symbolicDescription(sym9);
+      const kv = { Octal: octal, Symbolic: sym9, Description: description };
+      return [
+        new BoxBuilder('chmod', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // unrecognized input: explain expected formats
+    return [invalidFormatBox(this.priority)];
+  },
+};
+
+function invalidFormatBox(priority: number): Box {
+  return new BoxBuilder(
+    'chmod',
+    'Enter an octal permission (e.g. 755) or symbolic string (e.g. rwxr-xr-x).',
+  )
+    .setPriority(priority)
+    .build();
+}
+
+export default ChmodBoxSource;

--- a/src/modules/boxSources/__test__/ChmodBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ChmodBoxSource.test.ts
@@ -1,0 +1,207 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ChmodBoxSource } from '../ChmodBoxSource';
+
+describe('ChmodBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] with no options', async () => {
+      expect(await ChmodBoxSource.generateBoxes('755', null)).toHaveLength(0);
+    });
+
+    it('returns [] with unrelated options', async () => {
+      expect(
+        await ChmodBoxSource.generateBoxes('755', { foo: true }),
+      ).toHaveLength(0);
+    });
+
+    it('triggers on ::chmod option', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('triggers on ::permissions option', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', {
+        permissions: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('octal → symbolic', () => {
+    it('755 → rwxr-xr-x', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({
+        Octal: '755',
+        Symbolic: 'rwxr-xr-x',
+      });
+    });
+
+    it('644 → rw-r--r--', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('644', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({
+        Octal: '644',
+        Symbolic: 'rw-r--r--',
+      });
+    });
+
+    it('777 → rwxrwxrwx', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('777', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({ Symbolic: 'rwxrwxrwx' });
+    });
+
+    it('000 → ---------', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('000', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({ Symbolic: '---------' });
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('includes Description with human-readable labels', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      const desc = boxes[0].props.options?.Description as string;
+      expect(desc).toMatch(/user/i);
+      expect(desc).toMatch(/group/i);
+      expect(desc).toMatch(/other/i);
+    });
+  });
+
+  describe('setuid / special bits (4-digit octal)', () => {
+    it('4755 → rwsr-xr-x (setuid sets user x to s)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('4755', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({
+        Octal: '4755',
+        Symbolic: 'rwsr-xr-x',
+      });
+    });
+
+    it('2755 → rwxr-sr-x (setgid sets group x to s)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('2755', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({ Symbolic: 'rwxr-sr-x' });
+    });
+
+    it('1755 → rwxr-xr-t (sticky sets other x to t)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('1755', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({ Symbolic: 'rwxr-xr-t' });
+    });
+
+    it('4644 → rwSr--r-- (setuid, no user x → S)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('4644', { chmod: true });
+      expect(boxes[0].props.options).toMatchObject({ Symbolic: 'rwSr--r--' });
+    });
+  });
+
+  describe('symbolic → octal', () => {
+    it('rwxr-xr-x → 755', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwxr-xr-x', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        Octal: '755',
+        Symbolic: 'rwxr-xr-x',
+      });
+    });
+
+    it('rw-r--r-- → 644', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rw-r--r--', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '644' });
+    });
+
+    it('rwxrwxrwx → 777', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwxrwxrwx', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '777' });
+    });
+
+    it('--------- → 000', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('---------', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '000' });
+    });
+
+    it('rwsr-xr-x → 4755 (setuid round-trip)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwsr-xr-x', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '4755' });
+    });
+
+    it('rwxr-sr-x → 2755 (setgid)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwxr-sr-x', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '2755' });
+    });
+
+    it('rwxr-xr-t → 1755 (sticky)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('rwxr-xr-t', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '1755' });
+    });
+  });
+
+  describe('leading file-type character', () => {
+    it('drwxr-xr-x → 755 (strips leading d)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('drwxr-xr-x', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '755' });
+    });
+
+    it('-rwxr-xr-x → 755 (strips leading -)', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('-rwxr-xr-x', {
+        chmod: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Octal: '755' });
+    });
+  });
+
+  describe('invalid input', () => {
+    it('abc → format hint box', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('abc', { chmod: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/octal|symbolic/i);
+    });
+
+    it('999 (invalid octal) → format hint box', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('999', { chmod: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/octal|symbolic/i);
+    });
+
+    it('empty string → format hint box', async () => {
+      const boxes = await ChmodBoxSource.generateBoxes('', { chmod: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/octal|symbolic/i);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('755 octal → symbolic → octal', async () => {
+      const box1 = await ChmodBoxSource.generateBoxes('755', { chmod: true });
+      const sym = box1[0].props.options?.Symbolic as string;
+      const box2 = await ChmodBoxSource.generateBoxes(sym, { chmod: true });
+      expect(box2[0].props.options).toMatchObject({ Octal: '755' });
+    });
+
+    it('4755 octal → symbolic → octal', async () => {
+      const box1 = await ChmodBoxSource.generateBoxes('4755', { chmod: true });
+      const sym = box1[0].props.options?.Symbolic as string;
+      const box2 = await ChmodBoxSource.generateBoxes(sym, { chmod: true });
+      expect(box2[0].props.options).toMatchObject({ Octal: '4755' });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import {
 } from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
+import ChmodBoxSource from './ChmodBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -76,6 +77,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  ChmodBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,


### PR DESCRIPTION
### Box Source: chmod (Convert)

Adds the `chmod` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `755 ::chmod`

#### Options:
- `::chmod`, `::permissions`

#### Description:
Convert Unix permissions between octal (755) and symbolic (rwxr-xr-x).

#### Usage Examples:
- **Input**: `755 ::chmod`
- **Output Box (`chmod`)**:
```
Octal: 755
Symbolic: rwxr-xr-x
Description: user: read, write, execute; group: read, execute; other: read, execute
```
