### PR TITLE
feat(JsonFlatten): add JSON Flatten BoxSource

### DIFF
--- a/src/modules/boxSources/JsonFlattenBoxSource.ts
+++ b/src/modules/boxSources/JsonFlattenBoxSource.ts
@@ -1,0 +1,189 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// recursively flatten a nested value into dot/bracket path → leaf entries
+function flattenValue(
+  value: unknown,
+  prefix: string,
+  result: Record<string, unknown>,
+): void {
+  if (value === null || typeof value !== 'object') {
+    result[prefix] = value;
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      result[prefix] = [];
+      return;
+    }
+    for (let i = 0; i < value.length; i++) {
+      flattenValue(value[i], `${prefix}[${i}]`, result);
+    }
+    return;
+  }
+
+  const keys = Object.keys(value as Record<string, unknown>);
+  if (keys.length === 0) {
+    result[prefix] = {};
+    return;
+  }
+  for (const key of keys) {
+    const nextPrefix = prefix === '' ? key : `${prefix}.${key}`;
+    flattenValue((value as Record<string, unknown>)[key], nextPrefix, result);
+  }
+}
+
+function flatten(input: unknown): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  if (input === null || typeof input !== 'object') {
+    return result;
+  }
+  if (Array.isArray(input)) {
+    for (let i = 0; i < input.length; i++) {
+      flattenValue(input[i], `[${i}]`, result);
+    }
+    return result;
+  }
+  for (const key of Object.keys(input as Record<string, unknown>)) {
+    flattenValue((input as Record<string, unknown>)[key], key, result);
+  }
+  return result;
+}
+
+// split a flat key like "a.b[0].c[1]" into segments ["a", "b", 0, "c", 1]
+function splitKey(key: string): (string | number)[] {
+  const segments: (string | number)[] = [];
+  // tokenize by '.' and '[n]'
+  const parts = key.split('.');
+  for (const part of parts) {
+    // a part may look like "arr[0][1]" after splitting on '.'
+    const re = /([^[]*)((?:\[\d+\])*)/g;
+    const m = re.exec(part);
+    if (m) {
+      if (m[1] !== '') segments.push(m[1]);
+      const brackets = m[2];
+      if (brackets) {
+        for (const idx of brackets.matchAll(/\[(\d+)\]/g)) {
+          segments.push(Number.parseInt(idx[1], 10));
+        }
+      }
+    }
+  }
+  return segments;
+}
+
+// keys that would walk into the prototype chain and let a crafted ?input=
+// pollute Object.prototype for the whole session
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+// set a value at a nested path described by segments, creating objects/arrays as needed
+function setPath(
+  root: Record<string, unknown> | unknown[],
+  segments: (string | number)[],
+  value: unknown,
+): void {
+  // refuse any path that touches a prototype-chain key
+  if (segments.some((s) => typeof s === 'string' && FORBIDDEN_KEYS.has(s))) {
+    return;
+  }
+
+  let current: Record<string, unknown> | unknown[] = root;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    const nextSeg = segments[i + 1];
+    const nextIsIndex = typeof nextSeg === 'number';
+
+    if (typeof seg === 'number') {
+      const arr = current as unknown[];
+      if (arr[seg] == null) {
+        arr[seg] = nextIsIndex ? [] : {};
+      }
+      current = arr[seg] as Record<string, unknown> | unknown[];
+    } else {
+      const obj = current as Record<string, unknown>;
+      if (obj[seg] == null) {
+        obj[seg] = nextIsIndex ? [] : {};
+      }
+      current = obj[seg] as Record<string, unknown> | unknown[];
+    }
+  }
+
+  const last = segments[segments.length - 1];
+  if (typeof last === 'number') {
+    (current as unknown[])[last] = value;
+  } else {
+    (current as Record<string, unknown>)[last] = value;
+  }
+}
+
+function unflatten(flat: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(flat)) {
+    const segments = splitKey(key);
+    if (segments.length === 0) continue;
+    setPath(result, segments, value);
+  }
+  return result;
+}
+
+export const JsonFlattenBoxSource = {
+  defaultDisabled: true,
+  name: 'JSON Flatten',
+  description:
+    'Flatten nested JSON to dot-notation keys, or unflatten dot keys back to nested JSON.',
+  defaultInput: '{"a":{"b":1,"c":[2,3]}} ::flatten',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantFlatten = hasOptionKeys(options, 'flatten', 'jsonflatten');
+    const wantUnflatten = hasOptionKeys(options, 'unflatten', 'jsonunflatten');
+    if (!wantFlatten && !wantUnflatten) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      const errorBox = new BoxBuilder(
+        'JSON Flatten',
+        `Invalid JSON: unable to parse input.\n\n${trimmed.slice(0, 200)}`,
+      )
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(Priority)
+        .build();
+      return [errorBox];
+    }
+
+    let output: string;
+    if (wantFlatten) {
+      output = JSON.stringify(flatten(parsed), null, 2);
+    } else {
+      // wantUnflatten — parsed must be a flat object
+      const flat = parsed as Record<string, unknown>;
+      output = JSON.stringify(unflatten(flat), null, 2);
+    }
+
+    const box = new BoxBuilder('JSON Flatten', output)
+      .setOptions({ language: 'json' })
+      .setTemplate(CodeBoxTemplate)
+      .setPriority(Priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default JsonFlattenBoxSource;

--- a/src/modules/boxSources/__test__/JsonFlattenBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonFlattenBoxSource.test.ts
@@ -1,0 +1,153 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { JsonFlattenBoxSource } from '../JsonFlattenBoxSource';
+
+describe('JsonFlattenBoxSource', () => {
+  describe('no option → empty array', () => {
+    it('returns [] when no flatten/unflatten option is given', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes(
+        '{"a":{"b":1}}',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are given', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{"a":1}', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('flatten', () => {
+    it('flattens nested JSON to dot/bracket keys', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes(
+        '{"a":{"b":1,"c":[2,3]}}',
+        { flatten: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON Flatten');
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+      expect(boxes[0].props.options).toEqual({ language: 'json' });
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ 'a.b': 1, 'a.c[0]': 2, 'a.c[1]': 3 });
+    });
+
+    it('accepts ::jsonflatten alias', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{"x":{"y":42}}', {
+        jsonflatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ 'x.y': 42 });
+    });
+
+    it('handles empty object as leaf value', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{"a":{}}', {
+        flatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: {} });
+    });
+
+    it('handles empty array as leaf value', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{"a":[]}', {
+        flatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: [] });
+    });
+
+    it('handles null and boolean primitives', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes(
+        '{"a":null,"b":true,"c":false}',
+        { flatten: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: null, b: true, c: false });
+    });
+  });
+
+  describe('unflatten', () => {
+    it('rebuilds nested JSON from flat dot/bracket keys', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes(
+        '{"a.b":1,"a.c[0]":2,"a.c[1]":3}',
+        { unflatten: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON Flatten');
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: { b: 1, c: [2, 3] } });
+    });
+
+    it('accepts ::jsonunflatten alias', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{"x.y":42}', {
+        jsonunflatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ x: { y: 42 } });
+    });
+  });
+
+  describe('round-trip', () => {
+    it('unflatten(flatten(x)) deep-equals x', async () => {
+      const fixture = {
+        a: { b: 1, c: [2, 3] },
+        d: { e: { f: 'hello' } },
+        g: [true, null, 0],
+      };
+      const flatBoxes = await JsonFlattenBoxSource.generateBoxes(
+        JSON.stringify(fixture),
+        { flatten: true },
+      );
+      expect(flatBoxes).toHaveLength(1);
+
+      const flatJson = flatBoxes[0].props.plaintextOutput;
+
+      const unflatBoxes = await JsonFlattenBoxSource.generateBoxes(flatJson, {
+        unflatten: true,
+      });
+      expect(unflatBoxes).toHaveLength(1);
+
+      const result = JSON.parse(unflatBoxes[0].props.plaintextOutput);
+      expect(result).toEqual(fixture);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns an error box for invalid JSON with ::flatten', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{bad}', {
+        flatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON Flatten');
+      // error box output should mention the failure
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+
+    it('returns an error box for invalid JSON with ::unflatten', async () => {
+      const boxes = await JsonFlattenBoxSource.generateBoxes('{bad}', {
+        unflatten: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+
+    it('unflatten does not pollute Object.prototype via __proto__ key', async () => {
+      await JsonFlattenBoxSource.generateBoxes('{"__proto__.polluted":"x"}', {
+        unflatten: true,
+      });
+      await JsonFlattenBoxSource.generateBoxes(
+        '{"constructor.prototype.polluted":"x"}',
+        { unflatten: true },
+      );
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import JsonFlattenBoxSource from './JsonFlattenBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  JsonFlattenBoxSource,
 ];


### PR DESCRIPTION
### Box Source: JSON Flatten (Transform)

Adds the `JSON Flatten` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `{`

#### Options:
- `::flatten`, `::jsonflatten`, `::jsonunflatten`, `::unflatten`

#### Description:
Flatten nested JSON to dot-notation keys, or unflatten dot keys back to nested JSON.

#### Usage Examples:
- **Input**: `{"a":{"b":1,"c":[2,3]}} ::flatten`
- **Output Box (`JSON Flatten`)**:
```
{
  "a.b": 1,
  "a.c[0]": 2,
  "a.c[1]": 3
}
```
