### PR TITLE
feat(GcdLcm): add GCD / LCM BoxSource

### DIFF
--- a/src/modules/boxSources/GcdLcmBoxSource.ts
+++ b/src/modules/boxSources/GcdLcmBoxSource.ts
@@ -1,0 +1,123 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 10_000;
+const MAX_OPERANDS = 1_000;
+
+// token pattern for a bare integer (no decimals, no exponents)
+const INTEGER_RE = /^-?\d+$/;
+
+function gcd(a: bigint, b: bigint): bigint {
+  a = a < 0n ? -a : a;
+  b = b < 0n ? -b : b;
+  while (b !== 0n) {
+    const t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+function lcmOfList(nums: bigint[]): bigint {
+  // if any operand is zero the LCM is zero
+  if (nums.some((n) => n === 0n)) return 0n;
+  // work on magnitudes so a negative first operand can't flip the sign
+  const abs = nums.map((n) => (n < 0n ? -n : n));
+  return abs.reduce((acc, n) => (acc / gcd(acc, n)) * n);
+}
+
+function gcdOfList(nums: bigint[]): bigint {
+  return nums.reduce((acc, n) => gcd(acc, n));
+}
+
+// build the plaintext representation of a key-value record
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const GcdLcmBoxSource = {
+  defaultDisabled: true,
+  name: 'GCD / LCM',
+  description:
+    'Compute the GCD and LCM of a list of integers (comma or space separated).',
+  defaultInput: '12, 18, 24 ::gcd',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'gcd', 'lcm')) return [];
+
+    const trimmed = trim(input).slice(0, MAX_INPUT);
+    if (!trimmed) {
+      const kv = { Note: 'provide at least two integers' };
+      return [
+        new BoxBuilder('GCD / LCM', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // split on commas and/or whitespace
+    const tokens = trimmed
+      .split(/[\s,]+/)
+      .filter((t: string) => t.length > 0)
+      .slice(0, MAX_OPERANDS);
+
+    // validate: every token must look like a bare integer
+    const invalid = tokens.find((t: string) => !INTEGER_RE.test(t));
+    if (invalid !== undefined) {
+      const kv = { Note: 'all tokens must be integers (e.g. 12, -5, 0)' };
+      return [
+        new BoxBuilder('GCD / LCM', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (tokens.length < 2) {
+      const kv = { Note: 'at least two integers are required' };
+      return [
+        new BoxBuilder('GCD / LCM', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // use BigInt directly — never go through Number to avoid precision loss
+    const nums = tokens.map((t: string) => BigInt(t));
+
+    const gcdResult = gcdOfList(nums);
+    const lcmResult = lcmOfList(nums);
+
+    const kv = {
+      Numbers: nums.join(', '),
+      GCD: String(gcdResult),
+      LCM: String(lcmResult),
+    };
+
+    return [
+      new BoxBuilder('GCD / LCM', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default GcdLcmBoxSource;

--- a/src/modules/boxSources/__test__/GcdLcmBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/GcdLcmBoxSource.test.ts
@@ -1,0 +1,100 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { GcdLcmBoxSource } from '../GcdLcmBoxSource';
+
+describe('GcdLcmBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option key is provided', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12, 18, 24', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option key is provided', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12, 18, 24', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('computes GCD=6 and LCM=72 for 12, 18, 24 with ::gcd', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12, 18, 24', {
+        gcd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('GCD / LCM');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.options).toMatchObject({ GCD: '6', LCM: '72' });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('computes GCD=6 and LCM=72 for 12, 18, 24 with ::lcm', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12, 18, 24', {
+        lcm: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ GCD: '6', LCM: '72' });
+    });
+
+    it('handles space-separated input: 4 6 → GCD=2 LCM=12', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('4 6', { gcd: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ GCD: '2', LCM: '12' });
+    });
+
+    it('handles zero operand: 0, 5 → GCD=5 LCM=0', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('0, 5', { gcd: true });
+      expect(boxes[0].props.options).toMatchObject({ GCD: '5', LCM: '0' });
+    });
+
+    it('handles negative numbers: -12, 8 → GCD=4 LCM=24', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('-12, 8', {
+        gcd: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ GCD: '4', LCM: '24' });
+    });
+
+    it('preserves full precision for large BigInt operands', async () => {
+      // gcd(12345678901234567890, 98765432109876543210)
+      // verify GCD * LCM == |a * b| (fundamental identity)
+      const a = 12345678901234567890n;
+      const b = 98765432109876543210n;
+      const boxes = await GcdLcmBoxSource.generateBoxes(
+        '12345678901234567890, 98765432109876543210',
+        { gcd: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      const gcdVal = BigInt(opts.GCD);
+      const lcmVal = BigInt(opts.LCM);
+      // GCD must be a multi-digit number (not 1 or trivially small)
+      expect(gcdVal > 1n).toBe(true);
+      // BigInt identity: gcd * lcm == |a * b|
+      expect(gcdVal * lcmVal).toBe(a * b);
+    });
+
+    it('returns error box for a single number', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('5', { gcd: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Note).toMatch(/at least two/i);
+    });
+
+    it('returns error box for non-integer tokens', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('a, b', {
+        gcd: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Note).toMatch(/integers/i);
+    });
+
+    it('plaintextOutput is non-empty and contains key: value lines', async () => {
+      const boxes = await GcdLcmBoxSource.generateBoxes('12, 18', {
+        gcd: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('GCD: 6');
+      expect(text).toContain('LCM: 36');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -12,6 +12,7 @@ import CronExpressionBoxSource from './CronExpressionBoxSource';
 import DataConverterBoxSource from './DataConverterBoxSource';
 import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
+import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import JWTBoxSource from './JWTBoxSource';
@@ -74,6 +75,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  GcdLcmBoxSource,
   LineToolsBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,


### PR DESCRIPTION
### Box Source: GCD / LCM (Calculate)

Adds the `GCD / LCM` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `12, 18, 24 ::gcd`

#### Options:
- `::gcd`, `::lcm`

#### Description:
Compute the GCD and LCM of a list of integers (comma or space separated).

#### Usage Examples:
- **Input**: `12, 18, 24 ::gcd`
- **Output Box (`GCD / LCM`)**:
```
Numbers: 12, 18, 24
GCD: 6
LCM: 72
```
