### PR TITLE
feat(JsonSortKeys): add JSON Sort Keys BoxSource

### DIFF
--- a/src/modules/boxSources/JsonSortKeysBoxSource.ts
+++ b/src/modules/boxSources/JsonSortKeysBoxSource.ts
@@ -1,0 +1,75 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// recursively sort object keys; arrays preserve element order but recurse into elements
+function sortKeys(value: unknown, descending: boolean): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortKeys(item, descending));
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    const sorted = entries.sort(([a], [b]) =>
+      descending ? (b < a ? -1 : b > a ? 1 : 0) : a < b ? -1 : a > b ? 1 : 0,
+    );
+    // Object.fromEntries assigns '__proto__' as a plain own data property, not prototype mutation
+    return Object.fromEntries(
+      sorted.map(([k, v]) => [k, sortKeys(v, descending)]),
+    );
+  }
+
+  return value;
+}
+
+export const JsonSortKeysBoxSource = {
+  defaultDisabled: true,
+  name: 'JSON Sort Keys',
+  description:
+    'Recursively sort the keys of a JSON object (canonical form). Use ::jsonsort=desc for descending.',
+  defaultInput: '{"b":1,"a":{"d":4,"c":3}} ::jsonsort',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonsort', 'sortkeys')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const descending =
+      extractOptionKeys(options, 'jsonsort', 'sortkeys') === 'desc';
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trim(input));
+    } catch {
+      return [
+        new BoxBuilder('JSON Sort Keys', 'Invalid JSON: unable to parse input')
+          .setOptions({ language: 'json' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const sorted = sortKeys(parsed, descending);
+    const output = JSON.stringify(sorted, null, 2);
+
+    return [
+      new BoxBuilder('JSON Sort Keys', output)
+        .setOptions({ language: 'json' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonSortKeysBoxSource;

--- a/src/modules/boxSources/__test__/JsonSortKeysBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonSortKeysBoxSource.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonSortKeysBoxSource } from '../JsonSortKeysBoxSource';
+
+describe('JsonSortKeysBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no trigger option is provided', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes(
+        '{"b":1,"a":2}',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options is null', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes(
+        '{"b":1,"a":2}',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should sort object keys ascending by default with ::jsonsort', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes(
+        '{"b":1,"a":{"d":4,"c":3}}',
+        { jsonsort: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+
+      const output = boxes[0].props.plaintextOutput;
+      const parsed = JSON.parse(output);
+
+      // deep value equality
+      expect(parsed).toEqual({ a: { c: 3, d: 4 }, b: 1 });
+
+      // key order in serialised output: "a" must appear before "b", "c" before "d"
+      expect(output.indexOf('"a"')).toBeLessThan(output.indexOf('"b"'));
+      expect(output.indexOf('"c"')).toBeLessThan(output.indexOf('"d"'));
+    });
+
+    it('should sort keys descending when ::jsonsort=desc', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes('{"a":1,"b":2}', {
+        jsonsort: 'desc',
+      });
+
+      expect(boxes).toHaveLength(1);
+
+      const output = boxes[0].props.plaintextOutput;
+      // "b" must appear before "a" in descending order
+      expect(output.indexOf('"b"')).toBeLessThan(output.indexOf('"a"'));
+    });
+
+    it('should also trigger on ::sortkeys option', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes('{"b":1,"a":2}', {
+        sortkeys: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+
+      const output = boxes[0].props.plaintextOutput;
+      expect(output.indexOf('"a"')).toBeLessThan(output.indexOf('"b"'));
+    });
+
+    it('should preserve array element order (not sort array contents)', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes('{"x":[3,1,2]}', {
+        jsonsort: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed.x).toEqual([3, 1, 2]);
+    });
+
+    it('should sort keys inside objects that are elements of an array', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes(
+        '[{"b":1,"a":2}]',
+        { jsonsort: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+
+      const output = boxes[0].props.plaintextOutput;
+      const parsed = JSON.parse(output);
+
+      expect(parsed[0]).toEqual({ a: 2, b: 1 });
+      // "a" must come before "b" in the serialised output
+      expect(output.indexOf('"a"')).toBeLessThan(output.indexOf('"b"'));
+    });
+
+    it('should return an error box for invalid JSON', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes('{bad', {
+        jsonsort: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('Invalid JSON');
+    });
+
+    it('should not pollute Object prototype when __proto__ is a JSON key', async () => {
+      const input = '{"__proto__":{"x":1},"a":2}';
+      await JsonSortKeysBoxSource.generateBoxes(input, { jsonsort: true });
+
+      // prototype pollution would make ({}).x === 1
+      expect(({} as Record<string, unknown>).x).toBeUndefined();
+    });
+
+    it('should set language option to json on the output box', async () => {
+      const boxes = await JsonSortKeysBoxSource.generateBoxes('{"b":1,"a":2}', {
+        jsonsort: true,
+      });
+
+      expect(boxes[0].props.options).toEqual({ language: 'json' });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import JsonSortKeysBoxSource from './JsonSortKeysBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  JsonSortKeysBoxSource,
 ];


### PR DESCRIPTION
### Box Source: JSON Sort Keys (Transform)

Adds the `JSON Sort Keys` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `{"b":1,"a":{"d":4,"c":3}} ::jsonsort`

#### Options:
- `::jsonsort`, `::sortkeys`

#### Description:
Recursively sort the keys of a JSON object (canonical form). Use ::jsonsort=desc for descending.

#### Usage Examples:
- **Input**: `{"b":1,"a":{"d":4,"c":3}} ::jsonsort`
- **Output Box (`JSON Sort Keys`)**:
```
{
  "a": {
    "c": 3,
    "d": 4
  },
  "b": 1
}
```
