### PR TITLE
feat(DurationFormat): add Duration BoxSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev-debug.log
 *.sln
 *.sw?
 # OS specific
+.gemini/

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: box.defaultDisabled ? false : true,
+        enabled: !box.defaultDisabled,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: box.defaultDisabled ? false : true,
+            enabled: !box.defaultDisabled,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: true,
+        enabled: box.defaultDisabled ? false : true,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: true,
+            enabled: box.defaultDisabled ? false : true,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/modules/BoxSource.ts
+++ b/src/modules/BoxSource.ts
@@ -9,5 +9,6 @@ export interface BoxSource {
   tag: string;
   kind: string;
   priority?: number;
+  defaultDisabled?: boolean;
   generateBoxes: (input: string, options: BoxOptions) => Promise<Box[]>;
 }

--- a/src/modules/boxSources/DurationFormatBoxSource.ts
+++ b/src/modules/boxSources/DurationFormatBoxSource.ts
@@ -1,0 +1,177 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100;
+
+// unit constants in seconds
+const WEEK = 604800;
+const DAY = 86400;
+const HOUR = 3600;
+const MINUTE = 60;
+
+// build k:v plaintext for the KeyValueBoxTemplate plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// convert a total-seconds value to a human-readable string, e.g. '1h 1m 1s'
+function secondsToHuman(totalSeconds: number): string {
+  if (totalSeconds === 0) return '0s';
+
+  const w = Math.floor(totalSeconds / WEEK);
+  const remaining1 = totalSeconds % WEEK;
+  const d = Math.floor(remaining1 / DAY);
+  const remaining2 = remaining1 % DAY;
+  const h = Math.floor(remaining2 / HOUR);
+  const remaining3 = remaining2 % HOUR;
+  const m = Math.floor(remaining3 / MINUTE);
+  const s = remaining3 % MINUTE;
+
+  const parts: string[] = [];
+  if (w > 0) parts.push(`${w}w`);
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
+  if (s > 0) parts.push(`${s}s`);
+
+  return parts.join(' ');
+}
+
+// format a total-seconds value as a clock string HH:MM:SS or D:HH:MM:SS
+function secondsToClock(totalSeconds: number): string {
+  const d = Math.floor(totalSeconds / DAY);
+  const remaining = totalSeconds % DAY;
+  const h = Math.floor(remaining / HOUR);
+  const m = Math.floor((remaining % HOUR) / MINUTE);
+  const s = remaining % MINUTE;
+
+  const hh = String(h).padStart(2, '0');
+  const mm = String(m).padStart(2, '0');
+  const ss = String(s).padStart(2, '0');
+
+  if (d > 0) {
+    return `${d}:${hh}:${mm}:${ss}`;
+  }
+  return `${hh}:${mm}:${ss}`;
+}
+
+// parse a human duration string to total seconds using a linear regex
+// supports tokens like 1w, 2d, 3h, 4m, 5s (case-insensitive, optional spaces between)
+function humanToSeconds(input: string): number {
+  const tokenRegex = /(\d+(?:\.\d+)?)\s*(w|d|h|m|s)/gi;
+  const unitMap: Record<string, number> = {
+    w: WEEK,
+    d: DAY,
+    h: HOUR,
+    m: MINUTE,
+    s: 1,
+  };
+
+  let total = 0;
+  let match: RegExpExecArray | null;
+
+  // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex loop
+  while ((match = tokenRegex.exec(input)) !== null) {
+    const value = Number.parseFloat(match[1]);
+    const unit = match[2].toLowerCase();
+    total += value * (unitMap[unit] ?? 0);
+  }
+
+  return total;
+}
+
+// count how many tokens the humanToSeconds parser matched
+function countTokens(input: string): number {
+  const tokenRegex = /(\d+(?:\.\d+)?)\s*(w|d|h|m|s)/gi;
+  let count = 0;
+  while (tokenRegex.exec(input) !== null) count++;
+  return count;
+}
+
+export const DurationFormatBoxSource = {
+  defaultDisabled: true,
+  name: 'Duration',
+  description:
+    'Convert seconds to a human duration (1h 1m 1s) or parse a duration back to seconds.',
+  defaultInput: '3661 ::duration',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'duration', 'humantime')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT) return [];
+
+    // plain number → treat as seconds and convert to human form
+    if (/^\d+(\.\d+)?$/.test(raw)) {
+      // parseFloat (not parseInt) so a fractional input like 3661.5 isn't
+      // silently truncated; the %/floor math below preserves the fraction
+      const totalSeconds = Number.parseFloat(raw);
+      const human = secondsToHuman(totalSeconds);
+      const clock = secondsToClock(totalSeconds);
+
+      const kv: Record<string, string> = {
+        Seconds: String(totalSeconds),
+        Human: human,
+        Clock: clock,
+      };
+
+      return [
+        new BoxBuilder('Duration', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // human string → parse to total seconds
+    const tokenCount = countTokens(raw);
+
+    if (tokenCount === 0) {
+      // no recognizable tokens — show a usage hint
+      const hint =
+        'No duration tokens found. Use units: w d h m s, e.g. "1h 30m" or "2d 4h".';
+      const kv: Record<string, string> = {
+        Input: raw,
+        Hint: hint,
+      };
+      return [
+        new BoxBuilder('Duration', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const totalSeconds = humanToSeconds(raw);
+    const human = secondsToHuman(totalSeconds);
+
+    const kv: Record<string, string> = {
+      Input: raw,
+      'Total Seconds': String(Math.round(totalSeconds)),
+      Human: human,
+    };
+
+    return [
+      new BoxBuilder('Duration', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DurationFormatBoxSource;

--- a/src/modules/boxSources/__test__/DurationFormatBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DurationFormatBoxSource.test.ts
@@ -1,0 +1,194 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DurationFormatBoxSource } from '../DurationFormatBoxSource';
+
+describe('DurationFormatBoxSource', () => {
+  describe('no option key → empty array', () => {
+    it('returns [] when options is null', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options has no duration/humantime key', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', {
+        foo: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('seconds → human conversion', () => {
+    it('3661 → Human "1h 1m 1s", Clock "01:01:01"', async () => {
+      // verify: 1*3600 + 1*60 + 1 = 3661
+      expect(1 * 3600 + 1 * 60 + 1).toBe(3661);
+
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1h 1m 1s');
+      expect(opts.Clock).toBe('01:01:01');
+      expect(opts.Seconds).toBe('3661');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('90 → Human "1m 30s", Clock "00:01:30"', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('90', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1m 30s');
+      expect(opts.Clock).toBe('00:01:30');
+    });
+
+    it('0 → Human "0s"', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('0', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('0s');
+      expect(opts.Clock).toBe('00:00:00');
+    });
+
+    it('604800 (1 week) → Human contains "1w", Clock uses D:HH:MM:SS', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('604800', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toContain('1w');
+      // 7 days → clock should use D:HH:MM:SS form
+      expect(opts.Clock).toBe('7:00:00:00');
+    });
+
+    it('86461 (1d 1m 1s) → Human "1d 1m 1s"', async () => {
+      // verify: 86400 + 60 + 1 = 86461
+      expect(86400 + 60 + 1).toBe(86461);
+
+      const boxes = await DurationFormatBoxSource.generateBoxes('86461', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1d 1m 1s');
+      expect(opts.Clock).toBe('1:00:01:01');
+    });
+
+    it('also triggers on ::humantime option', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', {
+        humantime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Human).toBe('1h 1m 1s');
+    });
+  });
+
+  describe('human string → seconds conversion', () => {
+    it('"1h30m" → Total Seconds "5400"', async () => {
+      // verify: 1*3600 + 30*60 = 5400
+      expect(1 * 3600 + 30 * 60).toBe(5400);
+
+      const boxes = await DurationFormatBoxSource.generateBoxes('1h30m', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('5400');
+    });
+
+    it('"2d 4h" → Total Seconds "187200"', async () => {
+      // verify: 2*86400 + 4*3600 = 172800 + 14400 = 187200
+      expect(2 * 86400 + 4 * 3600).toBe(187200);
+
+      const boxes = await DurationFormatBoxSource.generateBoxes('2d 4h', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('187200');
+    });
+
+    it('"90m" → Total Seconds "5400"', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('90m', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('5400');
+    });
+
+    it('"1h 1m 1s" → Total Seconds "3661"', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('1h 1m 1s', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('3661');
+    });
+
+    it('"1w" → Total Seconds "604800"', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('1w', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('604800');
+    });
+  });
+
+  describe('invalid / unrecognized input', () => {
+    it('"hello" → returns a box with a hint (not empty)', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('hello', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // should contain a hint key explaining the supported formats
+      expect(opts.Hint).toBeTruthy();
+      expect(opts.Input).toBe('hello');
+    });
+
+    it('input over 100 chars → []', async () => {
+      const long = 'a'.repeat(101);
+      const boxes = await DurationFormatBoxSource.generateBoxes(long, {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('box metadata', () => {
+    it('box name is "Duration" and uses KeyValueBoxTemplate', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', {
+        duration: true,
+      });
+      expect(boxes[0].props.name).toBe('Duration');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('plaintextOutput is non-empty k:v text', async () => {
+      const boxes = await DurationFormatBoxSource.generateBoxes('3661', {
+        duration: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('Human: 1h 1m 1s');
+      expect(boxes[0].props.plaintextOutput).toContain('Clock: 01:01:01');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -6,6 +6,7 @@ import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DurationFormatBoxSource from './DurationFormatBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
@@ -50,5 +51,6 @@ export const boxSources = [
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
+  DurationFormatBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Duration (Convert)

Adds the `Duration` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `3661 ::duration`

#### Options:
- `::duration`, `::humantime`

#### Description:
Convert seconds to a human duration (1h 1m 1s) or parse a duration back to seconds.

#### Usage Examples:
- **Input**:
```
3661 ::duration
```
- **Output Box (`Duration`)**:
```
Seconds: 3661
Human: 1h 1m 1s
Clock: 01:01:01
```
