### PR TITLE
feat(Divisors): add Divisors BoxSource

### DIFF
--- a/src/modules/boxSources/DivisorsBoxSource.ts
+++ b/src/modules/boxSources/DivisorsBoxSource.ts
@@ -1,0 +1,140 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_VALUE = 1_000_000_000_000n;
+
+// build a k:v plaintext block from an ordered record — KeyValueBoxTemplate reads
+// this as a fallback when no `options` object is set, but we always set both.
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// trial-division up to sqrt(n). returns divisors sorted ascending.
+function computeDivisors(n: bigint): bigint[] {
+  const lo: bigint[] = [];
+  const hi: bigint[] = [];
+  for (let i = 1n; i * i <= n; i++) {
+    if (n % i === 0n) {
+      lo.push(i);
+      if (i !== n / i) {
+        hi.push(n / i);
+      }
+    }
+  }
+  // lo is ascending, hi must be reversed to keep full list sorted
+  return [...lo, ...hi.reverse()];
+}
+
+function buildErrorBox(message: string): Box {
+  const pairs = { Error: message };
+  return new BoxBuilder('Divisors', kvToPlaintext(pairs))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(pairs)
+    .setPriority(Priority)
+    .build();
+}
+
+export const DivisorsBoxSource = {
+  defaultDisabled: true,
+  name: 'Divisors',
+  description:
+    'List the divisors of a positive integer (up to 10^12) with count, sum, and classification.',
+  defaultInput: '28 ::divisors',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    // not ::factors — that conventionally means prime factorization, a
+    // different tool; this lists all divisors
+    if (!hasOptionKeys(options, 'divisors')) return [];
+
+    const raw = trim(input);
+
+    // guard: must be a non-empty decimal integer string
+    if (!/^\d+$/.test(raw)) {
+      return [buildErrorBox('Input must be a positive integer.')];
+    }
+
+    // guard: cap string length before BigInt conversion to avoid DoS via very
+    // large decimal strings that are still within JS memory limits
+    if (raw.length > 13) {
+      return [
+        buildErrorBox(`Input too large. Maximum is 10^12 (1,000,000,000,000).`),
+      ];
+    }
+
+    const n = BigInt(raw);
+
+    if (n < 1n) {
+      return [buildErrorBox('Input must be >= 1.')];
+    }
+    if (n > MAX_VALUE) {
+      return [
+        buildErrorBox(
+          `Input too large. Maximum is 10^12 (${MAX_VALUE.toString()}).`,
+        ),
+      ];
+    }
+
+    const divisors = computeDivisors(n);
+
+    const count = divisors.length;
+    const sigma = divisors.reduce((acc, d) => acc + d, 0n);
+    const properSum = sigma - n;
+
+    // classify by proper divisor sum
+    let classification: string;
+    if (n === 1n) {
+      // 1 has no proper divisors; its proper sum is 0
+      classification = 'deficient';
+    } else if (properSum === n) {
+      classification = 'perfect';
+    } else if (properSum > n) {
+      classification = 'abundant';
+    } else {
+      classification = 'deficient';
+    }
+
+    // a prime has exactly two divisors: 1 and itself
+    if (count === 2) {
+      classification += ' (prime)';
+    }
+
+    // cap displayed list at 200 entries to avoid overwhelming the UI
+    const MAX_DISPLAY = 200;
+    const divisorList =
+      divisors.length > MAX_DISPLAY
+        ? `${divisors
+            .slice(0, MAX_DISPLAY)
+            .map((d) => d.toString())
+            .join(', ')}…`
+        : divisors.map((d) => d.toString()).join(', ');
+
+    const pairs: Record<string, string> = {
+      Number: n.toString(),
+      Divisors: divisorList,
+      Count: count.toString(),
+      Sum: sigma.toString(),
+      Classification: classification,
+    };
+
+    return [
+      new BoxBuilder('Divisors', kvToPlaintext(pairs))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(pairs)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DivisorsBoxSource;

--- a/src/modules/boxSources/__test__/DivisorsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DivisorsBoxSource.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+
+import { DivisorsBoxSource } from '../DivisorsBoxSource';
+
+describe('DivisorsBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for an unrelated option', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('does not trigger on ::factors (that means prime factorization)', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('6', {
+        factors: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('28 — perfect number', () => {
+    it('lists all divisors of 28', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Divisors).toBe('1, 2, 4, 7, 14, 28');
+    });
+
+    it('count is 6 for 28', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Count).toBe('6');
+    });
+
+    it('sigma(28) = 56', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Sum).toBe('56');
+    });
+
+    it('28 is classified as perfect', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Classification).toBe('perfect');
+    });
+
+    it('box name is Divisors', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      expect(boxes[0].props.name).toBe('Divisors');
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('28', {
+        divisors: true,
+      });
+      expect(boxes[0].props.priority).toBe(DivisorsBoxSource.priority);
+    });
+  });
+
+  describe('12 — abundant number', () => {
+    it('divisors of 12', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('12', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Divisors).toBe('1, 2, 3, 4, 6, 12');
+    });
+
+    it('count is 6 for 12', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('12', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Count).toBe('6');
+    });
+
+    it('sigma(12) = 28', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('12', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1+2+3+4+6+12 = 28
+      expect(opts.Sum).toBe('28');
+    });
+
+    it('12 is classified as abundant (proper sum 16 > 12)', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('12', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Classification).toBe('abundant');
+    });
+  });
+
+  describe('13 — prime / deficient', () => {
+    it('divisors of 13 are 1 and 13', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('13', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Divisors).toBe('1, 13');
+    });
+
+    it('count is 2 for 13', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('13', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Count).toBe('2');
+    });
+
+    it('13 is classified as deficient (prime)', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('13', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Classification).toBe('deficient (prime)');
+    });
+  });
+
+  describe('1 — edge case', () => {
+    it('divisors of 1 is just 1', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('1', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Divisors).toBe('1');
+      expect(opts.Count).toBe('1');
+    });
+
+    it('1 is classified as deficient', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('1', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Classification).toBe('deficient');
+    });
+  });
+
+  describe('6 — perfect number', () => {
+    it('6 is perfect (1+2+3=6)', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('6', {
+        divisors: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Classification).toBe('perfect');
+      expect(opts.Divisors).toBe('1, 2, 3, 6');
+    });
+  });
+
+  describe('invalid / out-of-range inputs', () => {
+    it('returns an error box for too-large input (10^13)', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('10000000000000', {
+        divisors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for "0"', async () => {
+      // 0 passes the digit regex but fails the n >= 1 check
+      const boxes = await DivisorsBoxSource.generateBoxes('0', {
+        divisors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for non-numeric input "abc"', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('abc', {
+        divisors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('returns an error box for negative-looking input "-5"', async () => {
+      const boxes = await DivisorsBoxSource.generateBoxes('-5', {
+        divisors: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+  });
+
+  describe('static metadata', () => {
+    it('has correct name, tag, kind', () => {
+      expect(DivisorsBoxSource.name).toBe('Divisors');
+      expect(DivisorsBoxSource.tag).toBe('#');
+      expect(DivisorsBoxSource.kind).toBe('Calculate');
+      expect(typeof DivisorsBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,16 +1,13 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DivisorsBoxSource from './DivisorsBoxSource';
 import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import FractionBoxSource from './FractionBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  DivisorsBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Divisors (Calculate)

Adds the `Divisors` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `28 ::divisors`

#### Options:
- `::divisors`

#### Description:
List the divisors of a positive integer (up to 10^12) with count, sum, and classification.

#### Usage Examples:
- **Input**:
```
28 ::divisors
```
- **Output Box (`Divisors`)**:
```
Number: 28
Divisors: 1, 2, 4, 7, 14, 28
Count: 6
Sum: 56
Classification: perfect
```
