### PR TITLE
feat(HumanizeDuration): add Humanize Duration BoxSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev-debug.log
 *.sln
 *.sw?
 # OS specific
+.gemini/

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: box.defaultDisabled ? false : true,
+        enabled: !box.defaultDisabled,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: box.defaultDisabled ? false : true,
+            enabled: !box.defaultDisabled,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: true,
+        enabled: box.defaultDisabled ? false : true,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: true,
+            enabled: box.defaultDisabled ? false : true,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/modules/BoxSource.ts
+++ b/src/modules/BoxSource.ts
@@ -9,5 +9,6 @@ export interface BoxSource {
   tag: string;
   kind: string;
   priority?: number;
+  defaultDisabled?: boolean;
   generateBoxes: (input: string, options: BoxOptions) => Promise<Box[]>;
 }

--- a/src/modules/boxSources/HumanizeDurationBoxSource.ts
+++ b/src/modules/boxSources/HumanizeDurationBoxSource.ts
@@ -1,0 +1,104 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length guard against runaway regex backtracking
+const MAX_INPUT_LENGTH = 50;
+
+interface DurationParts {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  totalSeconds: number;
+}
+
+function decompose(totalSeconds: number): DurationParts {
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return { days, hours, minutes, seconds, totalSeconds };
+}
+
+function toCompact({ days, hours, minutes, seconds }: DurationParts): string {
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+  return parts.join(' ');
+}
+
+function pluralize(value: number, unit: string): string {
+  return value === 1 ? `${value} ${unit}` : `${value} ${unit}s`;
+}
+
+function toLong({ days, hours, minutes, seconds }: DurationParts): string {
+  const parts: string[] = [];
+  if (days > 0) parts.push(pluralize(days, 'day'));
+  if (hours > 0) parts.push(pluralize(hours, 'hour'));
+  if (minutes > 0) parts.push(pluralize(minutes, 'minute'));
+  if (seconds > 0 || parts.length === 0)
+    parts.push(pluralize(seconds, 'second'));
+  return parts.join(', ');
+}
+
+export const HumanizeDurationBoxSource = {
+  defaultDisabled: true,
+  name: 'Humanize Duration',
+  description:
+    'Turn a number of seconds into a human-readable duration. Use ::humanize=ms to treat the input as milliseconds.',
+  defaultInput: '90061 ::humanize',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'humanize', 'duration')) return [];
+    if (!isString(input)) return [];
+
+    const raw = trim(input);
+    if (raw.length === 0 || raw.length > MAX_INPUT_LENGTH) return [];
+    if (!/^\d+(\.\d+)?$/.test(raw)) return [];
+
+    const parsed = Number.parseFloat(raw);
+    if (!Number.isFinite(parsed) || parsed < 0) return [];
+
+    // treat as milliseconds when the option value is the string 'ms'
+    const unitValue = extractOptionKeys(options, 'humanize', 'duration');
+    const isMs = unitValue === 'ms';
+
+    const totalSeconds = Math.floor(isMs ? parsed / 1000 : parsed);
+    const parts = decompose(totalSeconds);
+
+    const compact = toCompact(parts);
+    const long = toLong(parts);
+    const totalSecondsStr = totalSeconds.toString();
+
+    // plaintext summary shown when no template renders
+    const plaintextOutput = `Compact: ${compact}\nLong: ${long}\nTotal Seconds: ${totalSecondsStr}`;
+
+    const outputOptions: Record<string, string> = {
+      Compact: compact,
+      Long: long,
+      'Total Seconds': totalSecondsStr,
+    };
+
+    return [
+      new BoxBuilder('Humanize Duration', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(outputOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default HumanizeDurationBoxSource;

--- a/src/modules/boxSources/__test__/HumanizeDurationBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/HumanizeDurationBoxSource.test.ts
@@ -1,0 +1,196 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { HumanizeDurationBoxSource } from '../HumanizeDurationBoxSource';
+
+describe('HumanizeDurationBoxSource', () => {
+  describe('gate conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes(
+        '90061',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options has neither humanize nor duration key', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90061', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('abc', {
+        humanize: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('', {
+        humanize: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding 50 characters', async () => {
+      const long = '1'.repeat(51);
+      const boxes = await HumanizeDurationBoxSource.generateBoxes(long, {
+        humanize: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for negative-looking input (sign not in pattern)', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('-1', {
+        humanize: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('seconds mode (default)', () => {
+    it('90061s → Compact "1d 1h 1m 1s"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90061', {
+        humanize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1d 1h 1m 1s');
+    });
+
+    it('90061s → Total Seconds "90061"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90061', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('90061');
+    });
+
+    it('60s → Compact "1m"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('60', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1m');
+    });
+
+    it('3661s → Compact "1h 1m 1s"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('3661', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1h 1m 1s');
+    });
+
+    it('0s → Compact "0s"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('0', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('0s');
+    });
+
+    it('3600s → Compact "1h"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('3600', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1h');
+    });
+  });
+
+  describe('milliseconds mode (::humanize=ms)', () => {
+    it('90000ms → 90s → Compact "1m 30s"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90000', {
+        humanize: 'ms',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1m 30s');
+    });
+
+    it('90000ms → Total Seconds "90"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90000', {
+        humanize: 'ms',
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Total Seconds']).toBe('90');
+    });
+  });
+
+  describe('::duration option key also triggers', () => {
+    it('60s with ::duration → Compact "1m"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('60', {
+        duration: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Compact).toBe('1m');
+    });
+  });
+
+  describe('Long form pluralization', () => {
+    it('3661s → Long "1 hour, 1 minute, 1 second"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('3661', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Long).toBe('1 hour, 1 minute, 1 second');
+    });
+
+    it('7200s → Long "2 hours"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('7200', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Long).toBe('2 hours');
+    });
+
+    it('90061s → Long "1 day, 1 hour, 1 minute, 1 second"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('90061', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Long).toBe('1 day, 1 hour, 1 minute, 1 second');
+    });
+
+    it('0s → Long "0 seconds"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('0', {
+        humanize: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Long).toBe('0 seconds');
+    });
+  });
+
+  describe('box properties', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('60', {
+        humanize: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets name to "Humanize Duration"', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('60', {
+        humanize: true,
+      });
+      expect(boxes[0].props.name).toBe('Humanize Duration');
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await HumanizeDurationBoxSource.generateBoxes('60', {
+        humanize: true,
+      });
+      expect(boxes[0].props.priority).toBe(HumanizeDurationBoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(HumanizeDurationBoxSource.name).toBe('Humanize Duration');
+      expect(HumanizeDurationBoxSource.kind).toBe('Convert');
+      expect(typeof HumanizeDurationBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -9,6 +9,7 @@ import DateCalculateBoxSource from './DateCalculateBoxSource';
 import EscapeStringBoxSource from './EscapeStringBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
+import HumanizeDurationBoxSource from './HumanizeDurationBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
@@ -50,5 +51,6 @@ export const boxSources = [
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
+  HumanizeDurationBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Humanize Duration (Convert)

Adds the `Humanize Duration` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `90061 ::humanize`

#### Options:
- `::duration`, `::humanize`

#### Description:
Turn a number of seconds into a human-readable duration. Use ::humanize=ms to treat the input as milliseconds.

#### Usage Examples:
- **Input**: `90061 ::humanize`
- **Output Box (`Humanize Duration`)**:
```
Compact: 1d 1h 1m 1s
Long: 1 day, 1 hour, 1 minute, 1 second
Total Seconds: 90061
```
