### PR TITLE
feat(Crc16): add CRC-16 BoxSource

### DIFF
--- a/src/modules/boxSources/Crc16BoxSource.ts
+++ b/src/modules/boxSources/Crc16BoxSource.ts
@@ -1,0 +1,84 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// CRC-16/CCITT-FALSE: init=0xFFFF, poly=0x1021, no input/output reflection
+function crc16CcittFalse(bytes: Uint8Array): number {
+  let crc = 0xffff;
+  for (const byte of bytes) {
+    crc ^= byte << 8;
+    for (let i = 0; i < 8; i++) {
+      crc =
+        (crc & 0x8000) !== 0
+          ? ((crc << 1) ^ 0x1021) & 0xffff
+          : (crc << 1) & 0xffff;
+    }
+  }
+  return crc & 0xffff;
+}
+
+// CRC-16/MODBUS: init=0xFFFF, poly=0xA001 (reflected 0x8005)
+function crc16Modbus(bytes: Uint8Array): number {
+  let crc = 0xffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i++) {
+      crc = (crc & 1) !== 0 ? (crc >> 1) ^ 0xa001 : crc >> 1;
+    }
+  }
+  return crc & 0xffff;
+}
+
+function toHex4(value: number): string {
+  return `0x${value.toString(16).padStart(4, '0')}`;
+}
+
+export const Crc16BoxSource = {
+  defaultDisabled: true,
+  name: 'CRC-16',
+  description:
+    'Compute CRC-16 (CCITT-FALSE and Modbus) checksums of the input text.',
+  defaultInput: '123456789 ::crc16',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'crc16')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const bytes = new TextEncoder().encode(input);
+
+    const ccittFalse = toHex4(crc16CcittFalse(bytes));
+    const modbus = toHex4(crc16Modbus(bytes));
+
+    const plaintextOutput = `CCITT-FALSE: ${ccittFalse}\nModbus: ${modbus}`;
+
+    const outputOptions: Record<string, string> = {
+      'CCITT-FALSE': ccittFalse,
+      Modbus: modbus,
+    };
+
+    return [
+      new BoxBuilder('CRC-16', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(outputOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Crc16BoxSource;

--- a/src/modules/boxSources/__test__/Crc16BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Crc16BoxSource.test.ts
@@ -1,0 +1,116 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Crc16BoxSource } from '../Crc16BoxSource';
+
+describe('Crc16BoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Crc16BoxSource.name).toBe('CRC-16');
+      expect(Crc16BoxSource.tag).toBe('#');
+      expect(Crc16BoxSource.kind).toBe('Encode');
+      expect(typeof Crc16BoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - gate', () => {
+    it('returns empty array when crc16 option is absent', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options object has no crc16 key', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input with crc16 option', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('', { crc16: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('   ', { crc16: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - canonical check values for "123456789"', () => {
+    it('returns exactly one box', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('box uses KeyValueBoxTemplate', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box is named CRC-16', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes[0].props.name).toBe('CRC-16');
+    });
+
+    // canonical CRC-16/CCITT-FALSE check value for "123456789"
+    it('CCITT-FALSE option value is 0x29b1', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes[0].props.options?.['CCITT-FALSE']).toBe('0x29b1');
+    });
+
+    // canonical CRC-16/MODBUS check value for "123456789"
+    it('Modbus option value is 0x4b37', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes[0].props.options?.Modbus).toBe('0x4b37');
+    });
+
+    it('plaintextOutput is non-empty and contains CCITT-FALSE result', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toBeTruthy();
+      expect(text).toContain('CCITT-FALSE: 0x29b1');
+    });
+
+    it('plaintextOutput contains Modbus result', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('123456789', {
+        crc16: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('Modbus: 0x4b37');
+    });
+  });
+
+  describe('generateBoxes - priority', () => {
+    it('box carries the source priority', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('hello', {
+        crc16: true,
+      });
+      expect(boxes[0].props.priority).toBe(Crc16BoxSource.priority);
+    });
+  });
+
+  describe('generateBoxes - UTF-8 input', () => {
+    it('processes non-ASCII input without throwing', async () => {
+      const boxes = await Crc16BoxSource.generateBoxes('héllo wörld', {
+        crc16: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['CCITT-FALSE']).toMatch(
+        /^0x[0-9a-f]{4}$/,
+      );
+      expect(boxes[0].props.options?.Modbus).toMatch(/^0x[0-9a-f]{4}$/);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -8,6 +8,7 @@ import {
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import Crc16BoxSource from './Crc16BoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  Crc16BoxSource,
 ];


### PR DESCRIPTION
### Box Source: CRC-16 (Encode)

Adds the `CRC-16` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `123456789 ::crc16`

#### Options:
- `::crc16`

#### Description:
Compute CRC-16 (CCITT-FALSE and Modbus) checksums of the input text.

#### Usage Examples:
- **Input**:
```
123456789 ::crc16
```
- **Output Box (`CRC-16`)**:
```
CCITT-FALSE: 0x29b1
Modbus: 0x4b37
```
