### PR TITLE
feat(DurationParse): add Parse Duration BoxSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev-debug.log
 *.sln
 *.sw?
 # OS specific
+.gemini/

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: box.defaultDisabled ? false : true,
+        enabled: !box.defaultDisabled,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: box.defaultDisabled ? false : true,
+            enabled: !box.defaultDisabled,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: true,
+        enabled: box.defaultDisabled ? false : true,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: true,
+            enabled: box.defaultDisabled ? false : true,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/modules/BoxSource.ts
+++ b/src/modules/BoxSource.ts
@@ -9,5 +9,6 @@ export interface BoxSource {
   tag: string;
   kind: string;
   priority?: number;
+  defaultDisabled?: boolean;
   generateBoxes: (input: string, options: BoxOptions) => Promise<Box[]>;
 }

--- a/src/modules/boxSources/DurationParseBoxSource.ts
+++ b/src/modules/boxSources/DurationParseBoxSource.ts
@@ -1,0 +1,127 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// maps unit letter(s) to their value in seconds
+const UNIT_SECONDS: Record<string, number> = {
+  w: 604800,
+  d: 86400,
+  h: 3600,
+  m: 60,
+  s: 1,
+  ms: 0.001,
+};
+
+// tokenizes a duration string into (value, unit) pairs; returns null on any invalid segment
+const SEGMENT_RE = /(\d+(?:\.\d+)?)\s*(ms|[wdhms])/gi;
+
+function parseTotalSeconds(input: string): number | null {
+  const cleaned = input.trim();
+  if (!cleaned) return null;
+
+  const matches = [...cleaned.matchAll(SEGMENT_RE)];
+  if (matches.length === 0) return null;
+
+  // verify the full string is covered — no leftover garbage characters
+  const reconstructed = matches.map((m) => m[0].replace(/\s+/g, '')).join('');
+  const withoutSpaces = cleaned.replace(/\s+/g, '');
+  if (reconstructed !== withoutSpaces) return null;
+
+  let total = 0;
+  for (const match of matches) {
+    const value = Number.parseFloat(match[1]);
+    const unit = match[2].toLowerCase();
+    const multiplier = UNIT_SECONDS[unit];
+    if (multiplier === undefined) return null;
+    total += value * multiplier;
+  }
+
+  return total;
+}
+
+// rebuilds a human-readable string (e.g. '1h 30m 20s') from total seconds
+function toHumanDuration(totalSeconds: number): string {
+  const units: Array<[string, number]> = [
+    ['w', 604800],
+    ['d', 86400],
+    ['h', 3600],
+    ['m', 60],
+    ['s', 1],
+  ];
+
+  const parts: string[] = [];
+  let remaining = totalSeconds;
+
+  for (const [label, secs] of units) {
+    if (remaining >= secs) {
+      const count = Math.floor(remaining / secs);
+      parts.push(`${count}${label}`);
+      remaining -= count * secs;
+    }
+  }
+
+  // include sub-second milliseconds when no whole seconds remain
+  if (remaining > 0) {
+    const ms = Math.round(remaining * 1000);
+    parts.push(`${ms}ms`);
+  }
+
+  return parts.join(' ') || '0s';
+}
+
+export const DurationParseBoxSource = {
+  defaultDisabled: true,
+  name: 'Parse Duration',
+  description:
+    'Parse a human duration like "1h30m" or "2d4h" into total seconds.',
+  defaultInput: '1h30m20s ::parseduration',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'parseduration', 'duration2s')) return [];
+
+    const cleaned = trim(input).slice(0, 100);
+    const totalSeconds = parseTotalSeconds(cleaned);
+    if (totalSeconds === null) return [];
+
+    const totalMs = totalSeconds * 1000;
+    const human = toHumanDuration(totalSeconds);
+
+    // format numbers without trailing zeros for clean display
+    const fmtSeconds = Number.isInteger(totalSeconds)
+      ? totalSeconds.toString()
+      : Number.parseFloat(totalSeconds.toFixed(6)).toString();
+
+    const fmtMs = Number.isInteger(totalMs)
+      ? totalMs.toString()
+      : Number.parseFloat(totalMs.toFixed(3)).toString();
+
+    const output: Record<string, string> = {
+      'Total Seconds': fmtSeconds,
+      'Total Milliseconds': fmtMs,
+      Human: human,
+    };
+
+    const content = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Parse Duration', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default DurationParseBoxSource;

--- a/src/modules/boxSources/__test__/DurationParseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DurationParseBoxSource.test.ts
@@ -1,0 +1,157 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { DurationParseBoxSource } from '../DurationParseBoxSource';
+
+describe('DurationParseBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes(
+        '1h30m20s',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is set', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::parseduration trigger', () => {
+    it('parses 1h30m20s to 5420 total seconds', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('5420');
+    });
+
+    it('parses 2d to 172800 total seconds', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('2d', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('172800');
+    });
+
+    it('parses 90m to 5400 total seconds', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('90m', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('5400');
+    });
+
+    it('parses 1.5h to 5400 total seconds', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1.5h', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('5400');
+    });
+
+    it('parses 500ms to 0.5 total seconds and 500 total milliseconds', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('500ms', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('0.5');
+      expect(boxes[0].props.options?.['Total Milliseconds']).toBe('500');
+    });
+
+    it('parses duration with spaces between segments (1h 30m)', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h 30m', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('5400');
+    });
+  });
+
+  describe('generateBoxes - ::duration2s trigger', () => {
+    it('also triggers on ::duration2s option key', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        duration2s: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Total Seconds']).toBe('5420');
+    });
+  });
+
+  describe('generateBoxes - garbage input', () => {
+    it('returns empty array for alphabetic garbage "abc"', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('abc', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unknown unit "1x"', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1x', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty string', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('', {
+        parseduration: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - output structure', () => {
+    it('box name is Parse Duration', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        parseduration: true,
+      });
+      expect(boxes[0].props.name).toBe('Parse Duration');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        parseduration: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('includes Total Milliseconds key for 1h30m20s', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        parseduration: true,
+      });
+      expect(boxes[0].props.options?.['Total Milliseconds']).toBe('5420000');
+    });
+
+    it('includes Human key with rebuilt duration for 1h30m20s', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h30m20s', {
+        parseduration: true,
+      });
+      expect(boxes[0].props.options?.Human).toBe('1h 30m 20s');
+    });
+
+    it('has correct priority', async () => {
+      const boxes = await DurationParseBoxSource.generateBoxes('1h', {
+        parseduration: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(DurationParseBoxSource.name).toBe('Parse Duration');
+      expect(DurationParseBoxSource.kind).toBe('Convert');
+      expect(typeof DurationParseBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -6,6 +6,7 @@ import ColorBoxSource from './ColorBoxSource';
 import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
+import DurationParseBoxSource from './DurationParseBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
@@ -50,5 +51,6 @@ export const boxSources = [
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
+  DurationParseBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Parse Duration (Convert)

Adds the `Parse Duration` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1h30m20s ::parseduration`

#### Options:
- `::duration2s`, `::parseduration`

#### Description:
Parse a human duration like "1h30m" or "2d4h" into total seconds.

#### Usage Examples:
- **Input**:
```
1h30m20s ::parseduration
```
- **Output Box (`Parse Duration`)**:
```
Total Seconds: 5420
Total Milliseconds: 5420000
Human: 1h 30m 20s
```
