### PR TITLE
feat(Ieee754): add IEEE 754 BoxSource

### DIFF
--- a/src/modules/boxSources/Ieee754BoxSource.ts
+++ b/src/modules/boxSources/Ieee754BoxSource.ts
@@ -1,0 +1,180 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// regex for a valid decimal float literal, including scientific notation and special values
+const FLOAT_LITERAL_RE =
+  /^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$|^-?Infinity$|^NaN$/;
+
+// regex for a hex bit-pattern (8 digits = single, 16 digits = double)
+const HEX_PATTERN_RE = /^0x([0-9a-fA-F]+)$/;
+
+// convert an ArrayBuffer to a zero-padded hex string without the 0x prefix
+function bufToHex(buf: ArrayBuffer, byteLength: number): string {
+  return Array.from(new Uint8Array(buf, 0, byteLength))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// extract the full bit string from the first `byteLength` bytes of a DataView
+function toBitString(dv: DataView, byteLength: number): string {
+  return Array.from({ length: byteLength }, (_, i) =>
+    dv.getUint8(i).toString(2).padStart(8, '0'),
+  ).join('');
+}
+
+interface DoubleRepr {
+  hex: string;
+  sign: string;
+  exponent: string;
+  mantissa: string;
+}
+
+interface SingleRepr {
+  hex: string;
+  sign: string;
+  exponent: string;
+  mantissa: string;
+  /** value after the double→single→double round-trip */
+  roundTrip: number;
+}
+
+function encodeDouble(value: number): DoubleRepr {
+  const buf = new ArrayBuffer(8);
+  const dv = new DataView(buf);
+  dv.setFloat64(0, value, false);
+  const bits = toBitString(dv, 8);
+  return {
+    hex: `0x${bufToHex(buf, 8)}`,
+    sign: bits[0],
+    exponent: bits.slice(1, 12),
+    mantissa: bits.slice(12),
+  };
+}
+
+function encodeSingle(value: number): SingleRepr {
+  const buf = new ArrayBuffer(4);
+  const dv = new DataView(buf);
+  dv.setFloat32(0, value, false);
+  const bits = toBitString(dv, 4);
+  const roundTrip = dv.getFloat32(0, false);
+  return {
+    hex: `0x${bufToHex(buf, 4)}`,
+    sign: bits[0],
+    exponent: bits.slice(1, 9),
+    mantissa: bits.slice(9),
+    roundTrip,
+  };
+}
+
+function decodeHex(
+  hexDigits: string,
+): { value: number; type: 'double' | 'single' } | null {
+  const len = hexDigits.length;
+  if (len === 16) {
+    const buf = new ArrayBuffer(8);
+    const dv = new DataView(buf);
+    for (let i = 0; i < 8; i++) {
+      dv.setUint8(i, Number.parseInt(hexDigits.slice(i * 2, i * 2 + 2), 16));
+    }
+    return { value: dv.getFloat64(0, false), type: 'double' };
+  }
+  if (len === 8) {
+    const buf = new ArrayBuffer(4);
+    const dv = new DataView(buf);
+    for (let i = 0; i < 4; i++) {
+      dv.setUint8(i, Number.parseInt(hexDigits.slice(i * 2, i * 2 + 2), 16));
+    }
+    return { value: dv.getFloat32(0, false), type: 'single' };
+  }
+  return null;
+}
+
+export const Ieee754BoxSource = {
+  defaultDisabled: true,
+  name: 'IEEE 754',
+  description:
+    'Show the IEEE-754 (double + single) bit representation of a number, or decode a hex pattern back to a float.',
+  defaultInput: '3.14 ::ieee754',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ieee754', 'floatbits')) return [];
+
+    const raw = trim(input).slice(0, 64);
+    if (!raw) return [];
+
+    // check for hex bit-pattern decode (must come before float parse to avoid
+    // misidentifying '0x...' as a numeric literal in some environments)
+    const hexMatch = HEX_PATTERN_RE.exec(raw);
+    if (hexMatch) {
+      const hexDigits = hexMatch[1];
+      const decoded = decodeHex(hexDigits);
+      if (!decoded) return [];
+
+      const kvOptions: Record<string, string> = {
+        Hex: `0x${hexDigits}`,
+        Value: String(decoded.value),
+        Type: decoded.type,
+      };
+
+      const plaintext = Object.entries(kvOptions)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('\n');
+
+      return [
+        new BoxBuilder('IEEE 754', plaintext)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kvOptions)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // check for a decimal float literal or special values
+    if (!FLOAT_LITERAL_RE.test(raw)) return [];
+
+    const value = Number.parseFloat(raw);
+    if (
+      !Number.isFinite(value) &&
+      !Number.isNaN(value) &&
+      raw !== 'Infinity' &&
+      raw !== '-Infinity'
+    ) {
+      return [];
+    }
+
+    const dbl = encodeDouble(value);
+    const sgl = encodeSingle(value);
+
+    const kvOptions: Record<string, string> = {
+      Value: String(value),
+      'Double (hex)': dbl.hex,
+      'Double (bits)': `${dbl.sign} ${dbl.exponent} ${dbl.mantissa}`,
+      'Single (hex)': sgl.hex,
+      'Single (value)': String(sgl.roundTrip),
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('IEEE 754', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Ieee754BoxSource;

--- a/src/modules/boxSources/__test__/Ieee754BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Ieee754BoxSource.test.ts
@@ -1,0 +1,217 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Ieee754BoxSource } from '../Ieee754BoxSource';
+
+describe('Ieee754BoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Ieee754BoxSource.name).toBe('IEEE 754');
+      expect(Ieee754BoxSource.priority).toBe(10);
+    });
+  });
+
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('3.14', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('3.14', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for unrelated options', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('3.14', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns [] for non-numeric string', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('xyz', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty string', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('', { ieee754: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for partial hex (not 8 or 16 digits)', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0xdeadbeef00', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('float encoding — double (64-bit)', () => {
+    it('3.14 → Double (hex) 0x40091eb851eb851f', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('3.14', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0x40091eb851eb851f',
+      );
+    });
+
+    it('1.0 → Double (hex) 0x3ff0000000000000', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0x3ff0000000000000',
+      );
+    });
+
+    it('0.5 → Double (hex) 0x3fe0000000000000', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0.5', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0x3fe0000000000000',
+      );
+    });
+
+    it('-2 → Double (hex) 0xc000000000000000', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('-2', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0xc000000000000000',
+      );
+    });
+
+    it('NaN → Double (hex) 0x7ff8000000000000', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('NaN', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0x7ff8000000000000',
+      );
+    });
+  });
+
+  describe('float encoding — single (32-bit)', () => {
+    it('0.5 → Single (hex) 0x3f000000', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0.5', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.options?.['Single (hex)']).toBe('0x3f000000');
+    });
+
+    it('includes Single (value) round-trip for 0.5', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0.5', {
+        ieee754: true,
+      });
+      // 0.5 is exactly representable in both precisions
+      expect(boxes[0].props.options?.['Single (value)']).toBe('0.5');
+    });
+  });
+
+  describe('float encoding — output shape', () => {
+    it('box uses KeyValueBoxTemplate', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        ieee754: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is "IEEE 754"', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.name).toBe('IEEE 754');
+    });
+
+    it('options include all five expected keys', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        ieee754: true,
+      });
+      const opts = boxes[0].props.options ?? {};
+      expect(opts).toHaveProperty('Value');
+      expect(opts).toHaveProperty('Double (hex)');
+      expect(opts).toHaveProperty('Double (bits)');
+      expect(opts).toHaveProperty('Single (hex)');
+      expect(opts).toHaveProperty('Single (value)');
+    });
+
+    it('Double (bits) has sign + exponent + mantissa separated by spaces', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        ieee754: true,
+      });
+      const bits = boxes[0].props.options?.['Double (bits)'] as string;
+      const parts = bits.split(' ');
+      expect(parts).toHaveLength(3);
+      expect(parts[0]).toHaveLength(1); // sign: 1 bit
+      expect(parts[1]).toHaveLength(11); // exponent: 11 bits
+      expect(parts[2]).toHaveLength(52); // mantissa: 52 bits
+    });
+
+    it('triggers on ::floatbits option as well', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('1.0', {
+        floatbits: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Double (hex)']).toBe(
+        '0x3ff0000000000000',
+      );
+    });
+  });
+
+  describe('hex decode — double (16 hex digits)', () => {
+    it('0x40091eb851eb851f → Value 3.14', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0x40091eb851eb851f', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Value).toBe('3.14');
+      expect(boxes[0].props.options?.Type).toBe('double');
+    });
+
+    it('0x3ff0000000000000 → Value 1', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0x3ff0000000000000', {
+        ieee754: true,
+      });
+      expect(boxes[0].props.options?.Value).toBe('1');
+    });
+  });
+
+  describe('hex decode — single (8 hex digits)', () => {
+    it('0x3f000000 → Value 0.5, Type single', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0x3f000000', {
+        ieee754: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Value).toBe('0.5');
+      expect(boxes[0].props.options?.Type).toBe('single');
+    });
+  });
+
+  describe('hex decode — output shape', () => {
+    it('box uses KeyValueBoxTemplate', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0x3f000000', {
+        ieee754: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('options include Hex, Value, Type keys', async () => {
+      const boxes = await Ieee754BoxSource.generateBoxes('0x3f000000', {
+        ieee754: true,
+      });
+      const opts = boxes[0].props.options ?? {};
+      expect(opts).toHaveProperty('Hex');
+      expect(opts).toHaveProperty('Value');
+      expect(opts).toHaveProperty('Type');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import Ieee754BoxSource from './Ieee754BoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  Ieee754BoxSource,
 ];


### PR DESCRIPTION
### Box Source: IEEE 754 (Analyze)

Adds the `IEEE 754` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `3.14 ::ieee754`

#### Options:
- `::floatbits`, `::ieee754`

#### Description:
Show the IEEE-754 (double + single) bit representation of a number, or decode a hex pattern back to a float.

#### Usage Examples:
- **Input**: `3.14 ::ieee754`
- **Output Box (`IEEE 754`)**:
```
Value: 3.14
Double (hex): 0x40091eb851eb851f
Double (bits): 0 10000000000 1001000111101011100001010001111010111000010100011111
Single (hex): 0x4048f5c3
Single (value): 3.140000104904175
```
