### PR TITLE
feat(Duration): add Duration BoxSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev-debug.log
 *.sln
 *.sw?
 # OS specific
+.gemini/

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: box.defaultDisabled ? false : true,
+        enabled: !box.defaultDisabled,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: box.defaultDisabled ? false : true,
+            enabled: !box.defaultDisabled,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: true,
+        enabled: box.defaultDisabled ? false : true,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: true,
+            enabled: box.defaultDisabled ? false : true,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/modules/BoxSource.ts
+++ b/src/modules/BoxSource.ts
@@ -9,5 +9,6 @@ export interface BoxSource {
   tag: string;
   kind: string;
   priority?: number;
+  defaultDisabled?: boolean;
   generateBoxes: (input: string, options: BoxOptions) => Promise<Box[]>;
 }

--- a/src/modules/boxSources/DurationBoxSource.ts
+++ b/src/modules/boxSources/DurationBoxSource.ts
@@ -1,0 +1,90 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// seconds per unit
+const SECONDS_PER_DAY = 86400;
+const SECONDS_PER_HOUR = 3600;
+const SECONDS_PER_MINUTE = 60;
+
+interface DurationParts {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  totalSeconds: number;
+}
+
+// break a non-negative total-seconds value into d/h/m/s components
+function decompose(total: number): DurationParts {
+  const days = Math.floor(total / SECONDS_PER_DAY);
+  const afterDays = total - days * SECONDS_PER_DAY;
+  const hours = Math.floor(afterDays / SECONDS_PER_HOUR);
+  const afterHours = afterDays - hours * SECONDS_PER_HOUR;
+  const minutes = Math.floor(afterHours / SECONDS_PER_MINUTE);
+  // round to 3 decimals so fractional input doesn't surface float noise (1.900000000000091)
+  const seconds =
+    Math.round((afterHours - minutes * SECONDS_PER_MINUTE) * 1000) / 1000;
+  return { days, hours, minutes, seconds, totalSeconds: total };
+}
+
+// join only non-zero components; for zero total return '0s'
+function humanize(parts: DurationParts): string {
+  const segments: string[] = [];
+  if (parts.days > 0) segments.push(`${parts.days}d`);
+  if (parts.hours > 0) segments.push(`${parts.hours}h`);
+  if (parts.minutes > 0) segments.push(`${parts.minutes}m`);
+  if (parts.seconds > 0 || segments.length === 0) {
+    segments.push(`${parts.seconds}s`);
+  }
+  return segments.join(' ');
+}
+
+export const DurationBoxSource = {
+  defaultDisabled: true,
+  name: 'Duration',
+  description:
+    'Convert a number of seconds into a human-readable duration (days, hours, minutes, seconds).',
+  defaultInput: '3661 ::duration',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'duration')) return [];
+
+    const raw = trim(input).slice(0, 50);
+    if (!/^\d+(\.\d+)?$/.test(raw)) return [];
+
+    const total = Number.parseFloat(raw);
+    if (Number.isNaN(total) || total < 0) return [];
+
+    const parts = decompose(total);
+    const human = humanize(parts);
+
+    const data: Record<string, string> = {
+      Human: human,
+      Days: String(parts.days),
+      Hours: String(parts.hours),
+      Minutes: String(parts.minutes),
+      Seconds: String(parts.seconds),
+      'Total Seconds': String(total),
+    };
+
+    return [
+      new BoxBuilder('Duration', '')
+        .setOptions(data)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DurationBoxSource;

--- a/src/modules/boxSources/__test__/DurationBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DurationBoxSource.test.ts
@@ -1,0 +1,83 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DurationBoxSource } from '../DurationBoxSource';
+
+describe('DurationBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::duration option is absent', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('3661', null);
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('abc', {
+        duration: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] for negative input', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('-5', {
+        duration: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns 0s for total of 0 seconds', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('0', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Human: '0s' });
+    });
+
+    it('humanizes 3661 seconds as 1h 1m 1s', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('3661', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1h 1m 1s');
+      expect(opts.Days).toBe('0');
+      expect(opts.Hours).toBe('1');
+      expect(opts.Minutes).toBe('1');
+      expect(opts.Seconds).toBe('1');
+    });
+
+    it('humanizes 90 seconds as 1m 30s', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('90', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect((boxes[0].props.options as Record<string, string>).Human).toBe(
+        '1m 30s',
+      );
+    });
+
+    it('humanizes 93784 seconds as 1d 2h 3m 4s', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('93784', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1d 2h 3m 4s');
+    });
+
+    it('rounds fractional seconds without floating-point noise', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('3661.9', {
+        duration: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1h 1m 1.9s');
+      expect(opts.Seconds).toBe('1.9');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await DurationBoxSource.generateBoxes('3661', {
+        duration: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -6,6 +6,7 @@ import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
@@ -50,5 +51,6 @@ export const boxSources = [
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
+  DurationBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Duration (Convert)

Adds the `Duration` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `3661 ::duration`

#### Options:
- `::duration`

#### Description:
Convert a number of seconds into a human-readable duration (days, hours, minutes, seconds).

#### Usage Examples:
- **Input**:
```
3661 ::duration
```
- **Output Box (`Duration`)**:
```
Human: 1h 1m 1s
Days: 0
Hours: 1
Minutes: 1
Seconds: 1
Total Seconds: 3661
```
