### PR TITLE
feat(Fullwidth): add Fullwidth BoxSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev-debug.log
 *.sln
 *.sw?
 # OS specific
+.gemini/

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: box.defaultDisabled ? false : true,
+        enabled: !box.defaultDisabled,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: box.defaultDisabled ? false : true,
+            enabled: !box.defaultDisabled,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: true,
+        enabled: box.defaultDisabled ? false : true,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: true,
+            enabled: box.defaultDisabled ? false : true,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/modules/BoxSource.ts
+++ b/src/modules/BoxSource.ts
@@ -9,5 +9,6 @@ export interface BoxSource {
   tag: string;
   kind: string;
   priority?: number;
+  defaultDisabled?: boolean;
   generateBoxes: (input: string, options: BoxOptions) => Promise<Box[]>;
 }

--- a/src/modules/boxSources/FullwidthBoxSource.ts
+++ b/src/modules/boxSources/FullwidthBoxSource.ts
@@ -1,0 +1,96 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// offset between ASCII printable range (0x21-0x7E) and fullwidth Unicode block (U+FF01-U+FF5E)
+const FULLWIDTH_OFFSET = 0xfee0;
+
+// convert ASCII printable chars to their fullwidth Unicode equivalents
+function toFullwidth(input: string): string {
+  let result = '';
+  for (const ch of input) {
+    const cp = ch.codePointAt(0) ?? 0;
+    if (cp === 0x20) {
+      // ASCII space → ideographic space U+3000
+      result += '　';
+    } else if (cp >= 0x21 && cp <= 0x7e) {
+      // printable ASCII → fullwidth form
+      result += String.fromCodePoint(cp + FULLWIDTH_OFFSET);
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+// reverse fullwidth Unicode forms back to ASCII
+function toHalfwidth(input: string): string {
+  let result = '';
+  for (const ch of input) {
+    const cp = ch.codePointAt(0) ?? 0;
+    if (cp === 0x3000) {
+      // ideographic space → ASCII space
+      result += ' ';
+    } else if (cp >= 0xff01 && cp <= 0xff5e) {
+      // fullwidth form → ASCII printable
+      result += String.fromCodePoint(cp - FULLWIDTH_OFFSET);
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+export const FullwidthBoxSource = {
+  defaultDisabled: true,
+  name: 'Fullwidth',
+  description:
+    'Convert ASCII text to fullwidth Unicode forms, or fullwidth back to ASCII.',
+  defaultInput: 'Hello 123 ::fullwidth',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'fullwidth', 'tofullwidth');
+    const wantDecode = hasOptionKeys(options, 'halfwidth', 'fromfullwidth');
+    if (!wantEncode && !wantDecode) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const output = toFullwidth(input);
+      boxes.push(
+        new BoxBuilder('Fullwidth', output)
+          .setTemplate(DefaultBoxTemplate)
+          .setPriority(this.priority)
+          .setShowExpandButton(false)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const output = toHalfwidth(input);
+      boxes.push(
+        new BoxBuilder('Halfwidth', output)
+          .setTemplate(DefaultBoxTemplate)
+          .setPriority(this.priority)
+          .setShowExpandButton(false)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default FullwidthBoxSource;

--- a/src/modules/boxSources/__test__/FullwidthBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/FullwidthBoxSource.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { FullwidthBoxSource } from '../FullwidthBoxSource';
+
+describe('FullwidthBoxSource', () => {
+  describe('generateBoxes — guard conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is empty string', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('', {
+        fullwidth: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ASCII to fullwidth', () => {
+    it('converts ASCII letters with +0xFEE0 offset', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Hello', {
+        fullwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      // 'H' (0x48) should become U+FF28
+      expect(output.codePointAt(0)).toBe('H'.charCodeAt(0) + 0xfee0);
+      expect(output).toBe('Ｈｅｌｌｏ');
+    });
+
+    it('maps ASCII space to ideographic space U+3000', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('a b', {
+        fullwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      // index 1 should be U+3000
+      expect(output.codePointAt(1)).toBe(0x3000);
+      expect(output).toBe('ａ　ｂ');
+    });
+
+    it('accepts ::tofullwidth alias', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Hi', {
+        tofullwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Fullwidth');
+    });
+  });
+
+  describe('decode — fullwidth to ASCII', () => {
+    it('converts fullwidth letters back to ASCII', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Ｈｉ', {
+        halfwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+
+    it('accepts ::fromfullwidth alias', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Ｈｉ', {
+        fromfullwidth: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Halfwidth');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('halfwidth(fullwidth(input)) === original for ASCII printable + space', async () => {
+      const original = 'Hello 123!';
+
+      const encoded = await FullwidthBoxSource.generateBoxes(original, {
+        fullwidth: true,
+      });
+      expect(encoded).toHaveLength(1);
+      const fullwidthStr = encoded[0].props.plaintextOutput;
+
+      const decoded = await FullwidthBoxSource.generateBoxes(fullwidthStr, {
+        halfwidth: true,
+      });
+      expect(decoded).toHaveLength(1);
+      expect(decoded[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('both options produce two boxes', () => {
+    it('returns a Fullwidth box and a Halfwidth box', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Hi', {
+        fullwidth: true,
+        halfwidth: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Fullwidth');
+      expect(boxes[1].props.name).toBe('Halfwidth');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets priority and disables expand button', async () => {
+      const boxes = await FullwidthBoxSource.generateBoxes('Hello', {
+        fullwidth: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -7,6 +7,7 @@ import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import FullwidthBoxSource from './FullwidthBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import JWTBoxSource from './JWTBoxSource';
@@ -50,5 +51,6 @@ export const boxSources = [
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
+  FullwidthBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Fullwidth (Transform)

Adds the `Fullwidth` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `Hello 123 ::fullwidth`

#### Options:
- `::fromfullwidth`, `::fullwidth`, `::halfwidth`, `::tofullwidth`

#### Description:
Convert ASCII text to fullwidth Unicode forms, or fullwidth back to ASCII.

#### Usage Examples:
- **Input**:
```
Hello 123 ::fullwidth
```
- **Output Box (`Fullwidth`)**:
```
Ｈｅｌｌｏ　１２３
```
