### PR TITLE
feat(DotEnv): add Dotenv / JSON BoxSource

### DIFF
--- a/src/modules/boxSources/DotEnvBoxSource.ts
+++ b/src/modules/boxSources/DotEnvBoxSource.ts
@@ -1,0 +1,109 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// strips one layer of surrounding single or double quotes from a value
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+// parses .env text into a plain string-keyed object
+function parseEnv(input: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of input.split('\n')) {
+    const trimmed = trim(line);
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+
+    const key = trim(trimmed.slice(0, eqIndex));
+    const rawValue = trim(trimmed.slice(eqIndex + 1));
+    result[key] = stripQuotes(rawValue);
+  }
+  return result;
+}
+
+// serializes a flat object to .env lines, quoting values that need it
+function serializeEnv(obj: Record<string, string>): string {
+  return Object.entries(obj)
+    .map(([key, rawValue]) => {
+      const value = String(rawValue);
+      // quote values that contain spaces, '#', or '=' to avoid ambiguity
+      const needsQuotes = /[ #=]/.test(value);
+      if (needsQuotes) {
+        const escaped = value.replace(/"/g, '\\"');
+        return `${key}="${escaped}"`;
+      }
+      return `${key}=${value}`;
+    })
+    .join('\n');
+}
+
+export const DotEnvBoxSource = {
+  defaultDisabled: true,
+  name: 'Dotenv / JSON',
+  description:
+    'Convert a .env file to a JSON object, or a flat JSON object to .env format.',
+  defaultInput: 'API_KEY=abc123\nDEBUG=true ::dotenv',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'dotenv', 'envjson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    // detect direction: JSON-looking input goes JSON→env, otherwise env→JSON
+    if (trimmed.startsWith('{')) {
+      try {
+        const obj = JSON.parse(trimmed) as Record<string, unknown>;
+        const flat: Record<string, string> = {};
+        for (const [k, v] of Object.entries(obj)) {
+          flat[k] = String(v);
+        }
+        const output = serializeEnv(flat);
+        return [
+          new BoxBuilder('JSON → Dotenv', output)
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      } catch {
+        return [
+          new BoxBuilder('JSON → Dotenv', 'Error: invalid JSON input')
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // env→JSON direction
+    const obj = parseEnv(trimmed);
+    const output = JSON.stringify(obj, null, 2);
+    return [
+      new BoxBuilder('Dotenv → JSON', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DotEnvBoxSource;

--- a/src/modules/boxSources/DotEnvBoxSource.ts
+++ b/src/modules/boxSources/DotEnvBoxSource.ts
@@ -64,13 +64,17 @@ export const DotEnvBoxSource = {
     input: string,
     options: BoxOptions = null,
   ): Promise<Box[]> {
-    if (!hasOptionKeys(options, 'dotenv', 'envjson')) return [];
+    if (!hasOptionKeys(options, 'dotenv', 'envjson', 'tojson', 'toenv'))
+      return [];
     if (input.length > MAX_INPUT) return [];
 
     const trimmed = trim(input);
 
-    // detect direction: JSON-looking input goes JSON→env, otherwise env→JSON
-    if (trimmed.startsWith('{')) {
+    const forceToJson = hasOptionKeys(options, 'tojson');
+    const forceToEnv = hasOptionKeys(options, 'toenv');
+
+    // detect direction: forceToEnv or (not forceToJson and JSON-looking input) goes JSON→env
+    if (forceToEnv || (!forceToJson && trimmed.startsWith('{'))) {
       try {
         const obj = JSON.parse(trimmed) as Record<string, unknown>;
         const flat: Record<string, string> = {};

--- a/src/modules/boxSources/__test__/DotEnvBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DotEnvBoxSource.test.ts
@@ -84,5 +84,24 @@ describe('DotEnvBoxSource', () => {
       expect(boxes).toHaveLength(1);
       expect(boxes[0].props.plaintextOutput).toContain('COLOR="#ff0000"');
     });
+
+    it('should trigger on ::tojson option', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('FOO=bar', {
+        tojson: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Dotenv → JSON');
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ FOO: 'bar' });
+    });
+
+    it('should trigger on ::toenv option', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('{"FOO":"bar"}', {
+        toenv: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → Dotenv');
+      expect(boxes[0].props.plaintextOutput).toBe('FOO=bar');
+    });
   });
 });

--- a/src/modules/boxSources/__test__/DotEnvBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DotEnvBoxSource.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { DotEnvBoxSource } from '../DotEnvBoxSource';
+
+describe('DotEnvBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no matching option is provided', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('API_KEY=abc', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when unrelated option is provided', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('API_KEY=abc', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert env to JSON with ::dotenv option', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes(
+        'API_KEY=abc123\nDEBUG=true',
+        { dotenv: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Dotenv → JSON');
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ API_KEY: 'abc123', DEBUG: 'true' });
+    });
+
+    it('should skip comment lines and strip surrounding quotes', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes(
+        '# comment\nNAME="John Doe"',
+        { dotenv: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ NAME: 'John Doe' });
+    });
+
+    it('should convert JSON to env with ::dotenv option when input starts with {', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes(
+        '{"PORT":"3000","MSG":"hello world"}',
+        { dotenv: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → Dotenv');
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('PORT=3000');
+      // value with space must be double-quoted
+      expect(output).toContain('MSG="hello world"');
+    });
+
+    it('should split on the first = only, preserving = in the value', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes(
+        'URL=http://a.com?x=1',
+        { dotenv: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed.URL).toBe('http://a.com?x=1');
+    });
+
+    it('should return an error box for invalid JSON-looking input', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('{bad}', {
+        dotenv: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('Error');
+    });
+
+    it('should also trigger on ::envjson option', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('KEY=val', {
+        envjson: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ KEY: 'val' });
+    });
+
+    it('should quote values containing #', async () => {
+      const boxes = await DotEnvBoxSource.generateBoxes('{"COLOR":"#ff0000"}', {
+        dotenv: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('COLOR="#ff0000"');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -10,7 +10,7 @@ import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
-import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DotEnvBoxSource from './DotEnvBoxSource';
 import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import FractionBoxSource from './FractionBoxSource';
@@ -85,6 +85,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  DotEnvBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Dotenv / JSON (Convert)

Adds the `Dotenv / JSON` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `API_KEY=abc123
DEBUG=true ::dotenv`

#### Options:
- `::dotenv`, `::envjson`

#### Description:
Convert a .env file to a JSON object, or a flat JSON object to .env format.

#### Usage Examples:
- **Input**:
```
API_KEY=abc123
DEBUG=true ::dotenv
```
- **Output Box (`Dotenv → JSON`)**:
```
{
  "API_KEY": "abc123",
  "DEBUG": "true"
}
```
