### PR TITLE
feat(Frequency): add Frequency BoxSource

### DIFF
--- a/src/modules/boxSources/FrequencyBoxSource.ts
+++ b/src/modules/boxSources/FrequencyBoxSource.ts
@@ -1,0 +1,78 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+const MAX_ROWS = 200;
+
+// counts non-whitespace characters by code point, returns entries sorted by
+// count descending then by codepoint ascending for stable tie-breaking
+function computeFrequency(input: string): [string, number][] {
+  const counts = new Map<string, number>();
+  for (const char of input) {
+    // skip whitespace (space, tab, newline, carriage return, etc.)
+    if (/\s/u.test(char)) continue;
+    counts.set(char, (counts.get(char) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort(([aChar, aCount], [bChar, bCount]) => {
+    if (bCount !== aCount) return bCount - aCount;
+    return (aChar.codePointAt(0) ?? 0) - (bChar.codePointAt(0) ?? 0);
+  });
+}
+
+function buildTable(entries: [string, number][], total: number): string {
+  const truncated = entries.length > MAX_ROWS;
+  const rows = truncated ? entries.slice(0, MAX_ROWS) : entries;
+
+  const lines = rows.map(([char, count]) => {
+    const percent = ((count / total) * 100).toFixed(1);
+    return `${char}  ${count}  ${percent}%`;
+  });
+
+  if (truncated) {
+    lines.push(`... (truncated to ${MAX_ROWS} rows)`);
+  }
+
+  return lines.join('\n');
+}
+
+export const FrequencyBoxSource = {
+  defaultDisabled: true,
+  name: 'Frequency',
+  description: 'Count character frequencies in the input, sorted by count.',
+  defaultInput: 'hello world ::freq',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'freq', 'frequency')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const entries = computeFrequency(input);
+    if (entries.length === 0) return [];
+
+    const total = entries.reduce((sum, [, count]) => sum + count, 0);
+    const output = buildTable(entries, total);
+
+    return [
+      new BoxBuilder('Frequency', output)
+        .setTemplate(CodeBoxTemplate)
+        .setShowExpandButton(true)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FrequencyBoxSource;

--- a/src/modules/boxSources/__test__/FrequencyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FrequencyBoxSource.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import { FrequencyBoxSource } from '../FrequencyBoxSource';
+
+describe('FrequencyBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('hello', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty / whitespace input', () => {
+    it('returns empty array for empty string', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('', { freq: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('   \t\n', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::freq trigger', () => {
+    it("counts 'l' twice in 'hello' and places it first", async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('hello', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const firstLine = boxes[0].props.plaintextOutput.split('\n')[0];
+      expect(firstLine).toMatch(/^l/);
+      expect(firstLine).toContain('2');
+    });
+
+    it("counts 'a' three times and 'b' once in 'aaab'", async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('aaab', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines[0]).toMatch(/^a/);
+      expect(lines[0]).toContain('3');
+      expect(lines[1]).toMatch(/^b/);
+      expect(lines[1]).toContain('1');
+    });
+  });
+
+  describe('generateBoxes - ::frequency trigger', () => {
+    it('also triggers on ::frequency option key', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('abc', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes - whitespace exclusion', () => {
+    it("counts 'a' as 2 and excludes the space in 'a a'", async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('a a', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      // only one unique non-whitespace char
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatch(/^a/);
+      expect(lines[0]).toContain('2');
+    });
+  });
+
+  describe('generateBoxes - astral / multi-codepoint characters', () => {
+    it("counts '😀' as one character per occurrence", async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('😀😀', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatch(/^😀/);
+      expect(lines[0]).toContain('2');
+    });
+  });
+
+  describe('generateBoxes - output format', () => {
+    it('includes percent in each row', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('aa', {
+        freq: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('100.0%');
+    });
+
+    it('box name is Frequency', async () => {
+      const boxes = await FrequencyBoxSource.generateBoxes('x', { freq: true });
+      expect(boxes[0].props.name).toBe('Frequency');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(FrequencyBoxSource.name).toBe('Frequency');
+      expect(FrequencyBoxSource.tag).toBe('#');
+      expect(FrequencyBoxSource.kind).toBe('Analyze');
+      expect(typeof FrequencyBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -12,6 +12,7 @@ import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FrequencyBoxSource from './FrequencyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
@@ -75,6 +76,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
   SemverBoxSource,


### PR DESCRIPTION
### Box Source: Frequency (Analyze)

Adds the `Frequency` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `hello world ::freq`

#### Options:
- `::freq`, `::frequency`

#### Description:
Count character frequencies in the input, sorted by count.

#### Usage Examples:
- **Input**:
```
hello world ::freq
```
- **Output Box (`Frequency`)**:
```
l  3  30.0%
o  2  20.0%
d  1  10.0%
e  1  10.0%
h  1  10.0%
r  1  10.0%
w  1  10.0%
```
