### PR TITLE
feat(Combinations): add Combinations / Permutations BoxSource

### DIFF
--- a/src/modules/boxSources/CombinationsBoxSource.ts
+++ b/src/modules/boxSources/CombinationsBoxSource.ts
@@ -1,0 +1,126 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_N = 100_000;
+// independently cap k = min(r, n-r): cost is O(k) BigInt mults on a product
+// that grows to ~k*log(n) digits, so a large k (even with n in range) can
+// hang the main thread for minutes. 10000 keeps worst-case well under a second.
+const MAX_K = 10_000;
+
+// builds a "key: value\n..." plaintext string for headless rendering
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// computes C(n, r) via the integer-safe multiplicative formula using BigInt.
+// uses r' = min(r, n-r) for efficiency and avoids huge intermediate factorials.
+function combination(n: bigint, r: bigint): bigint {
+  const k = r < n - r ? r : n - r;
+  let result = 1n;
+  for (let i = 0n; i < k; i++) {
+    // multiply before divide keeps the running product integral at each step
+    result = (result * (n - i)) / (i + 1n);
+  }
+  return result;
+}
+
+// computes P(n, r) = product of (n, n-1, ..., n-r+1) via BigInt
+function permutation(n: bigint, r: bigint): bigint {
+  let result = 1n;
+  for (let i = 0n; i < r; i++) {
+    result *= n - i;
+  }
+  return result;
+}
+
+const PARSE_RE = /^(\d+)[\s,]+(\d+)$/;
+const CONSTRAINT_MSG = '0 ≤ r ≤ n ≤ 1000000';
+
+export const CombinationsBoxSource = {
+  defaultDisabled: true,
+  name: 'Combinations / Permutations',
+  description:
+    'Compute C(n, r) and P(n, r) exactly. Input: "n r" (e.g. "52 5").',
+  defaultInput: '52 5 ::ncr',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ncr', 'npr', 'choose')) return [];
+
+    const raw = trim(input).slice(0, 100);
+    const match = PARSE_RE.exec(raw);
+
+    if (!match) {
+      // invalid format — explain expected input
+      const pairs = {
+        Error: 'expected two non-negative integers, e.g. "52 5"',
+        Constraints: CONSTRAINT_MSG,
+      };
+      return [
+        new BoxBuilder('Combinations / Permutations', kvToPlaintext(pairs))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(pairs)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const n = Number(match[1]);
+    const r = Number(match[2]);
+
+    const effectiveK = Math.min(r, n - r);
+    if (r > n || n > MAX_N || effectiveK > MAX_K) {
+      let error: string;
+      if (r > n) {
+        error = `r (${r}) must be ≤ n (${n})`;
+      } else if (n > MAX_N) {
+        error = `n (${n}) must be ≤ ${MAX_N}`;
+      } else {
+        error = `min(r, n-r) = ${effectiveK} is too large; must be ≤ ${MAX_K}`;
+      }
+      const pairs = {
+        Error: error,
+        Constraints: CONSTRAINT_MSG,
+      };
+      return [
+        new BoxBuilder('Combinations / Permutations', kvToPlaintext(pairs))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(pairs)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const bn = BigInt(n);
+    const br = BigInt(r);
+    const c = combination(bn, br);
+    const p = permutation(bn, br);
+
+    const pairs = {
+      n: String(n),
+      r: String(r),
+      'C(n, r)': String(c),
+      'P(n, r)': String(p),
+    };
+
+    return [
+      new BoxBuilder('Combinations / Permutations', kvToPlaintext(pairs))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(pairs)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CombinationsBoxSource;

--- a/src/modules/boxSources/__test__/CombinationsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CombinationsBoxSource.test.ts
@@ -1,0 +1,170 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { CombinationsBoxSource } from '../CombinationsBoxSource';
+
+describe('CombinationsBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] when no options are provided', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when no matching option key is present', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('accepts ::ncr option', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('accepts ::npr option', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        npr: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('accepts ::choose option', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        choose: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('poker hands — C(52, 5) and P(52, 5)', () => {
+    it('computes C(52,5) = 2598960 and P(52,5) = 311875200', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.n).toBe('52');
+      expect(kv.r).toBe('5');
+      expect(kv['C(n, r)']).toBe('2598960');
+      expect(kv['P(n, r)']).toBe('311875200');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        ncr: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52 5', {
+        ncr: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('edge cases r = 0 and r = n', () => {
+    it('C(5,0) = 1 and P(5,0) = 1', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('5 0', {
+        ncr: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['C(n, r)']).toBe('1');
+      expect(kv['P(n, r)']).toBe('1');
+    });
+
+    it('C(5,5) = 1 and P(5,5) = 120', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('5 5', {
+        ncr: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['C(n, r)']).toBe('1');
+      expect(kv['P(n, r)']).toBe('120');
+    });
+  });
+
+  describe('C(10,3) and P(10,3)', () => {
+    it('C(10,3) = 120 and P(10,3) = 720', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('10 3', {
+        ncr: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['C(n, r)']).toBe('120');
+      expect(kv['P(n, r)']).toBe('720');
+    });
+  });
+
+  describe('large input — C(1000, 500)', () => {
+    it('returns an exact BigInt result with no precision loss (>200 digits)', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('1000 500', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const c = kv['C(n, r)'];
+      // C(1000,500) has ~299 decimal digits — verify no floating-point rounding occurred
+      expect(c.length).toBeGreaterThan(200);
+      // must be all digits — no 'e' notation which would indicate float fallback
+      expect(c).toMatch(/^\d+$/);
+    });
+  });
+
+  describe('constraint violations', () => {
+    it('r > n returns an error box mentioning r ≤ n', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('3 5', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+      // error must reference the constraint
+      expect(kv.Constraints).toContain('r ≤ n');
+    });
+
+    it('rejects a large min(r, n-r) to avoid a main-thread hang (DoS guard)', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes(
+        '1000000 500000',
+        {
+          ncr: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toMatch(/too large|10000|min/i);
+    });
+
+    it('invalid input "a b" returns an error box', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('a b', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+
+    it('n > MAX_N returns an error box', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('2000000 1', {
+        ncr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+      expect(kv.Constraints).toContain('1000000');
+    });
+  });
+
+  describe('comma-separated input', () => {
+    it('accepts "52,5" with comma separator', async () => {
+      const boxes = await CombinationsBoxSource.generateBoxes('52,5', {
+        ncr: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['C(n, r)']).toBe('2598960');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,13 +1,10 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CombinationsBoxSource from './CombinationsBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  CombinationsBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Combinations / Permutations (Calculate)

Adds the `Combinations / Permutations` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `52 5 ::ncr`

#### Options:
- `::choose`, `::ncr`, `::npr`

#### Description:
Compute C(n, r) and P(n, r) exactly. Input: "n r" (e.g. "52 5").

#### Usage Examples:
- **Input**:
```
52 5 ::ncr
```
- **Output Box (`Combinations / Permutations`)**:
```
n: 52
r: 5
C(n, r): 2598960
P(n, r): 311875200
```
