### PR TITLE
feat(FrequencyConvert): add Frequency Convert BoxSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev-debug.log
 *.sln
 *.sw?
 # OS specific
+.gemini/

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: box.defaultDisabled ? false : true,
+        enabled: !box.defaultDisabled,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: box.defaultDisabled ? false : true,
+            enabled: !box.defaultDisabled,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: true,
+        enabled: box.defaultDisabled ? false : true,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: true,
+            enabled: box.defaultDisabled ? false : true,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/modules/BoxSource.ts
+++ b/src/modules/BoxSource.ts
@@ -9,5 +9,6 @@ export interface BoxSource {
   tag: string;
   kind: string;
   priority?: number;
+  defaultDisabled?: boolean;
   generateBoxes: (input: string, options: BoxOptions) => Promise<Box[]>;
 }

--- a/src/modules/boxSources/FrequencyConvertBoxSource.ts
+++ b/src/modules/boxSources/FrequencyConvertBoxSource.ts
@@ -1,0 +1,126 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit (normalized) -> hertz
+const TO_HZ: Record<string, number> = {
+  hz: 1,
+  khz: 1e3,
+  mhz: 1e6,
+  ghz: 1e9,
+  thz: 1e12,
+};
+
+const BOX_NAME = 'Frequency Convert';
+
+const FORMAT_ERROR_MSG =
+  'Invalid input. Expected format: <number> <unit>\n' +
+  'Supported units: Hz, kHz, MHz, GHz, THz\n' +
+  'Example: 2.4 GHz';
+
+/** renders key-value record as plaintext for headless consumers */
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+/**
+ * formats a frequency/period number with integer-exact display when possible,
+ * 6-decimal fixed notation for normal ranges, or exponential for extremes.
+ */
+function fmtNum(n: number): string {
+  if (n === 0) return '0';
+  const abs = Math.abs(n);
+  if (abs >= 1e15 || abs < 1e-4) {
+    return n.toExponential(6);
+  }
+  // use integer if it rounds exactly
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(6).replace(/\.?0+$/, '');
+}
+
+export const FrequencyConvertBoxSource = {
+  defaultDisabled: true,
+  name: 'Frequency Convert',
+  description:
+    'Convert a frequency between Hz, kHz, MHz, GHz, THz and its period.',
+  defaultInput: '2.4 GHz ::frequency',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'frequency', 'freq')) return [];
+
+    const raw = trim(input);
+    if (raw.length > 64) {
+      // prose message → leave the template undefined (DefaultBoxTemplate)
+      // so it renders; a KeyValue template with no options would show blank
+      return [
+        new BoxBuilder(BOX_NAME, FORMAT_ERROR_MSG)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // parse "<number> <unit>", allowing scientific notation in the number
+    const match = raw.match(
+      /^([+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?)\s+(\S+)$/,
+    );
+    if (!match) {
+      return [
+        new BoxBuilder(BOX_NAME, FORMAT_ERROR_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitKey = match[2].toLowerCase();
+
+    if (Number.isNaN(value) || !(unitKey in TO_HZ)) {
+      return [
+        new BoxBuilder(BOX_NAME, FORMAT_ERROR_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const hz = value * TO_HZ[unitKey];
+
+    // period is only meaningful for positive frequency
+    const periodSec = hz > 0 ? 1 / hz : null;
+
+    const kv: Record<string, string> = {
+      Input: `${value} ${match[2]}`,
+      Hz: fmtNum(hz),
+      kHz: fmtNum(hz / 1e3),
+      MHz: fmtNum(hz / 1e6),
+      GHz: fmtNum(hz / 1e9),
+      THz: fmtNum(hz / 1e12),
+    };
+
+    if (periodSec !== null) {
+      kv.Period = `${fmtNum(periodSec)} s`;
+    }
+
+    return [
+      new BoxBuilder(BOX_NAME, kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FrequencyConvertBoxSource;

--- a/src/modules/boxSources/__test__/FrequencyConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FrequencyConvertBoxSource.test.ts
@@ -1,0 +1,244 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { FrequencyConvertBoxSource } from '../FrequencyConvertBoxSource';
+
+describe('FrequencyConvertBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(FrequencyConvertBoxSource.name).toBe('Frequency Convert');
+      expect(FrequencyConvertBoxSource.tag).toBe('#');
+      expect(FrequencyConvertBoxSource.kind).toBe('Convert');
+      expect(FrequencyConvertBoxSource.priority).toBe(10);
+    });
+  });
+
+  describe('option gate', () => {
+    it('returns [] when options is null', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes(
+        '2.4 GHz',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes(
+        '2.4 GHz',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('activates on ::frequency option', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('activates on ::freq option', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        freq: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('2.4 GHz → Hz / MHz / GHz', () => {
+    it('Hz is 2400000000', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      // 2.4 GHz = 2.4e9 Hz exactly
+      expect(Number.parseFloat(kv.Hz)).toBe(2_400_000_000);
+    });
+
+    it('MHz is 2400', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      // 2.4 GHz = 2400 MHz
+      expect(Number.parseFloat(kv.MHz)).toBe(2400);
+    });
+
+    it('GHz is 2.4', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.GHz)).toBeCloseTo(2.4, 9);
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is Frequency Convert', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      expect(boxes[0].props.name).toBe('Frequency Convert');
+    });
+
+    it('priority is set to 10', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('kv options contain all expected keys', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv).toHaveProperty('Input');
+      expect(kv).toHaveProperty('Hz');
+      expect(kv).toHaveProperty('kHz');
+      expect(kv).toHaveProperty('MHz');
+      expect(kv).toHaveProperty('GHz');
+      expect(kv).toHaveProperty('THz');
+      expect(kv).toHaveProperty('Period');
+    });
+  });
+
+  describe('1 kHz → Hz / Period', () => {
+    it('Hz is 1000', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('1 kHz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.Hz)).toBe(1000);
+    });
+
+    it('Period is approximately 0.001 s (1 ms)', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('1 kHz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      // period should contain "0.001 s"
+      const periodVal = Number.parseFloat(kv.Period);
+      expect(periodVal).toBeCloseTo(0.001, 9);
+    });
+  });
+
+  describe('1 Hz', () => {
+    it('Period is 1 s', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('1 Hz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      const periodVal = Number.parseFloat(kv.Period);
+      expect(periodVal).toBe(1);
+    });
+
+    it('Hz is 1', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('1 Hz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.Hz)).toBe(1);
+    });
+  });
+
+  describe('440 Hz', () => {
+    it('kHz is 0.44', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('440 Hz', {
+        frequency: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.kHz)).toBeCloseTo(0.44, 9);
+    });
+  });
+
+  describe('1000000 Hz', () => {
+    it('MHz is 1', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes(
+        '1000000 Hz',
+        {
+          frequency: true,
+        },
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.MHz)).toBe(1);
+    });
+
+    it('kHz is 1000', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes(
+        '1000000 Hz',
+        {
+          frequency: true,
+        },
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.kHz)).toBe(1000);
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('returns an error box for "abc"', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('abc', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box for "5 foo" (unknown unit)', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('5 foo', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box for input exceeding 64 chars', async () => {
+      const long = `${'1'.repeat(70)} GHz`;
+      const boxes = await FrequencyConvertBoxSource.generateBoxes(long, {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+  });
+
+  describe('plaintext output', () => {
+    it('plaintextOutput contains key: value lines', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('2.4 GHz', {
+        frequency: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toMatch(/Hz:/);
+      expect(text).toMatch(/MHz:/);
+      expect(text).toMatch(/GHz:/);
+      expect(text).toMatch(/Period:/);
+    });
+  });
+
+  describe('case-insensitive unit parsing', () => {
+    it('accepts "ghz" lowercase', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('1 ghz', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.Hz)).toBe(1e9);
+    });
+
+    it('accepts "MHZ" uppercase', async () => {
+      const boxes = await FrequencyConvertBoxSource.generateBoxes('100 MHZ', {
+        frequency: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(kv.Hz)).toBe(1e8);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FrequencyConvertBoxSource from './FrequencyConvertBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import JWTBoxSource from './JWTBoxSource';
@@ -50,5 +51,6 @@ export const boxSources = [
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
+  FrequencyConvertBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Frequency Convert (Convert)

Adds the `Frequency Convert` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `2.4 GHz ::frequency`

#### Options:
- `::freq`, `::frequency`

#### Description:
Convert a frequency between Hz, kHz, MHz, GHz, THz and its period.

#### Usage Examples:
- **Input**:
```
2.4 GHz ::frequency
```
- **Output Box (`Frequency Convert`)**:
```
Input: 2.4 GHz
Hz: 2400000000
kHz: 2400000
MHz: 2400
GHz: 2.4
THz: 0.0024
Period: 4.166667e-10 s
```
