### PR TITLE
feat(IpInCidr): add IP in CIDR BoxSource

### DIFF
--- a/src/modules/boxSources/IpInCidrBoxSource.ts
+++ b/src/modules/boxSources/IpInCidrBoxSource.ts
@@ -1,0 +1,143 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// converts a dotted IPv4 string to an unsigned 32-bit integer, or null if invalid
+function ipToUint32(ip: string): number | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+
+  let result = 0;
+  for (const part of parts) {
+    const octet = Number.parseInt(part, 10);
+    if (
+      Number.isNaN(octet) ||
+      octet < 0 ||
+      octet > 255 ||
+      part.trim() !== String(octet)
+    ) {
+      return null;
+    }
+    result = ((result << 8) | octet) >>> 0;
+  }
+  return result;
+}
+
+// converts an unsigned 32-bit integer to dotted IPv4 notation
+function uint32ToIp(n: number): string {
+  return [
+    (n >>> 24) & 0xff,
+    (n >>> 16) & 0xff,
+    (n >>> 8) & 0xff,
+    n & 0xff,
+  ].join('.');
+}
+
+interface ParsedCidr {
+  cidrInt: number;
+  prefix: number;
+  mask: number;
+  network: number;
+  broadcast: number;
+}
+
+// parses a CIDR string "A.B.C.D/P" and derives mask, network, and broadcast
+function parseCidr(cidr: string): ParsedCidr | null {
+  const slashIdx = cidr.lastIndexOf('/');
+  if (slashIdx === -1) return null;
+
+  const ipPart = cidr.slice(0, slashIdx);
+  const prefixPart = cidr.slice(slashIdx + 1);
+  const prefix = Number.parseInt(prefixPart, 10);
+
+  if (
+    Number.isNaN(prefix) ||
+    prefix < 0 ||
+    prefix > 32 ||
+    prefixPart.trim() !== String(prefix)
+  ) {
+    return null;
+  }
+
+  const cidrInt = ipToUint32(ipPart);
+  if (cidrInt === null) return null;
+
+  // a /0 mask is all zeros; otherwise shift and zero-extend to uint32
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  const network = (cidrInt & mask) >>> 0;
+  const broadcast = (network | (~mask >>> 0)) >>> 0;
+
+  return { cidrInt, prefix, mask, network, broadcast };
+}
+
+export const IpInCidrBoxSource = {
+  defaultDisabled: true,
+  name: 'IP in CIDR',
+  description:
+    'Check whether an IPv4 address is within a CIDR range. e.g. 10.0.0.5 ::ipincidr=10.0.0.0/24',
+  defaultInput: '10.0.0.5 ::ipincidr=10.0.0.0/24',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ipincidr', 'incidr')) return [];
+
+    const cidrRaw = extractOptionKeys(options, 'ipincidr', 'incidr');
+    const ipStr = trim(input);
+
+    // validate both ip and cidr before computing
+    const ipInt = ipToUint32(ipStr);
+    const parsed = typeof cidrRaw === 'string' ? parseCidr(cidrRaw) : null;
+
+    if (ipInt === null || parsed === null) {
+      const reason =
+        ipInt === null && parsed === null
+          ? 'Invalid IPv4 address and CIDR.'
+          : ipInt === null
+            ? 'Invalid IPv4 address. Expected format: A.B.C.D (each octet 0-255).'
+            : 'Invalid CIDR. Expected format: A.B.C.D/P (prefix 0-32).';
+
+      return [
+        new BoxBuilder('IP in CIDR', reason)
+          .setOptions({ Error: reason })
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { prefix, mask, network, broadcast } = parsed;
+    const inRange = (ipInt & mask) >>> 0 === network;
+
+    const kvOptions: Record<string, string> = {
+      IP: ipStr,
+      // show the canonical network/prefix form, not the raw input
+      CIDR: `${uint32ToIp(network)}/${prefix}`,
+      Network: uint32ToIp(network),
+      Broadcast: uint32ToIp(broadcast),
+      'In Range': String(inRange),
+    };
+
+    // plaintext k:v for headless/TUI consumers
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('IP in CIDR', plaintextOutput)
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default IpInCidrBoxSource;

--- a/src/modules/boxSources/__test__/IpInCidrBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/IpInCidrBoxSource.test.ts
@@ -1,0 +1,150 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { IpInCidrBoxSource } from '../IpInCidrBoxSource';
+
+describe('IpInCidrBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no trigger option is present', async () => {
+      const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.5', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options exist but neither ipincidr nor incidr key', async () => {
+      const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.5', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('/24 network', () => {
+      it('10.0.0.5 is in 10.0.0.0/24', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.5', {
+          ipincidr: '10.0.0.0/24',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('true');
+        expect(boxes[0].props.options?.Network).toBe('10.0.0.0');
+        expect(boxes[0].props.options?.Broadcast).toBe('10.0.0.255');
+        expect(boxes[0].props.options?.IP).toBe('10.0.0.5');
+        expect(boxes[0].props.options?.CIDR).toBe('10.0.0.0/24');
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      });
+
+      it('10.0.1.5 is NOT in 10.0.0.0/24', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.1.5', {
+          ipincidr: '10.0.0.0/24',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('false');
+        expect(boxes[0].props.options?.Network).toBe('10.0.0.0');
+        expect(boxes[0].props.options?.Broadcast).toBe('10.0.0.255');
+      });
+    });
+
+    describe('/25 network boundary', () => {
+      it('192.168.1.130 is in 192.168.1.128/25 (upper half)', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('192.168.1.130', {
+          ipincidr: '192.168.1.128/25',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('true');
+        expect(boxes[0].props.options?.Network).toBe('192.168.1.128');
+        expect(boxes[0].props.options?.Broadcast).toBe('192.168.1.255');
+      });
+
+      it('192.168.1.100 is NOT in 192.168.1.128/25 (lower half)', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('192.168.1.100', {
+          ipincidr: '192.168.1.128/25',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('false');
+      });
+    });
+
+    describe('/32 exact host match', () => {
+      it('1.2.3.4 is in 1.2.3.4/32', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('1.2.3.4', {
+          ipincidr: '1.2.3.4/32',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('true');
+        expect(boxes[0].props.options?.Network).toBe('1.2.3.4');
+        expect(boxes[0].props.options?.Broadcast).toBe('1.2.3.4');
+      });
+
+      it('1.2.3.5 is NOT in 1.2.3.4/32', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('1.2.3.5', {
+          ipincidr: '1.2.3.4/32',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('false');
+      });
+    });
+
+    describe('incidr alias', () => {
+      it('accepts ::incidr option key as an alias', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.1', {
+          incidr: '10.0.0.0/24',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.['In Range']).toBe('true');
+      });
+    });
+
+    describe('invalid inputs', () => {
+      it('invalid IP 999.1.1.1 produces an error box', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('999.1.1.1', {
+          ipincidr: '10.0.0.0/24',
+        });
+        expect(boxes).toHaveLength(1);
+        const errMsg = boxes[0].props.options?.Error as string;
+        expect(errMsg).toBeTruthy();
+        expect(errMsg.toLowerCase()).toContain('invalid');
+      });
+
+      it('invalid CIDR produces an error box', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.1', {
+          ipincidr: 'notacidr',
+        });
+        expect(boxes).toHaveLength(1);
+        const errMsg = boxes[0].props.options?.Error as string;
+        expect(errMsg).toBeTruthy();
+        expect(errMsg.toLowerCase()).toContain('invalid');
+      });
+
+      it('CIDR prefix out of range (> 32) produces an error box', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.1', {
+          ipincidr: '10.0.0.0/33',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Error).toBeTruthy();
+      });
+
+      it('both IP and CIDR invalid produces an error box mentioning both', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('bad', {
+          ipincidr: 'also-bad',
+        });
+        expect(boxes).toHaveLength(1);
+        const errMsg = boxes[0].props.options?.Error as string;
+        expect(errMsg.toLowerCase()).toContain('invalid');
+      });
+    });
+
+    describe('priority and template', () => {
+      it('sets priority to 10', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.1', {
+          ipincidr: '10.0.0.0/24',
+        });
+        expect(boxes[0].props.priority).toBe(10);
+      });
+
+      it('uses KeyValueBoxTemplate', async () => {
+        const boxes = await IpInCidrBoxSource.generateBoxes('10.0.0.1', {
+          ipincidr: '10.0.0.0/24',
+        });
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import IpInCidrBoxSource from './IpInCidrBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  IpInCidrBoxSource,
 ];


### PR DESCRIPTION
### Box Source: IP in CIDR (Analyze)

Adds the `IP in CIDR` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `10.0.0.5 ::ipincidr=10.0.0.0/24`

#### Options:
- `::incidr`, `::ipincidr`

#### Description:
Check whether an IPv4 address is within a CIDR range. e.g. 10.0.0.5 ::ipincidr=10.0.0.0/24

#### Usage Examples:
- **Input**: `10.0.0.5 ::ipincidr=10.0.0.0/24`
- **Output Box (`IP in CIDR`)**:
```
IP: 10.0.0.5
CIDR: 10.0.0.0/24
Network: 10.0.0.0
Broadcast: 10.0.0.255
In Range: true
```
