### PR TITLE
feat(GrayCode): add Gray Code BoxSource

### DIFF
--- a/src/modules/boxSources/GrayCodeBoxSource.ts
+++ b/src/modules/boxSources/GrayCodeBoxSource.ts
@@ -1,0 +1,76 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length guard to avoid runaway allocations on huge strings
+// cap kept low: BigInt() decimal parsing is O(n^2) in digit count, and 100
+// digits covers any realistic Gray-code use while preventing a main-thread stall
+const MAX_INPUT_LENGTH = 100;
+
+export const GrayCodeBoxSource = {
+  defaultDisabled: true,
+  name: 'Gray Code',
+  description:
+    'Convert a non-negative integer to its reflected binary Gray code.',
+  defaultInput: '5 ::gray',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'gray', 'graycode')) return [];
+
+    const raw = trim(input);
+    if (raw.length > MAX_INPUT_LENGTH) return [];
+
+    // only accept non-negative decimal integers
+    if (!/^\d+$/.test(raw)) {
+      const plaintextOutput = 'Error: a non-negative integer is required.';
+      return [
+        new BoxBuilder('Gray Code', plaintextOutput)
+          .setOptions({ Error: 'a non-negative integer is required.' })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    const n = BigInt(raw);
+    const gray = n ^ (n >> 1n);
+
+    const decimalStr = n.toString();
+    const binaryStr = n === 0n ? '0' : n.toString(2);
+    const grayBinaryStr = gray === 0n ? '0' : gray.toString(2);
+    const grayDecimalStr = gray.toString();
+
+    const plaintextOutput = [
+      `Decimal: ${decimalStr}`,
+      `Binary: ${binaryStr}`,
+      `Gray (binary): ${grayBinaryStr}`,
+      `Gray (decimal): ${grayDecimalStr}`,
+    ].join('\n');
+
+    const outputOptions: Record<string, string> = {
+      Decimal: decimalStr,
+      Binary: binaryStr,
+      'Gray (binary)': grayBinaryStr,
+      'Gray (decimal)': grayDecimalStr,
+    };
+
+    return [
+      new BoxBuilder('Gray Code', plaintextOutput)
+        .setOptions(outputOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default GrayCodeBoxSource;

--- a/src/modules/boxSources/__test__/GrayCodeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/GrayCodeBoxSource.test.ts
@@ -1,0 +1,136 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { GrayCodeBoxSource } from '../GrayCodeBoxSource';
+
+describe('GrayCodeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no option key is provided', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('5', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated option key is provided', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('5', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert 5 to Gray code 7 (101 → 111)', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('5', { gray: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Gray Code');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('5');
+      expect(opts.Binary).toBe('101');
+      expect(opts['Gray (binary)']).toBe('111');
+      expect(opts['Gray (decimal)']).toBe('7');
+    });
+
+    it('should accept ::graycode option key', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('5', {
+        graycode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Gray (decimal)']).toBe('7');
+    });
+
+    it('should convert 0 → Gray 0', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('0', { gray: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('0');
+      expect(opts.Binary).toBe('0');
+      expect(opts['Gray (binary)']).toBe('0');
+      expect(opts['Gray (decimal)']).toBe('0');
+    });
+
+    it('should convert 1 → Gray 1 (1 ^ 0 = 1)', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('1', { gray: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('1');
+      expect(opts.Binary).toBe('1');
+      expect(opts['Gray (binary)']).toBe('1');
+      expect(opts['Gray (decimal)']).toBe('1');
+    });
+
+    it('should convert 4 → Gray 6 (100 → 110)', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('4', { gray: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('4');
+      expect(opts.Binary).toBe('100');
+      expect(opts['Gray (binary)']).toBe('110');
+      expect(opts['Gray (decimal)']).toBe('6');
+    });
+
+    it('should convert 255 → Gray 128 (11111111 ^ 01111111 = 10000000)', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('255', {
+        gray: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('255');
+      expect(opts.Binary).toBe('11111111');
+      expect(opts['Gray (binary)']).toBe('10000000');
+      expect(opts['Gray (decimal)']).toBe('128');
+    });
+
+    it('should handle 2^32 (4294967296) without overflow using BigInt', async () => {
+      // 4294967296 = 0x1_0000_0000; gray = n ^ (n >> 1) = 0x1_0000_0000 ^ 0x8000_0000 = 0x1_8000_0000 = 6442450944
+      const boxes = await GrayCodeBoxSource.generateBoxes('4294967296', {
+        gray: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(() => boxes[0].props.options).not.toThrow();
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('4294967296');
+      expect(opts['Gray (decimal)']).toBe('6442450944');
+      // binary of 4294967296 = 100000000000000000000000000000000 (33 bits)
+      expect(opts.Binary).toBe('100000000000000000000000000000000');
+      expect(opts['Gray (binary)']).toBe('110000000000000000000000000000000');
+    });
+
+    it('should return an error box for invalid input "abc"', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('abc', {
+        gray: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Gray Code');
+      // plaintext must mention non-negative integer
+      expect(boxes[0].props.plaintextOutput).toMatch(/non-negative integer/);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/non-negative integer/);
+    });
+
+    it('should return an error box for negative input "-1"', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('-1', { gray: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/non-negative integer/);
+    });
+
+    it('should return an error box for float input "3.14"', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('3.14', {
+        gray: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/non-negative integer/);
+    });
+
+    it('plaintextOutput should be non-empty k:v lines for valid input', async () => {
+      const boxes = await GrayCodeBoxSource.generateBoxes('5', { gray: true });
+      const pt = boxes[0].props.plaintextOutput;
+      expect(pt).toContain('Decimal: 5');
+      expect(pt).toContain('Binary: 101');
+      expect(pt).toContain('Gray (binary): 111');
+      expect(pt).toContain('Gray (decimal): 7');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -17,6 +17,7 @@ import FractionBoxSource from './FractionBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
+import GrayCodeBoxSource from './GrayCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  GrayCodeBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Gray Code (Convert)

Adds the `Gray Code` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `5 ::gray`

#### Options:
- `::gray`, `::graycode`

#### Description:
Convert a non-negative integer to its reflected binary Gray code.

#### Usage Examples:
- **Input**: `5 ::gray`
- **Output Box (`Gray Code`)**:
```
Decimal: 5
Binary: 101
Gray (binary): 111
Gray (decimal): 7
```
