### PR TITLE
feat(Crc8): add CRC-8 BoxSource

### DIFF
--- a/src/modules/boxSources/Crc8BoxSource.ts
+++ b/src/modules/boxSources/Crc8BoxSource.ts
@@ -1,0 +1,84 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// CRC-8/SMBUS: poly 0x07, init 0x00, no reflect, no xorout
+function crc8Smbus(bytes: Uint8Array): number {
+  let crc = 0x00;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i++) {
+      crc = crc & 0x80 ? ((crc << 1) ^ 0x07) & 0xff : (crc << 1) & 0xff;
+    }
+  }
+  return crc & 0xff;
+}
+
+// CRC-8/MAXIM (Dallas 1-Wire): poly 0x31 reflected as 0x8C, refin/refout true
+function crc8Maxim(bytes: Uint8Array): number {
+  let crc = 0x00;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i++) {
+      crc = crc & 1 ? ((crc >> 1) ^ 0x8c) & 0xff : (crc >> 1) & 0xff;
+    }
+  }
+  return crc & 0xff;
+}
+
+function toHex2(value: number): string {
+  return `0x${value.toString(16).padStart(2, '0')}`;
+}
+
+export const Crc8BoxSource = {
+  defaultDisabled: true,
+  name: 'CRC-8',
+  description:
+    'Compute CRC-8 (SMBUS and Maxim/Dallas) checksums of the input text.',
+  defaultInput: '123456789 ::crc8',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'crc8')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    // hash the trimmed input so the guard and the computed bytes agree
+    const bytes = new TextEncoder().encode(trim(input));
+    const smbus = crc8Smbus(bytes);
+    const maxim = crc8Maxim(bytes);
+
+    const kv: Record<string, string> = {
+      SMBUS: toHex2(smbus),
+      Maxim: toHex2(maxim),
+    };
+
+    const plaintextOutput = Object.entries(kv)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('CRC-8', plaintextOutput)
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Crc8BoxSource;

--- a/src/modules/boxSources/__test__/Crc8BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Crc8BoxSource.test.ts
@@ -1,0 +1,103 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Crc8BoxSource } from '../Crc8BoxSource';
+
+describe('Crc8BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is provided', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns [] for empty string with ::crc8', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('', { crc8: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::crc8', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('   ', { crc8: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - canonical check values for "123456789"', () => {
+    it('returns one CRC-8 box', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('box name is CRC-8', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      expect(boxes[0].props.name).toBe('CRC-8');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('SMBUS check value is 0xf4 (canonical CRC-8/SMBUS)', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.SMBUS).toBe('0xf4');
+    });
+
+    it('Maxim check value is 0xa1 (canonical CRC-8/MAXIM)', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Maxim).toBe('0xa1');
+    });
+
+    it('plaintextOutput is non-empty and contains SMBUS: 0xf4', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      const pt = boxes[0].props.plaintextOutput;
+      expect(pt.length).toBeGreaterThan(0);
+      expect(pt).toContain('SMBUS: 0xf4');
+    });
+
+    it('plaintextOutput contains Maxim: 0xa1', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('123456789', {
+        crc8: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('Maxim: 0xa1');
+    });
+  });
+
+  describe('generateBoxes - priority', () => {
+    it('box priority matches source priority', async () => {
+      const boxes = await Crc8BoxSource.generateBoxes('hello', { crc8: true });
+      expect(boxes[0].props.priority).toBe(Crc8BoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Crc8BoxSource.name).toBe('CRC-8');
+      expect(Crc8BoxSource.tag).toBe('#');
+      expect(Crc8BoxSource.kind).toBe('Encode');
+      expect(typeof Crc8BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -8,6 +8,7 @@ import {
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import Crc8BoxSource from './Crc8BoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  Crc8BoxSource,
 ];


### PR DESCRIPTION
### Box Source: CRC-8 (Encode)

Adds the `CRC-8` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `123456789 ::crc8`

#### Options:
- `::crc8`

#### Description:
Compute CRC-8 (SMBUS and Maxim/Dallas) checksums of the input text.

#### Usage Examples:
- **Input**:
```
123456789 ::crc8
```
- **Output Box (`CRC-8`)**:
```
SMBUS: 0xf4
Maxim: 0xa1
```
