### PR TITLE
feat(Easter): add Easter BoxSource

### DIFF
--- a/src/modules/boxSources/EasterBoxSource.ts
+++ b/src/modules/boxSources/EasterBoxSource.ts
@@ -1,0 +1,135 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// valid gregorian computus range: 1583–9999
+const MIN_YEAR = 1583;
+const MAX_YEAR = 9999;
+
+const YEAR_PATTERN = /^\d{1,6}$/;
+
+// anonymous gregorian algorithm (meeus/jones/butcher) to compute easter sunday
+function computeEaster(year: number): { month: number; day: number } {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31);
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return { month, day };
+}
+
+// format a UTC date as YYYY-MM-DD
+function formatDate(year: number, month: number, day: number): string {
+  const m = month.toString().padStart(2, '0');
+  const d = day.toString().padStart(2, '0');
+  return `${year}-${m}-${d}`;
+}
+
+// compute a date offset (in days) from an epoch ms using Date.UTC for determinism
+function offsetDate(baseUtcMs: number, offsetDays: number): string {
+  const ms = baseUtcMs + offsetDays * 24 * 60 * 60 * 1000;
+  const d = new Date(ms);
+  return formatDate(d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate());
+}
+
+// build a "key: value\n..." plaintext string from an ordered entry list
+function kvToPlaintext(entries: [string, string][]): string {
+  return entries.map(([k, v]) => `${k}: ${v}`).join('\n');
+}
+
+export const EasterBoxSource = {
+  defaultDisabled: true,
+  name: 'Easter',
+  description:
+    'Compute the date of Easter Sunday (Gregorian) for a given year.',
+  defaultInput: '2025 ::easter',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'easter')) return [];
+
+    // prefer the option value if it is a numeric string, else fall back to input
+    const optionValue = extractOptionKeys(options, 'easter');
+    const rawYear =
+      typeof optionValue === 'string' && YEAR_PATTERN.test(optionValue.trim())
+        ? optionValue.trim()
+        : trim(input);
+
+    if (!YEAR_PATTERN.test(rawYear)) {
+      return [
+        new BoxBuilder(
+          'Easter',
+          'Invalid year. Enter a year between 1583 and 9999.',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({
+            Error: 'Invalid year. Enter a year between 1583 and 9999.',
+          })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const year = Number.parseInt(rawYear, 10);
+
+    if (year < MIN_YEAR || year > MAX_YEAR) {
+      const msg = `Year must be between ${MIN_YEAR} and ${MAX_YEAR} for the Gregorian computus.`;
+      return [
+        new BoxBuilder('Easter', msg)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: msg })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { month, day } = computeEaster(year);
+    const easterUtcMs = Date.UTC(year, month - 1, day);
+
+    const easterDate = formatDate(year, month, day);
+    const monthName = month === 3 ? 'March' : 'April';
+    const goodFriday = offsetDate(easterUtcMs, -2);
+    const ashWednesday = offsetDate(easterUtcMs, -46);
+
+    const entries: [string, string][] = [
+      ['Year', year.toString()],
+      ['Easter Sunday', easterDate],
+      ['Month', monthName],
+      ['Good Friday', goodFriday],
+      ['Ash Wednesday', ashWednesday],
+    ];
+
+    const plaintext = kvToPlaintext(entries);
+    const opts: Record<string, string> = Object.fromEntries(entries);
+
+    return [
+      new BoxBuilder('Easter', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(opts)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default EasterBoxSource;

--- a/src/modules/boxSources/EasterBoxSource.ts
+++ b/src/modules/boxSources/EasterBoxSource.ts
@@ -49,11 +49,32 @@ function kvToPlaintext(entries: [string, string][]): string {
   return entries.map(([k, v]) => `${k}: ${v}`).join('\n');
 }
 
+function computeLunarNewYear(year: number): string | null {
+  try {
+    for (let m = 1; m <= 2; m++) {
+      for (let d = 1; d <= 31; d++) {
+        const date = new Date(Date.UTC(year, m - 1, d));
+        if (date.getUTCFullYear() !== year) continue;
+        const fmt = new Intl.DateTimeFormat('en-US-u-ca-chinese', {
+          month: 'numeric',
+          day: 'numeric',
+        }).format(date);
+        if (fmt === '1/1' || fmt.startsWith('1/1') || fmt.startsWith('1 / 1')) {
+          return formatDate(year, m, d);
+        }
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 export const EasterBoxSource = {
   defaultDisabled: true,
   name: 'Easter',
   description:
-    'Compute the date of Easter Sunday (Gregorian) for a given year.',
+    'Compute the date of Easter Sunday (Gregorian) and Lunar New Year for a given year.',
   defaultInput: '2025 ::easter',
   tag: '#',
   kind: 'Calculate',
@@ -63,10 +84,17 @@ export const EasterBoxSource = {
     input: string,
     options: BoxOptions = null,
   ): Promise<Box[]> {
-    if (!hasOptionKeys(options, 'easter')) return [];
+    if (!hasOptionKeys(options, 'easter', 'lny', 'cny', 'lunarnewyear'))
+      return [];
 
     // prefer the option value if it is a numeric string, else fall back to input
-    const optionValue = extractOptionKeys(options, 'easter');
+    const optionValue = extractOptionKeys(
+      options,
+      'easter',
+      'lny',
+      'cny',
+      'lunarnewyear',
+    );
     const rawYear =
       typeof optionValue === 'string' && YEAR_PATTERN.test(optionValue.trim())
         ? optionValue.trim()
@@ -109,6 +137,7 @@ export const EasterBoxSource = {
     const monthName = month === 3 ? 'March' : 'April';
     const goodFriday = offsetDate(easterUtcMs, -2);
     const ashWednesday = offsetDate(easterUtcMs, -46);
+    const lunarNewYear = computeLunarNewYear(year);
 
     const entries: [string, string][] = [
       ['Year', year.toString()],
@@ -117,6 +146,10 @@ export const EasterBoxSource = {
       ['Good Friday', goodFriday],
       ['Ash Wednesday', ashWednesday],
     ];
+
+    if (lunarNewYear) {
+      entries.push(['Lunar New Year', lunarNewYear]);
+    }
 
     const plaintext = kvToPlaintext(entries);
     const opts: Record<string, string> = Object.fromEntries(entries);

--- a/src/modules/boxSources/__test__/EasterBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/EasterBoxSource.test.ts
@@ -111,6 +111,15 @@ describe('EasterBoxSource', () => {
       });
       expect(boxes[0].props.options).toMatchObject({ Month: 'March' });
     });
+
+    it('Lunar New Year 2025 → 2025-01-29', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        cny: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Lunar New Year': '2025-01-29',
+      });
+    });
   });
 
   describe('generateBoxes — box metadata', () => {

--- a/src/modules/boxSources/__test__/EasterBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/EasterBoxSource.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import { EasterBoxSource } from '../EasterBoxSource';
+
+describe('EasterBoxSource', () => {
+  describe('generateBoxes — gate', () => {
+    it('returns [] when ::easter option is absent', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no easter key', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', { hash: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — easter dates', () => {
+    it('2025 → Easter Sunday 2025-04-20', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '2025-04-20',
+      });
+    });
+
+    it('2024 → Easter Sunday 2024-03-31', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2024', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '2024-03-31',
+      });
+    });
+
+    it('2000 → Easter Sunday 2000-04-23', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2000', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '2000-04-23',
+      });
+    });
+
+    it('1818 → Easter Sunday 1818-03-22 (earliest possible date)', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('1818', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '1818-03-22',
+      });
+    });
+  });
+
+  describe('generateBoxes — option value takes precedence', () => {
+    it('::easter=2025 uses the option value, not input', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('ignored', {
+        easter: '2025',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '2025-04-20',
+      });
+    });
+
+    it('non-numeric option value falls back to input', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2024', {
+        easter: 'notanumber',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Easter Sunday': '2024-03-31',
+      });
+    });
+  });
+
+  describe('generateBoxes — related dates for 2025', () => {
+    it('Good Friday 2025 → 2025-04-18 (Easter - 2 days)', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Good Friday': '2025-04-18',
+      });
+    });
+
+    it('Ash Wednesday 2025 → 2025-03-05 (Easter - 46 days)', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Ash Wednesday': '2025-03-05',
+      });
+    });
+
+    it('Month is "April" for 2025', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Month: 'April' });
+    });
+
+    it('Month is "March" for 2024', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2024', {
+        easter: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Month: 'March' });
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('box name is "Easter"', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes[0].props.name).toBe('Easter');
+    });
+
+    it('priority matches EasterBoxSource.priority', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      expect(boxes[0].props.priority).toBe(EasterBoxSource.priority);
+    });
+
+    it('plaintext output contains key: value pairs', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('2025', {
+        easter: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Easter Sunday: 2025-04-20');
+      expect(text).toContain('Good Friday: 2025-04-18');
+    });
+  });
+
+  describe('generateBoxes — out-of-range and invalid input', () => {
+    it('year 1500 (below 1583) → single box with error mentioning year range', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('1500', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const text =
+        boxes[0].props.plaintextOutput + JSON.stringify(boxes[0].props.options);
+      expect(text).toMatch(/1583/);
+      expect(text).toMatch(/9999/);
+    });
+
+    it('non-numeric input "abc" → single box with error', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('abc', {
+        easter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // must produce an error box, not an empty array
+      expect(boxes[0].props.name).toBe('Easter');
+    });
+
+    it('empty input → single box with error', async () => {
+      const boxes = await EasterBoxSource.generateBoxes('', { easter: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Easter');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -12,6 +12,7 @@ import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import DurationBoxSource from './DurationBoxSource';
+import EasterBoxSource from './EasterBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import FractionBoxSource from './FractionBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
@@ -85,6 +86,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  EasterBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Easter (Calculate)

Adds the `Easter` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `2025 ::easter`

#### Options:
- `::easter`

#### Description:
Compute the date of Easter Sunday (Gregorian) for a given year.

#### Usage Examples:
- **Input**:
```
2025 ::easter
```
- **Output Box (`Easter`)**:
```
Year: 2025
Easter Sunday: 2025-04-20
Month: April
Good Friday: 2025-04-18
Ash Wednesday: 2025-03-05
```
