### PR TITLE
feat(HttpHeaders): add HTTP Headers BoxSource

### DIFF
--- a/src/modules/boxSources/HttpHeadersBoxSource.ts
+++ b/src/modules/boxSources/HttpHeadersBoxSource.ts
@@ -1,0 +1,71 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 50_000;
+
+export const HttpHeadersBoxSource = {
+  defaultDisabled: true,
+  name: 'HTTP Headers',
+  description: 'Parse a raw HTTP header block into key/value pairs.',
+  defaultInput:
+    'Content-Type: application/json\nCache-Control: no-cache ::headers',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'headers', 'httpheaders')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    // accumulate header values, merging repeated names with ', '. HTTP field
+    // names are case-insensitive (RFC 9110), so dedupe by lowercased name while
+    // preserving the first-seen display casing
+    const headers = new Map<string, { name: string; value: string }>();
+
+    for (const rawLine of input.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (line.length === 0) continue;
+
+      const colonIdx = line.indexOf(':');
+      // skip lines without a colon (e.g. request/status lines like 'GET /path HTTP/1.1')
+      if (colonIdx === -1) continue;
+
+      const name = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim();
+
+      if (name.length === 0) continue;
+
+      const key = name.toLowerCase();
+      const existing = headers.get(key);
+      if (existing) {
+        existing.value = `${existing.value}, ${value}`;
+      } else {
+        headers.set(key, { name, value });
+      }
+    }
+
+    if (headers.size === 0) return [];
+
+    const output: Record<string, string> = {};
+    for (const { name, value } of headers.values()) {
+      output[name] = value;
+    }
+
+    return [
+      new BoxBuilder('HTTP Headers', '')
+        .setOptions(output)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HttpHeadersBoxSource;

--- a/src/modules/boxSources/__test__/HttpHeadersBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HttpHeadersBoxSource.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { HttpHeadersBoxSource } from '../HttpHeadersBoxSource';
+
+describe('HttpHeadersBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no option is provided', async () => {
+      const boxes = await HttpHeadersBoxSource.generateBoxes(
+        'Content-Type: application/json',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] for empty input', async () => {
+      const boxes = await HttpHeadersBoxSource.generateBoxes('', {
+        headers: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should parse basic headers with ::headers option', async () => {
+      const input = 'Content-Type: application/json\nCache-Control: no-cache';
+      const boxes = await HttpHeadersBoxSource.generateBoxes(input, {
+        headers: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Content-Type']).toBe('application/json');
+      expect(boxes[0].props.options?.['Cache-Control']).toBe('no-cache');
+    });
+
+    it('should parse basic headers with ::httpheaders option', async () => {
+      const input = 'Content-Type: application/json';
+      const boxes = await HttpHeadersBoxSource.generateBoxes(input, {
+        httpheaders: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Content-Type']).toBe('application/json');
+    });
+
+    it('should preserve colons in the value (split on first colon only)', async () => {
+      const input = 'Date: Mon, 01 Jan 2024 00:00:00 GMT';
+      const boxes = await HttpHeadersBoxSource.generateBoxes(input, {
+        headers: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Date).toBe(
+        'Mon, 01 Jan 2024 00:00:00 GMT',
+      );
+    });
+
+    it('should skip request/status lines that have no colon', async () => {
+      const input = 'GET / HTTP/1.1\nHost: example.com';
+      const boxes = await HttpHeadersBoxSource.generateBoxes(input, {
+        headers: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Host).toBe('example.com');
+      expect(boxes[0].props.options?.['GET / HTTP/1.1']).toBeUndefined();
+    });
+
+    it('should merge repeated header names with ", "', async () => {
+      const input = 'Set-Cookie: a=1\nSet-Cookie: b=2';
+      const boxes = await HttpHeadersBoxSource.generateBoxes(input, {
+        headers: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Set-Cookie']).toBe('a=1, b=2');
+    });
+
+    it('should return [] when input has no valid header lines', async () => {
+      const boxes = await HttpHeadersBoxSource.generateBoxes(
+        'just text no colon',
+        { headers: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('merges case-insensitive duplicate header names (RFC 9110)', async () => {
+      const boxes = await HttpHeadersBoxSource.generateBoxes(
+        'Set-Cookie: a=1\nset-cookie: b=2',
+        { headers: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Set-Cookie']).toBe('a=1, b=2');
+      expect(opts['set-cookie']).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import HttpHeadersBoxSource from './HttpHeadersBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  HttpHeadersBoxSource,
 ];


### PR DESCRIPTION
### Box Source: HTTP Headers (Analyze)

Adds the `HTTP Headers` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `Content-Type: application/json\nCache-Control: no-cache ::headers`

#### Options:
- `::headers`, `::httpheaders`

#### Description:
Parse a raw HTTP header block into key/value pairs.

#### Usage Examples:
- **Input**: `Content-Type: application/json
Cache-Control: no-cache ::headers`
- **Output Box (`HTTP Headers`)**:
```

```
