### PR TITLE
feat(HtmlEntity): add HTML Entity BoxSource

### DIFF
--- a/src/modules/boxSources/HtmlEntityBoxSource.ts
+++ b/src/modules/boxSources/HtmlEntityBoxSource.ts
@@ -1,0 +1,90 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// encode special HTML characters; & must go first to avoid double-encoding
+function encodeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// map a numeric entity to its character; out-of-range code points (> U+10FFFF)
+// are left as the original entity text instead of throwing a RangeError
+function fromCodePointSafe(codePoint: number, original: string): string {
+  return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : original;
+}
+
+// decode named and numeric entities; &amp; goes last to prevent over-decoding
+function decodeHtml(input: string): string {
+  return input
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&#[xX]([0-9a-fA-F]+);/g, (match, hex) =>
+      fromCodePointSafe(Number.parseInt(hex, 16), match),
+    )
+    .replace(/&#(\d+);/g, (match, dec) =>
+      fromCodePointSafe(Number.parseInt(dec, 10), match),
+    )
+    .replace(/&amp;/g, '&');
+}
+
+export const HtmlEntityBoxSource = {
+  defaultDisabled: true,
+  name: 'HTML Entity',
+  description:
+    'Encode text to HTML entities or decode HTML entities back to text.',
+  defaultInput: '<div class="x">Tom & Jerry</div> ::htmlencode',
+  tag: '&',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(
+      options,
+      'htmlencode',
+      'htmlentity',
+      'htmlentities',
+    );
+    const wantDecode = hasOptionKeys(
+      options,
+      'htmldecode',
+      'htmlentity',
+      'htmlentities',
+    );
+    if (!wantEncode && !wantDecode) return [];
+
+    const boxes: Box[] = [];
+    if (wantEncode) {
+      boxes.push(
+        new BoxBuilder('HTML Encode', encodeHtml(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+    if (wantDecode) {
+      boxes.push(
+        new BoxBuilder('HTML Decode', decodeHtml(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+    return boxes;
+  },
+};
+
+export default HtmlEntityBoxSource;

--- a/src/modules/boxSources/__test__/HtmlEntityBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HtmlEntityBoxSource.test.ts
@@ -1,0 +1,162 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { HtmlEntityBoxSource } from '../HtmlEntityBoxSource';
+
+describe('HtmlEntityBoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('<b>hi</b>', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('<b>hi</b>', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::htmlencode', () => {
+    it('produces exactly one encode box', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes(
+        '<a href="x">A & B</a>',
+        { htmlencode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('HTML Encode');
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '&lt;a href=&quot;x&quot;&gt;A &amp; B&lt;/a&gt;',
+      );
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('encodes & before < to avoid double-encoding', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&<>', {
+        htmlencode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('&amp;&lt;&gt;');
+    });
+
+    it('encodes single quotes', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes("it's", {
+        htmlencode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('it&#39;s');
+    });
+  });
+
+  describe('generateBoxes - ::htmldecode', () => {
+    it('produces exactly one decode box', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes(
+        '&lt;b&gt;hi&amp;bye&lt;/b&gt;',
+        { htmldecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('HTML Decode');
+      expect(boxes[0].props.plaintextOutput).toBe('<b>hi&bye</b>');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('decodes &amp; last so &amp;lt; becomes &lt; not <', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&amp;lt;', {
+        htmldecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('&lt;');
+    });
+
+    it('decodes double-quotes', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes(
+        'say &quot;hi&quot;',
+        {
+          htmldecode: true,
+        },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('say "hi"');
+    });
+  });
+
+  describe('generateBoxes - ::htmlentity / ::htmlentities', () => {
+    it('produces two boxes for ::htmlentity', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('<x>', {
+        htmlentity: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('HTML Encode');
+      expect(boxes[1].props.name).toBe('HTML Decode');
+    });
+
+    it('produces two boxes for ::htmlentities', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('<x>', {
+        htmlentities: true,
+      });
+      expect(boxes).toHaveLength(2);
+    });
+  });
+
+  describe('generateBoxes - numeric entity decode', () => {
+    it('decodes decimal numeric entities', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&#65;&#66;', {
+        htmldecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+
+    it('decodes hex numeric entities', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&#x41;&#x42;', {
+        htmldecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+
+    it('decodes mixed decimal and hex', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&#65;&#x42;', {
+        htmldecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns encode box with empty string on empty input when triggered', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('', {
+        htmlencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('');
+    });
+
+    it('returns decode box with empty string on empty input when triggered', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('', {
+        htmldecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HtmlEntityBoxSource.name).toBe('HTML Entity');
+      expect(HtmlEntityBoxSource.tag).toBe('&');
+      expect(HtmlEntityBoxSource.kind).toBe('Encode');
+      expect(typeof HtmlEntityBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('numeric entity edge cases', () => {
+    it('decodes in-range numeric entities', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes('&#65;&#x42;', {
+        htmldecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+
+    it('leaves out-of-range code points untouched instead of throwing', async () => {
+      const boxes = await HtmlEntityBoxSource.generateBoxes(
+        '&#x110000;&#2147483647;',
+        { htmldecode: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('&#x110000;&#2147483647;');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import HtmlEntityBoxSource from './HtmlEntityBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  HtmlEntityBoxSource,
 ];


### PR DESCRIPTION
### Box Source: HTML Entity (Encode)

Adds the `HTML Entity` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `&`
- **Default Input**: `<div class=`

#### Options:
- `::`, `::htmldecode`, `::htmlencode`, `::htmlentities`, `::htmlentity`

#### Description:
Encode text to HTML entities or decode HTML entities back to text.

#### Usage Examples:
- **Input**: `<div class="x">Tom & Jerry</div> ::htmlencode`
- **Output Box (`HTML Encode`)**:
```
&lt;div class=&quot;x&quot;&gt;Tom &amp; Jerry&lt;/div&gt;
```
