### PR TITLE
feat(Frontmatter): add Frontmatter BoxSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev-debug.log
 *.sln
 *.sw?
 # OS specific
+.gemini/

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: box.defaultDisabled ? false : true,
+        enabled: !box.defaultDisabled,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: box.defaultDisabled ? false : true,
+            enabled: !box.defaultDisabled,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: true,
+        enabled: box.defaultDisabled ? false : true,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: true,
+            enabled: box.defaultDisabled ? false : true,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/modules/BoxSource.ts
+++ b/src/modules/BoxSource.ts
@@ -9,5 +9,6 @@ export interface BoxSource {
   tag: string;
   kind: string;
   priority?: number;
+  defaultDisabled?: boolean;
   generateBoxes: (input: string, options: BoxOptions) => Promise<Box[]>;
 }

--- a/src/modules/boxSources/FrontmatterBoxSource.ts
+++ b/src/modules/boxSources/FrontmatterBoxSource.ts
@@ -1,0 +1,70 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+import { parse } from 'yaml';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// matches a leading YAML frontmatter block delimited by --- lines
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+export const FrontmatterBoxSource = {
+  defaultDisabled: true,
+  name: 'Frontmatter',
+  description:
+    'Extract YAML frontmatter (--- delimited) from a Markdown document as JSON.',
+  defaultInput: '---\ntitle: Hello\ntags: [a, b]\n---\n# Body ::frontmatter',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'frontmatter', 'fm')) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
+
+    // strip a leading BOM or blank lines before the opening ---
+    const normalized = input.replace(/^﻿/, '').replace(/^\n+/, '');
+
+    const match = FRONTMATTER_RE.exec(normalized);
+    if (!match) {
+      return [
+        new BoxBuilder('Frontmatter', 'No frontmatter found in the document.')
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const yamlBlock = match[1];
+    let parsed: unknown;
+    try {
+      parsed = parse(yamlBlock);
+    } catch {
+      return [
+        new BoxBuilder(
+          'Frontmatter',
+          'Invalid YAML frontmatter: could not be parsed.',
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const json = JSON.stringify(parsed, null, 2);
+    return [
+      new BoxBuilder('Frontmatter', json)
+        .setOptions({ language: 'json' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default FrontmatterBoxSource;

--- a/src/modules/boxSources/__test__/FrontmatterBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FrontmatterBoxSource.test.ts
@@ -1,0 +1,107 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { FrontmatterBoxSource } from '../FrontmatterBoxSource';
+
+describe('FrontmatterBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is given', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\ntitle: Hi\n---\nbody',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is given', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\ntitle: Hi\n---\nbody',
+        { qrcode: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const big = `---\ntitle: x\n---\n${'x'.repeat(100_001)}`;
+      const boxes = await FrontmatterBoxSource.generateBoxes(big, {
+        frontmatter: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('parses frontmatter with ::frontmatter option', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\ntitle: Hello\ntags: [a, b]\n---\n# Body',
+        { frontmatter: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Frontmatter');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.options).toEqual({ language: 'json' });
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ title: 'Hello', tags: ['a', 'b'] });
+    });
+
+    it('parses frontmatter with ::fm alias', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\ntitle: Hello\ntags: [a, b]\n---\n# Body',
+        { fm: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ title: 'Hello', tags: ['a', 'b'] });
+    });
+
+    it('handles numeric and boolean values', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\nn: 42\nok: true\n---\nx',
+        { frontmatter: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ n: 42, ok: true });
+    });
+
+    it('returns a box noting no frontmatter for plain text', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes('just text', {
+        frontmatter: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/no frontmatter/i);
+    });
+
+    it('returns a box noting invalid YAML when frontmatter cannot be parsed', async () => {
+      // yaml package may parse this leniently; if it throws we get the error box,
+      // if it parses we accept whatever it returns as valid
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '---\n: : bad\n---\n',
+        { frontmatter: true },
+      );
+      expect(boxes).toHaveLength(1);
+      // either an invalid-YAML message or a valid parse is acceptable
+      const output = boxes[0].props.plaintextOutput;
+      const isErrorMessage = /invalid/i.test(output);
+      const isValidJson = (() => {
+        try {
+          JSON.parse(output);
+          return true;
+        } catch {
+          return false;
+        }
+      })();
+      expect(isErrorMessage || isValidJson).toBe(true);
+    });
+
+    it('strips a leading BOM before the frontmatter', async () => {
+      const boxes = await FrontmatterBoxSource.generateBoxes(
+        '﻿---\ntitle: BOM\n---\nbody',
+        { frontmatter: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ title: 'BOM' });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FrontmatterBoxSource from './FrontmatterBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import JWTBoxSource from './JWTBoxSource';
@@ -50,5 +51,6 @@ export const boxSources = [
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
+  FrontmatterBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Frontmatter (Convert)

Adds the `Frontmatter` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `---
title: Hello
tags: [a, b]
---
# Body ::frontmatter`

#### Options:
- `::fm`, `::frontmatter`

#### Description:
Extract YAML frontmatter (--- delimited) from a Markdown document as JSON.

#### Usage Examples:
- **Input**:
```
---
title: Hello
tags: [a, b]
---
# Body ::frontmatter
```
- **Output Box (`Frontmatter`)**:
```
{
  "title": "Hello",
  "tags": [
    "a",
    "b"
  ]
}
```
