### PR TITLE
feat(EnergyConvert): add Energy Convert BoxSource

### DIFF
--- a/src/modules/boxSources/EnergyConvertBoxSource.ts
+++ b/src/modules/boxSources/EnergyConvertBoxSource.ts
@@ -1,0 +1,129 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit -> joules conversion factors (SI exact where defined by convention)
+const TO_J: Record<string, number> = {
+  j: 1,
+  kj: 1000,
+  mj: 1e6,
+  cal: 4.184,
+  kcal: 4184,
+  wh: 3600,
+  kwh: 3.6e6,
+  btu: 1055.05585262,
+  ev: 1.602176634e-19,
+};
+
+// display labels in output order
+const OUTPUT_UNITS: Array<[string, string]> = [
+  ['J', 'j'],
+  ['kJ', 'kj'],
+  ['cal', 'cal'],
+  ['kcal', 'kcal'],
+  ['Wh', 'wh'],
+  ['kWh', 'kwh'],
+  ['BTU', 'btu'],
+  ['eV', 'ev'],
+];
+
+// format a joule-based result value for display:
+// - very large or very small non-zero values use exponential notation (6 decimal places)
+// - integers display without decimal point
+// - otherwise toFixed(6) with trailing zeros stripped
+function formatValue(n: number): string {
+  const abs = Math.abs(n);
+  if (n !== 0 && (abs >= 1e15 || abs < 1e-4)) {
+    return n.toExponential(6);
+  }
+  if (Number.isInteger(n)) {
+    return n.toString();
+  }
+  return n.toFixed(6).replace(/\.?0+$/, '');
+}
+
+// build plaintext k:v representation for headless consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+const SUPPORTED_UNITS = Object.keys(TO_J).join(', ');
+const INPUT_RE = /^(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\s*([a-zA-Z]+)$/;
+
+export const EnergyConvertBoxSource = {
+  defaultDisabled: true,
+  name: 'Energy Convert',
+  description: 'Convert energy between J, kJ, cal, kcal, Wh, kWh, BTU, and eV.',
+  defaultInput: '1 kWh ::energy',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'energy')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > 64) {
+      return [];
+    }
+
+    const match = INPUT_RE.exec(raw);
+    if (!match) {
+      const kv: Record<string, string> = {
+        Error: 'Invalid format. Use: <number> <unit>',
+        'Supported units': SUPPORTED_UNITS,
+      };
+      return [
+        new BoxBuilder('Energy Convert', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitKey = match[2].toLowerCase();
+
+    if (!(unitKey in TO_J)) {
+      const kv: Record<string, string> = {
+        Error: `Unknown unit: ${match[2]}`,
+        'Supported units': SUPPORTED_UNITS,
+      };
+      return [
+        new BoxBuilder('Energy Convert', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const joules = value * TO_J[unitKey];
+
+    const kv: Record<string, string> = {
+      Input: `${match[1]} ${match[2]}`,
+    };
+    for (const [label, key] of OUTPUT_UNITS) {
+      kv[label] = formatValue(joules / TO_J[key]);
+    }
+
+    return [
+      new BoxBuilder('Energy Convert', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default EnergyConvertBoxSource;

--- a/src/modules/boxSources/__test__/EnergyConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/EnergyConvertBoxSource.test.ts
@@ -1,0 +1,121 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { EnergyConvertBoxSource } from '../EnergyConvertBoxSource';
+
+describe('EnergyConvertBoxSource', () => {
+  describe('generateBoxes — no option key', () => {
+    it('returns [] when no options are provided', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 kWh', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when ::energy option is absent', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 kWh', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — 1 kWh', () => {
+    it('produces one box with correct energy conversions', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 kWh', {
+        energy: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options).not.toBeNull();
+      const kv = options as Record<string, string>;
+
+      expect(kv.Input).toBe('1 kWh');
+      // 1 kWh = 3 600 000 J exactly
+      expect(kv.J).toBe('3600000');
+      // 1 kWh = 3 600 kJ exactly
+      expect(kv.kJ).toBe('3600');
+      // 1 kWh = 1 000 Wh exactly
+      expect(kv.Wh).toBe('1000');
+      // 1 kWh = 3 600 000 / 4 184 kcal ≈ 860.420650
+      expect(Number.parseFloat(kv.kcal)).toBeCloseTo(860.42065, 3);
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 kWh', {
+        energy: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 kWh', {
+        energy: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes — 1 cal', () => {
+    it('converts 1 cal to J = 4.184', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 cal', {
+        energy: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.J).toBe('4.184');
+    });
+  });
+
+  describe('generateBoxes — 1000 cal', () => {
+    it('converts 1000 cal to exactly 1 kcal', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1000 cal', {
+        energy: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.kcal).toBe('1');
+    });
+  });
+
+  describe('generateBoxes — 1 BTU', () => {
+    it('converts 1 BTU to J ≈ 1055.055853', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 BTU', {
+        energy: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.J)).toBeCloseTo(1055.05585262, 5);
+    });
+  });
+
+  describe('generateBoxes — eV exponential notation', () => {
+    it('1 J → eV is ~6.241509e18 and uses exponential notation', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('1 J', {
+        energy: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      // value must be in exponential notation (contains 'e' or 'E')
+      expect(kv.eV).toMatch(/e/i);
+      // numeric value should be close to 1/1.602176634e-19
+      expect(Number.parseFloat(kv.eV)).toBeCloseTo(6.241509e18, 10);
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns an error box for bare text "abc"', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('abc', {
+        energy: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Supported units']).toBeTruthy();
+    });
+
+    it('returns an error box for unknown unit "5 foo"', async () => {
+      const boxes = await EnergyConvertBoxSource.generateBoxes('5 foo', {
+        energy: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Supported units']).toBeTruthy();
+      expect(kv.Error).toMatch(/foo/i);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,10 +1,6 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -12,6 +8,7 @@ import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import DurationBoxSource from './DurationBoxSource';
+import EnergyConvertBoxSource from './EnergyConvertBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import FractionBoxSource from './FractionBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  EnergyConvertBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Energy Convert (Convert)

Adds the `Energy Convert` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1 kWh ::energy`

#### Options:
- `::energy`

#### Description:
Convert energy between J, kJ, cal, kcal, Wh, kWh, BTU, and eV.

#### Usage Examples:
- **Input**:
```
1 kWh ::energy
```
- **Output Box (`Energy Convert`)**:
```
Input: 1 kWh
J: 3600000
kJ: 3600
cal: 860420.650096
kcal: 860.42065
Wh: 1000
kWh: 1
BTU: 3412.141633
eV: 2.246943e+25
```
