### PR TITLE
feat(InvisibleChars): add Invisible Characters BoxSource

### DIFF
--- a/src/modules/boxSources/InvisibleCharsBoxSource.ts
+++ b/src/modules/boxSources/InvisibleCharsBoxSource.ts
@@ -1,0 +1,126 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// well-known invisible/zero-width character metadata
+const INVISIBLE_CHARS: Map<number, string> = new Map([
+  [0x00a0, 'NO-BREAK SPACE'],
+  [0x00ad, 'SOFT HYPHEN'],
+  [0x200b, 'ZERO WIDTH SPACE'],
+  [0x200c, 'ZERO WIDTH NON-JOINER'],
+  [0x200d, 'ZERO WIDTH JOINER'],
+  [0x2060, 'WORD JOINER'],
+  [0x2000, 'EN QUAD'],
+  [0x2001, 'EM QUAD'],
+  [0x2002, 'EN SPACE'],
+  [0x2003, 'EM SPACE'],
+  [0x2004, 'THREE-PER-EM SPACE'],
+  [0x2005, 'FOUR-PER-EM SPACE'],
+  [0x2006, 'SIX-PER-EM SPACE'],
+  [0x2007, 'FIGURE SPACE'],
+  [0x2008, 'PUNCTUATION SPACE'],
+  [0x2009, 'THIN SPACE'],
+  [0x200a, 'HAIR SPACE'],
+  [0x202f, 'NARROW NO-BREAK SPACE'],
+  [0x205f, 'MEDIUM MATHEMATICAL SPACE'],
+  [0x3000, 'IDEOGRAPHIC SPACE'],
+  [0xfeff, 'BYTE ORDER MARK'],
+]);
+
+// format a code point as U+XXXX with at least 4 hex digits
+function toUPlus(cp: number): string {
+  return `U+${cp.toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
+// get a display name for a code point
+function charName(cp: number): string {
+  const known = INVISIBLE_CHARS.get(cp);
+  if (known) return known;
+  // control chars below 0x20 (excluding normal whitespace \t \n \r)
+  return `CONTROL CHAR`;
+}
+
+// returns true if a code point should be flagged as invisible/hidden
+function isInvisible(cp: number): boolean {
+  // allow normal whitespace
+  if (cp === 0x09 || cp === 0x0a || cp === 0x0d) return false;
+  // flag control chars below 0x20
+  if (cp < 0x20) return true;
+  // allow normal printable ASCII (0x20-0x7e)
+  if (cp >= 0x20 && cp <= 0x7e) return false;
+  // flag DEL and the C1 control block (common homograph-attack injects)
+  if (cp === 0x7f || (cp >= 0x80 && cp <= 0x9f)) return true;
+  // flag all specifically listed invisible unicode chars
+  if (INVISIBLE_CHARS.has(cp)) return true;
+  return false;
+}
+
+export const InvisibleCharsBoxSource = {
+  defaultDisabled: true,
+  name: 'Invisible Characters',
+  description:
+    'Detect and reveal hidden/invisible characters (zero-width, non-breaking space, BOM, etc.).',
+  defaultInput: 'hello​world ::invisibles',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'invisibles', 'hiddenchars')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    // scan input by unicode code point
+    const counts = new Map<number, number>();
+    let revealed = '';
+
+    for (const char of input) {
+      const cp = char.codePointAt(0) as number;
+      if (isInvisible(cp)) {
+        const token = toUPlus(cp);
+        counts.set(cp, (counts.get(cp) ?? 0) + 1);
+        revealed += `[${token}]`;
+      } else {
+        revealed += char;
+      }
+    }
+
+    if (counts.size === 0) {
+      const box = new BoxBuilder(
+        'Invisible Characters',
+        'No invisible characters found.',
+      )
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    // build header: one line per distinct flagged char
+    const headerLines: string[] = [];
+    for (const [cp, count] of counts) {
+      const uplus = toUPlus(cp);
+      const name = charName(cp);
+      headerLines.push(`${name} (${uplus}): ${count}`);
+    }
+
+    const output = [...headerLines, '', revealed].join('\n');
+
+    const box = new BoxBuilder('Invisible Characters', output)
+      .setTemplate(CodeBoxTemplate)
+      .setShowExpandButton(true)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default InvisibleCharsBoxSource;

--- a/src/modules/boxSources/__test__/InvisibleCharsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/InvisibleCharsBoxSource.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { InvisibleCharsBoxSource } from '../InvisibleCharsBoxSource';
+
+describe('InvisibleCharsBoxSource', () => {
+  it('returns [] when no option is provided', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes(
+      'hello​world',
+      null,
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when an unrelated option is provided', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('hello​world', {
+      base64: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for empty input', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('', {
+      invisibles: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('detects zero-width space U+200B with ::invisibles', async () => {
+    // 'hello​world' contains U+200B between hello and world
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('hello​world', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const output = boxes[0].props.plaintextOutput;
+    expect(output).toContain('U+200B');
+    expect(output).toContain('hello[U+200B]world');
+  });
+
+  it('detects zero-width space with ::hiddenchars alias', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('hello​world', {
+      hiddenchars: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toContain('U+200B');
+  });
+
+  it('detects non-breaking space U+00A0 (NBSP)', async () => {
+    // 'a b' — non-breaking space between a and b
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('a b', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const output = boxes[0].props.plaintextOutput;
+    expect(output).toContain('U+00A0');
+    expect(output).toContain('NO-BREAK SPACE');
+  });
+
+  it('reports no invisible characters for clean ASCII', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('hello world', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe(
+      'No invisible characters found.',
+    );
+  });
+
+  it('does not flag visible unicode letters and emoji (café 😀)', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('café 😀', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe(
+      'No invisible characters found.',
+    );
+  });
+
+  it('detects BOM U+FEFF', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('﻿hello', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const output = boxes[0].props.plaintextOutput;
+    expect(output).toContain('U+FEFF');
+    expect(output).toContain('BYTE ORDER MARK');
+  });
+
+  it('counts multiple occurrences of the same invisible char', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('a​b​c', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const output = boxes[0].props.plaintextOutput;
+    // count should be 2
+    expect(output).toContain('ZERO WIDTH SPACE (U+200B): 2');
+  });
+
+  it('revealed text replaces each invisible char with its token', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('x‌y‍z', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const output = boxes[0].props.plaintextOutput;
+    expect(output).toContain('x[U+200C]y[U+200D]z');
+  });
+
+  it('allows normal tab, newline, and carriage return', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('a\tb\nc\rd', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toBe(
+      'No invisible characters found.',
+    );
+  });
+
+  it('flags DEL and C1 control characters', async () => {
+    const boxes = await InvisibleCharsBoxSource.generateBoxes('a\x7fb\x9fc', {
+      invisibles: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toContain('U+007F');
+    expect(boxes[0].props.plaintextOutput).toContain('U+009F');
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import InvisibleCharsBoxSource from './InvisibleCharsBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  InvisibleCharsBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Invisible Characters (Analyze)

Adds the `Invisible Characters` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `hello​world ::invisibles`

#### Options:
- `::hiddenchars`, `::invisibles`

#### Description:
Detect and reveal hidden/invisible characters (zero-width, non-breaking space, BOM, etc.).

#### Usage Examples:
- **Input**: `hello​world ::invisibles`
- **Output Box (`Invisible Characters`)**:
```
ZERO WIDTH SPACE (U+200B): 1

hello[U+200B]world
```
