### PR TITLE
feat(JsonPick): add JSON Pick BoxSource

### DIFF
--- a/src/modules/boxSources/JsonPickBoxSource.ts
+++ b/src/modules/boxSources/JsonPickBoxSource.ts
@@ -1,0 +1,135 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+// keys that must never be read or written to prevent prototype pollution
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export const JsonPickBoxSource = {
+  defaultDisabled: true,
+  name: 'JSON Pick',
+  description:
+    'Pick or omit top-level keys from a JSON object. ::jsonpick=a,b or ::jsonomit=a,b.',
+  defaultInput: '{"a":1,"b":2,"c":3} ::jsonpick=a,c',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const pick = extractOptionKeys(options, 'jsonpick');
+    const omit = extractOptionKeys(options, 'jsonomit');
+
+    if (pick === null && omit === null) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    // show usage only when NEITHER flag carries a usable key list — a bare
+    // ::jsonomit alongside ::jsonpick=a,b must not suppress the pick
+    if (typeof pick !== 'string' && typeof omit !== 'string') {
+      const flag = pick === true ? '::jsonpick' : '::jsonomit';
+      return [
+        new BoxBuilder(
+          'JSON Pick',
+          `Usage: provide a comma-separated key list, e.g. ${flag}=a,b,c`,
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'json' })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // parse input as a JSON object
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trim(input));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return [
+        new BoxBuilder('JSON Pick', `JSON parse error: ${msg}`)
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'json' })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      return [
+        new BoxBuilder(
+          'JSON Pick',
+          'Input must be a JSON object (not an array or scalar).',
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'json' })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const source = parsed as Record<string, unknown>;
+    const result: Record<string, unknown> = Object.create(null);
+
+    if (typeof pick === 'string') {
+      // pick mode: include only listed keys that exist as own enumerable properties,
+      // using the original object's key order for determinism
+      const requested = new Set(
+        pick
+          .split(',')
+          .map((k) => k.trim())
+          .filter((k) => k.length > 0 && !FORBIDDEN_KEYS.has(k)),
+      );
+      for (const key of Object.keys(source)) {
+        if (
+          requested.has(key) &&
+          Object.hasOwn(source, key) &&
+          !FORBIDDEN_KEYS.has(key)
+        ) {
+          result[key] = source[key];
+        }
+      }
+    } else if (typeof omit === 'string') {
+      // omit mode: include all own keys except the listed ones
+      const excluded = new Set(
+        omit
+          .split(',')
+          .map((k) => k.trim())
+          .filter((k) => k.length > 0),
+      );
+      for (const key of Object.keys(source)) {
+        if (
+          !excluded.has(key) &&
+          Object.hasOwn(source, key) &&
+          !FORBIDDEN_KEYS.has(key)
+        ) {
+          result[key] = source[key];
+        }
+      }
+    }
+
+    // convert to a plain object so JSON.stringify uses the normal prototype
+    const output = JSON.stringify(Object.assign({}, result), null, 2);
+
+    return [
+      new BoxBuilder('JSON Pick', output)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'json' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonPickBoxSource;

--- a/src/modules/boxSources/__test__/JsonPickBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonPickBoxSource.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonPickBoxSource } from '../JsonPickBoxSource';
+
+describe('JsonPickBoxSource', () => {
+  describe('trigger guard', () => {
+    it('returns [] when neither jsonpick nor jsonomit is provided', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('pick mode', () => {
+    it('picks listed keys and omits the rest', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes(
+        '{"a":1,"b":2,"c":3}',
+        { jsonpick: 'a,c' },
+      );
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: 1, c: 3 });
+      // b must not appear
+      expect(Object.hasOwn(result, 'b')).toBe(false);
+    });
+
+    it('preserves original key order from the source object', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes(
+        '{"a":1,"b":2,"c":3}',
+        { jsonpick: 'c,a' },
+      );
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      // order follows the original object (a before c), not the requested order
+      expect(Object.keys(result)).toEqual(['a', 'c']);
+    });
+
+    it('silently skips a requested key that does not exist in the source', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', {
+        jsonpick: 'a,z',
+      });
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: 1 });
+      expect(Object.hasOwn(result, 'z')).toBe(false);
+    });
+
+    it('preserves nested values unchanged', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes(
+        '{"a":{"x":1},"b":2}',
+        { jsonpick: 'a' },
+      );
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: { x: 1 } });
+    });
+  });
+
+  describe('omit mode', () => {
+    it('omits listed keys and retains the rest', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes(
+        '{"a":1,"b":2,"c":3}',
+        { jsonomit: 'b' },
+      );
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(result).toEqual({ a: 1, c: 3 });
+    });
+  });
+
+  describe('prototype safety', () => {
+    it('does not pollute Object.prototype when __proto__ is in the pick list', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', {
+        jsonpick: '__proto__,a',
+      });
+      expect(boxes).toHaveLength(1);
+      const result = JSON.parse(boxes[0].props.plaintextOutput);
+      // a is included, __proto__ is not an own key on the result
+      expect(result).toEqual({ a: 1 });
+      expect(Object.hasOwn(result, '__proto__')).toBe(false);
+      // prototype must not have been polluted
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+  });
+
+  describe('bare flag (usage hint)', () => {
+    it('returns a usage box when ::jsonpick is a bare boolean', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', {
+        jsonpick: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/usage/i);
+    });
+
+    it('returns a usage box when ::jsonomit is a bare boolean', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{"a":1}', {
+        jsonomit: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/usage/i);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns an error box for invalid JSON', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('{bad', {
+        jsonpick: 'a',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/parse error/i);
+    });
+
+    it('returns an error box when input is a JSON array', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('[1,2]', {
+        jsonpick: 'a',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/object/i);
+    });
+
+    it('returns an error box when input is a JSON scalar', async () => {
+      const boxes = await JsonPickBoxSource.generateBoxes('"hello"', {
+        jsonpick: 'a',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/object/i);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(JsonPickBoxSource.name).toBe('JSON Pick');
+      expect(JsonPickBoxSource.tag).toBe('#');
+      expect(JsonPickBoxSource.kind).toBe('Transform');
+      expect(typeof JsonPickBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import JsonPickBoxSource from './JsonPickBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  JsonPickBoxSource,
 ];


### PR DESCRIPTION
### Box Source: JSON Pick (Transform)

Adds the `JSON Pick` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `{`

#### Options:
- None

#### Description:
Pick or omit top-level keys from a JSON object. ::jsonpick=a,b or ::jsonomit=a,b.

#### Usage Examples:
- **Input**: `{"a":1,"b":2,"c":3} ::jsonpick=a,c`
- **Output Box (`JSON Pick`)**:
```
{
  "a": 1,
  "c": 3
}
```
