### PR TITLE
feat(DiceRoll): add Dice Roll BoxSource

### DIFF
--- a/src/components/BoxTemplate/DiceRollBoxTemplate.tsx
+++ b/src/components/BoxTemplate/DiceRollBoxTemplate.tsx
@@ -1,0 +1,144 @@
+import type { BoxProps } from '@modules/Box';
+import { memo, useMemo } from 'react';
+
+const PIP_MAP: Record<number, string> = {
+  1: '⚀',
+  2: '⚁',
+  3: '⚂',
+  4: '⚃',
+  5: '⚄',
+  6: '⚅',
+};
+
+const DiceRollBoxTemplateComponent = ({
+  options,
+  onClick,
+}: BoxProps): React.JSX.Element => {
+  const data = useMemo(() => {
+    const notation = (options?.Notation as string) || '';
+    const rollsStr = (options?.Rolls as string) || '[]';
+    const sum = (options?.Sum as string) || '0';
+    const modifier = (options?.Modifier as string) || '0';
+    const total = (options?.Total as string) || '0';
+
+    let rolls: number[] = [];
+    try {
+      rolls = JSON.parse(rollsStr) as number[];
+    } catch {
+      /* fallback */
+    }
+
+    return { notation, rolls, sum, modifier, total };
+  }, [options]);
+
+  const handleCopy = (val: string) => {
+    onClick(val);
+  };
+
+  return (
+    <div
+      className="dice-roll-template"
+      data-testid="magic-box-dice-roll"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+        padding: '4px 0',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <span
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            color: 'var(--ink-4)',
+            letterSpacing: '0.05em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {data.notation || 'DICE ROLL'}
+        </span>
+        <button
+          type="button"
+          onClick={() => handleCopy(data.total)}
+          style={{
+            fontSize: 20,
+            fontWeight: 700,
+            color: 'var(--accent, #6366f1)',
+            background: 'var(--accent-bg, rgba(99, 102, 241, 0.1))',
+            padding: '4px 12px',
+            borderRadius: 8,
+            border: 'none',
+            cursor: 'pointer',
+          }}
+          title="Click to copy total"
+        >
+          Total: {data.total}
+        </button>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 8,
+          alignItems: 'center',
+        }}
+      >
+        {data.rolls.map((roll, idx) => {
+          const keyId = `dice-roll-val-${roll}-item-${String(idx)}`;
+          return (
+            <div
+              key={keyId}
+              style={{
+                width: 38,
+                height: 38,
+                borderRadius: 8,
+                border: '1px solid var(--border-color, #ccc)',
+                background: 'var(--bg-card, #ffffff)',
+                boxShadow: '0 2px 4px rgba(0,0,0,0.08)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: PIP_MAP[roll] ? 24 : 14,
+                fontWeight: 700,
+                color: 'var(--ink)',
+                transition: 'transform 0.15s ease',
+              }}
+              title={`Die #${idx + 1}: ${roll}`}
+            >
+              {PIP_MAP[roll] || roll}
+            </div>
+          );
+        })}
+        {data.modifier !== '0' && (
+          <span
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: 'var(--ink-3, #666)',
+              marginLeft: 4,
+            }}
+          >
+            ({data.modifier > '0' ? `+${data.modifier}` : data.modifier})
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const DiceRollBoxTemplate = Object.assign(
+  memo(DiceRollBoxTemplateComponent),
+  {
+    supportsLarge: false,
+  },
+);
+
+export default DiceRollBoxTemplate;

--- a/src/components/BoxTemplate/index.tsx
+++ b/src/components/BoxTemplate/index.tsx
@@ -1,5 +1,6 @@
 import CodeBoxTemplate from './CodeBoxTemplate';
 import DefaultBoxTemplate from './DefaultBoxTemplate';
+import DiceRollBoxTemplate from './DiceRollBoxTemplate';
 import KeyValueBoxTemplate from './KeyValueBoxTemplate';
 import NotingMatchBoxTemplate from './NotingMatchBoxTemplate';
 import QRCodeBoxTemplate from './QRCodeBoxTemplate';
@@ -8,6 +9,7 @@ import ShortenURLBoxTemplate from './ShortenURLBoxTemplate';
 export {
   CodeBoxTemplate,
   DefaultBoxTemplate,
+  DiceRollBoxTemplate,
   KeyValueBoxTemplate,
   NotingMatchBoxTemplate,
   QRCodeBoxTemplate,

--- a/src/modules/boxSources/DiceRollBoxSource.ts
+++ b/src/modules/boxSources/DiceRollBoxSource.ts
@@ -1,0 +1,164 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max caps prevent pathological inputs from blocking the event loop
+const MAX_COUNT = 1000;
+const MAX_SIDES = 1_000_000;
+
+const NOTATION_RE = /^(\d*)d(\d+)([+-]\d+)?$/i;
+
+interface ParsedNotation {
+  count: number;
+  sides: number;
+  modifier: number;
+  raw: string;
+}
+
+/** Parses XdY+Z dice notation. Returns null when the string is not valid notation. */
+function parseNotation(raw: string): ParsedNotation | null {
+  const match = NOTATION_RE.exec(raw.trim());
+  if (!match) return null;
+
+  const count = match[1] === '' ? 1 : Number.parseInt(match[1], 10);
+  const sides = Number.parseInt(match[2], 10);
+  const modifier = match[3] ? Number.parseInt(match[3], 10) : 0;
+
+  if (sides < 1 || count < 1) return null;
+
+  return {
+    count: Math.min(count, MAX_COUNT),
+    sides: Math.min(sides, MAX_SIDES),
+    modifier,
+    raw,
+  };
+}
+
+/** Returns a cryptographically unbiased integer in [1, sides] via rejection sampling. */
+function rollOne(
+  sides: number,
+  buf: Uint32Array<ArrayBuffer>,
+  cursor: { i: number },
+): number {
+  // largest multiple of `sides` that fits in a uint32 to avoid modulo bias
+  const limit = Math.floor(0x1_0000_0000 / sides) * sides;
+  for (;;) {
+    if (cursor.i >= buf.length) {
+      crypto.getRandomValues(buf);
+      cursor.i = 0;
+    }
+    const val = buf[cursor.i++];
+    if (val < limit) {
+      return (val % sides) + 1;
+    }
+    // rejected — try next value
+  }
+}
+
+/** Rolls `count` fair dice each with `sides` faces. Falls back to Math.random when crypto is unavailable. */
+function rollDice(count: number, sides: number): number[] {
+  const results: number[] = [];
+
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.getRandomValues === 'function'
+  ) {
+    // over-allocate by a small factor to reduce refill frequency from rejection sampling
+    const buf = new Uint32Array(Math.min(count + 16, 4096));
+    crypto.getRandomValues(buf);
+    const cursor = { i: 0 };
+    for (let i = 0; i < count; i++) {
+      results.push(rollOne(sides, buf, cursor));
+    }
+  } else {
+    // fallback for environments without a secure context (e.g. some jest setups)
+    for (let i = 0; i < count; i++) {
+      results.push(Math.floor(Math.random() * sides) + 1);
+    }
+  }
+
+  return results;
+}
+
+/** Formats a modifier as a signed string, or '0' if zero. */
+function formatModifier(modifier: number): string {
+  if (modifier === 0) return '0';
+  return modifier > 0 ? `+${modifier}` : `${modifier}`;
+}
+
+const INVALID_BOX_OUTPUT =
+  'Dice Roll requires valid dice notation, e.g. 2d6+3 or 1d20.';
+
+export const DiceRollBoxSource = {
+  defaultDisabled: true,
+  name: 'Dice Roll',
+  description:
+    'Roll dice with standard notation, e.g. 2d6+3 or 1d20. ::roll or ::roll=3d8.',
+  defaultInput: '2d6+3 ::roll',
+  tag: '#',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'roll', 'dice')) return [];
+
+    // prefer explicit notation from the option value; fall back to the input string
+    const optionValue = extractOptionKeys(options, 'roll', 'dice');
+    const notationRaw =
+      typeof optionValue === 'string' && optionValue.trim() !== ''
+        ? optionValue.trim()
+        : trim(input);
+
+    const parsed = parseNotation(notationRaw);
+
+    if (!parsed) {
+      const kvOptions: Record<string, string> = {
+        Info: INVALID_BOX_OUTPUT,
+      };
+      const plaintext = `Info: ${INVALID_BOX_OUTPUT}`;
+      return [
+        new BoxBuilder('Dice Roll', plaintext)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kvOptions)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const rolls = rollDice(parsed.count, parsed.sides);
+    const sum = rolls.reduce((a, b) => a + b, 0);
+    const total = sum + parsed.modifier;
+    const modifierStr = formatModifier(parsed.modifier);
+
+    // reconstruct from capped values so the label matches what was rolled
+    const effectiveNotation = `${parsed.count}d${parsed.sides}${modifierStr === '0' ? '' : modifierStr}`;
+
+    const kvOptions: Record<string, string> = {
+      Notation: effectiveNotation,
+      Rolls: `[${rolls.join(', ')}]`,
+      Sum: String(sum),
+      Modifier: modifierStr,
+      Total: String(total),
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Dice Roll', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DiceRollBoxSource;

--- a/src/modules/boxSources/DiceRollBoxSource.ts
+++ b/src/modules/boxSources/DiceRollBoxSource.ts
@@ -1,4 +1,4 @@
-import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { DiceRollBoxTemplate } from '@components/BoxTemplate';
 import { trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
@@ -124,7 +124,7 @@ export const DiceRollBoxSource = {
       const plaintext = `Info: ${INVALID_BOX_OUTPUT}`;
       return [
         new BoxBuilder('Dice Roll', plaintext)
-          .setTemplate(KeyValueBoxTemplate)
+          .setTemplate(DiceRollBoxTemplate)
           .setOptions(kvOptions)
           .setPriority(this.priority)
           .build(),
@@ -153,7 +153,7 @@ export const DiceRollBoxSource = {
 
     return [
       new BoxBuilder('Dice Roll', plaintext)
-        .setTemplate(KeyValueBoxTemplate)
+        .setTemplate(DiceRollBoxTemplate)
         .setOptions(kvOptions)
         .setPriority(this.priority)
         .build(),

--- a/src/modules/boxSources/__test__/DiceRollBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DiceRollBoxSource.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import { DiceRollBoxSource } from '../DiceRollBoxSource';
+
+describe('DiceRollBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no roll/dice option is present', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('2d6');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when options is null', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('2d6', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated option is present', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('2d6', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should roll 2d6 and return values within range', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('2d6', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Notation).toBe('2d6');
+
+      const rollsRaw = options?.Rolls as string;
+      // parse "[4, 2]" style string
+      const rolls = JSON.parse(rollsRaw) as number[];
+      expect(rolls).toHaveLength(2);
+      for (const r of rolls) {
+        expect(r).toBeGreaterThanOrEqual(1);
+        expect(r).toBeLessThanOrEqual(6);
+      }
+
+      const total = Number(options?.Total);
+      expect(total).toBeGreaterThanOrEqual(2);
+      expect(total).toBeLessThanOrEqual(12);
+      expect(options?.Modifier).toBe('0');
+    });
+
+    it('should handle 1d20+5 with modifier applied to total', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('1d20+5', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Notation).toBe('1d20+5');
+      expect(options?.Modifier).toBe('+5');
+
+      const total = Number(options?.Total);
+      expect(total).toBeGreaterThanOrEqual(6);
+      expect(total).toBeLessThanOrEqual(25);
+    });
+
+    it('should use the option value as notation when ::roll=4d4', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('', {
+        roll: '4d4',
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Notation).toBe('4d4');
+
+      const rolls = JSON.parse(options?.Rolls as string) as number[];
+      expect(rolls).toHaveLength(4);
+      for (const r of rolls) {
+        expect(r).toBeGreaterThanOrEqual(1);
+        expect(r).toBeLessThanOrEqual(4);
+      }
+    });
+
+    it('should default count to 1 when notation omits the count (d6)', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('d6', { roll: true });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      const rolls = JSON.parse(options?.Rolls as string) as number[];
+      expect(rolls).toHaveLength(1);
+      expect(rolls[0]).toBeGreaterThanOrEqual(1);
+      expect(rolls[0]).toBeLessThanOrEqual(6);
+    });
+
+    it('should accept ::dice option as an alias', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('1d6', {
+        dice: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Notation).toBe('1d6');
+    });
+
+    it('should return an error box for invalid notation "abc"', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('abc', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      // no Notation/Rolls — only an Info key explaining the required format
+      expect(options?.Notation).toBeUndefined();
+      expect(options?.Info).toBeTruthy();
+      const info = options?.Info as string;
+      expect(info.toLowerCase()).toContain('notation');
+    });
+
+    it('should roll 10d10 and all results should be within [1, 10]', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('10d10', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      const rolls = JSON.parse(options?.Rolls as string) as number[];
+      expect(rolls).toHaveLength(10);
+      for (const r of rolls) {
+        expect(r).toBeGreaterThanOrEqual(1);
+        expect(r).toBeLessThanOrEqual(10);
+      }
+
+      const total = Number(options?.Total);
+      expect(total).toBeGreaterThanOrEqual(10);
+      expect(total).toBeLessThanOrEqual(100);
+    });
+
+    it('should include k: v plaintext lines in plaintextOutput for headless TUI', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('1d6', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { plaintextOutput } = boxes[0].props;
+      expect(plaintextOutput).toContain('Notation: 1d6');
+      expect(plaintextOutput).toContain('Rolls:');
+      expect(plaintextOutput).toContain('Sum:');
+      expect(plaintextOutput).toContain('Modifier:');
+      expect(plaintextOutput).toContain('Total:');
+    });
+
+    it('should set priority from source priority', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('1d6', {
+        roll: true,
+      });
+      expect(boxes[0].props.priority).toBe(DiceRollBoxSource.priority);
+    });
+
+    it('should handle negative modifier (1d6-2) and apply it to total', async () => {
+      const boxes = await DiceRollBoxSource.generateBoxes('1d6-2', {
+        roll: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Modifier).toBe('-2');
+
+      const total = Number(options?.Total);
+      // 1d6-2 range: [1-2, 6-2] = [-1, 4]
+      expect(total).toBeGreaterThanOrEqual(-1);
+      expect(total).toBeLessThanOrEqual(4);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -10,7 +10,7 @@ import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
-import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DiceRollBoxSource from './DiceRollBoxSource';
 import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import FractionBoxSource from './FractionBoxSource';
@@ -85,6 +85,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  DiceRollBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Dice Roll (Generate)

Adds the `Dice Roll` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Generate`
- **Tag**: `#`
- **Default Input**: `2d6+3 ::roll`

#### Options:
- `::dice`, `::roll`

#### Description:
Roll dice with standard notation, e.g. 2d6+3 or 1d20. ::roll or ::roll=3d8.

#### Usage Examples:
- **Input**:
```
2d6+3 ::roll
```
- **Output Box (`Dice Roll`)**:
```
Notation: 2d6+3
Rolls: [1, 6]
Sum: 7
Modifier: +3
Total: 10
```
