### PR TITLE
feat(JsonMinify): add JSON Minify BoxSource

### DIFF
--- a/src/modules/boxSources/JsonMinifyBoxSource.ts
+++ b/src/modules/boxSources/JsonMinifyBoxSource.ts
@@ -1,0 +1,55 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+export const JsonMinifyBoxSource = {
+  defaultDisabled: true,
+  name: 'JSON Minify',
+  description:
+    'Minify a JSON document by removing all insignificant whitespace.',
+  defaultInput: '{ "a": 1, "b": [1, 2, 3] } ::jsonmin',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonmin', 'minifyjson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    if (trimmed === '') return [];
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      const minified = JSON.stringify(parsed);
+      return [
+        new BoxBuilder('JSON Minify', minified)
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(true)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    } catch {
+      // input is not valid JSON — surface a descriptive error box
+      return [
+        new BoxBuilder(
+          'JSON Minify',
+          'Invalid JSON: unable to parse the input.',
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+  },
+};
+
+export default JsonMinifyBoxSource;

--- a/src/modules/boxSources/__test__/JsonMinifyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonMinifyBoxSource.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonMinifyBoxSource } from '../JsonMinifyBoxSource';
+
+describe('JsonMinifyBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{ "a": 1 }', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{ "a": 1 }', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{ "a": 1 }', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty input', () => {
+    it('returns empty array for empty string with ::jsonmin', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('', {
+        jsonmin: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input with ::jsonmin', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('   ', {
+        jsonmin: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::jsonmin option', () => {
+    it('minifies a simple flat object', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes(
+        '{ "a": 1, "b": [1, 2, 3] }',
+        { jsonmin: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('{"a":1,"b":[1,2,3]}');
+    });
+
+    it('collapses pretty-printed multi-line JSON to a single compact line', async () => {
+      const pretty = `{
+  "name": "magic-box",
+  "version": "1.0.0",
+  "active": true
+}`;
+      const boxes = await JsonMinifyBoxSource.generateBoxes(pretty, {
+        jsonmin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '{"name":"magic-box","version":"1.0.0","active":true}',
+      );
+      // result must be a single line
+      expect(boxes[0].props.plaintextOutput).not.toContain('\n');
+    });
+
+    it('minifies a nested object', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes(
+        '{ "x": { "y": 2 } }',
+        { jsonmin: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('{"x":{"y":2}}');
+    });
+  });
+
+  describe('::minifyjson alias', () => {
+    it('also triggers on ::minifyjson', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{ "a": 1 }', {
+        minifyjson: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('{"a":1}');
+    });
+  });
+
+  describe('invalid JSON', () => {
+    it('returns a box mentioning invalid JSON for malformed input', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{bad}', {
+        jsonmin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON Minify');
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+
+    it('returns a box for trailing-comma JSON', async () => {
+      const boxes = await JsonMinifyBoxSource.generateBoxes('{ "a": 1, }', {
+        jsonmin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain('invalid');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(JsonMinifyBoxSource.name).toBe('JSON Minify');
+      expect(JsonMinifyBoxSource.tag).toBe('#');
+      expect(JsonMinifyBoxSource.kind).toBe('Transform');
+      expect(typeof JsonMinifyBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import JsonMinifyBoxSource from './JsonMinifyBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  JsonMinifyBoxSource,
 ];


### PR DESCRIPTION
### Box Source: JSON Minify (Transform)

Adds the `JSON Minify` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `{ `

#### Options:
- `::jsonmin`, `::minifyjson`

#### Description:
Minify a JSON document by removing all insignificant whitespace.

#### Usage Examples:
- **Input**: `{ "a": 1, "b": [1, 2, 3] } ::jsonmin`
- **Output Box (`JSON Minify`)**:
```
{"a":1,"b":[1,2,3]}
```
