### PR TITLE
feat(Haversine): add Distance BoxSource

### DIFF
--- a/src/modules/boxSources/HaversineBoxSource.ts
+++ b/src/modules/boxSources/HaversineBoxSource.ts
@@ -1,0 +1,153 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// mean earth radius per IUGG
+const EARTH_RADIUS_KM = 6371.0088;
+const KM_TO_MILES = 0.621371;
+const KM_TO_NM = 1 / 1.852;
+
+// coordinate separators: ' to ', ';', '|'
+const PAIR_SEP = /\s+to\s+|;|\|/i;
+
+interface Coord {
+  lat: number;
+  lng: number;
+}
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+/** formats a display string for the coordinate */
+function formatCoord(c: Coord): string {
+  return `${c.lat}, ${c.lng}`;
+}
+
+/** parses "lat,lng" and validates ranges; returns null if invalid */
+function parseCoord(s: string): Coord | null {
+  const parts = s.split(',');
+  if (parts.length !== 2) return null;
+  const lat = Number.parseFloat(parts[0].trim());
+  const lng = Number.parseFloat(parts[1].trim());
+  if (Number.isNaN(lat) || Number.isNaN(lng)) return null;
+  if (lat < -90 || lat > 90) return null;
+  if (lng < -180 || lng > 180) return null;
+  return { lat, lng };
+}
+
+/** haversine great-circle distance in km */
+function haversineKm(a: Coord, b: Coord): number {
+  const φ1 = toRad(a.lat);
+  const φ2 = toRad(b.lat);
+  const dφ = toRad(b.lat - a.lat);
+  const dλ = toRad(b.lng - a.lng);
+  const sinDφ = Math.sin(dφ / 2);
+  const sinDλ = Math.sin(dλ / 2);
+  const val = sinDφ * sinDφ + Math.cos(φ1) * Math.cos(φ2) * sinDλ * sinDλ;
+  const c = 2 * Math.atan2(Math.sqrt(val), Math.sqrt(1 - val));
+  return EARTH_RADIUS_KM * c;
+}
+
+/** initial bearing (forward azimuth) in degrees 0..360 */
+function initialBearing(a: Coord, b: Coord): number {
+  const φ1 = toRad(a.lat);
+  const φ2 = toRad(b.lat);
+  const dλ = toRad(b.lng - a.lng);
+  const y = Math.sin(dλ) * Math.cos(φ2);
+  const x =
+    Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(dλ);
+  return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+}
+
+/** renders key-value record as plaintext for headless consumers */
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+const FORMAT_ERROR_BOX_NAME = 'Distance';
+const FORMAT_ERROR_MSG =
+  'Invalid input. Expected format: lat1,lng1 to lat2,lng2\n' +
+  'Latitude must be -90..90, longitude must be -180..180.';
+
+export const HaversineBoxSource = {
+  defaultDisabled: true,
+  name: 'Distance',
+  description:
+    'Great-circle distance between two coordinates. Input: "lat1,lng1 to lat2,lng2".',
+  defaultInput: '40.7128,-74.0060 to 51.5074,-0.1278 ::haversine',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'haversine', 'distance')) return [];
+
+    const raw = trim(input);
+    if (raw.length > 100) {
+      return [
+        new BoxBuilder(FORMAT_ERROR_BOX_NAME, FORMAT_ERROR_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const parts = raw.split(PAIR_SEP);
+    if (parts.length !== 2) {
+      return [
+        new BoxBuilder(FORMAT_ERROR_BOX_NAME, FORMAT_ERROR_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const coordA = parseCoord(parts[0]);
+    const coordB = parseCoord(parts[1]);
+
+    if (!coordA || !coordB) {
+      return [
+        new BoxBuilder(FORMAT_ERROR_BOX_NAME, FORMAT_ERROR_MSG)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const km = haversineKm(coordA, coordB);
+    const miles = km * KM_TO_MILES;
+    const nm = km * KM_TO_NM;
+    const bearing = initialBearing(coordA, coordB);
+
+    // integer-exact for zero distance; otherwise 3 decimals
+    const fmtDist = (n: number): string => (n === 0 ? '0' : n.toFixed(3));
+
+    const kv: Record<string, string> = {
+      From: formatCoord(coordA),
+      To: formatCoord(coordB),
+      Kilometers: fmtDist(km),
+      Miles: fmtDist(miles),
+      'Nautical Miles': fmtDist(nm),
+      'Initial Bearing': `${bearing.toFixed(1)}°`,
+    };
+
+    return [
+      new BoxBuilder(FORMAT_ERROR_BOX_NAME, kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HaversineBoxSource;

--- a/src/modules/boxSources/__test__/HaversineBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HaversineBoxSource.test.ts
@@ -1,0 +1,229 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { HaversineBoxSource } from '../HaversineBoxSource';
+
+describe('HaversineBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HaversineBoxSource.name).toBe('Distance');
+      expect(HaversineBoxSource.tag).toBe('#');
+      expect(HaversineBoxSource.kind).toBe('Calculate');
+      expect(HaversineBoxSource.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes - option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('activates on ::haversine option', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('activates on ::distance option', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { distance: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes - NYC to London', () => {
+    it('Kilometers is approximately 5570 km', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      expect(km).toBeGreaterThan(5560);
+      expect(km).toBeLessThan(5580);
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is Distance', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      expect(boxes[0].props.name).toBe('Distance');
+    });
+
+    it('priority is set', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('Miles ≈ km * 0.621371', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      const miles = Number.parseFloat(kv.Miles);
+      expect(miles).toBeCloseTo(km * 0.621371, 2);
+    });
+
+    it('kv options contain all expected keys', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv).toHaveProperty('From');
+      expect(kv).toHaveProperty('To');
+      expect(kv).toHaveProperty('Kilometers');
+      expect(kv).toHaveProperty('Miles');
+      expect(kv).toHaveProperty('Nautical Miles');
+      expect(kv).toHaveProperty('Initial Bearing');
+    });
+  });
+
+  describe('generateBoxes - same point (0,0 to 0,0)', () => {
+    it('Kilometers is 0', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0 to 0,0', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Kilometers).toBe('0');
+    });
+  });
+
+  describe('generateBoxes - equator quarter (0,0 to 0,90)', () => {
+    it('Kilometers ≈ 10018.75 (quarter circumference)', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0 to 0,90', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      expect(km).toBeGreaterThan(10000);
+      expect(km).toBeLessThan(10040);
+    });
+  });
+
+  describe('generateBoxes - equator half (0,0 to 0,180)', () => {
+    it('Kilometers ≈ 20037.5 (half circumference)', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0 to 0,180', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      // half circumference: 2 * pi * R / 2 = pi * 6371.0088 ≈ 20015
+      expect(km).toBeGreaterThan(20000);
+      expect(km).toBeLessThan(20060);
+    });
+  });
+
+  describe('generateBoxes - alternate separators', () => {
+    it('accepts semicolon separator', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0;0,90', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      expect(km).toBeGreaterThan(10000);
+    });
+
+    it('accepts pipe separator', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0|0,90', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      const km = Number.parseFloat(kv.Kilometers);
+      expect(km).toBeGreaterThan(10000);
+    });
+  });
+
+  describe('generateBoxes - invalid inputs', () => {
+    it('returns an error box for "hello"', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('hello', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box for bad lat (91,0 to 0,0)', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('91,0 to 0,0', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box for bad lng (0,0 to 0,181)', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('0,0 to 0,181', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box when only one pair is given', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes('40.7128,-74.0060', {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+
+    it('returns an error box for input exceeding 100 chars', async () => {
+      const long = `${'0,0'.repeat(20)} to 0,0`;
+      const boxes = await HaversineBoxSource.generateBoxes(long, {
+        haversine: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid input/i);
+    });
+  });
+
+  describe('generateBoxes - plaintext output', () => {
+    it('plaintextOutput contains key: value lines', async () => {
+      const boxes = await HaversineBoxSource.generateBoxes(
+        '40.7128,-74.0060 to 51.5074,-0.1278',
+        { haversine: true },
+      );
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toMatch(/Kilometers:/);
+      expect(text).toMatch(/Miles:/);
+      expect(text).toMatch(/Nautical Miles:/);
+      expect(text).toMatch(/Initial Bearing:/);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -16,6 +16,7 @@ import FrequencyBoxSource from './FrequencyBoxSource';
 import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -78,6 +79,7 @@ export const boxSources: BoxSource[] = [
   BmiBoxSource,
   FrequencyBoxSource,
   GcdLcmBoxSource,
+  HaversineBoxSource,
   LineToolsBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,


### PR DESCRIPTION
### Box Source: Distance (Calculate)

Adds the `Distance` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `40.7128,-74.0060 to 51.5074,-0.1278 ::haversine`

#### Options:
- `::distance`, `::haversine`

#### Description:
Great-circle distance between two coordinates. Input:

#### Usage Examples:
- **Input**: `40.7128,-74.0060 to 51.5074,-0.1278 ::haversine`
- **Output Box (`Distance`)**:
```
From: 40.7128, -74.006
To: 51.5074, -0.1278
Kilometers: 5570.230
Miles: 3461.179
Nautical Miles: 3007.684
Initial Bearing: 51.2°
```
