### PR TITLE
feat(CookingConvert): add Cooking Convert BoxSource

### DIFF
--- a/src/modules/boxSources/CookingConvertBoxSource.ts
+++ b/src/modules/boxSources/CookingConvertBoxSource.ts
@@ -1,0 +1,132 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit -> milliliters (US customary)
+const TO_ML: Record<string, number> = {
+  ml: 1,
+  l: 1000,
+  liter: 1000,
+  litre: 1000,
+  tsp: 4.92892159375,
+  tbsp: 14.78676478125,
+  floz: 29.5735295625,
+  'fl-oz': 29.5735295625,
+  cup: 236.5882365,
+  pint: 473.176473,
+  pt: 473.176473,
+  quart: 946.352946,
+  qt: 946.352946,
+  gallon: 3785.411784,
+  gal: 3785.411784,
+};
+
+// output units displayed in result, in order
+const OUTPUT_UNITS: Array<{ key: string; label: string }> = [
+  { key: 'ml', label: 'ml' },
+  { key: 'tsp', label: 'tsp' },
+  { key: 'tbsp', label: 'tbsp' },
+  { key: 'floz', label: 'fl oz' },
+  { key: 'cup', label: 'cup' },
+  { key: 'pint', label: 'pint' },
+  { key: 'quart', label: 'quart' },
+  { key: 'gallon', label: 'gallon' },
+  { key: 'l', label: 'L' },
+];
+
+const SUPPORTED_UNITS = Object.keys(TO_ML).join(', ');
+
+// formats a number: integer-exact when possible, otherwise 6 decimal places trimmed of trailing zeros
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// normalizes raw unit text to a TO_ML key: lowercase, collapse internal spaces
+function normalizeUnit(raw: string): string {
+  return raw.toLowerCase().replace(/\s+/g, '');
+}
+
+// builds k:v plaintext from a record for the box plaintextOutput field
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const CookingConvertBoxSource = {
+  defaultDisabled: true,
+  name: 'Cooking Convert',
+  description:
+    'Convert cooking volumes between cup, tbsp, tsp, fl oz, ml, L, pint, quart, gallon (US).',
+  defaultInput: '1 cup ::cooking',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cooking', 'volume')) return [];
+
+    const text = trim(input);
+    if (text.length > 64) return [];
+
+    // capture: <number> <rest-as-unit> — allow 'fl oz' with a space
+    const match = /^([+-]?\d+(?:\.\d*)?)[\s]+(.+)$/.exec(text);
+    if (!match) {
+      return [buildErrorBox()];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    if (!Number.isFinite(value) || value <= 0) {
+      return [buildErrorBox()];
+    }
+
+    const unitKey = normalizeUnit(match[2]);
+    const unitML = TO_ML[unitKey];
+    if (unitML === undefined) {
+      return [buildErrorBox()];
+    }
+
+    const valueML = value * unitML;
+
+    const kv: Record<string, string> = {
+      Input: `${formatValue(value)} ${match[2].trim()}`,
+    };
+
+    for (const { key, label } of OUTPUT_UNITS) {
+      const converted = valueML / TO_ML[key];
+      kv[label] = formatValue(converted);
+    }
+
+    const plaintext = kvToPlaintext(kv);
+
+    return [
+      new BoxBuilder('Cooking Convert', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+function buildErrorBox(): Box {
+  const kv = {
+    Error: 'Invalid input. Expected a positive: <number> <unit>',
+    'Supported units': SUPPORTED_UNITS,
+    Example: '1 cup ::cooking',
+  };
+  return new BoxBuilder('Cooking Convert', kvToPlaintext(kv))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(kv)
+    .setPriority(Priority)
+    .build();
+}
+
+export default CookingConvertBoxSource;

--- a/src/modules/boxSources/__test__/CookingConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CookingConvertBoxSource.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+
+import { CookingConvertBoxSource } from '../CookingConvertBoxSource';
+
+describe('CookingConvertBoxSource', () => {
+  describe('no option', () => {
+    it('returns empty array when no cooking/volume option is provided', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('1 cup with ::cooking', () => {
+    it('returns one box', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('box name is Cooking Convert', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      expect(boxes[0].props.name).toBe('Cooking Convert');
+    });
+
+    it('ml starts with 236.58823', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      const ml = boxes[0].props.options?.ml as string;
+      expect(ml).toMatch(/^236\.58823/);
+    });
+
+    it('tbsp is exactly 16 (1 cup = 16 tbsp)', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      expect(boxes[0].props.options?.tbsp).toBe('16');
+    });
+
+    it('tsp is exactly 48 (1 cup = 48 tsp)', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      expect(boxes[0].props.options?.tsp).toBe('48');
+    });
+
+    it('fl oz is exactly 8', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        cooking: true,
+      });
+      expect(boxes[0].props.options?.['fl oz']).toBe('8');
+    });
+  });
+
+  describe('3 tsp', () => {
+    it('tbsp is exactly 1 (3 tsp = 1 tbsp)', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('3 tsp', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.tbsp).toBe('1');
+    });
+  });
+
+  describe('1 tbsp', () => {
+    it('tsp is exactly 3 (1 tbsp = 3 tsp)', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 tbsp', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.tsp).toBe('3');
+    });
+  });
+
+  describe('1 gallon', () => {
+    it('quart is exactly 4', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 gallon', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.quart).toBe('4');
+    });
+
+    it('pint is exactly 8', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 gallon', {
+        cooking: true,
+      });
+      expect(boxes[0].props.options?.pint).toBe('8');
+    });
+
+    it('cup is exactly 16', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 gallon', {
+        cooking: true,
+      });
+      expect(boxes[0].props.options?.cup).toBe('16');
+    });
+  });
+
+  describe('1000 ml', () => {
+    it('L is exactly 1', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1000 ml', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.L).toBe('1');
+    });
+  });
+
+  describe('fl oz with space: 8 fl oz', () => {
+    it('cup is exactly 1 (8 fl oz = 1 cup)', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('8 fl oz', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.cup).toBe('1');
+    });
+  });
+
+  describe('::volume trigger', () => {
+    it('also triggers on ::volume option', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('1 cup', {
+        volume: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.tbsp).toBe('16');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns box mentioning supported units for non-numeric input "abc"', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('abc', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/supported units/i);
+    });
+
+    it('returns box mentioning supported units for unknown unit "5 stones"', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes('5 stones', {
+        cooking: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/supported units/i);
+    });
+
+    it('returns error box for input exceeding 64 characters', async () => {
+      const boxes = await CookingConvertBoxSource.generateBoxes(
+        '1 cup with a very long trailing string that exceeds the limit here',
+        { cooking: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(CookingConvertBoxSource.name).toBe('Cooking Convert');
+      expect(CookingConvertBoxSource.tag).toBe('#');
+      expect(CookingConvertBoxSource.kind).toBe('Convert');
+      expect(CookingConvertBoxSource.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,13 +1,10 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CookingConvertBoxSource from './CookingConvertBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  CookingConvertBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Cooking Convert (Convert)

Adds the `Cooking Convert` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1 cup ::cooking`

#### Options:
- `::cooking`, `::volume`

#### Description:
Convert cooking volumes between cup, tbsp, tsp, fl oz, ml, L, pint, quart, gallon (US).

#### Usage Examples:
- **Input**:
```
1 cup ::cooking
```
- **Output Box (`Cooking Convert`)**:
```
Input: 1 cup
ml: 236.588236
tsp: 48
tbsp: 16
fl oz: 8
cup: 1
pint: 0.5
quart: 0.25
gallon: 0.0625
L: 0.236588
```
