### PR TITLE
feat(FuelEconomy): add Fuel Economy BoxSource

### DIFF
--- a/src/modules/boxSources/FuelEconomyBoxSource.ts
+++ b/src/modules/boxSources/FuelEconomyBoxSource.ts
@@ -1,0 +1,159 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// conversion constants
+const LITERS_PER_US_GALLON = 3.785411784;
+const LITERS_PER_IMP_GALLON = 4.54609;
+const KM_PER_MILE = 1.609344;
+
+// derived shortcut constants for mpg → L/100km
+// L/100km = (litersPerGallon / (mpg * kmPerMile)) * 100
+const US_MPG_TO_L100KM = (LITERS_PER_US_GALLON / KM_PER_MILE) * 100; // ≈ 235.214583
+const IMP_MPG_TO_L100KM = (LITERS_PER_IMP_GALLON / KM_PER_MILE) * 100; // ≈ 282.480936
+
+const MAX_INPUT_LENGTH = 64;
+
+// supported unit aliases → canonical unit key
+const UNIT_MAP: Record<string, string> = {
+  mpg: 'mpgus',
+  mpgus: 'mpgus',
+  'mpg-us': 'mpgus',
+  mpguk: 'mpgimp',
+  'mpg-uk': 'mpgimp',
+  mpgimp: 'mpgimp',
+  'mpg-imp': 'mpgimp',
+  'l/100km': 'l100km',
+  l100km: 'l100km',
+  'km/l': 'kml',
+  kml: 'kml',
+};
+
+function formatValue(n: number): string {
+  if (!Number.isFinite(n)) return '∞';
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// convert any unit to L/100km as the canonical intermediate
+function toL100km(value: number, unit: string): number {
+  switch (unit) {
+    case 'mpgus':
+      return US_MPG_TO_L100KM / value;
+    case 'mpgimp':
+      return IMP_MPG_TO_L100KM / value;
+    case 'l100km':
+      return value;
+    case 'kml':
+      return 100 / value;
+    default:
+      return Number.NaN;
+  }
+}
+
+function buildErrorBox(message: string, priority: number): Box {
+  return new BoxBuilder('Fuel Economy', message)
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions({
+      Error: message,
+      'Supported units':
+        'mpg, mpg-us, mpg-uk, mpgimp, l/100km, l100km, km/l, kml',
+      Example: '30 mpg ::fuel',
+    })
+    .setPriority(priority)
+    .build();
+}
+
+export const FuelEconomyBoxSource = {
+  defaultDisabled: true,
+  name: 'Fuel Economy',
+  description:
+    'Convert fuel economy between MPG (US), MPG (imperial), L/100km, and km/L.',
+  defaultInput: '30 mpg ::fuel',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'fuel', 'mpg')) return [];
+
+    const raw = trim(input);
+    if (raw.length === 0 || raw.length > MAX_INPUT_LENGTH) {
+      return [
+        buildErrorBox(
+          'Input is empty or too long (max 64 chars).',
+          this.priority,
+        ),
+      ];
+    }
+
+    // expect "<number> <unit>"
+    const parts = raw.split(/\s+/);
+    if (parts.length !== 2) {
+      return [
+        buildErrorBox(
+          `Invalid format: "${raw}". Use "<number> <unit>".`,
+          this.priority,
+        ),
+      ];
+    }
+
+    const [rawValue, rawUnit] = parts;
+    const value = Number.parseFloat(rawValue);
+
+    if (Number.isNaN(value) || !Number.isFinite(value)) {
+      return [
+        buildErrorBox(`"${rawValue}" is not a valid number.`, this.priority),
+      ];
+    }
+
+    if (value <= 0) {
+      return [buildErrorBox('Value must be greater than 0.', this.priority)];
+    }
+
+    const unit = UNIT_MAP[rawUnit.toLowerCase()];
+    if (!unit) {
+      return [
+        buildErrorBox(
+          `Unknown unit "${rawUnit}". Supported: mpg, mpg-us, mpg-uk, mpgimp, l/100km, l100km, km/l, kml.`,
+          this.priority,
+        ),
+      ];
+    }
+
+    const l100km = toL100km(value, unit);
+    const mpgUS = US_MPG_TO_L100KM / l100km;
+    const mpgImp = IMP_MPG_TO_L100KM / l100km;
+    const kmPerL = 100 / l100km;
+
+    const inputLabel = `${formatValue(value)} ${rawUnit}`;
+    const output: Record<string, string> = {
+      Input: inputLabel,
+      'MPG (US)': formatValue(mpgUS),
+      'MPG (imp)': formatValue(mpgImp),
+      'L/100km': formatValue(l100km),
+      'km/L': formatValue(kmPerL),
+    };
+
+    // build human-readable plaintext for headless/TUI consumers
+    const plaintext = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    const box = new BoxBuilder('Fuel Economy', plaintext)
+      .setTemplate(KeyValueBoxTemplate)
+      .setOptions(output)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default FuelEconomyBoxSource;

--- a/src/modules/boxSources/__test__/FuelEconomyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FuelEconomyBoxSource.test.ts
@@ -1,0 +1,167 @@
+import type { BoxOptions } from '@modules/Box';
+import { describe, expect, it } from 'vitest';
+import { FuelEconomyBoxSource } from '../FuelEconomyBoxSource';
+
+// convenience wrapper — trigger via ::fuel option
+const gen = (input: string, opts: BoxOptions = { fuel: true }) =>
+  FuelEconomyBoxSource.generateBoxes(input, opts);
+
+describe('FuelEconomyBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no matching option is present', async () => {
+      expect(await gen('30 mpg', {})).toHaveLength(0);
+      expect(await gen('30 mpg', null)).toHaveLength(0);
+      expect(await gen('30 mpg', { unrelated: true })).toHaveLength(0);
+    });
+
+    it('triggers on ::fuel', async () => {
+      expect(await gen('30 mpg', { fuel: true })).toHaveLength(1);
+    });
+
+    it('triggers on ::mpg', async () => {
+      expect(await gen('30 mpg', { mpg: true })).toHaveLength(1);
+    });
+  });
+
+  describe('30 mpg (US) via ::fuel', () => {
+    it('produces one box', async () => {
+      const boxes = await gen('30 mpg');
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('box template is KeyValueBoxTemplate', async () => {
+      const { KeyValueBoxTemplate } = await import('@components/BoxTemplate');
+      const boxes = await gen('30 mpg');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is "Fuel Economy"', async () => {
+      const boxes = await gen('30 mpg');
+      expect(boxes[0].props.name).toBe('Fuel Economy');
+    });
+
+    it('L/100km ≈ 7.840486 (235.214583 / 30)', async () => {
+      const boxes = await gen('30 mpg');
+      const opts = boxes[0].props.options as Record<string, string>;
+      // well-known constant: 235.214583 / 30 ≈ 7.840486
+      expect(opts['L/100km']).toMatch(/^7\.84/);
+    });
+
+    it('Input field reflects original input', async () => {
+      const boxes = await gen('30 mpg');
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('30 mpg');
+    });
+
+    it('MPG (US) round-trips back to ~30', async () => {
+      const boxes = await gen('30 mpg');
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(opts['MPG (US)'])).toBeCloseTo(30, 3);
+    });
+  });
+
+  describe('round-trip: L/100km → MPG (US)', () => {
+    it('7.840486 l/100km → MPG (US) ≈ 30', async () => {
+      const boxes = await gen('7.840486 l/100km');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(Number.parseFloat(opts['MPG (US)'])).toBeCloseTo(30, 2);
+    });
+  });
+
+  describe('km/L input', () => {
+    it('10 km/l → L/100km = 10', async () => {
+      const boxes = await gen('10 km/l');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 100 / 10 = 10 exactly
+      expect(opts['L/100km']).toBe('10');
+    });
+
+    it('10 kml alias also works', async () => {
+      const boxes = await gen('10 kml');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['L/100km']).toBe('10');
+    });
+  });
+
+  describe('imperial MPG', () => {
+    it('50 mpguk → L/100km starts with 5.64 (282.480936/50)', async () => {
+      const boxes = await gen('50 mpguk');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 282.480936 / 50 = 5.649619
+      expect(opts['L/100km']).toMatch(/^5\.64/);
+    });
+
+    it('mpg-uk alias works', async () => {
+      const boxes = await gen('50 mpg-uk');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['L/100km']).toMatch(/^5\.64/);
+    });
+
+    it('mpgimp alias works', async () => {
+      const boxes = await gen('50 mpgimp');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['L/100km']).toMatch(/^5\.64/);
+    });
+  });
+
+  describe('error cases — return a box (not [])', () => {
+    it('value 0 → error box', async () => {
+      const boxes = await gen('0 mpg');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('negative value → error box', async () => {
+      const boxes = await gen('-5 mpg');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('non-numeric value "abc" → error box', async () => {
+      const boxes = await gen('abc mpg');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('unknown unit "5 foo" → error box', async () => {
+      const boxes = await gen('5 foo');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+
+    it('bare word with no unit → error box', async () => {
+      const boxes = await gen('abc');
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeDefined();
+    });
+  });
+
+  describe('unit aliases', () => {
+    it('mpg-us alias resolves same as mpg', async () => {
+      const a = await gen('30 mpg');
+      const b = await gen('30 mpg-us');
+      const optsA = a[0].props.options as Record<string, string>;
+      const optsB = b[0].props.options as Record<string, string>;
+      expect(optsA['L/100km']).toBe(optsB['L/100km']);
+    });
+
+    it('l100km alias resolves same as l/100km', async () => {
+      const a = await gen('7.840486 l/100km');
+      const b = await gen('7.840486 l100km');
+      const optsA = a[0].props.options as Record<string, string>;
+      const optsB = b[0].props.options as Record<string, string>;
+      expect(optsA['MPG (US)']).toBe(optsB['MPG (US)']);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -13,6 +13,7 @@ import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
+import FuelEconomyBoxSource from './FuelEconomyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
@@ -77,6 +78,7 @@ export const boxSources: BoxSource[] = [
   BinaryTextBoxSource,
   BmiBoxSource,
   FrequencyBoxSource,
+  FuelEconomyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
   SemverBoxSource,


### PR DESCRIPTION
### Box Source: Fuel Economy (Convert)

Adds the `Fuel Economy` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `30 mpg ::fuel`

#### Options:
- `::fuel`, `::mpg`

#### Description:
Convert fuel economy between MPG (US), MPG (imperial), L/100km, and km/L.

#### Usage Examples:
- **Input**:
```
30 mpg ::fuel
```
- **Output Box (`Fuel Economy`)**:
```
Input: 30 mpg
MPG (US): 30
MPG (imp): 36.028498
L/100km: 7.840486
km/L: 12.754311
```
