### PR TITLE
feat(ExcelColumn): add Spreadsheet Column BoxSource

### DIFF
--- a/src/modules/boxSources/ExcelColumnBoxSource.ts
+++ b/src/modules/boxSources/ExcelColumnBoxSource.ts
@@ -1,0 +1,116 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max column number supported (roughly 3-letter ZZZ = 18278; allow generous cap)
+const MAX_COL_NUMBER = 1_000_000_000;
+// 11 'Z's = 3.8e15 < Number.MAX_SAFE_INTEGER (9e15); 12+ would overflow to an
+// imprecise float and stop round-tripping, so cap the letter length here
+const MAX_COL_LETTERS_LEN = 11;
+
+// bijective base-26: A=1 … Z=26, AA=27, AB=28, ZZ=702, AAA=703
+function lettersToNumber(letters: string): number {
+  const upper = letters.toUpperCase();
+  let num = 0;
+  for (let i = 0; i < upper.length; i++) {
+    num = num * 26 + (upper.charCodeAt(i) - 64);
+  }
+  return num;
+}
+
+// inverse of bijective base-26
+function numberToLetters(n: number): string {
+  let result = '';
+  let remaining = n;
+  while (remaining > 0) {
+    const rem = (remaining - 1) % 26;
+    result = String.fromCharCode(65 + rem) + result;
+    remaining = Math.floor((remaining - 1) / 26);
+  }
+  return result;
+}
+
+// build plaintext output "Column: AB\nNumber: 28" for kvToPlaintext
+function kvToPlaintext(column: string, number: number): string {
+  return `Column: ${column}\nNumber: ${number}`;
+}
+
+export const ExcelColumnBoxSource = {
+  defaultDisabled: true,
+  name: 'Spreadsheet Column',
+  description:
+    'Convert a spreadsheet column letter to its number and back (A=1, AA=27).',
+  defaultInput: 'AB ::excelcol',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'excelcol', 'spreadsheetcol')) return [];
+
+    const trimmed = trim(input);
+
+    if (/^[A-Za-z]+$/.test(trimmed)) {
+      // guard against absurdly long letter strings
+      if (trimmed.length > MAX_COL_LETTERS_LEN) return [];
+
+      const column = trimmed.toUpperCase();
+      const number = lettersToNumber(column);
+      return [
+        new BoxBuilder('Spreadsheet Column', kvToPlaintext(column, number))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Column: column, Number: String(number) })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (/^\d+$/.test(trimmed)) {
+      const n = Number.parseInt(trimmed, 10);
+      if (n < 1 || n > MAX_COL_NUMBER) {
+        return [
+          new BoxBuilder(
+            'Spreadsheet Column',
+            'Number out of range (must be 1 – 1,000,000,000).',
+          )
+            .setTemplate(KeyValueBoxTemplate)
+            .setOptions({
+              Column: '',
+              Number: 'out of range',
+            })
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      const column = numberToLetters(n);
+      return [
+        new BoxBuilder('Spreadsheet Column', kvToPlaintext(column, n))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Column: column, Number: String(n) })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // mixed or unrecognised input — return an explanatory box
+    return [
+      new BoxBuilder(
+        'Spreadsheet Column',
+        'Enter column letters (e.g. AB) or a column number.',
+      )
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions({ Column: '', Number: '' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ExcelColumnBoxSource;

--- a/src/modules/boxSources/__test__/ExcelColumnBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ExcelColumnBoxSource.test.ts
@@ -1,0 +1,207 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ExcelColumnBoxSource } from '../ExcelColumnBoxSource';
+
+describe('ExcelColumnBoxSource', () => {
+  describe('no option → empty array', () => {
+    it('returns [] when options is null', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when no matching option key is present', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('letters → number (bijective base-26)', () => {
+    it('A → 1', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('A', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Number).toBe('1');
+      expect(boxes[0].props.options?.Column).toBe('A');
+    });
+
+    it('Z → 26', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('Z', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('26');
+    });
+
+    // AB = 1*26 + 2 = 28
+    it('AB → 28', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Number).toBe('28');
+      expect(boxes[0].props.options?.Column).toBe('AB');
+    });
+
+    // AA = 1*26 + 1 = 27
+    it('AA → 27', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AA', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('27');
+    });
+
+    // ZZ = 26*26 + 26 = 702
+    it('ZZ → 702', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('ZZ', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('702');
+    });
+
+    // AAA = 26^2 + 26 + 1 = 703
+    it('AAA → 703', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AAA', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('703');
+    });
+
+    // Excel's last column XFD → 16384
+    it('XFD → 16384 (Excel max column)', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('XFD', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('16384');
+    });
+
+    it('lowercase ab is treated case-insensitively → 28', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('ab', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Number).toBe('28');
+      // column is always uppercased in output
+      expect(boxes[0].props.options?.Column).toBe('AB');
+    });
+  });
+
+  describe('number → letters (reverse lookup)', () => {
+    it('28 → AB', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('28', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Column).toBe('AB');
+      expect(boxes[0].props.options?.Number).toBe('28');
+    });
+
+    it('1 → A', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('1', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Column).toBe('A');
+    });
+
+    it('27 → AA', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('27', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Column).toBe('AA');
+    });
+
+    it('702 → ZZ', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('702', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Column).toBe('ZZ');
+    });
+
+    it('16384 → XFD', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('16384', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.options?.Column).toBe('XFD');
+    });
+  });
+
+  describe('round-trip AB → 28 → AB', () => {
+    it('letters→number→letters stays consistent', async () => {
+      const fwd = await ExcelColumnBoxSource.generateBoxes('AB', {
+        excelcol: true,
+      });
+      const num = fwd[0].props.options?.Number as string;
+      const rev = await ExcelColumnBoxSource.generateBoxes(num, {
+        excelcol: true,
+      });
+      expect(rev[0].props.options?.Column).toBe('AB');
+    });
+  });
+
+  describe('alternate option key ::spreadsheetcol', () => {
+    it('accepts spreadsheetcol option', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        spreadsheetcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Number).toBe('28');
+    });
+  });
+
+  describe('invalid / mixed inputs → explanatory box', () => {
+    it('A1 (mixed) returns explanatory box, not empty', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('A1', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/enter column/i);
+    });
+
+    it('"hello world" (space) returns explanatory box', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('hello world', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/enter column/i);
+    });
+
+    it('0 returns out-of-range box', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('0', {
+        excelcol: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Number).toBe('out of range');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        excelcol: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is Spreadsheet Column', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.name).toBe('Spreadsheet Column');
+    });
+
+    it('priority is set', async () => {
+      const boxes = await ExcelColumnBoxSource.generateBoxes('AB', {
+        excelcol: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('source metadata', () => {
+      expect(ExcelColumnBoxSource.name).toBe('Spreadsheet Column');
+      expect(ExcelColumnBoxSource.tag).toBe('#');
+      expect(ExcelColumnBoxSource.kind).toBe('Convert');
+      expect(ExcelColumnBoxSource.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -13,6 +13,7 @@ import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import ExcelColumnBoxSource from './ExcelColumnBoxSource';
 import FractionBoxSource from './FractionBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  ExcelColumnBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Spreadsheet Column (Convert)

Adds the `Spreadsheet Column` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `AB ::excelcol`

#### Options:
- `::excelcol`, `::spreadsheetcol`

#### Description:
Convert a spreadsheet column letter to its number and back (A=1, AA=27).

#### Usage Examples:
- **Input**:
```
AB ::excelcol
```
- **Output Box (`Spreadsheet Column`)**:
```
Column: AB
Number: 28
```
