### PR TITLE
feat(DataSizeConvert): add Data Size BoxSource

### DIFF
--- a/src/modules/boxSources/DataSizeConvertBoxSource.ts
+++ b/src/modules/boxSources/DataSizeConvertBoxSource.ts
@@ -1,0 +1,139 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit string (lowercase) -> bytes multiplier
+const TO_BYTES: Record<string, number> = {
+  b: 1,
+  kb: 1e3,
+  mb: 1e6,
+  gb: 1e9,
+  tb: 1e12,
+  pb: 1e15,
+  kib: 1024,
+  mib: 1024 ** 2,
+  gib: 1024 ** 3,
+  tib: 1024 ** 4,
+  pib: 1024 ** 5,
+};
+
+// ordered output units shown in the result box
+const OUTPUT_UNITS: Array<{ label: string; divisor: number }> = [
+  { label: 'Bytes', divisor: 1 },
+  { label: 'KB', divisor: 1e3 },
+  { label: 'MB', divisor: 1e6 },
+  { label: 'GB', divisor: 1e9 },
+  { label: 'TB', divisor: 1e12 },
+  { label: 'KiB', divisor: 1024 },
+  { label: 'MiB', divisor: 1024 ** 2 },
+  { label: 'GiB', divisor: 1024 ** 3 },
+  { label: 'TiB', divisor: 1024 ** 4 },
+  { label: 'PB', divisor: 1e15 },
+  { label: 'PiB', divisor: 1024 ** 5 },
+];
+
+// format a byte-derived value: exact integers stay exact (sig-figs would
+// corrupt large byte counts like 1073741824), fractionals round to 6 decimals
+function formatSigFigs(value: number): string {
+  if (value === 0) return '0';
+  if (Number.isInteger(value)) return value.toString();
+  return Number.parseFloat(value.toFixed(6)).toString();
+}
+
+// parse "<value> <unit>" or bare "<value>" (no unit means bytes)
+function parseInput(raw: string): { bytes: number } | { error: string } | null {
+  const trimmed = trim(raw).slice(0, 64);
+  if (!trimmed) return null;
+
+  // bare number → treat as bytes
+  const bareMatch = /^(-?\d+(?:\.\d+)?)$/.exec(trimmed);
+  if (bareMatch) {
+    const value = Number.parseFloat(bareMatch[1]);
+    if (Number.isNaN(value)) return null;
+    return { bytes: value };
+  }
+
+  const m = /^(-?\d+(?:\.\d+)?)\s*([a-z]+)$/i.exec(trimmed);
+  if (!m) return null;
+
+  const value = Number.parseFloat(m[1]);
+  const unit = m[2].toLowerCase();
+
+  if (Number.isNaN(value)) return null;
+
+  if (!(unit in TO_BYTES)) {
+    const supported = Object.keys(TO_BYTES).join(', ');
+    return { error: `Unknown unit "${m[2]}". Supported units: ${supported}` };
+  }
+
+  return { bytes: value * TO_BYTES[unit] };
+}
+
+export const DataSizeConvertBoxSource = {
+  defaultDisabled: true,
+  name: 'Data Size',
+  description:
+    'Convert a data size between SI (KB, MB, GB) and IEC (KiB, MiB, GiB) units.',
+  defaultInput: '1.5 GB ::datasize',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'datasize', 'bytesize')) return [];
+
+    const parsed = parseInput(input);
+    if (!parsed) return [];
+
+    // error result: show a box explaining the problem
+    if ('error' in parsed) {
+      const kv: Record<string, string> = { Error: parsed.error };
+      const plaintext = `Error: ${parsed.error}`;
+      return [
+        new BoxBuilder('Data Size', plaintext)
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { bytes } = parsed;
+    const kv: Record<string, string> = {};
+
+    for (const { label, divisor } of OUTPUT_UNITS) {
+      kv[label] = formatSigFigs(bytes / divisor);
+    }
+
+    // if a target unit is specified (e.g. ::datasize=mib), add a Result entry
+    const targetRaw = extractOptionKeys(options, 'datasize', 'bytesize');
+    if (typeof targetRaw === 'string' && targetRaw.length > 0) {
+      const targetUnit = targetRaw.toLowerCase();
+      if (targetUnit in TO_BYTES) {
+        const resultValue = bytes / TO_BYTES[targetUnit];
+        kv.Result = `${formatSigFigs(resultValue)} ${targetRaw.toUpperCase()}`;
+      }
+    }
+
+    // build plaintext as "Key: value" lines for headless consumers
+    const plaintext = Object.entries(kv)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Data Size', plaintext)
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DataSizeConvertBoxSource;

--- a/src/modules/boxSources/__test__/DataSizeConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DataSizeConvertBoxSource.test.ts
@@ -1,0 +1,173 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DataSizeConvertBoxSource } from '../DataSizeConvertBoxSource';
+
+describe('DataSizeConvertBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no option keys are present', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes(
+        '1.5 GB',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are present', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 GB', {
+        something: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — 1.5 GB (SI)', () => {
+    it('produces one box with KeyValueBoxTemplate and correct priority', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 GB', {
+        datasize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.name).toBe('Data Size');
+    });
+
+    it('converts 1.5 GB → Bytes = 1500000000', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 GB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1500000000' });
+    });
+
+    it('converts 1.5 GB → GB = 1.5', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 GB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ GB: '1.5' });
+    });
+
+    it('converts 1.5 GB → GiB ≈ 1.39698 (1.5e9 / 1024^3)', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 GB', {
+        datasize: true,
+      });
+      const gib = Number.parseFloat(
+        (boxes[0].props.options as Record<string, string>).GiB,
+      );
+      // 1.5e9 / 1024^3 = 1.396984...
+      expect(gib).toBeCloseTo(1.396984, 4);
+    });
+  });
+
+  describe('generateBoxes — 1024 MiB (IEC round trip)', () => {
+    it('converts 1024 MiB → GiB = 1', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1024 MiB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ GiB: '1' });
+    });
+
+    it('converts 1024 MiB → Bytes = 1073741824', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1024 MiB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1073741824' });
+    });
+  });
+
+  describe('generateBoxes — 1 GiB', () => {
+    it('converts 1 GiB → Bytes = 1073741824', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1 GiB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1073741824' });
+    });
+
+    it('converts 1 GiB → MiB = 1024', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1 GiB', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ MiB: '1024' });
+    });
+  });
+
+  describe('generateBoxes — target unit via ::datasize=<unit>', () => {
+    it('adds Result key when ::datasize=mib and value is 1 GB', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1 GB', {
+        datasize: 'mib',
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Result).toBeDefined();
+      // 1e9 / 1024^2 = 953.6743...
+      expect(opts.Result).toContain('MIB');
+      const numPart = Number.parseFloat(opts.Result);
+      expect(numPart).toBeCloseTo(953.674, 2);
+    });
+  });
+
+  describe('generateBoxes — bytesize option alias', () => {
+    it('triggers on ::bytesize as well', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1 KB', {
+        bytesize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1000' });
+    });
+  });
+
+  describe('generateBoxes — bare number (no unit → bytes)', () => {
+    it('treats bare 2048 as 2048 bytes → KiB = 2, KB = 2.048', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('2048', {
+        datasize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Bytes).toBe('2048');
+      expect(opts.KiB).toBe('2');
+      expect(opts.KB).toBe('2.048');
+    });
+  });
+
+  describe('generateBoxes — invalid unit', () => {
+    it('returns a box with Error key for unknown unit "floppies"', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('5 floppies', {
+        datasize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+      expect(opts.Error).toContain('floppies');
+      // should list some known units in the message
+      expect(opts.Error).toContain('kb');
+    });
+  });
+
+  describe('generateBoxes — case insensitivity', () => {
+    it('parses "1.5 gb" (lowercase) correctly', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('1.5 gb', {
+        datasize: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1500000000' });
+    });
+
+    it('parses "512 MIB" (uppercase) correctly', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes('512 MIB', {
+        datasize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 512 * 1024^2 = 536870912
+      expect(opts.Bytes).toBe('536870912');
+    });
+  });
+
+  describe('generateBoxes — whitespace tolerance', () => {
+    it('handles extra whitespace around "  1.5   GB  "', async () => {
+      const boxes = await DataSizeConvertBoxSource.generateBoxes(
+        '  1.5   GB  ',
+        {
+          datasize: true,
+        },
+      );
+      expect(boxes[0].props.options).toMatchObject({ Bytes: '1500000000' });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,15 +1,12 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
+import DataSizeConvertBoxSource from './DataSizeConvertBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  DataSizeConvertBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Data Size (Convert)

Adds the `Data Size` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1.5 GB ::datasize`

#### Options:
- `::bytesize`, `::datasize`

#### Description:
Convert a data size between SI (KB, MB, GB) and IEC (KiB, MiB, GiB) units.

#### Usage Examples:
- **Input**:
```
1.5 GB ::datasize
```
- **Output Box (`Data Size`)**:
```
Bytes: 1500000000
KB: 1500000
MB: 1500
GB: 1.5
TB: 0.0015
KiB: 1464843.75
MiB: 1430.511475
GiB: 1.396984
TiB: 0.001364
PB: 0.000002
PiB: 0.000001
```
