### PR TITLE
feat(Ini): add INI / JSON BoxSource

### DIFF
--- a/src/modules/boxSources/IniBoxSource.ts
+++ b/src/modules/boxSources/IniBoxSource.ts
@@ -1,0 +1,150 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// keys that must never be set on parsed objects to prevent prototype pollution
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** parses an INI string into a plain object with optional top-level and section keys */
+function parseIni(input: string): Record<string, unknown> {
+  const root = Object.create(null) as Record<string, unknown>;
+  let current: Record<string, unknown> = root;
+
+  for (const rawLine of input.split('\n')) {
+    const line = rawLine.trim();
+
+    // skip blank lines and comments
+    if (!line || line.startsWith(';') || line.startsWith('#')) continue;
+
+    // section header
+    if (line.startsWith('[') && line.endsWith(']')) {
+      const section = line.slice(1, -1).trim();
+      if (FORBIDDEN_KEYS.has(section)) continue;
+      const sectionObj = Object.create(null) as Record<string, unknown>;
+      root[section] = sectionObj;
+      current = sectionObj;
+      continue;
+    }
+
+    // key = value
+    const eqIdx = line.indexOf('=');
+    if (eqIdx === -1) continue;
+
+    const key = line.slice(0, eqIdx).trim();
+    if (FORBIDDEN_KEYS.has(key)) continue;
+
+    let value = line.slice(eqIdx + 1).trim();
+    // strip one layer of surrounding quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    current[key] = value;
+  }
+
+  return root;
+}
+
+/** serialises a plain JSON object to INI format (one level of nesting supported) */
+function stringifyIni(obj: Record<string, unknown>): string {
+  const lines: string[] = [];
+
+  // top-level scalar values first
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== null && typeof value !== 'object') {
+      lines.push(`${key}=${value}`);
+    }
+  }
+
+  // nested sections
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      lines.push(`[${key}]`);
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        const serialised =
+          v !== null && typeof v === 'object' ? JSON.stringify(v) : String(v);
+        lines.push(`${k}=${serialised}`);
+      }
+    } else if (value !== null && typeof value === 'object') {
+      // arrays or deeper nesting — JSON-stringify the value as a scalar
+      lines.push(`${key}=${JSON.stringify(value)}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export const IniBoxSource = {
+  defaultDisabled: true,
+  name: 'INI / JSON',
+  description:
+    'Convert INI config to JSON, or a flat/sectioned JSON object to INI.',
+  defaultInput: '[server]\nhost = localhost\nport = 8080 ::ini',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ini', 'inijson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    if (!trimmed) return [];
+
+    // direction: JSON string → INI, otherwise INI → JSON
+    if (trimmed.startsWith('{')) {
+      try {
+        const obj = JSON.parse(trimmed) as Record<string, unknown>;
+        const output = stringifyIni(obj);
+        return [
+          new BoxBuilder('JSON → INI', output)
+            .setOptions({ language: 'ini' })
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      } catch {
+        return [
+          new BoxBuilder('JSON → INI', 'Error: invalid JSON input')
+            .setOptions({ language: 'ini' })
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // INI → JSON
+    try {
+      const obj = parseIni(trimmed);
+      const output = JSON.stringify(obj, null, 2);
+      return [
+        new BoxBuilder('INI → JSON', output)
+          .setOptions({ language: 'json' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    } catch {
+      return [
+        new BoxBuilder('INI → JSON', 'Error: failed to parse INI input')
+          .setOptions({ language: 'json' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+  },
+};
+
+export default IniBoxSource;

--- a/src/modules/boxSources/__test__/IniBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/IniBoxSource.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { IniBoxSource } from '../IniBoxSource';
+
+describe('IniBoxSource', () => {
+  describe('generateBoxes - option gating', () => {
+    it('returns empty array when no matching option is provided', async () => {
+      const boxes = await IniBoxSource.generateBoxes('[s]\nk=v', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await IniBoxSource.generateBoxes('[s]\nk=v', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('INI → JSON', () => {
+    it('parses a basic section with scalar values', async () => {
+      const boxes = await IniBoxSource.generateBoxes(
+        '[server]\nhost = localhost\nport = 8080',
+        { ini: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('INI → JSON');
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ server: { host: 'localhost', port: '8080' } });
+    });
+
+    it('handles comments and top-level keys before a section', async () => {
+      const input = '; this is a comment\nname=app\n[db]\nuser=admin';
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ name: 'app', db: { user: 'admin' } });
+    });
+
+    it('strips one layer of double quotes from values', async () => {
+      const boxes = await IniBoxSource.generateBoxes('msg = "hello world"', {
+        ini: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed.msg).toBe('hello world');
+    });
+
+    it('strips one layer of single quotes from values', async () => {
+      const boxes = await IniBoxSource.generateBoxes("path = '/usr/local'", {
+        ini: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed.path).toBe('/usr/local');
+    });
+
+    it('sets language option to json', async () => {
+      const boxes = await IniBoxSource.generateBoxes('[s]\nk=v', { ini: true });
+      expect(boxes[0].props.options?.language).toBe('json');
+    });
+  });
+
+  describe('JSON → INI', () => {
+    it('serialises a nested JSON object to INI sections', async () => {
+      const input = '{"server":{"host":"localhost","port":"8080"}}';
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → INI');
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('[server]');
+      expect(output).toContain('host=localhost');
+      expect(output).toContain('port=8080');
+    });
+
+    it('places top-level scalars before sections', async () => {
+      const input = '{"version":"1.0","db":{"host":"localhost"}}';
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      const output = boxes[0].props.plaintextOutput;
+      const versionLine = output.indexOf('version=1.0');
+      const sectionLine = output.indexOf('[db]');
+      expect(versionLine).toBeGreaterThanOrEqual(0);
+      expect(sectionLine).toBeGreaterThan(versionLine);
+    });
+
+    it('triggers on ::inijson option as well', async () => {
+      const input = '{"k":"v"}';
+      const boxes = await IniBoxSource.generateBoxes(input, { inijson: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → INI');
+    });
+
+    it('sets language option to ini', async () => {
+      const input = '{"k":"v"}';
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(boxes[0].props.options?.language).toBe('ini');
+    });
+
+    it('returns an error box for invalid JSON-looking input', async () => {
+      const boxes = await IniBoxSource.generateBoxes('{bad json', {
+        ini: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/error/i);
+    });
+  });
+
+  describe('prototype pollution guard', () => {
+    it('does not pollute Object.prototype via __proto__ section', async () => {
+      const input = '[__proto__]\npolluted=evil';
+      await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('does not pollute Object.prototype via top-level __proto__ key', async () => {
+      const input = '__proto__=evil';
+      await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(({} as Record<string, unknown>).__proto__).not.toBe('evil');
+    });
+
+    it('does not pollute via constructor key', async () => {
+      const input = '[constructor]\nx=1';
+      await IniBoxSource.generateBoxes(input, { ini: true });
+      // the section should have been silently skipped
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      // the forbidden section must not appear as an own key (reading
+      // parsed.constructor returns the inherited Object constructor)
+      expect(Object.hasOwn(parsed, 'constructor')).toBe(false);
+    });
+
+    it('produces a valid (empty) JSON object when all keys are forbidden', async () => {
+      const input = '__proto__=a\nconstructor=b\nprototype=c';
+      const boxes = await IniBoxSource.generateBoxes(input, { ini: true });
+      expect(boxes).toHaveLength(1);
+      // output should be a valid JSON object, just empty (or with no forbidden keys)
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(typeof parsed).toBe('object');
+      // all keys forbidden → no own keys survive (reading parsed.__proto__
+      // would return Object.prototype, so assert on own-key presence instead)
+      expect(Object.hasOwn(parsed, '__proto__')).toBe(false);
+      expect(Object.keys(parsed)).toHaveLength(0);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('INI → JSON → INI preserves section and key/value content', async () => {
+      const originalIni = '[app]\nname=magic\nversion=2';
+      const toJsonBoxes = await IniBoxSource.generateBoxes(originalIni, {
+        ini: true,
+      });
+      const jsonStr = toJsonBoxes[0].props.plaintextOutput;
+
+      const toIniBoxes = await IniBoxSource.generateBoxes(jsonStr, {
+        ini: true,
+      });
+      const roundTripped = toIniBoxes[0].props.plaintextOutput;
+      expect(roundTripped).toContain('[app]');
+      expect(roundTripped).toContain('name=magic');
+      expect(roundTripped).toContain('version=2');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import IniBoxSource from './IniBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  IniBoxSource,
 ];


### PR DESCRIPTION
### Box Source: INI / JSON (Convert)

Adds the `INI / JSON` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `[server]\nhost = localhost\nport = 8080 ::ini`

#### Options:
- `::ini`, `::inijson`

#### Description:
Convert INI config to JSON, or a flat/sectioned JSON object to INI.

#### Usage Examples:
- **Input**: `[server]
host = localhost
port = 8080 ::ini`
- **Output Box (`INI → JSON`)**:
```
{
  "server": {
    "host": "localhost",
    "port": "8080"
  }
}
```
