### PR TITLE
feat(CsvColumn): add CSV Column BoxSource

### DIFF
--- a/src/modules/boxSources/CsvColumnBoxSource.ts
+++ b/src/modules/boxSources/CsvColumnBoxSource.ts
@@ -1,0 +1,130 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// parses a single CSV row, handling quoted fields and "" escapes
+function parseCsvRow(row: string): string[] {
+  const fields: string[] = [];
+  let i = 0;
+
+  while (i < row.length) {
+    if (row[i] === '"') {
+      // quoted field: consume until closing quote, unescape "" → "
+      let field = '';
+      i++; // skip opening quote
+      while (i < row.length) {
+        if (row[i] === '"') {
+          if (row[i + 1] === '"') {
+            field += '"';
+            i += 2;
+          } else {
+            i++; // skip closing quote
+            break;
+          }
+        } else {
+          field += row[i];
+          i++;
+        }
+      }
+      // skip optional comma after the closing quote
+      if (row[i] === ',') i++;
+      fields.push(field);
+    } else {
+      // unquoted field: read until next comma
+      const end = row.indexOf(',', i);
+      if (end === -1) {
+        fields.push(row.slice(i));
+        break;
+      }
+      fields.push(row.slice(i, end));
+      i = end + 1;
+    }
+  }
+
+  return fields;
+}
+
+export const CsvColumnBoxSource = {
+  defaultDisabled: true,
+  name: 'CSV Column',
+  description:
+    'Extract one column from CSV by 0-based index or header name. e.g. ::csvcol=1 or ::csvcol=email.',
+  defaultInput: 'name,email\nAlice,a@x.com\nBob,b@y.com ::csvcol=email',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'csvcol', 'csvcolumn')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // selector is the option value (column index or header name)
+    const selectorRaw = extractOptionKeys(options, 'csvcol', 'csvcolumn');
+
+    // bare flag (true) means the option was provided without a value
+    if (selectorRaw === true || selectorRaw === null || selectorRaw === '') {
+      return [
+        new BoxBuilder(
+          'CSV Column',
+          'A column index or header name is required. e.g. ::csvcol=0 or ::csvcol=email',
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const selector = trim(String(selectorRaw));
+
+    // split lines, drop blanks
+    const lines = input.split('\n').filter((l) => l.trim() !== '');
+    if (lines.length === 0) return [];
+
+    const headerRow = parseCsvRow(lines[0]);
+    const dataRows = lines.slice(1).map(parseCsvRow);
+
+    // resolve column index
+    let colIndex: number;
+    if (/^\d+$/.test(selector)) {
+      colIndex = Number.parseInt(selector, 10);
+    } else {
+      // find header by trimmed case-sensitive match
+      colIndex = headerRow.findIndex((h) => trim(h) === selector);
+    }
+
+    if (colIndex < 0 || colIndex >= headerRow.length) {
+      return [
+        new BoxBuilder(
+          'CSV Column',
+          `Column not found: "${selector}". Available headers: ${headerRow.map(trim).join(', ')}`,
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const values = dataRows
+      .map((row) => (colIndex < row.length ? row[colIndex] : ''))
+      .join('\n');
+
+    return [
+      new BoxBuilder('CSV Column', values)
+        .setTemplate(CodeBoxTemplate)
+        .setShowExpandButton(true)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default CsvColumnBoxSource;

--- a/src/modules/boxSources/__test__/CsvColumnBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/CsvColumnBoxSource.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { CsvColumnBoxSource } from '../CsvColumnBoxSource';
+
+const CSV = 'name,email\nAlice,a@x.com\nBob,b@y.com';
+
+describe('CsvColumnBoxSource', () => {
+  describe('trigger guard', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('column selection by header name', () => {
+    it('extracts the email column by name', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: 'email',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a@x.com\nb@y.com');
+    });
+
+    it('extracts the name column by name', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: 'name',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Alice\nBob');
+    });
+  });
+
+  describe('column selection by index', () => {
+    it('extracts column 0 by index', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: '0',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Alice\nBob');
+    });
+
+    it('extracts column 1 by index', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a@x.com\nb@y.com');
+    });
+  });
+
+  describe('quoted fields', () => {
+    it('handles a field with an embedded comma inside quotes', async () => {
+      const input = 'a,b\n"x,y",2';
+      const boxes = await CsvColumnBoxSource.generateBoxes(input, {
+        csvcol: '0',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('x,y');
+    });
+
+    it('unescapes "" inside quoted fields', async () => {
+      const input = 'a,b\n"say ""hi""",2';
+      const boxes = await CsvColumnBoxSource.generateBoxes(input, {
+        csvcol: '0',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('say "hi"');
+    });
+  });
+
+  describe('error cases', () => {
+    it('returns an error box when header is not found', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: 'zzz',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/not found/i);
+    });
+
+    it('returns an error box for an out-of-range index', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: '5',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/not found/i);
+    });
+
+    it('returns an informational box when csvcol has no value (bare flag)', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/required/i);
+    });
+  });
+
+  describe('alternate trigger key', () => {
+    it('accepts ::csvcolumn as an alias', async () => {
+      const boxes = await CsvColumnBoxSource.generateBoxes(CSV, {
+        csvcolumn: 'email',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a@x.com\nb@y.com');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(CsvColumnBoxSource.name).toBe('CSV Column');
+      expect(CsvColumnBoxSource.tag).toBe('#');
+      expect(CsvColumnBoxSource.kind).toBe('Analyze');
+      expect(typeof CsvColumnBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -9,6 +9,7 @@ import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
+import CsvColumnBoxSource from './CsvColumnBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import DurationBoxSource from './DurationBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  CsvColumnBoxSource,
 ];


### PR DESCRIPTION
### Box Source: CSV Column (Analyze)

Adds the `CSV Column` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `name,email
Alice,a@x.com
Bob,b@y.com ::csvcol=email`

#### Options:
- `::csvcol`, `::csvcolumn`

#### Description:
Extract one column from CSV by 0-based index or header name. e.g. ::csvcol=1 or ::csvcol=email.

#### Usage Examples:
- **Input**:
```
name,email
Alice,a@x.com
Bob,b@y.com ::csvcol=email
```
- **Output Box (`CSV Column`)**:
```
a@x.com
b@y.com
```
