### PR TITLE
feat(Fraction): add Fraction BoxSource

### DIFF
--- a/src/modules/boxSources/FractionBoxSource.ts
+++ b/src/modules/boxSources/FractionBoxSource.ts
@@ -1,0 +1,176 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// euclid gcd for non-negative bigints
+function gcd(a: bigint, b: bigint): bigint {
+  while (b !== 0n) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+interface FractionResult {
+  numerator: bigint;
+  denominator: bigint;
+}
+
+// reduces a fraction to lowest terms; denominator is always positive
+function reduce(num: bigint, den: bigint): FractionResult {
+  if (den < 0n) {
+    num = -num;
+    den = -den;
+  }
+  const g = gcd(num < 0n ? -num : num, den);
+  return { numerator: num / g, denominator: den / g };
+}
+
+// formats a fraction string, e.g. '3/4' or '-1/2'
+function fractionStr(num: bigint, den: bigint): string {
+  if (den === 1n) return `${num}`;
+  return `${num}/${den}`;
+}
+
+// formats mixed number, e.g. '1 1/4' for 5/4; returns undefined if |num| < den
+function mixedStr(num: bigint, den: bigint): string | null {
+  const absNum = num < 0n ? -num : num;
+  if (absNum <= den) return null;
+  const whole = num / den;
+  const rem = num < 0n ? -(-num % den) : num % den;
+  if (rem === 0n) return `${whole}`;
+  return `${whole} ${rem < 0n ? -rem : rem}/${den}`;
+}
+
+// builds the plaintext kv string for KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// max input length to prevent abuse
+const MAX_INPUT_LENGTH = 64;
+
+const FRACTION_RE = /^(-?\d+)\s*\/\s*(\d+)$/;
+const DECIMAL_RE = /^-?\d+(\.\d+)?$/;
+
+export const FractionBoxSource = {
+  defaultDisabled: true,
+  name: 'Fraction',
+  description:
+    'Convert a decimal to a simplified fraction, or a fraction (a/b) to a decimal.',
+  defaultInput: '0.75 ::fraction',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'fraction', 'tofraction')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT_LENGTH) return [];
+
+    // fraction a/b → decimal
+    const fracMatch = FRACTION_RE.exec(raw);
+    if (fracMatch) {
+      const num = BigInt(fracMatch[1]);
+      const den = BigInt(fracMatch[2]);
+
+      if (den === 0n) {
+        const kv = { Error: 'denominator cannot be zero' };
+        return [
+          new BoxBuilder('Fraction', kvToPlaintext(kv))
+            .setTemplate(KeyValueBoxTemplate)
+            .setOptions(kv)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      const { numerator: sNum, denominator: sDen } = reduce(num, den);
+      const simplified = fractionStr(sNum, sDen);
+
+      // compute decimal — use Number since we need a floating-point result
+      const decimalVal = Number(num) / Number(den);
+      // show up to 6 significant decimal places, trim trailing zeros
+      const decimalStr = Number.isInteger(decimalVal)
+        ? String(decimalVal)
+        : decimalVal.toFixed(6).replace(/\.?0+$/, '');
+
+      const kv: Record<string, string> = {
+        Fraction: simplified,
+        Decimal: decimalStr,
+      };
+      return [
+        new BoxBuilder('Fraction', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // decimal → fraction
+    const decMatch = DECIMAL_RE.exec(raw);
+    if (decMatch) {
+      const dotIndex = raw.indexOf('.');
+      const decimalPlaces = dotIndex === -1 ? 0 : raw.length - dotIndex - 1;
+
+      const denominator = 10n ** BigInt(decimalPlaces);
+      // parse the number as an integer by removing the dot
+      const intStr = raw.replace('.', '');
+      const numerator = BigInt(intStr);
+
+      const { numerator: sNum, denominator: sDen } = reduce(
+        numerator,
+        denominator,
+      );
+      const fracResult = fractionStr(sNum, sDen);
+      const mixed = mixedStr(sNum, sDen);
+
+      // recompute the decimal for display
+      const decimalVal = Number.parseFloat(raw);
+      const decimalStr = Number.isInteger(decimalVal)
+        ? String(decimalVal)
+        : raw;
+
+      const kv: Record<string, string> = {
+        Decimal: decimalStr,
+        Fraction: fracResult,
+      };
+      if (mixed !== null) {
+        kv.Mixed = mixed;
+      }
+
+      return [
+        new BoxBuilder('Fraction', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // unrecognized format — show usage hint
+    const kv = {
+      Usage: 'Enter a decimal like 0.75 or a fraction like 3/4',
+    };
+    return [
+      new BoxBuilder('Fraction', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FractionBoxSource;

--- a/src/modules/boxSources/__test__/FractionBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FractionBoxSource.test.ts
@@ -1,0 +1,164 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { FractionBoxSource } from '../FractionBoxSource';
+
+describe('FractionBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no option is provided', async () => {
+      const boxes = await FractionBoxSource.generateBoxes('0.75', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await FractionBoxSource.generateBoxes('0.75', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('decimal → fraction', () => {
+      it('converts 0.75 to 3/4', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.75', {
+          fraction: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.name).toBe('Fraction');
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+        expect(boxes[0].props.options?.Fraction).toBe('3/4');
+        expect(boxes[0].props.options?.Decimal).toBe('0.75');
+      });
+
+      it('converts 0.5 to 1/2', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.5', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('1/2');
+      });
+
+      it('converts 0.333 exactly to 333/1000 (not 1/3)', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.333', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('333/1000');
+      });
+
+      it('converts 0.1 to 1/10', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.1', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('1/10');
+      });
+
+      it('converts 1.25 to 5/4 with mixed 1 1/4', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('1.25', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('5/4');
+        expect(boxes[0].props.options?.Mixed).toBe('1 1/4');
+      });
+
+      it('converts integer 2 to 2 (denominator 1 collapses)', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('2', {
+          fraction: true,
+        });
+        // 2/1 simplifies — denominator 1 means we just show the number
+        expect(boxes[0].props.options?.Fraction).toBe('2');
+      });
+
+      it('converts 0 to 0', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('0');
+      });
+
+      it('converts negative -0.5 to -1/2', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('-0.5', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('-1/2');
+      });
+
+      it('works with ::tofraction option key', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.75', {
+          tofraction: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Fraction).toBe('3/4');
+      });
+
+      it('does not include Mixed key when fraction is proper (< 1)', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.75', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Mixed).toBeUndefined();
+      });
+    });
+
+    describe('fraction a/b → decimal', () => {
+      it('converts 3/4 to decimal 0.75', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('3/4', {
+          fraction: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Fraction).toBe('3/4');
+        expect(boxes[0].props.options?.Decimal).toBe('0.75');
+      });
+
+      it('simplifies 6/8 to 3/4 and decimal 0.75', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('6/8', {
+          fraction: true,
+        });
+        expect(boxes[0].props.options?.Fraction).toBe('3/4');
+        expect(boxes[0].props.options?.Decimal).toBe('0.75');
+      });
+
+      it('converts 1/3 to a rounded decimal', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('1/3', {
+          fraction: true,
+        });
+        const decimal = boxes[0].props.options?.Decimal;
+        expect(decimal).toBeDefined();
+        // should start with 0.333
+        expect(String(decimal)).toMatch(/^0\.333/);
+      });
+
+      it('returns error box for division by zero (5/0)', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('5/0', {
+          fraction: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Error).toBeDefined();
+      });
+    });
+
+    describe('invalid / unknown input', () => {
+      it('returns a usage hint box for unrecognized input', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('hello', {
+          fraction: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Usage).toBeDefined();
+      });
+    });
+
+    describe('box metadata', () => {
+      it('sets priority correctly', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.75', {
+          fraction: true,
+        });
+        expect(boxes[0].props.priority).toBe(10);
+      });
+
+      it('sets plaintextOutput as k:v lines', async () => {
+        const boxes = await FractionBoxSource.generateBoxes('0.75', {
+          fraction: true,
+        });
+        const text = boxes[0].props.plaintextOutput;
+        expect(text).toContain('Decimal: 0.75');
+        expect(text).toContain('Fraction: 3/4');
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -12,6 +12,7 @@ import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FractionBoxSource from './FractionBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
@@ -76,6 +77,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  FractionBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,


### PR DESCRIPTION
### Box Source: Fraction (Convert)

Adds the `Fraction` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `0.75 ::fraction`

#### Options:
- `::fraction`, `::tofraction`

#### Description:
Convert a decimal to a simplified fraction, or a fraction (a/b) to a decimal.

#### Usage Examples:
- **Input**:
```
0.75 ::fraction
```
- **Output Box (`Fraction`)**:
```
Decimal: 0.75
Fraction: 3/4
```
