### PR TITLE
feat(ColumnarTransposition): add Columnar Transposition BoxSource

### DIFF
--- a/src/modules/boxSources/ColumnarTranspositionBoxSource.ts
+++ b/src/modules/boxSources/ColumnarTranspositionBoxSource.ts
@@ -1,0 +1,150 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const MAX_INPUT = 100_000;
+const Priority = 10;
+
+// returns the original column indices in the order they should be read during
+// encryption: sort key chars alphabetically (stable), extract their original positions.
+// e.g. ZEBRAS → sorted [A(4),B(2),E(1),R(3),S(5),Z(0)] → [4,2,1,3,5,0]
+function getColumnOrder(key: string): number[] {
+  const pairs = [...key].map((c, i) => [c, i] as [string, number]);
+  pairs.sort((a, b) => a[0].localeCompare(b[0]) || a[1] - b[1]);
+  return pairs.map(([, i]) => i);
+}
+
+// writes plaintext row-by-row into keyLen columns, then reads columns in sorted
+// key order. columns with grid index < (msgLen % keyLen) are one row taller than
+// the rest (standard row-major fill, no padding).
+function columnarEncrypt(plaintext: string, key: string): string {
+  const msg = plaintext.replace(/\s/g, '');
+  const k = key.length;
+  if (k === 0) return msg;
+
+  const colOrder = getColumnOrder(key);
+  const n = msg.length;
+  const numRows = Math.ceil(n / k);
+  const extra = n % k; // leftmost `extra` grid columns each have one extra row
+
+  let result = '';
+  for (const col of colOrder) {
+    const colLen = extra === 0 ? numRows : col < extra ? numRows : numRows - 1;
+    for (let row = 0; row < colLen; row++) {
+      result += msg[row * k + col];
+    }
+  }
+  return result;
+}
+
+// inverse of columnarEncrypt: given ciphertext and key, reconstructs the grid by
+// filling each grid column (in key-sorted reading order) from the ciphertext chunks,
+// then reads back row-by-row to recover the plaintext.
+function columnarDecrypt(ciphertext: string, key: string): string {
+  // strip whitespace to mirror columnarEncrypt (which strips before grouping),
+  // so space-formatted ciphertext still decrypts correctly
+  const cipher = ciphertext.replace(/\s/g, '');
+  const k = key.length;
+  if (k === 0) return cipher;
+
+  const colOrder = getColumnOrder(key);
+  const n = cipher.length;
+  const numRows = Math.ceil(n / k);
+  const extra = n % k;
+
+  // length of each grid column (same irregular-column rule as encryption)
+  const colLens = Array.from({ length: k }, (_, col) =>
+    extra === 0 ? numRows : col < extra ? numRows : numRows - 1,
+  );
+
+  // distribute ciphertext chunks back into the grid columns in reading order
+  const grid: string[][] = Array.from({ length: k }, () => []);
+  let pos = 0;
+  for (const col of colOrder) {
+    grid[col] = [...cipher.slice(pos, pos + colLens[col])];
+    pos += colLens[col];
+  }
+
+  // read row-by-row to reconstruct plaintext
+  let result = '';
+  for (let row = 0; row < numRows; row++) {
+    for (let col = 0; col < k; col++) {
+      if (row < grid[col].length) {
+        result += grid[col][row];
+      }
+    }
+  }
+  return result;
+}
+
+function usageBox(priority: number): Box {
+  return new BoxBuilder(
+    'Columnar Transposition (Usage)',
+    'Usage: ::columnar=KEY to encrypt, ::columnardecode=KEY to decrypt. KEY must be a non-empty string.',
+  )
+    .setPriority(priority)
+    .setShowExpandButton(false)
+    .setTemplate(DefaultBoxTemplate)
+    .build();
+}
+
+export const ColumnarTranspositionBoxSource = {
+  defaultDisabled: true,
+  name: 'Columnar Transposition',
+  description:
+    'Columnar transposition cipher. ::columnar=KEY to encrypt, ::columnardecode=KEY to decrypt.',
+  defaultInput: 'WEAREDISCOVEREDFLEEATONCE ::columnar=ZEBRAS',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const encVal = extractOptionKeys(options, 'columnar', 'columnarencode');
+    const decVal = extractOptionKeys(options, 'columnardecode');
+
+    if (encVal === null && decVal === null) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT) {
+      return [];
+    }
+
+    const boxes: Box[] = [];
+
+    if (encVal !== null) {
+      if (typeof encVal !== 'string' || encVal.length === 0) {
+        boxes.push(usageBox(this.priority));
+      } else {
+        const encrypted = columnarEncrypt(input, encVal);
+        boxes.push(
+          new BoxBuilder('Columnar Transposition (Encrypt)', encrypted)
+            .setPriority(this.priority)
+            .setShowExpandButton(false)
+            .setTemplate(DefaultBoxTemplate)
+            .build(),
+        );
+      }
+    }
+
+    if (decVal !== null) {
+      if (typeof decVal !== 'string' || decVal.length === 0) {
+        boxes.push(usageBox(this.priority));
+      } else {
+        const decrypted = columnarDecrypt(input, decVal);
+        boxes.push(
+          new BoxBuilder('Columnar Transposition (Decrypt)', decrypted)
+            .setPriority(this.priority)
+            .setShowExpandButton(false)
+            .setTemplate(DefaultBoxTemplate)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default ColumnarTranspositionBoxSource;

--- a/src/modules/boxSources/__test__/ColumnarTranspositionBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ColumnarTranspositionBoxSource.test.ts
@@ -1,0 +1,223 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { ColumnarTranspositionBoxSource } from '../ColumnarTranspositionBoxSource';
+
+const opts = (key: string, value: string | boolean = true) => ({
+  [key]: value,
+});
+
+describe('ColumnarTranspositionBoxSource', () => {
+  describe('no-match / guard conditions', () => {
+    it('returns [] when no columnar option is present', async () => {
+      expect(
+        await ColumnarTranspositionBoxSource.generateBoxes('HELLO', null),
+      ).toHaveLength(0);
+    });
+
+    it('returns [] when input is empty', async () => {
+      expect(
+        await ColumnarTranspositionBoxSource.generateBoxes(
+          '',
+          opts('columnar', 'KEY'),
+        ),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe('encrypt — ::columnar=KEY', () => {
+    it('encrypts the canonical ZEBRAS vector', async () => {
+      // Wikipedia columnar transposition example:
+      // msg=WEAREDISCOVEREDFLEEATONCE (25 chars), key=ZEBRAS
+      // expected ciphertext=EVLNACDTESEAROFODEECWIREE
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        opts('columnar', 'ZEBRAS'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Encrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('EVLNACDTESEAROFODEECWIREE');
+    });
+
+    it('strips whitespace from plaintext before encrypting', async () => {
+      // "WE ARE DISCOVERED FLEE AT ONCE" with spaces stripped == WEAREDISCOVEREDFLEEATONCE
+      const withSpaces = await ColumnarTranspositionBoxSource.generateBoxes(
+        'WE ARE DISCOVERED FLEE AT ONCE',
+        opts('columnar', 'ZEBRAS'),
+      );
+      const withoutSpaces = await ColumnarTranspositionBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        opts('columnar', 'ZEBRAS'),
+      );
+      expect(withSpaces[0].props.plaintextOutput).toBe(
+        withoutSpaces[0].props.plaintextOutput,
+      );
+    });
+
+    it('encrypts when msgLen is exactly divisible by keyLen', async () => {
+      // WEAREDISCOVEREDFLEEATONCE is 25 chars; use ABCD (4) with a 24-char msg
+      // HELLOWORLD123456789012 (22 chars) → not exact; use 20-char msg with key of len 4
+      // HELLOWORLD1234567890 (20 chars), key=ABCD (4): 20%4=0, all cols have 5 rows
+      // sorted ABCD: A(0),B(1),C(2),D(3) → read order [0,1,2,3]
+      // grid: HELL / OWOR / LD12 / 3456 / 7890
+      // col0: H,O,L,3,7  col1: E,W,D,4,8  col2: L,O,1,5,9  col3: L,R,2,6,0
+      // read order [0,1,2,3]: HOL37 + EWD48 + LO159 + LR260
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLOWORLD1234567890',
+        opts('columnar', 'ABCD'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('HOL37EWD48LO159LR260');
+    });
+
+    it('accepts ::columnarencode alias', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        opts('columnarencode', 'KEY'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Encrypt)');
+    });
+  });
+
+  describe('decrypt — ::columnardecode=KEY', () => {
+    it('decrypts the canonical ZEBRAS vector', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'EVLNACDTESEAROFODEECWIREE',
+        opts('columnardecode', 'ZEBRAS'),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Decrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('WEAREDISCOVEREDFLEEATONCE');
+    });
+  });
+
+  describe('round-trips', () => {
+    const roundTrip = async (text: string, key: string) => {
+      const enc = await ColumnarTranspositionBoxSource.generateBoxes(
+        text,
+        opts('columnar', key),
+      );
+      const ciphertext = enc[0].props.plaintextOutput;
+      const dec = await ColumnarTranspositionBoxSource.generateBoxes(
+        ciphertext,
+        opts('columnardecode', key),
+      );
+      return dec[0].props.plaintextOutput;
+    };
+
+    it('round-trips when msgLen is not divisible by keyLen', async () => {
+      expect(await roundTrip('HELLOWORLD', 'KEY')).toBe('HELLOWORLD');
+    });
+
+    it('round-trips when msgLen is exactly divisible by keyLen', async () => {
+      expect(await roundTrip('ATTACKATDAWN', 'KEY')).toBe('ATTACKATDAWN');
+    });
+
+    it('round-trips single-char key (identity)', async () => {
+      expect(await roundTrip('HELLO', 'A')).toBe('HELLO');
+    });
+
+    it('round-trips key longer than message', async () => {
+      expect(await roundTrip('HI', 'LONGKEY')).toBe('HI');
+    });
+
+    it('round-trips mixed-case input after whitespace strip', async () => {
+      const enc = await ColumnarTranspositionBoxSource.generateBoxes(
+        'Hello World',
+        opts('columnar', 'KEY'),
+      );
+      const dec = await ColumnarTranspositionBoxSource.generateBoxes(
+        enc[0].props.plaintextOutput,
+        opts('columnardecode', 'KEY'),
+      );
+      // spaces are stripped before encryption, so plaintext recovered is spaceless
+      expect(dec[0].props.plaintextOutput).toBe('HelloWorld');
+    });
+
+    it('round-trips ZEBRAS canonical vector', async () => {
+      expect(await roundTrip('WEAREDISCOVEREDFLEEATONCE', 'ZEBRAS')).toBe(
+        'WEAREDISCOVEREDFLEEATONCE',
+      );
+    });
+  });
+
+  describe('usage box', () => {
+    it('returns usage box for bare ::columnar (boolean true)', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        opts('columnar', true),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Usage)');
+    });
+
+    it('returns usage box for empty key string', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        { columnar: '' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Usage)');
+    });
+
+    it('returns usage box for bare ::columnardecode (boolean true)', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        opts('columnardecode', true),
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Usage)');
+    });
+  });
+
+  describe('both options present', () => {
+    it('returns 2 boxes when both encrypt and decrypt options are present', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLOWORLD',
+        { columnar: 'KEY', columnardecode: 'KEY' },
+      );
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Columnar Transposition (Encrypt)');
+      expect(boxes[1].props.name).toBe('Columnar Transposition (Decrypt)');
+    });
+  });
+
+  describe('box properties', () => {
+    it('uses DefaultBoxTemplate', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        opts('columnar', 'KEY'),
+      );
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'HELLO',
+        opts('columnar', 'KEY'),
+      );
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(ColumnarTranspositionBoxSource.name).toBe(
+        'Columnar Transposition',
+      );
+      expect(ColumnarTranspositionBoxSource.tag).toBe('#');
+      expect(ColumnarTranspositionBoxSource.kind).toBe('Encode');
+      expect(typeof ColumnarTranspositionBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('whitespace-formatted ciphertext', () => {
+    it('decrypts space-grouped ciphertext (strips whitespace like encrypt)', async () => {
+      const boxes = await ColumnarTranspositionBoxSource.generateBoxes(
+        'EVLN ACDT ESEA ROFO DEEC WIREE',
+        { columnardecode: 'ZEBRAS' },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('WEAREDISCOVEREDFLEEATONCE');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,13 +1,10 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import ColumnarTranspositionBoxSource from './ColumnarTranspositionBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  ColumnarTranspositionBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Columnar Transposition (Encode)

Adds the `Columnar Transposition` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `WEAREDISCOVEREDFLEEATONCE ::columnar=ZEBRAS`

#### Options:
- None

#### Description:
Columnar transposition cipher. ::columnar=KEY to encrypt, ::columnardecode=KEY to decrypt.

#### Usage Examples:
- **Input**:
```
WEAREDISCOVEREDFLEEATONCE ::columnar=ZEBRAS
```
- **Output Box (`Columnar Transposition (Encrypt)`)**:
```
EVLNACDTESEAROFODEECWIREE
```
