### PR TITLE
feat(JsonMerge): add JSON Merge BoxSource

### DIFF
--- a/src/modules/boxSources/JsonMergeBoxSource.ts
+++ b/src/modules/boxSources/JsonMergeBoxSource.ts
@@ -1,0 +1,159 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// keys that must never be assigned during merge to prevent prototype pollution
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** recursively merge `target` with `source`; source wins on conflict. arrays are replaced, not concatenated. */
+function deepMerge(
+  target: { [key: string]: JsonValue },
+  source: { [key: string]: JsonValue },
+): { [key: string]: JsonValue } {
+  const result: { [key: string]: JsonValue } = { ...target };
+
+  for (const key of Object.keys(source)) {
+    if (FORBIDDEN_KEYS.has(key)) continue;
+
+    const srcVal = source[key];
+    const tgtVal = result[key];
+
+    if (
+      srcVal !== null &&
+      typeof srcVal === 'object' &&
+      !Array.isArray(srcVal) &&
+      tgtVal !== null &&
+      typeof tgtVal === 'object' &&
+      !Array.isArray(tgtVal)
+    ) {
+      result[key] = deepMerge(
+        tgtVal as { [key: string]: JsonValue },
+        srcVal as { [key: string]: JsonValue },
+      );
+    } else {
+      result[key] = srcVal;
+    }
+  }
+
+  return result;
+}
+
+export const JsonMergeBoxSource = {
+  defaultDisabled: true,
+  name: 'JSON Merge',
+  description:
+    'Deep-merge two JSON documents (the second overrides the first). Separate them with a line containing only ---.',
+  defaultInput: '{"a":1,"b":{"x":1}}\n---\n{"b":{"y":2},"c":3} ::jsonmerge',
+  tag: '{}+',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonmerge', 'merge')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    // split on a line that is exactly '---'
+    const parts = trimmed.split(/^---$/m);
+
+    if (parts.length !== 2) {
+      return [
+        new BoxBuilder(
+          'JSON Merge',
+          'Provide two JSON documents separated by a line containing only ---.',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const [rawFirst, rawSecond] = parts;
+
+    let first: { [key: string]: JsonValue };
+    try {
+      const parsed = JSON.parse(trim(rawFirst));
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        throw new SyntaxError('not a JSON object');
+      }
+      first = parsed as { [key: string]: JsonValue };
+    } catch {
+      return [
+        new BoxBuilder(
+          'JSON Merge',
+          'The first document is not valid JSON. Check its syntax and try again.',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    let second: { [key: string]: JsonValue };
+    try {
+      const parsed = JSON.parse(trim(rawSecond));
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        throw new SyntaxError('not a JSON object');
+      }
+      second = parsed as { [key: string]: JsonValue };
+    } catch {
+      return [
+        new BoxBuilder(
+          'JSON Merge',
+          'The second document is not valid JSON. Check its syntax and try again.',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    let output: string;
+    try {
+      // deepMerge recurses per nesting level; a pathologically deep document
+      // (that JSON.parse still accepted) could overflow the stack — contain it
+      const merged = deepMerge(first, second);
+      output = JSON.stringify(merged, null, 2);
+    } catch {
+      return [
+        new BoxBuilder(
+          'JSON Merge',
+          'The documents are nested too deeply to merge.',
+        )
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    return [
+      new BoxBuilder('JSON Merge', output)
+        .setOptions({ language: 'json' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonMergeBoxSource;

--- a/src/modules/boxSources/__test__/JsonMergeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonMergeBoxSource.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonMergeBoxSource } from '../JsonMergeBoxSource';
+
+describe('JsonMergeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no trigger option is present', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"b":2}',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options object has no matching key', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"b":2}',
+        { format: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('deep-merges nested objects (second overrides first on conflict)', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1,"b":{"x":1}}\n---\n{"b":{"y":2},"c":3}',
+        { jsonmerge: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON Merge');
+      expect(JSON.parse(boxes[0].props.plaintextOutput)).toEqual({
+        a: 1,
+        b: { x: 1, y: 2 },
+        c: 3,
+      });
+    });
+
+    it('triggers on ::merge option as well', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"a":2}',
+        { merge: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('overrides scalar value from first doc with second', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"a":2}',
+        { jsonmerge: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(JSON.parse(boxes[0].props.plaintextOutput)).toEqual({ a: 2 });
+    });
+
+    it('replaces arrays rather than concatenating them', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":[1,2]}\n---\n{"a":[3]}',
+        { jsonmerge: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(JSON.parse(boxes[0].props.plaintextOutput)).toEqual({ a: [3] });
+    });
+
+    it('guards against prototype pollution via __proto__ key', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{}\n---\n{"__proto__":{"polluted":true}}',
+        { jsonmerge: true },
+      );
+      // merge itself must succeed without throwing
+      expect(boxes).toHaveLength(1);
+      // Object.prototype must remain clean
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it('returns an error box when the separator is missing', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes('{"a":1}', {
+        jsonmerge: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/---/);
+    });
+
+    it('returns an error box when the first document is invalid JSON', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes('{bad\n---\n{}', {
+        jsonmerge: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/first/i);
+    });
+
+    it('returns an error box when the second document is invalid JSON', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes('{}\n---\n{bad', {
+        jsonmerge: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/second/i);
+    });
+
+    it('uses CodeBoxTemplate with language:json for successful merge', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"b":2}',
+        { jsonmerge: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.language).toBe('json');
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+
+    it('sets priority on the returned box', async () => {
+      const boxes = await JsonMergeBoxSource.generateBoxes(
+        '{"a":1}\n---\n{"b":2}',
+        { jsonmerge: true },
+      );
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import JsonMergeBoxSource from './JsonMergeBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  JsonMergeBoxSource,
 ];


### PR DESCRIPTION
### Box Source: JSON Merge (Transform)

Adds the `JSON Merge` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `{}+`
- **Default Input**: `{`

#### Options:
- `::jsonmerge`, `::merge`

#### Description:
Deep-merge two JSON documents (the second overrides the first). Separate them with a line containing only ---.

#### Usage Examples:
- **Input**: `{"a":1,"b":{"x":1}}
---
{"b":{"y":2},"c":3} ::jsonmerge`
- **Output Box (`JSON Merge`)**:
```
{
  "a": 1,
  "b": {
    "x": 1,
    "y": 2
  },
  "c": 3
}
```
