### PR TITLE
feat(Crc32): add CRC-32 BoxSource

### DIFF
--- a/src/modules/boxSources/Crc32BoxSource.ts
+++ b/src/modules/boxSources/Crc32BoxSource.ts
@@ -1,0 +1,72 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// precompute the IEEE 802.3 (reflected) CRC-32 lookup table once at module load
+const CRC32_TABLE: Uint32Array = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let j = 0; j < 8; j++) {
+      // reflected polynomial 0xEDB88320 (bit-reversed 0x04C11DB7)
+      c = c & 1 ? (0xedb88320 ^ (c >>> 1)) >>> 0 : (c >>> 1) >>> 0;
+    }
+    table[i] = c;
+  }
+  return table;
+})();
+
+function computeCrc32(input: string): number {
+  const bytes = new TextEncoder().encode(input);
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = (CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8)) >>> 0;
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+export const Crc32BoxSource = {
+  defaultDisabled: true,
+  name: 'CRC-32',
+  description: 'Compute the CRC-32 (IEEE 802.3) checksum of the input text.',
+  defaultInput: 'hello ::crc32',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'crc32')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const checksum = computeCrc32(input);
+    const hex = checksum.toString(16).padStart(8, '0');
+
+    const output: Record<string, string> = {
+      Hex: hex,
+      Decimal: checksum.toString(10),
+      Uppercase: hex.toUpperCase(),
+    };
+
+    return [
+      new BoxBuilder('CRC-32', hex)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Crc32BoxSource;

--- a/src/modules/boxSources/__test__/Crc32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Crc32BoxSource.test.ts
@@ -1,0 +1,94 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Crc32BoxSource } from '../Crc32BoxSource';
+
+describe('Crc32BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no crc32 option is provided', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns empty array for empty string', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('', { crc32: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only string', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('   ', { crc32: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - known CRC-32 vectors', () => {
+    it('produces canonical check value cbf43926 for "123456789"', async () => {
+      // canonical CRC-32 check value per ISO 3309 / ITU-T V.42
+      const boxes = await Crc32BoxSource.generateBoxes('123456789', {
+        crc32: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Hex: 'cbf43926',
+        Decimal: (0xcbf43926).toString(10),
+        Uppercase: 'CBF43926',
+      });
+    });
+
+    it('produces 414fa339 for the quick-brown-fox sentence', async () => {
+      const input = 'The quick brown fox jumps over the lazy dog';
+      const boxes = await Crc32BoxSource.generateBoxes(input, { crc32: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Hex: '414fa339',
+        Uppercase: '414FA339',
+      });
+    });
+  });
+
+  describe('generateBoxes - output format', () => {
+    it('Hex is exactly 8 lowercase hex characters for "hello"', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        crc32: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { Hex, Uppercase, Decimal } = boxes[0].props.options as Record<
+        string,
+        string
+      >;
+      expect(Hex).toMatch(/^[0-9a-f]{8}$/);
+      expect(Uppercase).toBe(Hex.toUpperCase());
+      expect(Number.parseInt(Decimal, 10)).toBe(Number.parseInt(Hex, 16));
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        crc32: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await Crc32BoxSource.generateBoxes('hello', {
+        crc32: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Crc32BoxSource.name).toBe('CRC-32');
+      expect(Crc32BoxSource.tag).toBe('#');
+      expect(Crc32BoxSource.kind).toBe('Encode');
+      expect(Crc32BoxSource.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -8,6 +8,7 @@ import {
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import Crc32BoxSource from './Crc32BoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  Crc32BoxSource,
 ];


### PR DESCRIPTION
### Box Source: CRC-32 (Encode)

Adds the `CRC-32` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `hello ::crc32`

#### Options:
- `::crc32`

#### Description:
Compute the CRC-32 (IEEE 802.3) checksum of the input text.

#### Usage Examples:
- **Input**:
```
hello ::crc32
```
- **Output Box (`CRC-32`)**:
```
3610a686
```
