### PR TITLE
feat(Factorial): add Factorial BoxSource

### DIFF
--- a/src/modules/boxSources/FactorialBoxSource.ts
+++ b/src/modules/boxSources/FactorialBoxSource.ts
@@ -1,0 +1,116 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// cap to bound the O(n) bigint product and the output string size
+// cap at 20000: 20000! is ~77k digits and computes in ~25ms; 100000! blocks
+// the main thread for ~1.7s (O(n) bigint mults on a growing product)
+const MAX_N = 20_000;
+
+// threshold above which we abbreviate the full decimal expansion
+const FULL_DISPLAY_THRESHOLD = 2000;
+
+// build plaintext k:v representation for headless consumers
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// compute n! exactly using BigInt
+function factorial(n: number): bigint {
+  let result = 1n;
+  for (let i = 2n; i <= BigInt(n); i++) {
+    result *= i;
+  }
+  return result;
+}
+
+export const FactorialBoxSource = {
+  defaultDisabled: true,
+  name: 'Factorial',
+  description:
+    'Compute n! exactly for a non-negative integer. ::factorial=<n> or "<n> ::factorial".',
+  defaultInput: '20 ::factorial',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'factorial')) return [];
+
+    // prefer the option value if it carries a numeric string; else fall back to trimmed input
+    const optionVal = extractOptionKeys(options, 'factorial');
+    const raw =
+      typeof optionVal === 'string' && /^\d+$/.test(optionVal)
+        ? optionVal
+        : trim(input);
+
+    if (!/^\d+$/.test(raw)) {
+      const kv: Record<string, string> = {
+        Error: 'n must be a non-negative integer (digits only)',
+        Hint: `Use ::factorial=<n> or "<n> ::factorial" where n <= ${MAX_N}`,
+      };
+      return [
+        new BoxBuilder('Factorial', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const n = Number.parseInt(raw, 10);
+
+    if (n > MAX_N) {
+      const kv: Record<string, string> = {
+        Error: `n must be <= ${MAX_N} (got ${n})`,
+      };
+      return [
+        new BoxBuilder('Factorial', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const result = factorial(n);
+    const resultStr = result.toString();
+    const digits = resultStr.length;
+
+    const kv: Record<string, string> = {
+      n: n.toString(),
+    };
+
+    if (n <= FULL_DISPLAY_THRESHOLD) {
+      kv['n!'] = resultStr;
+    } else {
+      kv['n!'] = 'too long to display in full';
+      // scientific approximation: first digit + exponent
+      const firstDigit = resultStr[0];
+      const exp = digits - 1;
+      kv.Approx = `${firstDigit}.???e+${exp}`;
+      kv['First 20'] = resultStr.slice(0, 20);
+      kv['Last 20'] = resultStr.slice(-20);
+    }
+
+    kv.Digits = digits.toString();
+
+    return [
+      new BoxBuilder('Factorial', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FactorialBoxSource;

--- a/src/modules/boxSources/__test__/FactorialBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FactorialBoxSource.test.ts
@@ -1,0 +1,167 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { FactorialBoxSource } from '../FactorialBoxSource';
+
+describe('FactorialBoxSource', () => {
+  describe('generateBoxes — no option key', () => {
+    it('returns [] when options are null', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when ::factorial option is absent', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — option value carries n (::factorial=<n>)', () => {
+    it('computes 10! = 3628800 from option value', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('', {
+        factorial: '10',
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.n).toBe('10');
+      expect(kv['n!']).toBe('3628800');
+    });
+
+    it('ignores input when option value is numeric', async () => {
+      // option value '10' takes precedence over input 'abc'
+      const boxes = await FactorialBoxSource.generateBoxes('abc', {
+        factorial: '10',
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['n!']).toBe('3628800');
+    });
+  });
+
+  describe('generateBoxes — n from input (::factorial flag)', () => {
+    it('computes 5! = 120', async () => {
+      // verified: 5! = 120
+      const boxes = await FactorialBoxSource.generateBoxes('5', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.n).toBe('5');
+      expect(kv['n!']).toBe('120');
+      expect(kv.Digits).toBe('3');
+    });
+
+    it('computes 0! = 1', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('0', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['n!']).toBe('1');
+    });
+
+    it('computes 1! = 1', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('1', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['n!']).toBe('1');
+    });
+
+    it('computes 20! = 2432902008176640000', async () => {
+      // verified: 20! = 2432902008176640000
+      const boxes = await FactorialBoxSource.generateBoxes('20', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.n).toBe('20');
+      expect(kv['n!']).toBe('2432902008176640000');
+    });
+
+    it('computes 100! and reports 158 digits', async () => {
+      // verified: 100! has exactly 158 decimal digits
+      const boxes = await FactorialBoxSource.generateBoxes('100', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Digits).toBe('158');
+      // 100 <= 2000 so full value is shown
+      expect(kv['n!']).not.toBe('too long to display in full');
+      expect(kv['n!'].length).toBe(158);
+    });
+  });
+
+  describe('generateBoxes — large n (n > 2000)', () => {
+    it('abbreviates 5000! and provides First 20 / Last 20 / Digits', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5000', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['n!']).toBe('too long to display in full');
+      // verified: 5000! has 16326 digits
+      expect(kv.Digits).toBe('16326');
+      expect(kv['First 20']).toHaveLength(20);
+      expect(kv['Last 20']).toHaveLength(20);
+      // last 20 digits of 5000! must end in many zeros
+      expect(kv['Last 20']).toMatch(/0+$/);
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns error box for non-integer input "abc"', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('abc', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+
+    it('returns error box when n exceeds MAX_N (200000)', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('200000', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toMatch(/20000/);
+    });
+
+    it('returns error box for negative-like input "-5" (non-digit chars)', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('-5', {
+        factorial: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5', {
+        factorial: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5', {
+        factorial: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('sets box name to "Factorial"', async () => {
+      const boxes = await FactorialBoxSource.generateBoxes('5', {
+        factorial: true,
+      });
+      expect(boxes[0].props.name).toBe('Factorial');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,10 +1,6 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -13,6 +9,7 @@ import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FactorialBoxSource from './FactorialBoxSource';
 import FractionBoxSource from './FractionBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -82,6 +79,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  FactorialBoxSource,
   FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,


### PR DESCRIPTION
### Box Source: Factorial (Calculate)

Adds the `Factorial` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `20 ::factorial`

#### Options:
- `::factorial`

#### Description:
Compute n! exactly for a non-negative integer. ::factorial=<n> or "<n> ::factorial".

#### Usage Examples:
- **Input**:
```
20 ::factorial
```
- **Output Box (`Factorial`)**:
```
n: 20
n!: 2432902008176640000
Digits: 19
```
