### PR TITLE
feat(JsonPointer): add JSON Pointer BoxSource

### DIFF
--- a/src/modules/boxSources/JsonPointerBoxSource.ts
+++ b/src/modules/boxSources/JsonPointerBoxSource.ts
@@ -1,0 +1,131 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// unescape a single RFC 6901 reference token: ~1 → / then ~0 → ~
+function unescapeToken(token: string): string {
+  return token.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+// evaluate an RFC 6901 JSON Pointer against a parsed document.
+// returns the resolved value or throws with a descriptive message.
+function evaluatePointer(doc: unknown, pointer: string): unknown {
+  if (pointer === '') {
+    return doc;
+  }
+
+  if (!pointer.startsWith('/')) {
+    throw new Error(`Invalid pointer: must be empty or start with '/'`);
+  }
+
+  const tokens = pointer.slice(1).split('/').map(unescapeToken);
+  let current: unknown = doc;
+
+  for (const token of tokens) {
+    if (Array.isArray(current)) {
+      if (token === '-') {
+        throw new Error(
+          `Pointer token '-' refers to a non-existent array element`,
+        );
+      }
+      if (!/^(0|[1-9]\d*)$/.test(token)) {
+        // RFC 6901 §4: array index is "0" or a digit1-9 run (no leading zeros)
+        throw new Error(`Pointer token '${token}' is not a valid array index`);
+      }
+      const index = Number(token);
+      if (index >= current.length) {
+        throw new Error(
+          `Pointer did not resolve: index ${index} out of bounds (length ${current.length})`,
+        );
+      }
+      current = current[index];
+    } else if (current !== null && typeof current === 'object') {
+      // only allow own-property access — never prototype traversal
+      if (!Object.hasOwn(current as Record<string, unknown>, token)) {
+        throw new Error(`Pointer did not resolve: key '${token}' not found`);
+      }
+      current = (current as Record<string, unknown>)[token];
+    } else {
+      throw new Error(
+        `Pointer did not resolve: cannot index into ${JSON.stringify(current)} with '${token}'`,
+      );
+    }
+  }
+
+  return current;
+}
+
+function makeErrorBox(message: string, priority: number): Box {
+  return new BoxBuilder('JSON Pointer', message)
+    .setOptions({ language: 'text' })
+    .setTemplate(CodeBoxTemplate)
+    .setPriority(priority)
+    .build();
+}
+
+export const JsonPointerBoxSource = {
+  defaultDisabled: true,
+  name: 'JSON Pointer',
+  description:
+    'Evaluate an RFC 6901 JSON Pointer against a JSON document. ::jsonpointer=/path/to/value',
+  defaultInput: '{"a":{"b":[1,2,3]}} ::jsonpointer=/a/b/1',
+  tag: '#',
+  kind: 'Extract',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const pointer = extractOptionKeys(options, 'jsonpointer', 'jsonptr');
+
+    // option absent entirely — not our job
+    if (pointer === null) return [];
+
+    // bare flag (e.g. ::jsonpointer without a value) — show usage hint
+    if (typeof pointer !== 'string') {
+      return [
+        makeErrorBox(
+          'Usage: ::jsonpointer=/path/to/value\nExample: {"a":{"b":[1,2,3]}} ::jsonpointer=/a/b/1',
+          this.priority,
+        ),
+      ];
+    }
+
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    let doc: unknown;
+    try {
+      doc = JSON.parse(trimmed);
+    } catch {
+      return [
+        makeErrorBox(`Invalid JSON: ${trimmed.slice(0, 120)}`, this.priority),
+      ];
+    }
+
+    let resolved: unknown;
+    try {
+      resolved = evaluatePointer(doc, pointer);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return [makeErrorBox(msg, this.priority)];
+    }
+
+    const output = JSON.stringify(resolved, null, 2);
+    return [
+      new BoxBuilder('JSON Pointer', output)
+        .setOptions({ language: 'json' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonPointerBoxSource;

--- a/src/modules/boxSources/__test__/JsonPointerBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonPointerBoxSource.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonPointerBoxSource } from '../JsonPointerBoxSource';
+
+const gen = (input: string, options: Record<string, string | boolean>) =>
+  JsonPointerBoxSource.generateBoxes(input, options);
+
+describe('JsonPointerBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is present', async () => {
+      const boxes = await gen('{"a":1}', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is null', async () => {
+      const boxes = await JsonPointerBoxSource.generateBoxes('{"a":1}', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('shows a usage box for bare ::jsonpointer (boolean true)', async () => {
+      const boxes = await gen('{"a":1}', { jsonpointer: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/Usage/i);
+    });
+  });
+
+  describe('JSON parse errors', () => {
+    it('returns an error box for invalid JSON', async () => {
+      const boxes = await gen('{bad', { jsonpointer: '/a' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/invalid json/i);
+    });
+  });
+
+  describe('pointer resolution', () => {
+    it('resolves /a/b/1 to 2', async () => {
+      const boxes = await gen('{"a":{"b":[1,2,3]}}', { jsonpointer: '/a/b/1' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('2');
+    });
+
+    it('resolves empty pointer to the whole document', async () => {
+      const doc = '{"a":{"b":[1,2,3]}}';
+      const boxes = await gen(doc, { jsonpointer: '' });
+      expect(boxes).toHaveLength(1);
+      expect(JSON.parse(boxes[0].props.plaintextOutput)).toEqual(
+        JSON.parse(doc),
+      );
+    });
+
+    it('resolves nested string value /x/y', async () => {
+      const boxes = await gen('{"x":{"y":"hi"}}', { jsonpointer: '/x/y' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('"hi"');
+    });
+
+    it('accepts ::jsonptr alias', async () => {
+      const boxes = await gen('{"a":1}', { jsonptr: '/a' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1');
+    });
+  });
+
+  describe('RFC 6901 escape sequences', () => {
+    it('unescapes ~1 to / in key lookup', async () => {
+      const boxes = await gen('{"a/b":1}', { jsonpointer: '/a~1b' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1');
+    });
+
+    it('unescapes ~0 to ~ in key lookup', async () => {
+      const boxes = await gen('{"m~n":2}', { jsonpointer: '/m~0n' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('2');
+    });
+  });
+
+  describe('not-found / type errors', () => {
+    it('returns an error box when key does not exist', async () => {
+      const boxes = await gen('{"a":{"b":1}}', { jsonpointer: '/a/z' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/not found|not resolve/i);
+    });
+
+    it('returns an error box when array index is out of bounds', async () => {
+      const boxes = await gen('[1,2,3]', { jsonpointer: '/5' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(
+        /out of bounds|not resolve/i,
+      );
+    });
+  });
+
+  describe('prototype safety', () => {
+    it('does NOT resolve __proto__ to the prototype object', async () => {
+      const boxes = await gen('{}', { jsonpointer: '/__proto__' });
+      expect(boxes).toHaveLength(1);
+      // must be an error box, not the prototype
+      expect(boxes[0].props.plaintextOutput).toMatch(/not found|not resolve/i);
+      // make sure it did not accidentally return the Object prototype
+      expect(boxes[0].props.plaintextOutput).not.toContain('isPrototypeOf');
+    });
+
+    it('does NOT resolve /constructor to Function via prototype', async () => {
+      const boxes = await gen('{}', { jsonpointer: '/constructor' });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/not found|not resolve/i);
+    });
+  });
+
+  describe('metadata', () => {
+    it('sets priority on the result box', async () => {
+      const boxes = await gen('{"a":1}', { jsonpointer: '/a' });
+      expect(boxes[0].props.priority).toBe(JsonPointerBoxSource.priority);
+    });
+
+    it('sets box name to JSON Pointer', async () => {
+      const boxes = await gen('{"a":1}', { jsonpointer: '/a' });
+      expect(boxes[0].props.name).toBe('JSON Pointer');
+    });
+
+    it('rejects a leading-zero array index per RFC 6901', async () => {
+      const boxes = await gen('{"a":[10,20,30]}', { jsonpointer: '/a/01' });
+      expect(boxes[0].props.plaintextOutput).toMatch(/valid array index|not/i);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import JsonPointerBoxSource from './JsonPointerBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  JsonPointerBoxSource,
 ];


### PR DESCRIPTION
### Box Source: JSON Pointer (Extract)

Adds the `JSON Pointer` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Extract`
- **Tag**: `#`
- **Default Input**: `{`

#### Options:
- None

#### Description:
Evaluate an RFC 6901 JSON Pointer against a JSON document. ::jsonpointer=/path/to/value

#### Usage Examples:
- **Input**: `{"a":{"b":[1,2,3]}} ::jsonpointer=/a/b/1`
- **Output Box (`JSON Pointer`)**:
```
2
```
