### PR TITLE
feat(Cidr): add CIDR BoxSource

### DIFF
--- a/src/modules/boxSources/CidrBoxSource.ts
+++ b/src/modules/boxSources/CidrBoxSource.ts
@@ -1,0 +1,125 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box } from '@modules/Box';
+import { BoxBuilder } from '@modules/Box';
+
+const Priority = 20;
+
+// converts a 32-bit unsigned integer to dotted-quad notation
+function toIPv4(n: number): string {
+  return `${(n >>> 24) & 0xff}.${(n >>> 16) & 0xff}.${(n >>> 8) & 0xff}.${n & 0xff}`;
+}
+
+interface CidrMatch {
+  network: number;
+  broadcast: number;
+  netmask: number;
+  wildcard: number;
+  firstHost: number;
+  lastHost: number;
+  total: number;
+  usable: number;
+}
+
+const CIDR_REGEX = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})$/;
+
+function parseCidr(raw: string): CidrMatch | null {
+  const m = CIDR_REGEX.exec(raw);
+  if (!m) return null;
+
+  const octets = [m[1], m[2], m[3], m[4]].map((s) => Number.parseInt(s, 10));
+  const prefix = Number.parseInt(m[5], 10);
+
+  if (octets.some((o) => o > 255) || prefix > 32) return null;
+
+  const ip = (((octets[0] << 24) |
+    (octets[1] << 16) |
+    (octets[2] << 8) |
+    octets[3]) >>>
+    0) as number;
+
+  // left-shift by 0 is identity; handle prefix 0 explicitly to avoid UB on 32-bit shift
+  const netmask = (prefix === 0 ? 0 : 0xffffffff << (32 - prefix)) >>> 0;
+  const wildcard = ~netmask >>> 0;
+  const network = (ip & netmask) >>> 0;
+  const broadcast = (network | wildcard) >>> 0;
+  const total = prefix === 32 ? 1 : 2 ** (32 - prefix);
+
+  let firstHost: number;
+  let lastHost: number;
+  let usable: number;
+
+  if (prefix === 32) {
+    firstHost = network;
+    lastHost = network;
+    usable = 1;
+  } else if (prefix === 31) {
+    // point-to-point: both addresses are usable
+    firstHost = network;
+    lastHost = broadcast;
+    usable = 2;
+  } else {
+    firstHost = (network + 1) >>> 0;
+    lastHost = (broadcast - 1) >>> 0;
+    usable = total - 2;
+  }
+
+  return {
+    network,
+    broadcast,
+    netmask,
+    wildcard,
+    firstHost,
+    lastHost,
+    total,
+    usable,
+  };
+}
+
+export const CidrBoxSource = {
+  defaultDisabled: true,
+  name: 'CIDR',
+  description:
+    'Calculate IPv4 subnet details from a CIDR block (e.g. 192.168.1.0/24).',
+  defaultInput: '192.168.1.0/24',
+  tag: '#',
+  kind: 'Network',
+  priority: Priority,
+
+  async generateBoxes(input: string): Promise<Box[]> {
+    const match = parseCidr(trim(input));
+    if (!match) return [];
+
+    const {
+      network,
+      broadcast,
+      netmask,
+      wildcard,
+      firstHost,
+      lastHost,
+      total,
+      usable,
+    } = match;
+
+    const options: Record<string, string> = {
+      Network: toIPv4(network),
+      Broadcast: toIPv4(broadcast),
+      Netmask: toIPv4(netmask),
+      Wildcard: toIPv4(wildcard),
+      'First Host': toIPv4(firstHost),
+      'Last Host': toIPv4(lastHost),
+      'Total Addresses': String(total),
+      'Usable Hosts': String(usable),
+    };
+
+    return [
+      new BoxBuilder('CIDR', '')
+        .setOptions(options)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CidrBoxSource;

--- a/src/modules/boxSources/__test__/CidrBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CidrBoxSource.test.ts
@@ -1,0 +1,101 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { CidrBoxSource } from '@modules/boxSources/CidrBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('CidrBoxSource', () => {
+  describe('generateBoxes — non-matching input', () => {
+    it('returns [] for plain text', async () => {
+      expect(await CidrBoxSource.generateBoxes('hello')).toHaveLength(0);
+    });
+
+    it('returns [] for bare IP without prefix', async () => {
+      expect(await CidrBoxSource.generateBoxes('1.2.3.4')).toHaveLength(0);
+    });
+
+    it('returns [] for octet out of range', async () => {
+      expect(await CidrBoxSource.generateBoxes('999.1.1.1/24')).toHaveLength(0);
+    });
+
+    it('returns [] for prefix > 32', async () => {
+      expect(await CidrBoxSource.generateBoxes('10.0.0.0/33')).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — /24 network', () => {
+    it('returns one box with correct subnet values', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('192.168.1.0/24');
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options).toMatchObject({
+        Network: '192.168.1.0',
+        Broadcast: '192.168.1.255',
+        Netmask: '255.255.255.0',
+        Wildcard: '0.0.0.255',
+        'First Host': '192.168.1.1',
+        'Last Host': '192.168.1.254',
+        'Total Addresses': '256',
+        'Usable Hosts': '254',
+      });
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('192.168.1.0/24');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('applies configured priority', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('192.168.1.0/24');
+      expect(boxes[0].props.priority).toBe(20);
+    });
+  });
+
+  describe('generateBoxes — /8 network', () => {
+    it('computes correct netmask and total addresses', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('10.0.0.0/8');
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Netmask).toBe('255.0.0.0');
+      expect(options?.['Total Addresses']).toBe('16777216');
+    });
+  });
+
+  describe('generateBoxes — /32 host route', () => {
+    it('reports usable 1 with first == last == the address itself', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('192.168.1.5/32');
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Usable Hosts']).toBe('1');
+      expect(options?.['First Host']).toBe('192.168.1.5');
+      expect(options?.['Last Host']).toBe('192.168.1.5');
+    });
+  });
+
+  describe('generateBoxes — /31 point-to-point', () => {
+    it('reports usable 2', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('10.0.0.0/31');
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Usable Hosts']).toBe('2');
+    });
+  });
+
+  describe('generateBoxes — whitespace tolerance', () => {
+    it('trims surrounding whitespace before parsing', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('  192.168.1.0/24  ');
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes — /0 default route', () => {
+    it('computes the all-internet subnet (guards the 32-bit shift edge case)', async () => {
+      const boxes = await CidrBoxSource.generateBoxes('0.0.0.0/0');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Netmask).toBe('0.0.0.0');
+      expect(opts.Wildcard).toBe('255.255.255.255');
+      expect(opts['Total Addresses']).toBe('4294967296');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import {
 } from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
+import CidrBoxSource from './CidrBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  CidrBoxSource,
 ];


### PR DESCRIPTION
### Box Source: CIDR (Network)

Adds the `CIDR` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Network`
- **Tag**: `#`
- **Default Input**: `192.168.1.0/24`

#### Options:
- None

#### Description:
Calculate IPv4 subnet details from a CIDR block (e.g. 192.168.1.0/24).

#### Usage Examples:
- **Input**: `192.168.1.0/24`
- **Output Box (`CIDR`)**:
```

```
