### PR TITLE
feat(Dms): add DMS Coordinates BoxSource

### DIFF
--- a/src/modules/boxSources/DmsBoxSource.ts
+++ b/src/modules/boxSources/DmsBoxSource.ts
@@ -1,0 +1,165 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to avoid runaway regexes
+const MAX_INPUT_LENGTH = 100;
+
+// matches a plain decimal degree: optional sign, digits, optional decimal
+const DECIMAL_RE = /^(-?\d+(?:\.\d+)?)$/;
+
+// matches DMS in various formats, e.g. "40°26'40.3"N" or "40 26 40.3 N" or "40°26'40.3""
+// groups: deg, min, sec, optional hemisphere
+const DMS_RE = /^(\d+)[°\s]+(\d+)['\s]+(\d+(?:\.\d+)?)["\s]*([NSEWnsew]?)$/;
+
+interface DmsComponents {
+  degrees: number;
+  minutes: number;
+  seconds: number;
+  // sign: +1 or -1 (from input sign or hemisphere)
+  sign: number;
+}
+
+function decimalToDms(decimal: number): DmsComponents {
+  const sign = decimal < 0 ? -1 : 1;
+  const abs = Math.abs(decimal);
+  const degrees = Math.trunc(abs);
+  const minFloat = (abs - degrees) * 60;
+  const minutes = Math.trunc(minFloat);
+  const seconds = (minFloat - minutes) * 60;
+  return { degrees, minutes, seconds, sign };
+}
+
+function dmsToDecimal(components: DmsComponents): number {
+  const { degrees, minutes, seconds, sign } = components;
+  const abs = degrees + minutes / 60 + seconds / 3600;
+  return sign * abs;
+}
+
+function formatDmsString(components: DmsComponents): string {
+  const { degrees, minutes, seconds } = components;
+  return `${degrees}°${minutes}'${seconds.toFixed(2)}"`;
+}
+
+export const DmsBoxSource = {
+  defaultDisabled: true,
+  name: 'DMS Coordinates',
+  description:
+    'Convert a coordinate between decimal degrees and degrees/minutes/seconds (DMS).',
+  defaultInput: '40.446195 ::dms',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'dms', 'latlng')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT_LENGTH) return [];
+
+    // try decimal degrees first
+    const decimalMatch = raw.match(DECIMAL_RE);
+    if (decimalMatch) {
+      const decimal = Number.parseFloat(decimalMatch[1]);
+      if (Number.isNaN(decimal) || decimal < -180 || decimal > 180) {
+        return [
+          new BoxBuilder(
+            'DMS Coordinates',
+            'A coordinate must be between -180 and 180 degrees.',
+          )
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      const components = decimalToDms(decimal);
+      const dmsStr = formatDmsString(components);
+
+      // plaintext k:v output
+      const content = [
+        `Decimal: ${decimal}`,
+        `DMS: ${dmsStr}`,
+        `Degrees: ${components.degrees}`,
+        `Minutes: ${components.minutes}`,
+        `Seconds: ${components.seconds.toFixed(2)}`,
+      ].join('\n');
+
+      const opts: Record<string, string> = {
+        Decimal: String(decimal),
+        DMS: dmsStr,
+        Degrees: String(components.degrees),
+        Minutes: String(components.minutes),
+        Seconds: components.seconds.toFixed(2),
+      };
+
+      return [
+        new BoxBuilder('DMS Coordinates', content)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(opts)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // try DMS string
+    const dmsMatch = raw.match(DMS_RE);
+    if (dmsMatch) {
+      const degrees = Number.parseInt(dmsMatch[1], 10);
+      const minutes = Number.parseInt(dmsMatch[2], 10);
+      const seconds = Number.parseFloat(dmsMatch[3]);
+      const hemisphere = dmsMatch[4].toUpperCase();
+
+      // south and west hemispheres are negative
+      const sign = hemisphere === 'S' || hemisphere === 'W' ? -1 : 1;
+
+      const components: DmsComponents = { degrees, minutes, seconds, sign };
+      const decimal = dmsToDecimal(components);
+      const decimalStr = decimal.toFixed(6);
+      const dmsStr = formatDmsString(components);
+
+      const content = [
+        `Decimal: ${decimalStr}`,
+        `DMS: ${dmsStr}`,
+        `Degrees: ${degrees}`,
+        `Minutes: ${minutes}`,
+        `Seconds: ${seconds.toFixed(2)}`,
+      ].join('\n');
+
+      const opts: Record<string, string> = {
+        Decimal: decimalStr,
+        DMS: dmsStr,
+        Degrees: String(degrees),
+        Minutes: String(minutes),
+        Seconds: seconds.toFixed(2),
+      };
+
+      return [
+        new BoxBuilder('DMS Coordinates', content)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(opts)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // neither format matched — return a hint box
+    const hint =
+      'Expected formats:\n  Decimal: 40.446195 or -73.985\n  DMS: 40°26\'40.3"N or 40 26 40.3 N';
+
+    return [
+      new BoxBuilder('DMS Coordinates', hint)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions({ Format: 'Decimal or DMS' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DmsBoxSource;

--- a/src/modules/boxSources/__test__/DmsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DmsBoxSource.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { DmsBoxSource } from '../DmsBoxSource';
+
+describe('DmsBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await DmsBoxSource.generateBoxes('40.446195', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await DmsBoxSource.generateBoxes('40.446195', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('decimal → DMS', () => {
+      it('converts 40.446195 correctly with ::dms', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40.446195', {
+          dms: true,
+        });
+        expect(boxes).toHaveLength(1);
+
+        const opts = boxes[0].props.options as Record<string, string>;
+        // 0.446195 * 60 = 26.7717 → 26 min
+        // 0.7717 * 60 = 46.302 → 46.30 sec
+        expect(opts.Degrees).toBe('40');
+        expect(opts.Minutes).toBe('26');
+        expect(opts.Seconds).toBe('46.30');
+        expect(opts.DMS).toBe('40°26\'46.30"');
+        expect(opts.Decimal).toBe('40.446195');
+      });
+
+      it('converts 40.446195 correctly with ::latlng', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40.446195', {
+          latlng: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Degrees).toBe('40');
+        expect(opts.Minutes).toBe('26');
+      });
+
+      it('handles negative decimal -73.985', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('-73.985', {
+          dms: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        // magnitude degrees
+        expect(opts.Degrees).toBe('73');
+        expect(opts.Decimal).toBe('-73.985');
+      });
+
+      it('returns box name "DMS Coordinates"', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40.446195', {
+          dms: true,
+        });
+        expect(boxes[0].props.name).toBe('DMS Coordinates');
+      });
+
+      it('sets priority correctly', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40.446195', {
+          dms: true,
+        });
+        expect(boxes[0].props.priority).toBe(10);
+      });
+    });
+
+    describe('DMS → decimal', () => {
+      it('converts 40°26\'46.3"N to decimal ≈ 40.4462', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40°26\'46.3"N', {
+          dms: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        // 40 + 26/60 + 46.3/3600 ≈ 40.446194...
+        expect(opts.Decimal.startsWith('40.4461')).toBe(true);
+      });
+
+      it('converts 33°51\'54"S to negative decimal', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('33°51\'54"S', {
+          dms: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        // 33 + 51/60 + 54/3600 = 33.865 → negative due to S
+        expect(opts.Decimal.startsWith('-33.86')).toBe(true);
+      });
+
+      it('converts space-separated DMS without hemisphere', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('40 26 40.3', {
+          dms: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Degrees).toBe('40');
+        expect(opts.Minutes).toBe('26');
+      });
+    });
+
+    describe('invalid input', () => {
+      it('returns a hint box for non-parseable input "abc"', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('abc', { dms: true });
+        expect(boxes).toHaveLength(1);
+        // the hint box content should mention expected formats
+        expect(boxes[0].props.plaintextOutput).toContain('Expected formats');
+      });
+
+      it('returns [] for input exceeding 100 chars', async () => {
+        const long = 'a'.repeat(101);
+        const boxes = await DmsBoxSource.generateBoxes(long, { dms: true });
+        expect(boxes).toHaveLength(0);
+      });
+
+      it('returns a range hint box for out-of-range decimal 999', async () => {
+        const boxes = await DmsBoxSource.generateBoxes('999', { dms: true });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput).toMatch(/-180 and 180/);
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -11,6 +11,7 @@ import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DmsBoxSource from './DmsBoxSource';
 import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import FractionBoxSource from './FractionBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  DmsBoxSource,
 ];


### PR DESCRIPTION
### Box Source: DMS Coordinates (Convert)

Adds the `DMS Coordinates` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `40.446195 ::dms`

#### Options:
- `::dms`, `::latlng`

#### Description:
Convert a coordinate between decimal degrees and degrees/minutes/seconds (DMS).

#### Usage Examples:
- **Input**:
```
40.446195 ::dms
```
- **Output Box (`DMS Coordinates`)**:
```
Decimal: 40.446195
DMS: 40°26'46.30"
Degrees: 40
Minutes: 26
Seconds: 46.30
```
