### PR TITLE
feat(ColorMix): add Color Mix BoxSource

### DIFF
--- a/src/modules/boxSources/ColorMixBoxSource.ts
+++ b/src/modules/boxSources/ColorMixBoxSource.ts
@@ -1,0 +1,153 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// parses #RGB, #RRGGBB, or rgb(r,g,b) into an RGB struct; returns null on failure
+function parseColor(raw: string): RGB | null {
+  const hex = raw.trim();
+
+  if (hex.startsWith('#')) {
+    const digits = hex.slice(1);
+
+    if (digits.length === 3) {
+      const r = Number.parseInt(digits[0] + digits[0], 16);
+      const g = Number.parseInt(digits[1] + digits[1], 16);
+      const b = Number.parseInt(digits[2] + digits[2], 16);
+      if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+      return { r, g, b };
+    }
+
+    if (digits.length === 6) {
+      const r = Number.parseInt(digits.slice(0, 2), 16);
+      const g = Number.parseInt(digits.slice(2, 4), 16);
+      const b = Number.parseInt(digits.slice(4, 6), 16);
+      if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+      return { r, g, b };
+    }
+
+    return null;
+  }
+
+  const rgbMatch = hex.match(
+    /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i,
+  );
+  if (rgbMatch) {
+    const r = Number.parseInt(rgbMatch[1], 10);
+    const g = Number.parseInt(rgbMatch[2], 10);
+    const b = Number.parseInt(rgbMatch[3], 10);
+    if (r > 255 || g > 255 || b > 255) return null;
+    return { r, g, b };
+  }
+
+  return null;
+}
+
+// formats an RGB struct to a lowercase #rrggbb hex string
+function toHex(rgb: RGB): string {
+  const pad = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${pad(rgb.r)}${pad(rgb.g)}${pad(rgb.b)}`;
+}
+
+// naive sRGB linear blend: result = color1*(1-t) + color2*t  (not gamma-corrected)
+function blendRGB(c1: RGB, c2: RGB, t: number): RGB {
+  return {
+    r: Math.round(c1.r * (1 - t) + c2.r * t),
+    g: Math.round(c1.g * (1 - t) + c2.g * t),
+    b: Math.round(c1.b * (1 - t) + c2.b * t),
+  };
+}
+
+// builds a plain k:v string for headless / plaintext consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// extract color tokens by matching them directly — splitting on commas would
+// break rgb(r,g,b)'s internal commas, so match hex or rgb(...) groups instead
+function splitColors(input: string): string[] {
+  const matches = input.match(/#[0-9a-fA-F]+|rgba?\([^)]*\)/gi);
+  return matches ?? [];
+}
+
+export const ColorMixBoxSource = {
+  defaultDisabled: true,
+  name: 'Color Mix',
+  description:
+    'Mix two colors. Input: "#hex1 #hex2" (or rgb()). ::colormix=<percent of the second color> (default 50).',
+  defaultInput: '#ff0000 #0000ff ::colormix',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'colormix', 'mixcolor', 'blend')) return [];
+
+    const raw = trim(input).slice(0, 64);
+    const tokens = splitColors(raw);
+
+    // resolve ratio: percent of the second color, clamped to [0, 100]
+    const optVal = extractOptionKeys(options, 'colormix', 'mixcolor', 'blend');
+    let percent = 50;
+    if (typeof optVal === 'string') {
+      const parsed = Number.parseInt(optVal, 10);
+      if (!Number.isNaN(parsed)) {
+        percent = Math.min(100, Math.max(0, parsed));
+      }
+    }
+    const t = percent / 100;
+
+    const parsed = tokens.map(parseColor);
+    const valid = parsed.filter((c): c is RGB => c !== null);
+
+    if (valid.length < 2) {
+      // return a single explanatory box rather than an empty array
+      const kv = {
+        Error: 'Need exactly two colors.',
+        Format: '#RGB, #RRGGBB, or rgb(r,g,b)',
+        Example: '#ff0000 #0000ff',
+      };
+      const box = new BoxBuilder('Color Mix', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    const [c1, c2] = valid;
+    const mixed = blendRGB(c1, c2, t);
+    const mixedHex = toHex(mixed);
+
+    const kv: Record<string, string> = {
+      'Color 1': toHex(c1),
+      'Color 2': toHex(c2),
+      Ratio: `${100 - percent}% / ${percent}%`,
+      Mixed: mixedHex,
+      RGB: `rgb(${mixed.r}, ${mixed.g}, ${mixed.b})`,
+    };
+
+    const box = new BoxBuilder('Color Mix', kvToPlaintext(kv))
+      .setOptions(kv)
+      .setTemplate(KeyValueBoxTemplate)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default ColorMixBoxSource;

--- a/src/modules/boxSources/__test__/ColorMixBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ColorMixBoxSource.test.ts
@@ -1,0 +1,156 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ColorMixBoxSource } from '../ColorMixBoxSource';
+
+describe('ColorMixBoxSource', () => {
+  describe('no matching option → empty array', () => {
+    it('returns [] when no colormix/mixcolor/blend option is present', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes(
+        '#ff0000 #0000ff',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no relevant key', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        unrelated: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('valid hex colors — 50% blend', () => {
+    it('red + blue at 50% → #800080 (purple)', async () => {
+      // r=round(255*0.5)=128=0x80, g=0, b=round(255*0.5)=128=0x80
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        colormix: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.name).toBe('Color Mix');
+      expect(boxes[0].props.priority).toBe(10);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#800080');
+      expect(opts['Color 1']).toBe('#ff0000');
+      expect(opts['Color 2']).toBe('#0000ff');
+      expect(opts.Ratio).toBe('50% / 50%');
+    });
+
+    it('black + white at 50% → #808080 (mid-gray)', async () => {
+      // r=g=b=round(255*0.5)=128=0x80
+      const boxes = await ColorMixBoxSource.generateBoxes('#000000 #ffffff', {
+        colormix: '50',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#808080');
+    });
+  });
+
+  describe('ratio edge cases', () => {
+    it('colormix=0 → 100% first color (#ff0000)', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        colormix: '0',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#ff0000');
+      expect(opts.Ratio).toBe('100% / 0%');
+    });
+
+    it('colormix=100 → 100% second color (#0000ff)', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        colormix: '100',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#0000ff');
+      expect(opts.Ratio).toBe('0% / 100%');
+    });
+
+    it('colormix=25 on white+black → #bfbfbf', async () => {
+      // r=g=b=round(255*0.75)=191=0xbf
+      const boxes = await ColorMixBoxSource.generateBoxes('#ffffff #000000', {
+        colormix: '25',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#bfbfbf');
+    });
+  });
+
+  describe('option key aliases', () => {
+    it('mixcolor key triggers the box', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        mixcolor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#800080');
+    });
+
+    it('blend key triggers the box', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        blend: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#800080');
+    });
+  });
+
+  describe('rgb() input format', () => {
+    it('rgb(255,0,0) rgb(0,0,255) at 50% → #800080', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes(
+        'rgb(255,0,0) rgb(0,0,255)',
+        { colormix: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#800080');
+    });
+  });
+
+  describe('short hex (#RGB) input', () => {
+    it('#f00 #00f at 50% → #800080', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#f00 #00f', {
+        colormix: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mixed).toBe('#800080');
+    });
+  });
+
+  describe('invalid / insufficient colors → explanatory box', () => {
+    it('single valid color → error box explaining format', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000', {
+        colormix: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('"hello" (no valid color) → error box', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('hello', {
+        colormix: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+  });
+
+  describe('plaintext output', () => {
+    it('plaintextOutput contains Mixed key', async () => {
+      const boxes = await ColorMixBoxSource.generateBoxes('#ff0000 #0000ff', {
+        colormix: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('Mixed');
+      expect(boxes[0].props.plaintextOutput).toContain('#800080');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -8,6 +8,7 @@ import {
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import ColorMixBoxSource from './ColorMixBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  ColorMixBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Color Mix (Convert)

Adds the `Color Mix` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `#ff0000 #0000ff ::colormix`

#### Options:
- `::blend`, `::colormix`, `::mixcolor`

#### Description:
Mix two colors. Input: "#hex1 #hex2" (or rgb()). ::colormix=<percent of the second color> (default 50).

#### Usage Examples:
- **Input**:
```
#ff0000 #0000ff ::colormix
```
- **Output Box (`Color Mix`)**:
```
Color 1: #ff0000
Color 2: #0000ff
Ratio: 50% / 50%
Mixed: #800080
RGB: rgb(128, 0, 128)
```
