### PR TITLE
feat(DayOfWeek): add Day of Week BoxSource

### DIFF
--- a/src/modules/boxSources/DayOfWeekBoxSource.ts
+++ b/src/modules/boxSources/DayOfWeekBoxSource.ts
@@ -1,0 +1,200 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to avoid processing huge strings
+const MAX_INPUT_LENGTH = 40;
+
+const WEEKDAY_NAMES = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+] as const;
+
+// days in each month for a given year (1-indexed, month 1-12)
+function daysInMonth(year: number, month: number): number {
+  if (month === 2) {
+    return isLeapYear(year) ? 29 : 28;
+  }
+  return [31, 0, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+}
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+// Zeller's congruence (Gregorian) returns 0=Sunday … 6=Saturday
+function zellerWeekday(year: number, month: number, day: number): number {
+  // january and february are treated as months 13 and 14 of the previous year
+  let y = year;
+  let m = month;
+  if (m <= 2) {
+    m += 12;
+    y -= 1;
+  }
+  const k = y % 100;
+  const j = Math.floor(y / 100);
+  // normalize to handle negative JS modulo results
+  const h =
+    (((day +
+      Math.floor((13 * (m + 1)) / 5) +
+      k +
+      Math.floor(k / 4) +
+      Math.floor(j / 4) -
+      2 * j) %
+      7) +
+      7) %
+    7;
+  // h: 0=Sat,1=Sun,2=Mon,3=Tue,4=Wed,5=Thu,6=Fri → convert to 0=Sun…6=Sat
+  return (h + 6) % 7;
+}
+
+// day of year, 1-based
+function dayOfYear(year: number, month: number, day: number): number {
+  const DAYS_BEFORE_MONTH = [
+    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334,
+  ];
+  const base = DAYS_BEFORE_MONTH[month - 1];
+  const leapOffset = month > 2 && isLeapYear(year) ? 1 : 0;
+  return base + leapOffset + day;
+}
+
+// thursday of the week containing this date (ISO weeks pivot on Thursday)
+function isoWeekAndYear(
+  year: number,
+  month: number,
+  day: number,
+): { week: number; isoYear: number } {
+  const doy = dayOfYear(year, month, day);
+
+  // ISO weekday: 1=Mon … 7=Sun
+  const zellerDay = zellerWeekday(year, month, day); // 0=Sun…6=Sat
+  const isoWeekday = zellerDay === 0 ? 7 : zellerDay; // 1=Mon…7=Sun
+
+  // ordinal of the nearest Thursday (ISO weeks are numbered by their Thursday)
+  const thursdayOrdinal = doy + (4 - isoWeekday);
+
+  if (thursdayOrdinal < 1) {
+    // Thursday falls in the previous year
+    const prevYear = year - 1;
+    const daysInPrevYear = isLeapYear(prevYear) ? 366 : 365;
+    const prevThursdayOrdinal = daysInPrevYear + thursdayOrdinal;
+    const week = Math.ceil(prevThursdayOrdinal / 7);
+    return { week, isoYear: prevYear };
+  }
+
+  const daysInCurrentYear = isLeapYear(year) ? 366 : 365;
+  if (thursdayOrdinal > daysInCurrentYear) {
+    // Thursday falls in the next year → week 1 of next year
+    return { week: 1, isoYear: year + 1 };
+  }
+
+  const week = Math.ceil(thursdayOrdinal / 7);
+  return { week, isoYear: year };
+}
+
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+interface ParsedDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+// returns ParsedDate on valid input, or a string describing the error
+function parseDate(raw: string): ParsedDate | string {
+  const match = raw.match(/^(\d{1,6})-(\d{1,2})-(\d{1,2})$/);
+  if (!match) {
+    return 'Input must be a date in YYYY-MM-DD format (e.g. 2025-12-25).';
+  }
+
+  const year = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  const day = Number.parseInt(match[3], 10);
+
+  if (month < 1 || month > 12) {
+    return `Invalid month ${month}. Month must be between 1 and 12.`;
+  }
+
+  const maxDay = daysInMonth(year, month);
+  if (day < 1 || day > maxDay) {
+    return `Invalid day ${day} for ${year}-${String(month).padStart(2, '0')}. Day must be between 1 and ${maxDay}.`;
+  }
+
+  return { year, month, day };
+}
+
+export const DayOfWeekBoxSource = {
+  defaultDisabled: true,
+  name: 'Day of Week',
+  description:
+    'Compute the weekday, day-of-year, and ISO week for a date (YYYY-MM-DD).',
+  defaultInput: '2025-12-25 ::dayofweek',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'dayofweek', 'weekday')) return [];
+
+    const raw = trim(input);
+    if (raw.length === 0 || raw.length > MAX_INPUT_LENGTH) return [];
+
+    const parsed = parseDate(raw);
+
+    if (typeof parsed === 'string') {
+      // invalid input — return an explanatory box
+      const errorKv = { 'Invalid Date': parsed };
+      return [
+        new BoxBuilder('Day of Week', kvToPlaintext(errorKv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(errorKv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { year, month, day } = parsed;
+
+    const weekdayIndex = zellerWeekday(year, month, day);
+    const weekday = WEEKDAY_NAMES[weekdayIndex];
+    const doy = dayOfYear(year, month, day);
+    const { week, isoYear } = isoWeekAndYear(year, month, day);
+    const isoWeek = `${isoYear}-W${String(week).padStart(2, '0')}`;
+    const leap = isLeapYear(year) ? 'true' : 'false';
+
+    const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+
+    const kv: Record<string, string> = {
+      Date: dateStr,
+      Weekday: weekday,
+      'Day of Year': String(doy),
+      'ISO Week': isoWeek,
+      'Leap Year': leap,
+    };
+
+    return [
+      new BoxBuilder('Day of Week', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DayOfWeekBoxSource;

--- a/src/modules/boxSources/__test__/DayOfWeekBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DayOfWeekBoxSource.test.ts
@@ -1,0 +1,184 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DayOfWeekBoxSource } from '../DayOfWeekBoxSource';
+
+describe('DayOfWeekBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no options provided', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option provided', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with valid option', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — ::dayofweek trigger', () => {
+    it('2025-12-25 is Thursday', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Day of Week');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.options).toMatchObject({
+        Weekday: 'Thursday',
+        'Leap Year': 'false',
+      });
+    });
+
+    it('2000-01-01 is Saturday', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2000-01-01', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Weekday: 'Saturday' });
+    });
+
+    it('2024-02-29 is Thursday, leap year, day 60', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2024-02-29', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Weekday).toBe('Thursday');
+      expect(opts['Leap Year']).toBe('true');
+      expect(opts['Day of Year']).toBe('60');
+    });
+  });
+
+  describe('generateBoxes — ::weekday trigger', () => {
+    it('accepts ::weekday option', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25', {
+        weekday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Weekday: 'Thursday' });
+    });
+  });
+
+  describe('day of year', () => {
+    it('2025-01-01 → Day of Year 1', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-01-01', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Day of Year': '1' });
+    });
+
+    it('2025-12-31 → Day of Year 365 (non-leap)', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-31', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Day of Year': '365' });
+    });
+
+    it('2024-12-31 → Day of Year 366 (leap)', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2024-12-31', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'Day of Year': '366' });
+    });
+  });
+
+  describe('ISO week number', () => {
+    it('2021-01-01 → ISO Week 2020-W53', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2021-01-01', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'ISO Week': '2020-W53' });
+    });
+
+    it('2025-12-29 → ISO Week 2026-W01 (rolls into next year)', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-29', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'ISO Week': '2026-W01' });
+    });
+
+    it('2020-12-28 → ISO Week 2020-W53', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2020-12-28', {
+        dayofweek: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ 'ISO Week': '2020-W53' });
+    });
+  });
+
+  describe('invalid input', () => {
+    it('non-date string returns error box', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('hello', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Invalid Date']).toBeDefined();
+      expect(opts['Invalid Date'].length).toBeGreaterThan(0);
+    });
+
+    it('invalid month 2025-13-01 returns error box', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-13-01', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Invalid Date']).toMatch(/month/i);
+    });
+
+    it('invalid day 2025-02-30 returns error box', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-02-30', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Invalid Date']).toMatch(/day/i);
+    });
+
+    it('2023-02-29 (non-leap) returns error box', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2023-02-29', {
+        dayofweek: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Invalid Date']).toBeDefined();
+    });
+  });
+
+  describe('output structure', () => {
+    it('box has all required keys in options', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25', {
+        dayofweek: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(Object.keys(opts)).toEqual(
+        expect.arrayContaining([
+          'Date',
+          'Weekday',
+          'Day of Year',
+          'ISO Week',
+          'Leap Year',
+        ]),
+      );
+    });
+
+    it('plaintextOutput contains key: value pairs', async () => {
+      const boxes = await DayOfWeekBoxSource.generateBoxes('2025-12-25', {
+        dayofweek: true,
+      });
+      const plaintext = boxes[0].props.plaintextOutput;
+      expect(plaintext).toContain('Weekday: Thursday');
+      expect(plaintext).toContain('Date: 2025-12-25');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -11,6 +11,7 @@ import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DayOfWeekBoxSource from './DayOfWeekBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
@@ -76,6 +77,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  DayOfWeekBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,


### PR DESCRIPTION
### Box Source: Day of Week (Calculate)

Adds the `Day of Week` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `2025-12-25 ::dayofweek`

#### Options:
- `::dayofweek`, `::weekday`

#### Description:
Compute the weekday, day-of-year, and ISO week for a date (YYYY-MM-DD).

#### Usage Examples:
- **Input**:
```
2025-12-25 ::dayofweek
```
- **Output Box (`Day of Week`)**:
```
Date: 2025-12-25
Weekday: Thursday
Day of Year: 359
ISO Week: 2025-W52
Leap Year: false
```
