### PR TITLE
feat(HammingDistance): add Hamming Distance BoxSource

### DIFF
--- a/src/modules/boxSources/HammingDistanceBoxSource.ts
+++ b/src/modules/boxSources/HammingDistanceBoxSource.ts
@@ -1,0 +1,155 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// pure hex string (case-insensitive)
+const HEX_RE = /^[0-9a-f]+$/i;
+
+// render key/value pairs as `k: v` lines for the headless/TUI plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// count the number of set bits in a number using Brian Kernighan's algorithm
+function popcount(n: number): number {
+  let count = 0;
+  let v = n;
+  while (v !== 0) {
+    v &= v - 1;
+    count++;
+  }
+  return count;
+}
+
+// compute bit-level hamming distance between two equal-length hex strings
+// processes nibble by nibble to avoid bigint overflow on long inputs
+function hexBitDistance(a: string, b: string): number {
+  let dist = 0;
+  for (let i = 0; i < a.length; i++) {
+    const na = Number.parseInt(a[i], 16);
+    const nb = Number.parseInt(b[i], 16);
+    dist += popcount(na ^ nb);
+  }
+  return dist;
+}
+
+// count code points (not UTF-16 units) to handle surrogate pairs correctly
+function codePointCount(s: string): number {
+  return [...s].length;
+}
+
+// compute char-level hamming distance; caller must ensure equal lengths
+function charDistance(a: string, b: string): number {
+  const aPoints = [...a];
+  const bPoints = [...b];
+  let dist = 0;
+  for (let i = 0; i < aPoints.length; i++) {
+    if (aPoints[i] !== bPoints[i]) {
+      dist++;
+    }
+  }
+  return dist;
+}
+
+export const HammingDistanceBoxSource = {
+  defaultDisabled: true,
+  name: 'Hamming Distance',
+  description:
+    'Hamming distance between two equal-length strings. Separate the two with a comma or newline. ::hamming',
+  defaultInput: 'karolin, kathrin ::hamming',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hamming')) return [];
+
+    const capped = input.slice(0, MAX_INPUT);
+
+    // prefer newline split; fall back to first comma
+    let operands: string[];
+    if (capped.includes('\n')) {
+      operands = capped
+        .split('\n')
+        .map(trim)
+        .filter((s) => s.length > 0);
+    } else {
+      const commaIdx = capped.indexOf(',');
+      if (commaIdx === -1) {
+        operands = [trim(capped)];
+      } else {
+        operands = [
+          trim(capped.slice(0, commaIdx)),
+          trim(capped.slice(commaIdx + 1)),
+        ];
+      }
+    }
+
+    if (operands.length < 2) {
+      return [
+        new BoxBuilder(
+          'Hamming Distance',
+          'Two strings are required. Separate them with a comma or newline.',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({
+            Error: 'Two strings are required (comma or newline separated).',
+          })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const a = operands[0];
+    const b = operands[1];
+    const lenA = codePointCount(a);
+    const lenB = codePointCount(b);
+
+    if (lenA !== lenB) {
+      const kv = {
+        Error: `Hamming distance requires equal-length strings (got ${lenA} and ${lenB}).`,
+        'Length A': String(lenA),
+        'Length B': String(lenB),
+      };
+      return [
+        new BoxBuilder('Hamming Distance', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const distance = charDistance(a, b);
+    const kvOptions: Record<string, string> = {
+      A: a,
+      B: b,
+      Length: String(lenA),
+      Distance: String(distance),
+    };
+
+    // bonus: bit-level distance for equal-length pure-hex inputs
+    if (HEX_RE.test(a) && HEX_RE.test(b)) {
+      kvOptions['Bit Distance'] = String(hexBitDistance(a, b));
+    }
+
+    return [
+      new BoxBuilder('Hamming Distance', kvToPlaintext(kvOptions))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HammingDistanceBoxSource;

--- a/src/modules/boxSources/__test__/HammingDistanceBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HammingDistanceBoxSource.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import { HammingDistanceBoxSource } from '../HammingDistanceBoxSource';
+
+describe('HammingDistanceBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin, kathrin',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is provided', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin, kathrin',
+        { sha256: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('char-level distance', () => {
+    it('karolin vs kathrin → Distance 3, Length 7', async () => {
+      // positions 2(r/t), 3(o/h), 4(l/r) differ
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin, kathrin',
+        { hamming: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('3');
+      expect(opts.Length).toBe('7');
+      expect(opts.A).toBe('karolin');
+      expect(opts.B).toBe('kathrin');
+    });
+
+    it('newline-separated "abc\\nabd" → Distance 1', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('abc\nabd', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('1');
+    });
+
+    it('"1011101, 1001001" → Distance 2', async () => {
+      // positions 1(0/0 same), compare: 1011101 vs 1001001
+      // idx0:1=1, idx1:0=0, idx2:1=0 ✗, idx3:1=1, idx4:1=0 ✗, idx5:0=0, idx6:1=1 → 2 diffs
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        '1011101, 1001001',
+        { hamming: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('2');
+    });
+
+    it('equal strings "foo, foo" → Distance 0', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('foo, foo', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Distance).toBe('0');
+    });
+  });
+
+  describe('error cases', () => {
+    it('unequal-length strings "abc, ab" → error box mentioning equal-length', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('abc, ab', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/equal-length/i);
+      expect(opts['Length A']).toBe('3');
+      expect(opts['Length B']).toBe('2');
+    });
+
+    it('single operand "abc" (no separator) → error box mentioning two strings', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('abc', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/two strings/i);
+    });
+  });
+
+  describe('hex bit distance bonus', () => {
+    it('"ff, 0f" → Bit Distance 4 (0xff ^ 0x0f = 0xf0 = 4 bits set)', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('ff, 0f', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // char-level: 'f'≠'0', 'f'='f' → Distance 1
+      expect(opts.Distance).toBe('1');
+      // bit-level: 0xf ^ 0x0 = 0xf (4 bits), 0xf ^ 0xf = 0x0 (0 bits) → 4
+      expect(opts['Bit Distance']).toBe('4');
+    });
+
+    it('"00, ff" → Bit Distance 8', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes('00, ff', {
+        hamming: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Bit Distance']).toBe('8');
+    });
+
+    it('non-hex inputs do not produce Bit Distance key', async () => {
+      const boxes = await HammingDistanceBoxSource.generateBoxes(
+        'karolin, kathrin',
+        { hamming: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Bit Distance']).toBeUndefined();
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HammingDistanceBoxSource.name).toBe('Hamming Distance');
+      expect(HammingDistanceBoxSource.tag).toBe('#');
+      expect(HammingDistanceBoxSource.kind).toBe('Calculate');
+      expect(typeof HammingDistanceBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -17,6 +17,7 @@ import FractionBoxSource from './FractionBoxSource';
 import FrequencyBoxSource from './FrequencyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
+import HammingDistanceBoxSource from './HammingDistanceBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  HammingDistanceBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Hamming Distance (Calculate)

Adds the `Hamming Distance` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `karolin, kathrin ::hamming`

#### Options:
- `::hamming`

#### Description:
Hamming distance between two equal-length strings. Separate the two with a comma or newline. ::hamming

#### Usage Examples:
- **Input**: `karolin, kathrin ::hamming`
- **Output Box (`Hamming Distance`)**:
```
A: karolin
B: kathrin
Length: 7
Distance: 3
```
