### PR TITLE
feat(DataRate): add Data Rate BoxSource

### DIFF
--- a/src/modules/boxSources/DataRateBoxSource.ts
+++ b/src/modules/boxSources/DataRateBoxSource.ts
@@ -1,0 +1,128 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit (normalized) -> bits per second (SI: 1 kbit = 1000 bit; bytes: 1 B = 8 bit)
+const TO_BPS: Record<string, number> = {
+  bps: 1,
+  kbps: 1e3,
+  mbps: 1e6,
+  gbps: 1e9,
+  tbps: 1e12,
+  'b/s': 8,
+  'kb/s': 8e3,
+  'mb/s': 8e6,
+  'gb/s': 8e9,
+  'tb/s': 8e12,
+  'kib/s': 8 * 1024,
+  'mib/s': 8 * 1024 ** 2,
+  'gib/s': 8 * 1024 ** 3,
+};
+
+// supported unit aliases for user-facing display in the error message
+const SUPPORTED_UNITS = Object.keys(TO_BPS).join(', ');
+
+// convert k:v record to plaintext lines for box plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// format a bps value to a given output divisor, stripping trailing decimal noise
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// normalize the raw unit string to a key present in TO_BPS
+function normalizeUnit(raw: string): string {
+  // lowercase and preserve '/' so 'MB/s' → 'mb/s', 'Mbps' → 'mbps'
+  return raw.toLowerCase();
+}
+
+export const DataRateBoxSource = {
+  defaultDisabled: true,
+  name: 'Data Rate',
+  description:
+    'Convert a data rate between bit/s (bps/Mbps/Gbps) and byte/s (MB/s, MiB/s).',
+  defaultInput: '100 Mbps ::datarate',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'datarate', 'bandwidth')) return [];
+
+    const text = trim(input);
+    if (text.length > 64) return [];
+
+    // parse "<value> <unit>", separated by one or more spaces
+    const spaceIdx = text.indexOf(' ');
+    if (spaceIdx === -1) {
+      return [buildErrorBox(this.priority)];
+    }
+
+    const rawValue = text.slice(0, spaceIdx);
+    const rawUnit = text.slice(spaceIdx + 1).trim();
+
+    if (!rawUnit) {
+      return [buildErrorBox(this.priority)];
+    }
+
+    const value = Number.parseFloat(rawValue);
+    if (Number.isNaN(value) || value < 0) {
+      return [buildErrorBox(this.priority)];
+    }
+
+    const unitKey = normalizeUnit(rawUnit);
+    const multiplier = TO_BPS[unitKey];
+    if (multiplier === undefined) {
+      return [buildErrorBox(this.priority)];
+    }
+
+    const bps = value * multiplier;
+
+    const kv: Record<string, string> = {
+      Input: `${value} ${rawUnit}`,
+      bps: formatValue(bps),
+      Kbps: formatValue(bps / 1e3),
+      Mbps: formatValue(bps / 1e6),
+      Gbps: formatValue(bps / 1e9),
+      'B/s': formatValue(bps / 8),
+      'KB/s': formatValue(bps / 8 / 1e3),
+      'MB/s': formatValue(bps / 8 / 1e6),
+      'GB/s': formatValue(bps / 8 / 1e9),
+      'MiB/s': formatValue(bps / 8 / 1024 ** 2),
+    };
+
+    return [
+      new BoxBuilder('Data Rate', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+function buildErrorBox(priority: number): Box {
+  const kv: Record<string, string> = {
+    'Expected input': '<value> <unit>',
+    Example: '100 Mbps',
+    'Supported units': SUPPORTED_UNITS,
+  };
+  return new BoxBuilder('Data Rate', kvToPlaintext(kv))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(kv)
+    .setPriority(priority)
+    .build();
+}
+
+export default DataRateBoxSource;

--- a/src/modules/boxSources/__test__/DataRateBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DataRateBoxSource.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { DataRateBoxSource } from '../DataRateBoxSource';
+
+describe('DataRateBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no option key is present', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array with unrelated options', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', {
+        unrelated: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert 100 Mbps correctly (bitrate → byte rates)', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.bps).toBe('100000000');
+      expect(opts.Mbps).toBe('100');
+      // 100 Mbit/s / 8 = 12.5 MB/s
+      expect(opts['MB/s']).toBe('12.5');
+      expect(opts.Kbps).toBe('100000');
+      expect(opts.Gbps).toBe('0.1');
+    });
+
+    it('should convert 1 Gbps correctly', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('1 Gbps', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mbps).toBe('1000');
+      expect(opts['MB/s']).toBe('125');
+    });
+
+    it('should convert 8 bps to 1 B/s', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('8 bps', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['B/s']).toBe('1');
+    });
+
+    it('should convert 1 MB/s (megabyte/s) to 8 Mbps', async () => {
+      // 1 MB/s = 8 Mbit/s = 8 Mbps
+      const boxes = await DataRateBoxSource.generateBoxes('1 MB/s', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mbps).toBe('8');
+    });
+
+    it('should accept ::bandwidth option key', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', {
+        bandwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('should return an error box for purely alphabetic input', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('abc', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toContain('bps');
+    });
+
+    it('should return an error box for unknown unit', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('5 foo', {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toContain('mbps');
+    });
+
+    it('should produce a box named "Data Rate"', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', {
+        datarate: true,
+      });
+      expect(boxes[0].props.name).toBe('Data Rate');
+    });
+
+    it('should include the Input key showing original value and unit', async () => {
+      const boxes = await DataRateBoxSource.generateBoxes('100 Mbps', {
+        datarate: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('100 Mbps');
+    });
+
+    it('should handle unit matching case-insensitively (mbps vs Mbps vs MBPS)', async () => {
+      const [boxLower] = await DataRateBoxSource.generateBoxes('100 mbps', {
+        datarate: true,
+      });
+      const [boxUpper] = await DataRateBoxSource.generateBoxes('100 MBPS', {
+        datarate: true,
+      });
+      const optsLower = boxLower.props.options as Record<string, string>;
+      const optsUpper = boxUpper.props.options as Record<string, string>;
+      expect(optsLower.bps).toBe(optsUpper.bps);
+    });
+
+    it('should return empty array when input exceeds 64 characters', async () => {
+      const longInput = `${'1'.repeat(60)} Mbps`;
+      const boxes = await DataRateBoxSource.generateBoxes(longInput, {
+        datarate: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,15 +1,12 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
+import DataRateBoxSource from './DataRateBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  DataRateBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Data Rate (Convert)

Adds the `Data Rate` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `100 Mbps ::datarate`

#### Options:
- `::bandwidth`, `::datarate`

#### Description:
Convert a data rate between bit/s (bps/Mbps/Gbps) and byte/s (MB/s, MiB/s).

#### Usage Examples:
- **Input**:
```
100 Mbps ::datarate
```
- **Output Box (`Data Rate`)**:
```
Input: 100 Mbps
bps: 100000000
Kbps: 100000
Mbps: 100
Gbps: 0.1
B/s: 12500000
KB/s: 12500
MB/s: 12.5
GB/s: 0.0125
MiB/s: 11.920929
```
