### PR TITLE
feat(Hmac): add HMAC BoxSource

### DIFF
--- a/src/modules/boxSources/HmacBoxSource.ts
+++ b/src/modules/boxSources/HmacBoxSource.ts
@@ -1,0 +1,148 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// supported HMAC hash algorithms
+type HmacAlgorithm = 'SHA-1' | 'SHA-256' | 'SHA-512';
+
+function bufToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function computeHmac(
+  algorithm: HmacAlgorithm,
+  keyBytes: Uint8Array,
+  messageBytes: Uint8Array,
+): Promise<string> {
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    // cast: a Uint8Array is a valid BufferSource at runtime; the TS 5.7
+    // ArrayBufferLike-vs-ArrayBuffer narrowing is overly strict here
+    keyBytes as BufferSource,
+    { name: 'HMAC', hash: algorithm },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    cryptoKey,
+    messageBytes as BufferSource,
+  );
+  return bufToHex(signature);
+}
+
+// build k:v plaintext for the KeyValueBoxTemplate plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const HmacBoxSource = {
+  defaultDisabled: true,
+  name: 'HMAC',
+  description:
+    'Compute HMAC-SHA256/SHA1/SHA512 of the input using a key. ::hmac=<key>.',
+  defaultInput: 'The quick brown fox jumps over the lazy dog ::hmac=key',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hmac', 'hmacsha256')) {
+      return [];
+    }
+
+    const key = extractOptionKeys(options, 'hmac', 'hmacsha256');
+
+    // bare ::hmac without a value → show usage hint
+    if (key === true) {
+      return [
+        new BoxBuilder('HMAC', 'provide a key, e.g. ::hmac=secret')
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // key must be a non-empty string (typeof narrows for TS; isString does not)
+    if (typeof key !== 'string' || key.length === 0) {
+      return [];
+    }
+
+    if (!isString(input) || input.length > MAX_INPUT) {
+      return [];
+    }
+
+    // crypto.subtle requires a secure context (HTTPS or localhost)
+    if (typeof crypto === 'undefined' || !crypto?.subtle) {
+      return [
+        new BoxBuilder(
+          'HMAC',
+          'a secure context (HTTPS) is required — crypto.subtle is not available.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const encoder = new TextEncoder();
+    const keyBytes = encoder.encode(key);
+    const messageBytes = encoder.encode(input);
+
+    let sha256: string;
+    let sha1: string;
+    let sha512: string;
+    try {
+      [sha256, sha1, sha512] = await Promise.all([
+        computeHmac('SHA-256', keyBytes, messageBytes),
+        computeHmac('SHA-1', keyBytes, messageBytes),
+        computeHmac('SHA-512', keyBytes, messageBytes),
+      ]);
+    } catch {
+      return [
+        new BoxBuilder('HMAC', 'HMAC computation failed in this environment.')
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // key length in bytes (UTF-8); do NOT expose the key itself
+    const keyByteLength = keyBytes.byteLength;
+
+    const kv: Record<string, string> = {
+      'HMAC-SHA256': sha256,
+      'HMAC-SHA1': sha1,
+      'HMAC-SHA512': sha512,
+      'Key Length': String(keyByteLength),
+    };
+
+    return [
+      new BoxBuilder('HMAC', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HmacBoxSource;

--- a/src/modules/boxSources/__test__/HmacBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HmacBoxSource.test.ts
@@ -1,0 +1,166 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { HmacBoxSource } from '../HmacBoxSource';
+
+// canonical test message and key used across most test cases
+const MESSAGE = 'The quick brown fox jumps over the lazy dog';
+const KEY = 'key';
+
+// RFC 4231 / Wikipedia HMAC known vectors for message=MESSAGE, key=KEY
+const EXPECTED_SHA256 =
+  'f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8';
+const EXPECTED_SHA1 = 'de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9';
+
+describe('HmacBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HmacBoxSource.name).toBe('HMAC');
+      expect(HmacBoxSource.tag).toBe('#');
+      expect(HmacBoxSource.kind).toBe('Encode');
+      expect(HmacBoxSource.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes — no trigger option', () => {
+    it('returns empty array when no option is provided (null)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is set', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, {
+        sha256: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — bare ::hmac (boolean true) → usage box', () => {
+    it('returns a usage hint box when key value is boolean true', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('HMAC');
+      expect(boxes[0].props.plaintextOutput).toMatch(/provide a key/i);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+
+  describe('generateBoxes — HMAC-SHA256 known vector', () => {
+    it('produces the canonical HMAC-SHA256 digest (Wikipedia / RFC 4231)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['HMAC-SHA256']).toBe(EXPECTED_SHA256);
+    });
+
+    it('also accepts the ::hmacsha256 alias', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, {
+        hmacsha256: KEY,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['HMAC-SHA256']).toBe(EXPECTED_SHA256);
+    });
+  });
+
+  describe('generateBoxes — HMAC-SHA1 known vector', () => {
+    it('produces the canonical HMAC-SHA1 digest (Wikipedia)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes[0].props.options?.['HMAC-SHA1']).toBe(EXPECTED_SHA1);
+    });
+  });
+
+  describe('generateBoxes — Key Length field', () => {
+    it('reports key byte length as "3" for key "key" — does NOT echo the key', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes[0].props.options?.['Key Length']).toBe('3');
+      // confirm the raw key string is absent from plaintext output
+      expect(boxes[0].props.plaintextOutput).not.toContain(`${KEY}:`);
+    });
+
+    it('reports correct byte length for a multi-byte UTF-8 key', async () => {
+      // '€' is 3 UTF-8 bytes
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: '€' });
+      expect(boxes[0].props.options?.['Key Length']).toBe('3');
+    });
+  });
+
+  describe('generateBoxes — output shape', () => {
+    it('returns a single HMAC box using KeyValueBoxTemplate', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('HMAC');
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('options record contains all four expected keys', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      const opts = boxes[0].props.options ?? {};
+      expect(Object.keys(opts)).toEqual([
+        'HMAC-SHA256',
+        'HMAC-SHA1',
+        'HMAC-SHA512',
+        'Key Length',
+      ]);
+    });
+
+    it('plaintextOutput is non-empty k:v lines', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('HMAC-SHA256:');
+      expect(text).toContain('HMAC-SHA1:');
+      expect(text).toContain('HMAC-SHA512:');
+      expect(text).toContain('Key Length:');
+    });
+
+    it('priority is set on the box', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes — empty input', () => {
+    it('still returns an HMAC box (HMAC of empty message is valid)', async () => {
+      const boxes = await HmacBoxSource.generateBoxes('', { hmac: KEY });
+      expect(boxes).toHaveLength(1);
+      // HMAC-SHA256('', 'key') is a fixed deterministic value — just assert it is 64 hex chars
+      const sha256 = boxes[0].props.options?.['HMAC-SHA256'] as string;
+      expect(sha256).toHaveLength(64);
+      expect(sha256).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+
+  describe('generateBoxes — non-secure context fallback', () => {
+    const originalCrypto = globalThis.crypto;
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { subtle: undefined },
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('returns an informational box when crypto.subtle is unavailable', async () => {
+      const boxes = await HmacBoxSource.generateBoxes(MESSAGE, { hmac: KEY });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import HmacBoxSource from './HmacBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  HmacBoxSource,
 ];


### PR DESCRIPTION
### Box Source: HMAC (Encode)

Adds the `HMAC` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `The quick brown fox jumps over the lazy dog ::hmac=key`

#### Options:
- `::hmac`, `::hmacsha256`

#### Description:
Compute HMAC-SHA256/SHA1/SHA512 of the input using a key. ::hmac=<key>.

#### Usage Examples:
- **Input**: `The quick brown fox jumps over the lazy dog ::hmac=key`
- **Output Box (`HMAC`)**:
```
HMAC-SHA256: f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8
HMAC-SHA1: de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9
HMAC-SHA512: b42af09057bac1e2d41708e48a902e09b5ff7f12ab428a4fe86653c73dd248fb82f948a549f7b791a5b41915ee4d1ec3935357e4e2317250d0372afa2ebeeb3a
Key Length: 3
```
