### PR TITLE
feat(CrockfordBase32): add Crockford Base32 BoxSource

### DIFF
--- a/src/modules/boxSources/CrockfordBase32BoxSource.ts
+++ b/src/modules/boxSources/CrockfordBase32BoxSource.ts
@@ -1,0 +1,117 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// Crockford's base32: excludes I, L, O, U to avoid visual confusion; no padding
+const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+// reverse lookup table; aliases O→0, I→1, L→1 per Crockford spec
+const DECODE_MAP: Record<string, number> = {};
+for (let i = 0; i < ALPHABET.length; i++) {
+  DECODE_MAP[ALPHABET[i]] = i;
+}
+DECODE_MAP.O = 0;
+DECODE_MAP.I = 1;
+DECODE_MAP.L = 1;
+
+function crockfordEncode(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let bits = '';
+  for (const b of bytes) {
+    bits += b.toString(2).padStart(8, '0');
+  }
+  let result = '';
+  for (let i = 0; i < bits.length; i += 5) {
+    // pad the final group with trailing zeros if needed
+    const group = bits.slice(i, i + 5).padEnd(5, '0');
+    result += ALPHABET[Number.parseInt(group, 2)];
+  }
+  return result;
+}
+
+// returns decoded utf-8 string, or null if input contains invalid characters
+function crockfordDecode(input: string): string | null {
+  // uppercase and strip hyphens (allowed as visual separators per Crockford spec)
+  const normalized = input.toUpperCase().replace(/-/g, '');
+  let bits = '';
+  for (const c of normalized) {
+    const val = DECODE_MAP[c];
+    if (val === undefined) return null;
+    bits += val.toString(2).padStart(5, '0');
+  }
+  // discard trailing bits that don't form a full byte
+  const byteCount = Math.floor(bits.length / 8);
+  const bytes = new Uint8Array(byteCount);
+  for (let i = 0; i < byteCount; i++) {
+    bytes[i] = Number.parseInt(bits.slice(i * 8, i * 8 + 8), 2);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+export const CrockfordBase32BoxSource = {
+  defaultDisabled: true,
+  name: 'Crockford Base32',
+  description:
+    "Encode text to Crockford's Base32 or decode it back (case-insensitive, no padding).",
+  defaultInput: 'hello ::crockford',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'crockford', 'crockfordencode');
+    const wantDecode = hasOptionKeys(options, 'crockforddecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT) {
+      return [];
+    }
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = crockfordEncode(input);
+      boxes.push(
+        new BoxBuilder('Crockford Base32 (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = crockfordDecode(input);
+      if (decoded === null) {
+        boxes.push(
+          new BoxBuilder(
+            'Crockford Base32 (Decode)',
+            'invalid Crockford Base32 input',
+          )
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      } else {
+        boxes.push(
+          new BoxBuilder('Crockford Base32 (Decode)', decoded)
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(this.priority)
+            .build(),
+        );
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default CrockfordBase32BoxSource;

--- a/src/modules/boxSources/__test__/CrockfordBase32BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CrockfordBase32BoxSource.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { CrockfordBase32BoxSource } from '../CrockfordBase32BoxSource';
+
+describe('CrockfordBase32BoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no crockford option is present', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options object lacks crockford keys', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('encodes hello to D1JPRV3F', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('hello', {
+        crockford: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Crockford Base32 (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('D1JPRV3F');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('::crockfordencode also triggers encode', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('hello', {
+        crockfordencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Crockford Base32 (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('D1JPRV3F');
+    });
+
+    it('round-trips hello: decode(encode(hello)) === hello', async () => {
+      const encBoxes = await CrockfordBase32BoxSource.generateBoxes('hello', {
+        crockford: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput as string;
+
+      const decBoxes = await CrockfordBase32BoxSource.generateBoxes(encoded, {
+        crockforddecode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('round-trips foobar: decode(encode(foobar)) === foobar', async () => {
+      const encBoxes = await CrockfordBase32BoxSource.generateBoxes('foobar', {
+        crockford: true,
+      });
+      const encoded = encBoxes[0].props.plaintextOutput as string;
+
+      const decBoxes = await CrockfordBase32BoxSource.generateBoxes(encoded, {
+        crockforddecode: true,
+      });
+      expect(decBoxes[0].props.plaintextOutput).toBe('foobar');
+    });
+
+    it('decode is case-insensitive: lowercase encoded string decodes correctly', async () => {
+      // D1JPRV3F in lowercase
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('d1jprv3f', {
+        crockforddecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decode normalizes alias I→1: DIJPRV3F decodes as hello', async () => {
+      // replace '1' with 'I' (alias for 1 per Crockford spec)
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('DIJPRV3F', {
+        crockforddecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decode normalizes alias L→1: DLJPRV3F decodes as hello', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('DLJPRV3F', {
+        crockforddecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decode normalizes alias O→0: decodes O as 0', async () => {
+      // encode '0' → first character of alphabet is '0'
+      // '0' byte = 0x30 = 00110000; as 5-bit groups: 00110 00000 → 'C', '0'
+      // so '00' encodes to 'C0'; with O alias: 'CO' should decode same as 'C0'
+      const refBoxes = await CrockfordBase32BoxSource.generateBoxes('0', {
+        crockford: true,
+      });
+      const encoded = refBoxes[0].props.plaintextOutput as string;
+      const withO = encoded.replace('0', 'O');
+      const boxes = await CrockfordBase32BoxSource.generateBoxes(withO, {
+        crockforddecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('0');
+    });
+
+    it('decode ignores hyphens used as separators', async () => {
+      // D1JPRV3F with hyphens inserted
+      const boxes = await CrockfordBase32BoxSource.generateBoxes(
+        'D1-JP-RV-3F',
+        {
+          crockforddecode: true,
+        },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('decode returns invalid box for character U (not in alphabet and not an alias)', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('U', {
+        crockforddecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Crockford Base32 (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'invalid Crockford Base32 input',
+      );
+    });
+
+    it('both options produce 2 boxes (encode + decode)', async () => {
+      const boxes = await CrockfordBase32BoxSource.generateBoxes('D1JPRV3F', {
+        crockford: true,
+        crockforddecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Crockford Base32 (Encode)');
+      expect(boxes[1].props.name).toBe('Crockford Base32 (Decode)');
+    });
+
+    it('returns empty array when input exceeds MAX_INPUT', async () => {
+      const big = 'a'.repeat(100_001);
+      const boxes = await CrockfordBase32BoxSource.generateBoxes(big, {
+        crockford: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -8,6 +8,7 @@ import {
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
+import CrockfordBase32BoxSource from './CrockfordBase32BoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  CrockfordBase32BoxSource,
 ];


### PR DESCRIPTION
### Box Source: Crockford Base32 (Encode)

Adds the `Crockford Base32` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `hello ::crockford`

#### Options:
- `::crockford`, `::crockforddecode`, `::crockfordencode`

#### Description:
Encode text to Crockford's Base32 or decode it back (case-insensitive, no padding).

#### Usage Examples:
- **Input**:
```
hello ::crockford
```
- **Output Box (`Crockford Base32 (Encode)`)**:
```
D1JPRV3F
```
