### PR TITLE
feat(Hsv): add HSV BoxSource

### DIFF
--- a/src/modules/boxSources/HsvBoxSource.ts
+++ b/src/modules/boxSources/HsvBoxSource.ts
@@ -1,0 +1,250 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+const MAX_INPUT_LEN = 64;
+
+interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+interface HSV {
+  h: number;
+  s: number;
+  v: number;
+}
+
+// convert rgb integers 0-255 to hsv (h in [0,360), s/v in [0,100])
+export function rgbToHsv(r: number, g: number, b: number): HSV {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rn) {
+      h = 60 * (((gn - bn) / delta) % 6);
+    } else if (max === gn) {
+      h = 60 * ((bn - rn) / delta + 2);
+    } else {
+      h = 60 * ((rn - gn) / delta + 4);
+    }
+  }
+  if (h < 0) h += 360;
+
+  const s = max === 0 ? 0 : delta / max;
+  const v = max;
+
+  return {
+    h: Math.round(h),
+    s: Math.round(s * 100),
+    v: Math.round(v * 100),
+  };
+}
+
+// convert hsv (h deg, s/v percent) to rgb integers 0-255
+export function hsvToRgb(h: number, s: number, v: number): RGB {
+  const sn = s / 100;
+  const vn = v / 100;
+
+  const c = vn * sn;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = vn - c;
+
+  let r = 0;
+  let g = 0;
+  let b = 0;
+
+  if (h < 60) {
+    [r, g, b] = [c, x, 0];
+  } else if (h < 120) {
+    [r, g, b] = [x, c, 0];
+  } else if (h < 180) {
+    [r, g, b] = [0, c, x];
+  } else if (h < 240) {
+    [r, g, b] = [0, x, c];
+  } else if (h < 300) {
+    [r, g, b] = [x, 0, c];
+  } else {
+    [r, g, b] = [c, 0, x];
+  }
+
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255),
+  };
+}
+
+// format rgb as lowercase 6-digit hex
+export function rgbToHex(r: number, g: number, b: number): string {
+  const hex = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${hex(r)}${hex(g)}${hex(b)}`;
+}
+
+// parse 3 or 6-digit hex to rgb, or null if invalid
+function parseHex(input: string): RGB | null {
+  const m = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(input);
+  if (!m) return null;
+  const h = m[1];
+  if (h.length === 3) {
+    return {
+      r: Number.parseInt(h[0] + h[0], 16),
+      g: Number.parseInt(h[1] + h[1], 16),
+      b: Number.parseInt(h[2] + h[2], 16),
+    };
+  }
+  return {
+    r: Number.parseInt(h.slice(0, 2), 16),
+    g: Number.parseInt(h.slice(2, 4), 16),
+    b: Number.parseInt(h.slice(4, 6), 16),
+  };
+}
+
+// parse rgb(r,g,b) to rgb, or null if invalid
+function parseRgb(input: string): RGB | null {
+  const m = /^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/.exec(input);
+  if (!m) return null;
+  const r = Number.parseInt(m[1], 10);
+  const g = Number.parseInt(m[2], 10);
+  const b = Number.parseInt(m[3], 10);
+  if (r > 255 || g > 255 || b > 255) return null;
+  return { r, g, b };
+}
+
+// parse hsv(h,s%,v%) or hsb(h,s%,v%) to hsv, or null if invalid
+function parseHsv(input: string): HSV | null {
+  const m =
+    /^hs[vb]\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)%?\s*,\s*(\d+(?:\.\d+)?)%?\s*\)$/i.exec(
+      input,
+    );
+  if (!m) return null;
+  const h = Number.parseFloat(m[1]);
+  const s = Number.parseFloat(m[2]);
+  const v = Number.parseFloat(m[3]);
+  if (h < 0 || h > 360 || s < 0 || s > 100 || v < 0 || v > 100) return null;
+  return { h: Math.round(h), s: Math.round(s), v: Math.round(v) };
+}
+
+// build the key:value plaintext for headless/TUI consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, val]) => `${k}: ${val}`)
+    .join('\n');
+}
+
+type Direction = 'toHsv' | 'toRgb' | 'unknown';
+
+interface Match {
+  direction: Direction;
+  rgb?: RGB;
+  hsv?: HSV;
+}
+
+export const HsvBoxSource = {
+  defaultDisabled: true,
+  name: 'HSV',
+  description: 'Convert a color between hex/RGB and HSV (HSB).',
+  defaultInput: '#ff6347 ::hsv',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  checkMatch(input: string): Match | undefined {
+    const s = trim(input);
+    if (!s || s.length > MAX_INPUT_LEN) return undefined;
+
+    const lower = s.toLowerCase();
+
+    // hsv()/hsb() → rgb/hex direction
+    const hsv = parseHsv(lower);
+    if (hsv) return { direction: 'toRgb', hsv };
+
+    // hex or rgb() → hsv direction
+    const rgb = parseHex(lower) ?? parseRgb(lower);
+    if (rgb) return { direction: 'toHsv', rgb };
+
+    // input is present but unparseable — show format hint
+    if (s.length > 0) return { direction: 'unknown' };
+
+    return undefined;
+  },
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'hsv', 'hsb')) return [];
+
+    const match = this.checkMatch(input);
+    if (!match) return [];
+
+    if (match.direction === 'toHsv' && match.rgb) {
+      const { r, g, b } = match.rgb;
+      const { h, s, v } = rgbToHsv(r, g, b);
+      const hexStr = rgbToHex(r, g, b);
+      const rgbStr = `rgb(${r}, ${g}, ${b})`;
+      const hsvStr = `hsv(${h}, ${s}%, ${v}%)`;
+
+      const kv: Record<string, string> = {
+        Hex: hexStr,
+        RGB: rgbStr,
+        HSV: hsvStr,
+      };
+
+      return [
+        new BoxBuilder('HSV', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (match.direction === 'toRgb' && match.hsv) {
+      const { h, s, v } = match.hsv;
+      const { r, g, b } = hsvToRgb(h, s, v);
+      const hexStr = rgbToHex(r, g, b);
+      const rgbStr = `rgb(${r}, ${g}, ${b})`;
+      const hsvStr = `hsv(${h}, ${s}%, ${v}%)`;
+
+      const kv: Record<string, string> = {
+        HSV: hsvStr,
+        RGB: rgbStr,
+        Hex: hexStr,
+      };
+
+      return [
+        new BoxBuilder('HSV', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // unknown direction: show format hint
+    const kv: Record<string, string> = {
+      Accepted: '#RRGGBB, #RGB, rgb(r,g,b), hsv(h,s%,v%), hsb(h,s%,v%)',
+    };
+
+    return [
+      new BoxBuilder('HSV', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HsvBoxSource;

--- a/src/modules/boxSources/__test__/HsvBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HsvBoxSource.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+
+import { HsvBoxSource, hsvToRgb, rgbToHex, rgbToHsv } from '../HsvBoxSource';
+
+// ─── conversion helper unit tests ────────────────────────────────────────────
+
+describe('rgbToHsv', () => {
+  it('converts red rgb(255,0,0) to hsv(0, 100%, 100%)', () => {
+    expect(rgbToHsv(255, 0, 0)).toEqual({ h: 0, s: 100, v: 100 });
+  });
+
+  it('converts green rgb(0,255,0) to hsv(120, 100%, 100%)', () => {
+    expect(rgbToHsv(0, 255, 0)).toEqual({ h: 120, s: 100, v: 100 });
+  });
+
+  it('converts blue rgb(0,0,255) to hsv(240, 100%, 100%)', () => {
+    expect(rgbToHsv(0, 0, 255)).toEqual({ h: 240, s: 100, v: 100 });
+  });
+
+  it('converts white rgb(255,255,255) to hsv(0, 0%, 100%)', () => {
+    expect(rgbToHsv(255, 255, 255)).toEqual({ h: 0, s: 0, v: 100 });
+  });
+
+  it('converts black rgb(0,0,0) to hsv(0, 0%, 0%)', () => {
+    expect(rgbToHsv(0, 0, 0)).toEqual({ h: 0, s: 0, v: 0 });
+  });
+
+  it('converts tomato rgb(255,99,71) to hsv(9, 72%, 100%)', () => {
+    // max=255(v=100%), min=71, delta=184
+    // s=184/255≈72%, h=60*((99-71)/184 % 6)=60*(28/184)≈9.13→9
+    expect(rgbToHsv(255, 99, 71)).toEqual({ h: 9, s: 72, v: 100 });
+  });
+});
+
+describe('hsvToRgb', () => {
+  it('converts hsv(0, 100%, 100%) to rgb(255,0,0)', () => {
+    expect(hsvToRgb(0, 100, 100)).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it('converts hsv(120, 100%, 100%) to rgb(0,255,0)', () => {
+    expect(hsvToRgb(120, 100, 100)).toEqual({ r: 0, g: 255, b: 0 });
+  });
+
+  it('converts hsv(240, 100%, 100%) to rgb(0,0,255)', () => {
+    expect(hsvToRgb(240, 100, 100)).toEqual({ r: 0, g: 0, b: 255 });
+  });
+
+  it('converts hsv(0, 0%, 100%) to rgb(255,255,255)', () => {
+    expect(hsvToRgb(0, 0, 100)).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it('converts hsv(0, 0%, 0%) to rgb(0,0,0)', () => {
+    expect(hsvToRgb(0, 0, 0)).toEqual({ r: 0, g: 0, b: 0 });
+  });
+});
+
+describe('rgbToHex', () => {
+  it('formats rgb(255,0,0) as #ff0000', () => {
+    expect(rgbToHex(255, 0, 0)).toBe('#ff0000');
+  });
+
+  it('formats rgb(0,255,0) as #00ff00', () => {
+    expect(rgbToHex(0, 255, 0)).toBe('#00ff00');
+  });
+
+  it('formats rgb(0,0,255) as #0000ff', () => {
+    expect(rgbToHex(0, 0, 255)).toBe('#0000ff');
+  });
+});
+
+// ─── HsvBoxSource.generateBoxes ───────────────────────────────────────────────
+
+describe('HsvBoxSource.generateBoxes', () => {
+  it('returns [] when no ::hsv/::hsb option is present', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff6347', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] when options is empty object', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff6347', {});
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('tomato #ff6347 + ::hsv → HSV hsv(9, 72%, 100%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff6347', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(9, 72%, 100%)');
+    expect(kv.Hex).toBe('#ff6347');
+    expect(kv.RGB).toBe('rgb(255, 99, 71)');
+  });
+
+  it('pure red #ff0000 → hsv(0, 100%, 100%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff0000', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(0, 100%, 100%)');
+  });
+
+  it('white #ffffff → hsv(0, 0%, 100%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ffffff', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(0, 0%, 100%)');
+  });
+
+  it('black #000000 → hsv(0, 0%, 0%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#000000', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(0, 0%, 0%)');
+  });
+
+  it('green #00ff00 → hsv(120, 100%, 100%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#00ff00', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(120, 100%, 100%)');
+  });
+
+  it('blue #0000ff → hsv(240, 100%, 100%)', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#0000ff', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(240, 100%, 100%)');
+  });
+
+  it('accepts ::hsb alias', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff0000', { hsb: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(0, 100%, 100%)');
+  });
+
+  it('rgb(255,99,71) input → same HSV as hex tomato', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('rgb(255, 99, 71)', {
+      hsv: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.HSV).toBe('hsv(9, 72%, 100%)');
+  });
+
+  // reverse: hsv → rgb/hex
+
+  it('reverse hsv(120, 100%, 100%) → Hex #00ff00', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('hsv(120, 100%, 100%)', {
+      hsv: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Hex).toBe('#00ff00');
+    expect(kv.RGB).toBe('rgb(0, 255, 0)');
+  });
+
+  it('reverse hsv(0, 0%, 100%) → Hex #ffffff', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('hsv(0, 0%, 100%)', {
+      hsv: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Hex).toBe('#ffffff');
+  });
+
+  it('reverse hsv without % signs hsv(120, 100, 100) → Hex #00ff00', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('hsv(120, 100, 100)', {
+      hsv: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Hex).toBe('#00ff00');
+  });
+
+  it('reverse hsb(240, 100%, 100%) → Hex #0000ff', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('hsb(240, 100%, 100%)', {
+      hsv: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Hex).toBe('#0000ff');
+  });
+
+  // invalid input → format hint box
+
+  it('invalid input "hello" → returns a hint box', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('hello', { hsv: true });
+    expect(boxes).toHaveLength(1);
+    const kv = boxes[0].props.options as Record<string, string>;
+    expect(kv.Accepted).toBeDefined();
+  });
+
+  // box metadata
+
+  it('box name is "HSV"', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff0000', { hsv: true });
+    expect(boxes[0].props.name).toBe('HSV');
+  });
+
+  it('box priority matches HsvBoxSource.priority', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff0000', { hsv: true });
+    expect(boxes[0].props.priority).toBe(HsvBoxSource.priority);
+  });
+
+  it('plaintext contains key:value pairs', async () => {
+    const boxes = await HsvBoxSource.generateBoxes('#ff0000', { hsv: true });
+    const text = boxes[0].props.plaintextOutput;
+    expect(text).toContain('Hex:');
+    expect(text).toContain('RGB:');
+    expect(text).toContain('HSV:');
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import HsvBoxSource from './HsvBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  HsvBoxSource,
 ];


### PR DESCRIPTION
### Box Source: HSV (Convert)

Adds the `HSV` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `#ff6347 ::hsv`

#### Options:
- `::hsb`, `::hsv`

#### Description:
Convert a color between hex/RGB and HSV (HSB).

#### Usage Examples:
- **Input**: `#ff6347 ::hsv`
- **Output Box (`HSV`)**:
```
Hex: #ff6347
RGB: rgb(255, 99, 71)
HSV: hsv(9, 72%, 100%)
```
