### PR TITLE
feat(CssToJs): add CSS to JS BoxSource

### DIFF
--- a/src/modules/boxSources/CssToJsBoxSource.ts
+++ b/src/modules/boxSources/CssToJsBoxSource.ts
@@ -1,0 +1,152 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// convert kebab-case CSS property to camelCase JS property
+// vendor prefixes like -webkit-x become WebkitX (capital first letter per React convention)
+function kebabToCamel(prop: string): string {
+  const trimmed = prop.trim();
+
+  // vendor prefix: leading hyphen, e.g. -webkit-box-shadow → WebkitBoxShadow
+  if (trimmed.startsWith('-')) {
+    return trimmed
+      .slice(1)
+      .split('-')
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join('');
+  }
+
+  // standard kebab-case → camelCase
+  return trimmed.replace(/-([a-z])/g, (_, ch) => ch.toUpperCase());
+}
+
+// convert camelCase JS property back to kebab-case CSS property
+// React vendor prefix convention: leading uppercase segment → hyphen prefix
+// e.g. WebkitBoxShadow → -webkit-box-shadow
+function camelToKebab(prop: string): string {
+  // detect leading capital-only segment as vendor prefix (e.g. Webkit, Moz, Ms, O)
+  const vendorMatch = prop.match(/^([A-Z][a-z]*)(.+)/);
+  if (vendorMatch) {
+    const vendor = vendorMatch[1].toLowerCase();
+    const rest = vendorMatch[2];
+    const restKebab = rest.replace(/([A-Z])/g, '-$1').toLowerCase();
+    return `-${vendor}${restKebab}`;
+  }
+
+  return prop.replace(/([A-Z])/g, '-$1').toLowerCase();
+}
+
+// split declarations on ';' that are outside parentheses, so values like
+// url(data:image/png;base64,...) aren't truncated
+function splitDeclarations(css: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < css.length; i++) {
+    const ch = css[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') depth = Math.max(0, depth - 1);
+    else if (ch === ';' && depth === 0) {
+      parts.push(css.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(css.slice(start));
+  return parts;
+}
+
+// convert CSS declaration block to a JS object literal string
+function cssToJs(css: string): string {
+  const pairs: string[] = [];
+
+  for (const decl of splitDeclarations(css)) {
+    const colonIdx = decl.indexOf(':');
+    if (colonIdx === -1) continue;
+
+    const prop = decl.slice(0, colonIdx).trim();
+    const value = decl.slice(colonIdx + 1).trim();
+
+    if (!prop || !value) continue;
+
+    const jsProp = kebabToCamel(prop);
+    pairs.push(`  ${jsProp}: "${value}"`);
+  }
+
+  return `{\n${pairs.join(',\n')}\n}`;
+}
+
+// convert a JS style object literal to CSS declarations
+function jsToCss(js: string): string {
+  const lines: string[] = [];
+
+  // lenient extraction: match key: "value" or key: value pairs
+  const pairRegex = /([a-zA-Z][a-zA-Z0-9]*):\s*["']?([^"',}\n]+)["']?/g;
+  let match: RegExpExecArray | null;
+
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex loop pattern
+  while ((match = pairRegex.exec(js)) !== null) {
+    const jsProp = match[1].trim();
+    const value = match[2].trim();
+    if (!jsProp || !value) continue;
+
+    const cssProp = camelToKebab(jsProp);
+    lines.push(`${cssProp}: ${value};`);
+  }
+
+  return lines.join('\n');
+}
+
+export const CssToJsBoxSource = {
+  defaultDisabled: true,
+  name: 'CSS to JS',
+  description:
+    'Convert CSS declarations to a React/JS style object, or a JS style object back to CSS.',
+  defaultInput: 'background-color: red;\nfont-size: 14px; ::cssjs',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cssjs', 'csstojs')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    if (!trimmed) return [];
+
+    // detect direction: if input starts with '{' it is a JS object → convert to CSS
+    const isJsInput = trimmed.startsWith('{');
+
+    if (isJsInput) {
+      const cssOutput = jsToCss(trimmed);
+      if (!cssOutput) return [];
+
+      return [
+        new BoxBuilder('JS to CSS', cssOutput)
+          .setOptions({ language: 'css' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const jsOutput = cssToJs(trimmed);
+    if (!jsOutput || jsOutput === '{\n\n}') return [];
+
+    return [
+      new BoxBuilder('CSS to JS', jsOutput)
+        .setOptions({ language: 'javascript' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CssToJsBoxSource;

--- a/src/modules/boxSources/__test__/CssToJsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CssToJsBoxSource.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { CssToJsBoxSource } from '../CssToJsBoxSource';
+
+describe('CssToJsBoxSource', () => {
+  describe('generateBoxes — option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('color: red;', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are provided', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('color: red;', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('CSS → JS conversion', () => {
+    it('converts basic CSS declarations to a JS object', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes(
+        'background-color: red; font-size: 14px;',
+        { cssjs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('CSS to JS');
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('backgroundColor: "red"');
+      expect(out).toContain('fontSize: "14px"');
+    });
+
+    it('handles vendor prefix -webkit-box-shadow → WebkitBoxShadow', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes(
+        '-webkit-box-shadow: none;',
+        { csstojs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('WebkitBoxShadow: "none"');
+    });
+
+    it('skips empty declarations gracefully', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes(';;;', {
+        cssjs: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('color: blue;', {
+        cssjs: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('JS → CSS conversion', () => {
+    it('converts a JS object literal to CSS declarations', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes(
+        '{ backgroundColor: "red", fontSize: "14px" }',
+        { cssjs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JS to CSS');
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('background-color: red;');
+      expect(out).toContain('font-size: 14px;');
+    });
+
+    it('converts vendor prefix WebkitBoxShadow → -webkit-box-shadow', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes(
+        '{ WebkitBoxShadow: "0 0 5px rgba(0,0,0,0.5)" }',
+        { cssjs: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('-webkit-box-shadow:');
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('{ color: "blue" }', {
+        cssjs: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty string without crashing', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('', { cssjs: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('handles whitespace-only input without crashing', async () => {
+      const boxes = await CssToJsBoxSource.generateBoxes('   ', {
+        cssjs: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('handles garbage input without crashing', async () => {
+      // no valid declarations → empty object output → returns []
+      const boxes = await CssToJsBoxSource.generateBoxes(
+        'this is not css at all!!!',
+        { cssjs: true },
+      );
+      // may return [] or a box with empty output — must not throw
+      expect(Array.isArray(boxes)).toBe(true);
+    });
+
+    it('respects MAX_INPUT cap', async () => {
+      const huge = 'a'.repeat(100_001);
+      const boxes = await CssToJsBoxSource.generateBoxes(huge, { cssjs: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -9,6 +9,7 @@ import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
+import CssToJsBoxSource from './CssToJsBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import DurationBoxSource from './DurationBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  CssToJsBoxSource,
 ];


### PR DESCRIPTION
### Box Source: CSS to JS (Convert)

Adds the `CSS to JS` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `background-color: red;
font-size: 14px; ::cssjs`

#### Options:
- `::cssjs`, `::csstojs`

#### Description:
Convert CSS declarations to a React/JS style object, or a JS style object back to CSS.

#### Usage Examples:
- **Input**:
```
background-color: red;
font-size: 14px; ::cssjs
```
- **Output Box (`CSS to JS`)**:
```
{
  backgroundColor: "red",
  fontSize: "14px"
}
```
