### PR TITLE
feat(CountryFlag): add Country Flag BoxSource

### DIFF
--- a/src/modules/boxSources/CountryFlagBoxSource.ts
+++ b/src/modules/boxSources/CountryFlagBoxSource.ts
@@ -1,0 +1,172 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// base code point for regional indicator symbols (🇦 = U+1F1E6)
+const REGIONAL_INDICATOR_BASE = 0x1f1e6;
+
+// map of ISO 3166-1 alpha-2 codes to country names for the ~50 most common countries
+const NAMES: Record<string, string> = {
+  AD: 'Andorra',
+  AE: 'United Arab Emirates',
+  AF: 'Afghanistan',
+  AR: 'Argentina',
+  AU: 'Australia',
+  AT: 'Austria',
+  BE: 'Belgium',
+  BR: 'Brazil',
+  CA: 'Canada',
+  CH: 'Switzerland',
+  CL: 'Chile',
+  CN: 'China',
+  CO: 'Colombia',
+  CZ: 'Czech Republic',
+  DE: 'Germany',
+  DK: 'Denmark',
+  EG: 'Egypt',
+  ES: 'Spain',
+  FI: 'Finland',
+  FR: 'France',
+  GB: 'United Kingdom',
+  GR: 'Greece',
+  HK: 'Hong Kong',
+  HU: 'Hungary',
+  ID: 'Indonesia',
+  IE: 'Ireland',
+  IL: 'Israel',
+  IN: 'India',
+  IT: 'Italy',
+  JP: 'Japan',
+  KR: 'South Korea',
+  MX: 'Mexico',
+  MY: 'Malaysia',
+  NL: 'Netherlands',
+  NO: 'Norway',
+  NZ: 'New Zealand',
+  PH: 'Philippines',
+  PK: 'Pakistan',
+  PL: 'Poland',
+  PT: 'Portugal',
+  RO: 'Romania',
+  RU: 'Russia',
+  SA: 'Saudi Arabia',
+  SE: 'Sweden',
+  SG: 'Singapore',
+  TH: 'Thailand',
+  TR: 'Turkey',
+  TW: 'Taiwan',
+  UA: 'Ukraine',
+  US: 'United States',
+  VN: 'Vietnam',
+  ZA: 'South Africa',
+};
+
+// converts a 2-letter ISO code (uppercase) to its flag emoji via regional indicator symbols
+function codeToFlag(code: string): string {
+  const a = code.charCodeAt(0) - 'A'.charCodeAt(0);
+  const b = code.charCodeAt(1) - 'A'.charCodeAt(0);
+  return String.fromCodePoint(
+    REGIONAL_INDICATOR_BASE + a,
+    REGIONAL_INDICATOR_BASE + b,
+  );
+}
+
+// extracts the two regional indicator code points from a flag emoji, returns uppercase 2-letter code or null
+function flagToCode(flag: string): string | null {
+  const codePoints: number[] = [];
+  for (const cp of flag) {
+    const n = cp.codePointAt(0) ?? 0;
+    if (n >= REGIONAL_INDICATOR_BASE && n <= 0x1f1ff) {
+      codePoints.push(n);
+    }
+  }
+  if (codePoints.length !== 2) return null;
+  const a = String.fromCharCode(
+    codePoints[0] - REGIONAL_INDICATOR_BASE + 'A'.charCodeAt(0),
+  );
+  const b = String.fromCharCode(
+    codePoints[1] - REGIONAL_INDICATOR_BASE + 'A'.charCodeAt(0),
+  );
+  return a + b;
+}
+
+export const CountryFlagBoxSource = {
+  defaultDisabled: true,
+  name: 'Country Flag',
+  description:
+    'Convert an ISO 3166-1 alpha-2 country code to its flag emoji, or a flag emoji back to its code.',
+  defaultInput: 'US ::flag',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'flag', 'countryflag')) return [];
+
+    const text = trim(input);
+
+    // code → flag path
+    if (/^[A-Za-z]{2}$/.test(text)) {
+      const code = text.toUpperCase();
+      const flag = codeToFlag(code);
+      const name = NAMES[code];
+
+      const kv: Record<string, string> = { Code: code, Flag: flag };
+      if (name) kv.Name = name;
+
+      const lines = Object.entries(kv)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('\n');
+
+      return [
+        new BoxBuilder('Country Flag', lines)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // flag → code path: check for two regional indicator symbols
+    const reverseCode = flagToCode(text);
+    if (reverseCode !== null) {
+      const flag = text;
+      const name = NAMES[reverseCode];
+
+      const kv: Record<string, string> = { Code: reverseCode, Flag: flag };
+      if (name) kv.Name = name;
+
+      const lines = Object.entries(kv)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('\n');
+
+      return [
+        new BoxBuilder('Country Flag', lines)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // unrecognized input — explain what is required
+    const message =
+      'Enter a 2-letter country code (e.g. US) or a flag emoji (e.g. 🇺🇸) with ::flag';
+
+    return [
+      new BoxBuilder('Country Flag', message)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions({ Info: message })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CountryFlagBoxSource;

--- a/src/modules/boxSources/__test__/CountryFlagBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CountryFlagBoxSource.test.ts
@@ -1,0 +1,149 @@
+import { CountryFlagBoxSource } from '@modules/boxSources/CountryFlagBoxSource';
+import { describe, expect, it } from 'vitest';
+
+// regional indicator base code point (🇦 = U+1F1E6)
+const RI_BASE = 0x1f1e6;
+
+describe('CountryFlagBoxSource', () => {
+  describe('no option key → empty array', () => {
+    it('returns [] when no ::flag option is present', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('US', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is present', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('US', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('code → flag', () => {
+    it('converts US to 🇺🇸 (U+1F1FA U+1F1F8)', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('US', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Code).toBe('US');
+
+      const flag = opts.Flag;
+      // verify the two regional indicator code points
+      const cp0 = flag.codePointAt(0);
+      const cp1 = flag.codePointAt(2); // each regional indicator is 2 UTF-16 units
+      expect(cp0).toBe(0x1f1fa); // 🇺 = RI_BASE + ('U' - 'A') = 0x1F1E6 + 20
+      expect(cp1).toBe(0x1f1f8); // 🇸 = RI_BASE + ('S' - 'A') = 0x1F1E6 + 18
+      expect(flag).toBe('🇺🇸');
+    });
+
+    it('converts lowercase jp to 🇯🇵', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('jp', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Code).toBe('JP');
+      expect(opts.Flag).toBe('🇯🇵');
+    });
+
+    it('includes Name "United States" for US', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('US', {
+        flag: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Name).toBe('United States');
+    });
+
+    it('accepts ::countryflag option key', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('US', {
+        countryflag: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Flag).toBe('🇺🇸');
+    });
+
+    it('verifies US flag code points via RI_BASE arithmetic', () => {
+      // U is the 21st letter (0-indexed: 20); S is the 19th (0-indexed: 18)
+      expect(RI_BASE + 20).toBe(0x1f1fa);
+      expect(RI_BASE + 18).toBe(0x1f1f8);
+    });
+  });
+
+  describe('flag → code (reverse)', () => {
+    it('converts 🇺🇸 back to US', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('🇺🇸', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Code).toBe('US');
+    });
+
+    it('converts 🇫🇷 to FR', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('🇫🇷', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Code).toBe('FR');
+    });
+
+    it('round-trips US → 🇺🇸 → US', async () => {
+      const forward = await CountryFlagBoxSource.generateBoxes('US', {
+        flag: true,
+      });
+      const flag = (forward[0].props.options as Record<string, string>).Flag;
+
+      const reverse = await CountryFlagBoxSource.generateBoxes(flag, {
+        flag: true,
+      });
+      const code = (reverse[0].props.options as Record<string, string>).Code;
+      expect(code).toBe('US');
+    });
+  });
+
+  describe('invalid input → info box', () => {
+    it('returns an info box for single-letter input "X"', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('X', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // the box name is still 'Country Flag'
+      expect(boxes[0].props.name).toBe('Country Flag');
+      // the output mentions country code or flag
+      const text = boxes[0].props.plaintextOutput.toLowerCase();
+      expect(text).toMatch(/country.*code|flag/);
+    });
+
+    it('returns an info box for "hello" (more than 2 letters)', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('hello', {
+        flag: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const text = boxes[0].props.plaintextOutput.toLowerCase();
+      expect(text).toMatch(/country.*code|flag/);
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets priority to 10', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('TW', {
+        flag: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('sets box name to "Country Flag"', async () => {
+      const boxes = await CountryFlagBoxSource.generateBoxes('TW', {
+        flag: true,
+      });
+      expect(boxes[0].props.name).toBe('Country Flag');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -8,6 +8,7 @@ import {
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CountryFlagBoxSource from './CountryFlagBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  CountryFlagBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Country Flag (Convert)

Adds the `Country Flag` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `US ::flag`

#### Options:
- `::countryflag`, `::flag`

#### Description:
Convert an ISO 3166-1 alpha-2 country code to its flag emoji, or a flag emoji back to its code.

#### Usage Examples:
- **Input**:
```
US ::flag
```
- **Output Box (`Country Flag`)**:
```
Code: US
Flag: 🇺🇸
Name: United States
```
