### PR TITLE
feat(Collatz): add Collatz BoxSource

### DIFF
--- a/src/modules/boxSources/CollatzBoxSource.ts
+++ b/src/modules/boxSources/CollatzBoxSource.ts
@@ -1,0 +1,146 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// cap iterations to prevent an infinite loop for pathological inputs
+const MAX_STEPS = 1_000_000;
+// magnitude cap: 10^16 fits well within fast BigInt arithmetic; larger inputs
+// (e.g. 5000-digit) make per-step BigInt ops slow enough to freeze the UI
+const MAX_VALUE = 10_000_000_000_000_000n;
+
+// cap sequence display to keep plaintextOutput from being enormous
+const MAX_SEQUENCE_DISPLAY = 200;
+
+// renders a key-value record as "key: value" lines for the plaintext output
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+interface CollatzResult {
+  number: bigint;
+  steps: number;
+  peak: bigint;
+  // full sequence capped at MAX_SEQUENCE_DISPLAY + ellipsis if truncated
+  sequenceDisplay: string;
+}
+
+function computeCollatz(n: bigint): CollatzResult | null {
+  let current = n;
+  let steps = 0;
+  let peak = n;
+  const sequence: bigint[] = [n];
+
+  while (current !== 1n) {
+    if (steps >= MAX_STEPS) {
+      return null;
+    }
+    current = current % 2n === 0n ? current / 2n : 3n * current + 1n;
+    steps++;
+    if (current > peak) {
+      peak = current;
+    }
+    // collect at most MAX_SEQUENCE_DISPLAY terms; truncation is detected from
+    // the true step count, not the (capped) collected length
+    if (sequence.length < MAX_SEQUENCE_DISPLAY) {
+      sequence.push(current);
+    }
+  }
+
+  const truncated = steps + 1 > MAX_SEQUENCE_DISPLAY;
+  const sequenceDisplay = truncated
+    ? `${sequence.join(' → ')} …`
+    : sequence.join(' → ');
+
+  return { number: n, steps, peak, sequenceDisplay };
+}
+
+export const CollatzBoxSource = {
+  defaultDisabled: true,
+  name: 'Collatz',
+  description:
+    'Compute the Collatz (3n+1) sequence length, peak value, and the sequence for a positive integer.',
+  defaultInput: '27 ::collatz',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'collatz')) return [];
+
+    const raw = trim(input).slice(0, 5000);
+
+    if (!/^\d+$/.test(raw)) {
+      const kv: Record<string, string> = {
+        Error: 'A positive integer is required (digits only, no sign).',
+      };
+      return [
+        new BoxBuilder('Collatz', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const n = BigInt(raw);
+
+    // cap magnitude, not just the step count: MAX_STEPS bounds iterations but
+    // each step on a many-limb BigInt is slow, so a 5000-digit input would
+    // freeze the main thread for seconds (input comes from the ?input= param)
+    if (n < 1n || n > MAX_VALUE) {
+      const kv: Record<string, string> = {
+        Error:
+          n < 1n
+            ? 'A positive integer >= 1 is required.'
+            : `Value exceeds the maximum of ${MAX_VALUE.toLocaleString()} (10^16).`,
+      };
+      return [
+        new BoxBuilder('Collatz', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const result = computeCollatz(n);
+
+    if (result === null) {
+      const kv: Record<string, string> = {
+        Error: `Sequence did not converge within ${MAX_STEPS.toLocaleString()} steps.`,
+      };
+      return [
+        new BoxBuilder('Collatz', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const kv: Record<string, string> = {
+      Number: result.number.toString(),
+      Steps: result.steps.toString(),
+      Peak: result.peak.toString(),
+      Sequence: result.sequenceDisplay,
+    };
+
+    return [
+      new BoxBuilder('Collatz', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CollatzBoxSource;

--- a/src/modules/boxSources/__test__/CollatzBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CollatzBoxSource.test.ts
@@ -1,0 +1,144 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { CollatzBoxSource } from '../CollatzBoxSource';
+
+describe('CollatzBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('27', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when collatz option is absent', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('27', { other: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns an error box for "0"', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('0', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/positive integer/i);
+    });
+
+    it('returns an error box for "abc"', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('abc', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/positive integer/i);
+    });
+
+    it('returns an error box for "-5"', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('-5', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/positive integer/i);
+    });
+  });
+
+  describe('known sequences', () => {
+    it('27 → 111 steps, peak 9232', async () => {
+      // Collatz(27) is the classic example: 111 steps, peak 9232
+      const boxes = await CollatzBoxSource.generateBoxes('27', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Steps).toBe('111');
+      expect(opts.Peak).toBe('9232');
+      expect(opts.Number).toBe('27');
+    });
+
+    it('1 → 0 steps (already at 1), peak 1', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('1', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Steps).toBe('0');
+      expect(opts.Peak).toBe('1');
+    });
+
+    it('6 → 8 steps (6→3→10→5→16→8→4→2→1)', async () => {
+      // verified: 6,3,10,5,16,8,4,2,1 — that is 8 steps from 6 to 1
+      const boxes = await CollatzBoxSource.generateBoxes('6', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Steps).toBe('8');
+    });
+
+    it('2 → 1 step (2→1)', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('2', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Steps).toBe('1');
+    });
+  });
+
+  describe('BigInt correctness', () => {
+    it('handles large number 9780657630 without overflow', async () => {
+      // this number has a very long sequence; assert Steps is present and numeric
+      const boxes = await CollatzBoxSource.generateBoxes('9780657630', {
+        collatz: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Steps).toBeDefined();
+      expect(Number(opts.Steps)).toBeGreaterThan(0);
+      expect(opts.Number).toBe('9780657630');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('6', {
+        collatz: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets name to "Collatz"', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('6', {
+        collatz: true,
+      });
+      expect(boxes[0].props.name).toBe('Collatz');
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('6', {
+        collatz: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('plaintextOutput contains key: value lines', async () => {
+      const boxes = await CollatzBoxSource.generateBoxes('2', {
+        collatz: true,
+      });
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('Steps: 1');
+      expect(out).toContain('Number: 2');
+    });
+
+    it('rejects a value beyond the magnitude cap (DoS guard)', async () => {
+      // a 5000-digit number would freeze the main thread; must be rejected fast
+      const huge = '9'.repeat(5000);
+      const start = Date.now();
+      const boxes = await CollatzBoxSource.generateBoxes(huge, {
+        collatz: true,
+      });
+      expect(Date.now() - start).toBeLessThan(200);
+      expect(boxes[0].props.options?.Error).toMatch(/maximum|exceeds/i);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,12 +1,9 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
+import CollatzBoxSource from './CollatzBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  CollatzBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Collatz (Calculate)

Adds the `Collatz` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `27 ::collatz`

#### Options:
- `::collatz`

#### Description:
Compute the Collatz (3n+1) sequence length, peak value, and the sequence for a positive integer.

#### Usage Examples:
- **Input**: `27 ::collatz`
- **Output Box (`Collatz`)**:
```
Number: 27
Steps: 111
Peak: 9232
Sequence: 27 → 82 → 41 → 124 → 62 → 31 → 94 → 47 → 142 → 71 → 214 → 107 → 322 → 161 → 484 → 242 → 121 → 364 → 182 → 91 → 274 → 137 → 412 → 206 → 103 → 310 → 155 → 466 → 233 → 700 → 350 → 175 → 526 → 263 → 790 → 395 → 1186 → 593 → 1780 → 890 → 445 → 1336 → 668 → 334 → 167 → 502 → 251 → 754 → 377 → 1132 → 566 → 283 → 850 → 425 → 1276 → 638 → 319 → 958 → 479 → 1438 → 719 → 2158 → 1079 → 3238 → 1619 → 4858 → 2429 → 7288 → 3644 → 1822 → 911 → 2734 → 1367 → 4102 → 2051 → 6154 → 3077 → 9232 → 4616 → 2308 → 1154 → 577 → 1732 → 866 → 433 → 1300 → 650 → 325 → 976 → 488 → 244 → 122 → 61 → 184 → 92 → 46 → 23 → 70 → 35 → 106 → 53 → 160 → 80 → 40 → 20 → 10 → 5 → 16 → 8 → 4 → 2 → 1
```
