### PR TITLE
feat(Ipv4Int): add IPv4 ↔ Integer BoxSource

### DIFF
--- a/src/modules/boxSources/Ipv4IntBoxSource.ts
+++ b/src/modules/boxSources/Ipv4IntBoxSource.ts
@@ -1,0 +1,120 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max valid IPv4 integer: 2^32 - 1
+const MAX_IPV4_INT = 4294967295;
+
+const IPV4_REGEX = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+// build a zero-padded 8-digit lowercase hex string prefixed with 0x
+function toHex(n: number): string {
+  return `0x${n.toString(16).padStart(8, '0')}`;
+}
+
+// convert an IPv4 string to its 32-bit unsigned integer representation
+function ipToInt(ip: string): number | null {
+  const m = IPV4_REGEX.exec(ip);
+  if (!m) return null;
+
+  const octets = [m[1], m[2], m[3], m[4]].map((s) => Number.parseInt(s, 10));
+  if (octets.some((o) => o < 0 || o > 255)) return null;
+
+  // use multiplication to stay unsigned (avoids signed-32-bit overflow of <<)
+  return octets[0] * 16777216 + octets[1] * 65536 + octets[2] * 256 + octets[3];
+}
+
+// convert a 32-bit unsigned integer to dotted-decimal IPv4
+function intToIp(n: number): string {
+  const a = Math.floor(n / 16777216) % 256;
+  const b = Math.floor(n / 65536) % 256;
+  const c = Math.floor(n / 256) % 256;
+  const d = n % 256;
+  return `${a}.${b}.${c}.${d}`;
+}
+
+// build a plaintext string consumed by KeyValueBoxTemplate
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const Ipv4IntBoxSource = {
+  defaultDisabled: true,
+  name: 'IPv4 ↔ Integer',
+  description:
+    'Convert an IPv4 address to its 32-bit integer and hex, or an integer back to an IPv4 address.',
+  defaultInput: '192.168.1.1 ::iptoint',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'iptoint', 'ipint')) return [];
+
+    const raw = trim(input);
+
+    // guard against absurdly long inputs
+    if (raw.length > 40) return [];
+
+    if (IPV4_REGEX.test(raw)) {
+      // ip → integer direction
+      const n = ipToInt(raw);
+      if (n === null) {
+        // invalid octet value — fall through to help box
+      } else {
+        const kv: Record<string, string> = {
+          IPv4: raw,
+          Integer: n.toString(),
+          Hex: toHex(n),
+        };
+        return [
+          new BoxBuilder('IPv4 ↔ Integer', kvToPlaintext(kv))
+            .setTemplate(KeyValueBoxTemplate)
+            .setOptions(kv)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    } else if (/^\d+$/.test(raw)) {
+      // integer → ip direction
+      const n = Number.parseInt(raw, 10);
+      if (n >= 0 && n <= MAX_IPV4_INT) {
+        const ip = intToIp(n);
+        const kv: Record<string, string> = {
+          Integer: raw,
+          IPv4: ip,
+          Hex: toHex(n),
+        };
+        return [
+          new BoxBuilder('IPv4 ↔ Integer', kvToPlaintext(kv))
+            .setTemplate(KeyValueBoxTemplate)
+            .setOptions(kv)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+    }
+
+    // unrecognised input — explain accepted formats
+    const helpText =
+      'Enter an IPv4 address (e.g. 192.168.1.1) or an integer 0..4294967295';
+    const kv: Record<string, string> = { Format: helpText };
+    return [
+      new BoxBuilder('IPv4 ↔ Integer', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Ipv4IntBoxSource;

--- a/src/modules/boxSources/__test__/Ipv4IntBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Ipv4IntBoxSource.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import { Ipv4IntBoxSource } from '../Ipv4IntBoxSource';
+
+describe('Ipv4IntBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('192.168.1.1', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('192.168.1.1', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('IPv4 → integer (::iptoint)', () => {
+    it('converts 192.168.1.1 to correct integer and hex', async () => {
+      // 192*16777216 + 168*65536 + 1*256 + 1 = 3232235777 = 0xC0A80101
+      const boxes = await Ipv4IntBoxSource.generateBoxes('192.168.1.1', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBe('192.168.1.1');
+      expect(opts.Integer).toBe('3232235777');
+      expect(opts.Hex).toBe('0xc0a80101');
+    });
+
+    it('converts 0.0.0.0 to integer 0 and hex 0x00000000', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('0.0.0.0', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Integer).toBe('0');
+      expect(opts.Hex).toBe('0x00000000');
+    });
+
+    it('converts 255.255.255.255 to integer 4294967295 and hex 0xffffffff', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('255.255.255.255', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Integer).toBe('4294967295');
+      expect(opts.Hex).toBe('0xffffffff');
+    });
+  });
+
+  describe('IPv4 → integer (::ipint alias)', () => {
+    it('accepts ::ipint as an alias for ::iptoint', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('10.0.0.1', {
+        ipint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBe('10.0.0.1');
+      // 10*16777216 + 0 + 0 + 1 = 167772161
+      expect(opts.Integer).toBe('167772161');
+    });
+  });
+
+  describe('integer → IPv4 (reverse direction)', () => {
+    it('converts 3232235777 back to 192.168.1.1', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('3232235777', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBe('192.168.1.1');
+      expect(opts.Integer).toBe('3232235777');
+      expect(opts.Hex).toBe('0xc0a80101');
+    });
+
+    it('converts 4294967295 to 255.255.255.255', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('4294967295', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBe('255.255.255.255');
+      expect(opts.Hex).toBe('0xffffffff');
+    });
+
+    it('converts 0 to 0.0.0.0', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('0', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBe('0.0.0.0');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('192.168.1.1 → integer → IPv4 is lossless', async () => {
+      const fwd = await Ipv4IntBoxSource.generateBoxes('192.168.1.1', {
+        iptoint: true,
+      });
+      const intStr = (fwd[0].props.options as Record<string, string>).Integer;
+
+      const rev = await Ipv4IntBoxSource.generateBoxes(intStr, {
+        iptoint: true,
+      });
+      const ip = (rev[0].props.options as Record<string, string>).IPv4;
+      expect(ip).toBe('192.168.1.1');
+    });
+  });
+
+  describe('invalid inputs → help box', () => {
+    it('rejects octet value 256 (256.1.1.1)', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('256.1.1.1', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // help box has Format key, not Integer
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Integer).toBeUndefined();
+      expect(opts.Format).toBeDefined();
+    });
+
+    it('rejects integer 4294967296 (out of 32-bit range)', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('4294967296', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.IPv4).toBeUndefined();
+      expect(opts.Format).toBeDefined();
+    });
+
+    it('rejects arbitrary text like "hello"', async () => {
+      const boxes = await Ipv4IntBoxSource.generateBoxes('hello', {
+        iptoint: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Format).toBeDefined();
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Ipv4IntBoxSource.name).toBe('IPv4 ↔ Integer');
+      expect(Ipv4IntBoxSource.tag).toBe('#');
+      expect(Ipv4IntBoxSource.kind).toBe('Convert');
+      expect(typeof Ipv4IntBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import Ipv4IntBoxSource from './Ipv4IntBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  Ipv4IntBoxSource,
 ];


### PR DESCRIPTION
### Box Source: IPv4 ↔ Integer (Convert)

Adds the `IPv4 ↔ Integer` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `192.168.1.1 ::iptoint`

#### Options:
- `::ipint`, `::iptoint`

#### Description:
Convert an IPv4 address to its 32-bit integer and hex, or an integer back to an IPv4 address.

#### Usage Examples:
- **Input**: `192.168.1.1 ::iptoint`
- **Output Box (`IPv4 ↔ Integer`)**:
```
IPv4: 192.168.1.1
Integer: 3232235777
Hex: 0xc0a80101
```
