### PR TITLE
feat(CompoundInterest): add Compound Interest BoxSource

### DIFF
--- a/src/modules/boxSources/CompoundInterestBoxSource.ts
+++ b/src/modules/boxSources/CompoundInterestBoxSource.ts
@@ -1,0 +1,121 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// build plaintext from key-value pairs as "key: value" lines
+function kvToPlaintext(record: Record<string, string>): string {
+  return Object.entries(record)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const CompoundInterestBoxSource = {
+  defaultDisabled: true,
+  name: 'Compound Interest',
+  description:
+    'Future value with compound interest. Input: "<principal> <annualRate%> <years>". ::compound=<n> for compounds/year (default 12).',
+  defaultInput: '1000 5 10 ::compound',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'compound', 'compoundinterest')) return [];
+
+    const trimmed = trim(input);
+
+    // cap to avoid runaway inputs
+    if (trimmed.length > 100) {
+      return [
+        new BoxBuilder(
+          'Compound Interest',
+          'Input too long (max 100 characters).',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const parts = trimmed.split(/\s+/).filter((p) => p.length > 0);
+    if (parts.length !== 3) {
+      return [
+        new BoxBuilder(
+          'Compound Interest',
+          'Invalid input. Expected: "<principal> <annualRate%> <years>".',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const principal = Number.parseFloat(parts[0]);
+    const annualRatePct = Number.parseFloat(parts[1]);
+    const years = Number.parseFloat(parts[2]);
+
+    if (
+      Number.isNaN(principal) ||
+      Number.isNaN(annualRatePct) ||
+      Number.isNaN(years) ||
+      principal < 0 ||
+      annualRatePct < 0 ||
+      years < 0
+    ) {
+      return [
+        new BoxBuilder(
+          'Compound Interest',
+          'Invalid values. Principal and years must be non-negative numbers.',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // resolve compounds/year from option value; default 12 (monthly)
+    let compoundsPerYear = 12;
+    const rawN = extractOptionKeys(options, 'compound', 'compoundinterest');
+    if (rawN !== null && rawN !== true) {
+      const parsed = Number.parseInt(String(rawN), 10);
+      if (!Number.isNaN(parsed)) {
+        // clamp to valid range
+        compoundsPerYear = Math.min(365, Math.max(1, parsed));
+      }
+    }
+
+    const r = annualRatePct / 100;
+    const n = compoundsPerYear;
+    const t = years;
+
+    // A = P * (1 + r/n)^(n*t)
+    const futureValue = principal * (1 + r / n) ** (n * t);
+    const interestEarned = futureValue - principal;
+
+    // EAR = (1 + r/n)^n - 1, expressed as a percentage
+    const ear = ((1 + r / n) ** n - 1) * 100;
+
+    const output: Record<string, string> = {
+      Principal: principal.toFixed(2),
+      'Annual Rate': `${annualRatePct.toFixed(2)}%`,
+      Years: years.toString(),
+      'Compounds/Year': n.toString(),
+      'Future Value': futureValue.toFixed(2),
+      'Interest Earned': interestEarned.toFixed(2),
+      'Effective Annual Rate': `${ear.toFixed(3)}%`,
+    };
+
+    return [
+      new BoxBuilder('Compound Interest', kvToPlaintext(output))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CompoundInterestBoxSource;

--- a/src/modules/boxSources/__test__/CompoundInterestBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CompoundInterestBoxSource.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { CompoundInterestBoxSource } from '../CompoundInterestBoxSource';
+
+describe('CompoundInterestBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no compound option is provided', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options is null', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes(
+        '1000 5 10',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should compute monthly compounding: 1000 at 5% for 10yr → ~1647.01', async () => {
+      // 1000 * (1 + 0.05/12)^120 ≈ 1647.009...
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Future Value']).toMatch(/^1647\.0/);
+    });
+
+    it('should compute annual compounding: 1000 at 5% for 10yr → ~1628.89', async () => {
+      // 1000 * 1.05^10 ≈ 1628.894...; ::compound=1 means annual compounding
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Future Value']).toMatch(/^1628\.8/);
+    });
+
+    it('should compute annual compounding: 1000 at 10% for 1yr → 1100.00', async () => {
+      // 1000 * (1 + 0.10/1)^1 = 1100
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 10 1', {
+        compound: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Future Value']).toBe('1100.00');
+    });
+
+    it('should compute interest earned for monthly 1000/5%/10yr ≈ 647.01', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Interest Earned']).toMatch(/^647\.0/);
+    });
+
+    it('should compute EAR for 5% monthly ≈ 5.116%', async () => {
+      // (1 + 0.05/12)^12 - 1 ≈ 0.05116... → 5.116%
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Effective Annual Rate']).toMatch(/^5\.11/);
+    });
+
+    it('should return an error box for wrong argument count', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('should return an error box for negative principal', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('-100 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid/i);
+    });
+
+    it('should use ::compoundinterest option key as alias', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compoundinterest: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Future Value']).toMatch(/^1647\.0/);
+    });
+
+    it('should include all required output keys', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts).toHaveProperty('Principal');
+      expect(opts).toHaveProperty('Annual Rate');
+      expect(opts).toHaveProperty('Years');
+      expect(opts).toHaveProperty('Compounds/Year');
+      expect(opts).toHaveProperty('Future Value');
+      expect(opts).toHaveProperty('Interest Earned');
+      expect(opts).toHaveProperty('Effective Annual Rate');
+    });
+
+    it('should default to 12 compounds/year when option has no numeric value', async () => {
+      const boxes = await CompoundInterestBoxSource.generateBoxes('1000 5 10', {
+        compound: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Compounds/Year']).toBe('12');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -8,6 +8,7 @@ import {
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CompoundInterestBoxSource from './CompoundInterestBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  CompoundInterestBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Compound Interest (Calculate)

Adds the `Compound Interest` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `1000 5 10 ::compound`

#### Options:
- `::compound`, `::compoundinterest`

#### Description:
Future value with compound interest. Input: "<principal> <annualRate%> <years>". ::compound=<n> for compounds/year (default 12).

#### Usage Examples:
- **Input**:
```
1000 5 10 ::compound
```
- **Output Box (`Compound Interest`)**:
```
Principal: 1000.00
Annual Rate: 5.00%
Years: 10
Compounds/Year: 12
Future Value: 1647.01
Interest Earned: 647.01
Effective Annual Rate: 5.116%
```
