### PR TITLE
feat(GlobToRegex): add Glob to Regex BoxSource

### DIFF
--- a/src/modules/boxSources/GlobToRegexBoxSource.ts
+++ b/src/modules/boxSources/GlobToRegexBoxSource.ts
@@ -1,0 +1,112 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 10_000;
+
+// regex-special chars that have no meaning in glob syntax and must be escaped
+const REGEX_SPECIAL = new Set([
+  '.',
+  '+',
+  '(',
+  ')',
+  '{',
+  '}',
+  '^',
+  '$',
+  '|',
+  '\\',
+]);
+
+// convert a glob pattern to an anchored regex string via a single left-to-right scan
+function globToRegex(glob: string): string {
+  let result = '^';
+  let i = 0;
+
+  while (i < glob.length) {
+    const ch = glob[i];
+
+    if (ch === '*') {
+      // peek ahead: ** matches across path separators, * stays within a segment
+      if (glob[i + 1] === '*') {
+        // `**/` means zero-or-more directory segments, so src/**/*.ts also
+        // matches src/x.ts; a bare `**` matches anything
+        if (glob[i + 2] === '/') {
+          result += '(?:.*/)?';
+          i += 3;
+        } else {
+          result += '.*';
+          i += 2;
+        }
+      } else {
+        result += '[^/]*';
+        i += 1;
+      }
+    } else if (ch === '?') {
+      result += '[^/]';
+      i += 1;
+    } else if (ch === '[') {
+      // character class — pass through to regex, translating leading ! to ^
+      let cls = '[';
+      i += 1; // consume '['
+
+      if (i < glob.length && glob[i] === '!') {
+        cls += '^';
+        i += 1;
+      }
+
+      // copy everything until the closing ']'
+      while (i < glob.length && glob[i] !== ']') {
+        cls += glob[i];
+        i += 1;
+      }
+
+      cls += ']';
+      i += 1; // consume ']'
+      result += cls;
+    } else if (REGEX_SPECIAL.has(ch)) {
+      result += `\\${ch}`;
+      i += 1;
+    } else {
+      result += ch;
+      i += 1;
+    }
+  }
+
+  result += '$';
+  return result;
+}
+
+export const GlobToRegexBoxSource = {
+  defaultDisabled: true,
+  name: 'Glob to Regex',
+  description:
+    'Convert a shell glob pattern (*, ?, [...], **) into an anchored regular expression.',
+  defaultInput: 'src/**/*.ts ::glob2regex',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'glob2regex', 'globregex')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const pattern = trim(input);
+    const regex = globToRegex(pattern);
+
+    return [
+      new BoxBuilder('Glob to Regex', regex)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default GlobToRegexBoxSource;

--- a/src/modules/boxSources/__test__/GlobToRegexBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/GlobToRegexBoxSource.test.ts
@@ -1,0 +1,105 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { GlobToRegexBoxSource } from '../GlobToRegexBoxSource';
+
+describe('GlobToRegexBoxSource', () => {
+  describe('generateBoxes - no matching option', () => {
+    it('returns [] when no glob option is present', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('*.ts', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is present', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('*.ts', {
+        sha256: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - single wildcard *', () => {
+    it('converts *.ts to ^[^/]*\\.ts$', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('*.ts', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^[^/]*\\.ts$');
+    });
+  });
+
+  describe('generateBoxes - double wildcard **', () => {
+    it('converts src/**/*.ts to ^src/(?:.*/)?[^/]*\\.ts$', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('src/**/*.ts', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^src/(?:.*/)?[^/]*\\.ts$');
+      // **/ matches zero directory segments too
+      expect(new RegExp(boxes[0].props.plaintextOutput).test('src/x.ts')).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('generateBoxes - single char wildcard ?', () => {
+    it('converts ? to ^[^/]$', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('?', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^[^/]$');
+    });
+  });
+
+  describe('generateBoxes - character class', () => {
+    it('preserves [0-9] and escapes dot in file[0-9].txt', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('file[0-9].txt', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^file[0-9]\\.txt$');
+    });
+  });
+
+  describe('generateBoxes - negated character class', () => {
+    it('converts [!a] to [^a] in [!a].txt', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('[!a].txt', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^[^a]\\.txt$');
+    });
+  });
+
+  describe('generateBoxes - literal regex-special chars', () => {
+    it('escapes + and . in a+b.c', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('a+b.c', {
+        glob2regex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^a\\+b\\.c$');
+    });
+  });
+
+  describe('generateBoxes - alternate option key', () => {
+    it('triggers on ::globregex option key as well', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('*.js', {
+        globregex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('^[^/]*\\.js$');
+    });
+  });
+
+  describe('generateBoxes - box metadata', () => {
+    it('uses DefaultBoxTemplate and correct name', async () => {
+      const boxes = await GlobToRegexBoxSource.generateBoxes('*.ts', {
+        glob2regex: true,
+      });
+      expect(boxes[0].props.name).toBe('Glob to Regex');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -17,6 +17,7 @@ import FractionBoxSource from './FractionBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
+import GlobToRegexBoxSource from './GlobToRegexBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  GlobToRegexBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Glob to Regex (Convert)

Adds the `Glob to Regex` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `src/**/*.ts ::glob2regex`

#### Options:
- `::glob2regex`, `::globregex`

#### Description:
Convert a shell glob pattern (*, ?, [...], **) into an anchored regular expression.

#### Usage Examples:
- **Input**: `src/**/*.ts ::glob2regex`
- **Output Box (`Glob to Regex`)**:
```
^src/(?:.*/)?[^/]*\.ts$
```
