### PR TITLE
feat(CronNext): add Cron Next Runs BoxSource

### DIFF
--- a/src/modules/boxSources/CronNextBoxSource.ts
+++ b/src/modules/boxSources/CronNextBoxSource.ts
@@ -1,0 +1,251 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// maximum minutes to scan forward before giving up (≈1 year + leap margin).
+// bounds the main-thread cost for impossible expressions like "0 0 30 2 *".
+const MAX_SEARCH_MINUTES = 366 * 24 * 60;
+
+interface CronFields {
+  // sets for O(1) membership in the per-minute scan
+  minute: Set<number>;
+  hour: Set<number>;
+  dom: Set<number>;
+  month: Set<number>;
+  dow: Set<number>;
+  // whether the field was explicitly restricted (not a bare '*')
+  domRestricted: boolean;
+  dowRestricted: boolean;
+}
+
+/** Expands a single cron field token into a sorted array of allowed values. */
+function expandField(token: string, min: number, max: number): number[] | null {
+  const values = new Set<number>();
+
+  for (const part of token.split(',')) {
+    // */step
+    if (part.startsWith('*/')) {
+      const step = Number.parseInt(part.slice(2), 10);
+      if (Number.isNaN(step) || step < 1) return null;
+      for (let v = min; v <= max; v += step) values.add(v);
+      continue;
+    }
+
+    // range with optional step: a-b or a-b/step
+    if (part.includes('-')) {
+      const [rangePart, stepStr] = part.split('/');
+      const [aStr, bStr] = rangePart.split('-');
+      const a = Number.parseInt(aStr, 10);
+      const b = Number.parseInt(bStr, 10);
+      if (Number.isNaN(a) || Number.isNaN(b) || a < min || b > max || a > b)
+        return null;
+      const step = stepStr !== undefined ? Number.parseInt(stepStr, 10) : 1;
+      if (Number.isNaN(step) || step < 1) return null;
+      for (let v = a; v <= b; v += step) values.add(v);
+      continue;
+    }
+
+    // bare '*'
+    if (part === '*') {
+      for (let v = min; v <= max; v++) values.add(v);
+      continue;
+    }
+
+    // single number
+    const n = Number.parseInt(part, 10);
+    if (Number.isNaN(n) || n < min || n > max) return null;
+    values.add(n);
+  }
+
+  return [...values].sort((a, b) => a - b);
+}
+
+/** Parses a 5-field cron string into expanded field arrays. */
+function parseCron(expr: string): CronFields | null {
+  const fields = expr.split(/\s+/);
+  if (fields.length !== 5) return null;
+
+  const [minuteTok, hourTok, domTok, monthTok, dowTok] = fields;
+
+  const minute = expandField(minuteTok, 0, 59);
+  const hour = expandField(hourTok, 0, 23);
+  const dom = expandField(domTok, 1, 31);
+  // month is 1–12 in cron; we keep it that way and compare against getUTCMonth()+1
+  const month = expandField(monthTok, 1, 12);
+  // allow 7 as a Sunday alias; expand with max 7 then normalise 7→0 AFTER
+  // expansion so ranges like "5-7" stay valid (pre-substitution broke them)
+  const dowRaw = expandField(dowTok, 0, 7);
+
+  if (!minute || !hour || !dom || !month || !dowRaw) return null;
+
+  const dow = new Set(dowRaw.map((v) => (v === 7 ? 0 : v)));
+
+  return {
+    minute: new Set(minute),
+    hour: new Set(hour),
+    dom: new Set(dom),
+    month: new Set(month),
+    dow,
+    domRestricted: domTok !== '*',
+    dowRestricted: dowTok !== '*' && dowTok !== '*/1',
+  };
+}
+
+/** Returns true when the UTC time represented by `date` matches the parsed cron. */
+function matches(date: Date, fields: CronFields): boolean {
+  const m = date.getUTCMinutes();
+  const h = date.getUTCHours();
+  const dom = date.getUTCDate();
+  // getUTCMonth is 0-based; cron month field is 1-based
+  const month = date.getUTCMonth() + 1;
+  const dow = date.getUTCDay();
+
+  if (!fields.minute.has(m)) return false;
+  if (!fields.hour.has(h)) return false;
+  if (!fields.month.has(month)) return false;
+
+  // Vixie cron dom/dow rule:
+  // if BOTH are restricted → match when EITHER dom OR dow matches
+  // if only one is restricted → that one must match
+  // if neither is restricted → always matches (already covered by '*' expanding to full range)
+  const domMatch = fields.dom.has(dom);
+  const dowMatch = fields.dow.has(dow);
+
+  if (fields.domRestricted && fields.dowRestricted) {
+    return domMatch || dowMatch;
+  }
+  if (fields.domRestricted) {
+    return domMatch;
+  }
+  if (fields.dowRestricted) {
+    return dowMatch;
+  }
+  // neither restricted — both are full ranges, always true here
+  return true;
+}
+
+/** Advances `date` by one minute in-place and returns it. */
+function addMinute(date: Date): Date {
+  date.setUTCMinutes(date.getUTCMinutes() + 1, 0, 0);
+  return date;
+}
+
+// max day each month can have (29 allows leap February)
+const DAYS_IN_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+// cheap static check: when dom is the only date constraint (dow unrestricted),
+// an impossible day/month pair (e.g. Feb 30) never matches. only prune in that
+// case — under the Vixie OR-rule a restricted dow could still match.
+function isDateSatisfiable(fields: CronFields): boolean {
+  if (!fields.domRestricted || fields.dowRestricted) return true;
+  for (const mo of fields.month) {
+    for (const d of fields.dom) {
+      if (d <= DAYS_IN_MONTH[mo - 1]) return true;
+    }
+  }
+  return false;
+}
+
+export const CronNextBoxSource = {
+  defaultDisabled: true,
+  name: 'Cron Next Runs',
+  description:
+    'Compute the next run times of a 5-field cron expression. Optionally ::from=ISO and ::count=N.',
+  defaultInput: '*/15 * * * * ::cronnext',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cronnext')) return [];
+
+    const expr = trim(input);
+    // cron expressions are short; bound work before splitting
+    if (expr.length > 200) return [];
+
+    // parse ::count option, clamp to [1, 20], default 5
+    const countRaw = extractOptionKeys(options, 'cronnextcount', 'count');
+    const count = Math.min(
+      20,
+      Math.max(
+        1,
+        countRaw !== null && countRaw !== true
+          ? Number.parseInt(String(countRaw), 10) || 5
+          : 5,
+      ),
+    );
+
+    // parse ::from option as base time, fall back to now
+    const fromRaw = extractOptionKeys(options, 'cronnextfrom', 'from');
+    let base: Date;
+    if (fromRaw !== null && fromRaw !== true) {
+      const parsed = new Date(String(fromRaw));
+      base = Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+    } else {
+      base = new Date();
+    }
+
+    const fields = parseCron(expr);
+    if (fields === null) {
+      const box = new BoxBuilder(
+        'Cron Next Runs',
+        `Invalid cron expression: "${expr}"\nExpected 5 fields: minute hour day-of-month month day-of-week`,
+      )
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    // O(1) guard: when day-of-month is the sole date constraint, a value like
+    // Feb 30 can never occur — bail before the scan instead of running it to
+    // the cap (avoids a multi-ms main-thread block on impossible expressions)
+    if (!isDateSatisfiable(fields)) {
+      return [
+        new BoxBuilder(
+          'Cron Next Runs',
+          'No matching times found within 1 year.',
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // scan forward from base+1min
+    const results: string[] = [];
+    const cursor = new Date(base.getTime());
+    // zero out seconds and ms, then add one minute
+    cursor.setUTCSeconds(0, 0);
+    addMinute(cursor);
+
+    let scanned = 0;
+    while (results.length < count && scanned < MAX_SEARCH_MINUTES) {
+      if (matches(cursor, fields)) {
+        results.push(cursor.toISOString());
+      }
+      addMinute(cursor);
+      scanned++;
+    }
+
+    const output =
+      results.length > 0
+        ? results.join('\n')
+        : 'No matching times found within 1 year.';
+
+    const box = new BoxBuilder('Cron Next Runs', output)
+      .setTemplate(CodeBoxTemplate)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default CronNextBoxSource;

--- a/src/modules/boxSources/__test__/CronNextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CronNextBoxSource.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { CronNextBoxSource } from '../CronNextBoxSource';
+
+describe('CronNextBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::cronnext option is absent', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('*/15 * * * *', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is an empty object without cronnext', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('*/15 * * * *', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('computes next 3 runs of */15 * * * * from 2024-01-01T00:00:00Z', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('*/15 * * * *', {
+        cronnext: true,
+        from: '2024-01-01T00:00:00Z',
+        count: '3',
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toEqual([
+        '2024-01-01T00:15:00.000Z',
+        '2024-01-01T00:30:00.000Z',
+        '2024-01-01T00:45:00.000Z',
+      ]);
+    });
+
+    it('computes daily midnight runs (0 0 * * *) from 2024-01-01T12:00:00Z count 2', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('0 0 * * *', {
+        cronnext: true,
+        from: '2024-01-01T12:00:00Z',
+        count: '2',
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toEqual([
+        '2024-01-02T00:00:00.000Z',
+        '2024-01-03T00:00:00.000Z',
+      ]);
+    });
+
+    it('computes 9am Mondays (0 9 * * 1) from 2024-01-01T00:00:00Z — 2024-01-01 is Monday', async () => {
+      // 2024-01-01 is indeed a Monday (day=1)
+      const boxes = await CronNextBoxSource.generateBoxes('0 9 * * 1', {
+        cronnext: true,
+        from: '2024-01-01T00:00:00Z',
+        count: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toEqual(['2024-01-01T09:00:00.000Z']);
+    });
+
+    it('returns an invalid-expression box for non-cron input', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('not a cron', {
+        cronnext: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+
+    it('defaults count to 5 when ::count is absent', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('* * * * *', {
+        cronnext: true,
+        from: '2024-01-01T00:00:00Z',
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toHaveLength(5);
+    });
+
+    it('clamps count to 20 when ::count exceeds maximum', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('* * * * *', {
+        cronnext: true,
+        from: '2024-01-01T00:00:00Z',
+        count: '100',
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toHaveLength(20);
+    });
+
+    it('accepts 7 as Sunday alias in dow field', async () => {
+      // 2024-01-07 is a Sunday
+      const boxes = await CronNextBoxSource.generateBoxes('0 12 * * 7', {
+        cronnext: true,
+        from: '2024-01-06T00:00:00Z',
+        count: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('2024-01-07T12:00:00.000Z');
+    });
+
+    it('handles a dow range that wraps through 7 (5-7 = Fri/Sat/Sun)', async () => {
+      // 2024-01-05 is a Friday; 5-7 covers Fri(5), Sat(6), Sun(0)
+      const boxes = await CronNextBoxSource.generateBoxes('0 0 * * 5-7', {
+        cronnext: true,
+        from: '2024-01-04T12:00:00Z',
+        count: '3',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe(
+        [
+          '2024-01-05T00:00:00.000Z', // Friday
+          '2024-01-06T00:00:00.000Z', // Saturday
+          '2024-01-07T00:00:00.000Z', // Sunday
+        ].join('\n'),
+      );
+    });
+
+    it('bails cleanly on an impossible expression (Feb 30)', async () => {
+      const boxes = await CronNextBoxSource.generateBoxes('0 0 30 2 *', {
+        cronnext: true,
+        from: '2024-01-01T00:00:00Z',
+      });
+      // no matches within the search window — surfaces a box, does not hang
+      expect(boxes).toHaveLength(1);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -9,6 +9,7 @@ import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
+import CronNextBoxSource from './CronNextBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import DurationBoxSource from './DurationBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  CronNextBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Cron Next Runs (Analyze)

Adds the `Cron Next Runs` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `*/15 * * * * ::cronnext`

#### Options:
- `::cronnext`

#### Description:
Compute the next run times of a 5-field cron expression. Optionally ::from=ISO and ::count=N.

#### Usage Examples:
- **Input**:
```
*/15 * * * * ::cronnext
```
- **Output Box (`Cron Next Runs`)**:
```
2026-06-24T07:00:00.000Z
2026-06-24T07:15:00.000Z
2026-06-24T07:30:00.000Z
2026-06-24T07:45:00.000Z
2026-06-24T08:00:00.000Z
```
