### PR TITLE
feat(Fletcher16): add Fletcher-16 BoxSource

### DIFF
--- a/src/modules/boxSources/Fletcher16BoxSource.ts
+++ b/src/modules/boxSources/Fletcher16BoxSource.ts
@@ -1,0 +1,70 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// fletcher-16 over utf-8 bytes; returns (sum2 << 8) | sum1
+function computeFletcher16(input: string): {
+  checksum: number;
+  sum1: number;
+  sum2: number;
+} {
+  const bytes = new TextEncoder().encode(input);
+  let sum1 = 0;
+  let sum2 = 0;
+  for (const b of bytes) {
+    sum1 = (sum1 + b) % 255;
+    sum2 = (sum2 + sum1) % 255;
+  }
+  return { checksum: (sum2 << 8) | sum1, sum1, sum2 };
+}
+
+export const Fletcher16BoxSource = {
+  defaultDisabled: true,
+  name: 'Fletcher-16',
+  description: 'Compute the Fletcher-16 checksum of the input text.',
+  defaultInput: 'abcde ::fletcher16',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'fletcher16', 'fletcher')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const { checksum, sum1, sum2 } = computeFletcher16(input);
+    const hex = `0x${checksum.toString(16).padStart(4, '0')}`;
+
+    const kvOptions: Record<string, string> = {
+      Checksum: checksum.toString(),
+      Hex: hex,
+      Sum1: sum1.toString(),
+      Sum2: sum2.toString(),
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Fletcher-16', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Fletcher16BoxSource;

--- a/src/modules/boxSources/__test__/Fletcher16BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Fletcher16BoxSource.test.ts
@@ -1,0 +1,130 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Fletcher16BoxSource } from '../Fletcher16BoxSource';
+
+describe('Fletcher16BoxSource', () => {
+  describe('generateBoxes - guard conditions', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('', {
+        fletcher16: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('   ', {
+        fletcher16: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - canonical Fletcher-16 vectors', () => {
+    it('"abcde" produces checksum 51440 / 0xc8f0', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Checksum: '51440',
+        Hex: '0xc8f0',
+      });
+    });
+
+    it('"abcdef" produces checksum 8279 / 0x2057', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcdef', {
+        fletcher16: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Checksum: '8279',
+        Hex: '0x2057',
+      });
+    });
+
+    it('"abcdefgh" produces checksum 1575 / 0x0627', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcdefgh', {
+        fletcher16: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Checksum: '1575',
+        Hex: '0x0627',
+      });
+    });
+  });
+
+  describe('generateBoxes - box shape', () => {
+    it('box name is "Fletcher-16"', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      expect(boxes[0].props.name).toBe('Fletcher-16');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('options include Sum1 and Sum2 keys', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts).toHaveProperty('Sum1');
+      expect(opts).toHaveProperty('Sum2');
+    });
+
+    it('plaintext output contains k:v lines', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      const text = boxes[0].props.plaintextOutput as string;
+      expect(text).toContain('Checksum: 51440');
+      expect(text).toContain('Hex: 0xc8f0');
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher16: true,
+      });
+      expect(boxes[0].props.priority).toBe(Fletcher16BoxSource.priority);
+    });
+  });
+
+  describe('generateBoxes - ::fletcher alias', () => {
+    it('::fletcher option triggers the box', async () => {
+      const boxes = await Fletcher16BoxSource.generateBoxes('abcde', {
+        fletcher: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Checksum: '51440',
+        Hex: '0xc8f0',
+      });
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Fletcher16BoxSource.name).toBe('Fletcher-16');
+      expect(Fletcher16BoxSource.tag).toBe('#');
+      expect(Fletcher16BoxSource.kind).toBe('Encode');
+      expect(typeof Fletcher16BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -13,6 +13,7 @@ import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import DurationBoxSource from './DurationBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import Fletcher16BoxSource from './Fletcher16BoxSource';
 import FractionBoxSource from './FractionBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  Fletcher16BoxSource,
 ];


### PR DESCRIPTION
### Box Source: Fletcher-16 (Encode)

Adds the `Fletcher-16` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `abcde ::fletcher16`

#### Options:
- `::fletcher`, `::fletcher16`

#### Description:
Compute the Fletcher-16 checksum of the input text.

#### Usage Examples:
- **Input**:
```
abcde ::fletcher16
```
- **Output Box (`Fletcher-16`)**:
```
Checksum: 51440
Hex: 0xc8f0
Sum1: 240
Sum2: 200
```
