### PR TITLE
feat(JsonToPython): add JSON to Python BoxSource

### DIFF
--- a/src/modules/boxSources/JsonToPythonBoxSource.ts
+++ b/src/modules/boxSources/JsonToPythonBoxSource.ts
@@ -1,0 +1,258 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// python reserved words that can't be used as bare field names
+const PY_KEYWORDS = new Set([
+  'False',
+  'None',
+  'True',
+  'and',
+  'as',
+  'assert',
+  'async',
+  'await',
+  'break',
+  'class',
+  'continue',
+  'def',
+  'del',
+  'elif',
+  'else',
+  'except',
+  'finally',
+  'for',
+  'from',
+  'global',
+  'if',
+  'import',
+  'in',
+  'is',
+  'lambda',
+  'nonlocal',
+  'not',
+  'or',
+  'pass',
+  'raise',
+  'return',
+  'try',
+  'while',
+  'with',
+  'yield',
+]);
+
+// maps a json key to a valid python identifier: non-identifier chars → '_',
+// digit-leading names get a prefix, reserved words get a trailing underscore
+function safePyName(key: string): string {
+  const id = key.replace(/[^a-zA-Z0-9_]/g, '_');
+  if (/^\d/.test(id)) return `f_${id}`;
+  if (PY_KEYWORDS.has(id)) return `${id}_`;
+  return id || '_';
+}
+
+// maps a json key to a safe PascalCase class name, de-duplicating against usedNames
+function toPascalCase(key: string): string {
+  // replace non-alphanumeric chars with spaces, then capitalise each word
+  return key
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join('');
+}
+
+function uniqueName(base: string, used: Set<string>): string {
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+  let counter = 2;
+  while (used.has(`${base}${counter}`)) {
+    counter++;
+  }
+  const name = `${base}${counter}`;
+  used.add(name);
+  return name;
+}
+
+interface ClassDef {
+  name: string;
+  fields: string[];
+}
+
+// resolves a json value to a python type string, collecting nested class definitions
+function resolveType(
+  value: unknown,
+  key: string,
+  classes: ClassDef[],
+  usedNames: Set<string>,
+  imports: Set<string>,
+): string {
+  if (value === null) {
+    imports.add('Optional');
+    imports.add('Any');
+    return 'Optional[Any]';
+  }
+  if (typeof value === 'boolean') {
+    return 'bool';
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? 'int' : 'float';
+  }
+  if (typeof value === 'string') {
+    return 'str';
+  }
+  if (Array.isArray(value)) {
+    imports.add('List');
+    if (value.length === 0) {
+      imports.add('Any');
+      return 'List[Any]';
+    }
+    const elemType = resolveType(
+      value[0],
+      `${key}Item`,
+      classes,
+      usedNames,
+      imports,
+    );
+    return `List[${elemType}]`;
+  }
+  if (typeof value === 'object') {
+    const className = uniqueName(toPascalCase(key) || 'Nested', usedNames);
+    buildClass(
+      value as Record<string, unknown>,
+      className,
+      classes,
+      usedNames,
+      imports,
+    );
+    return className;
+  }
+  imports.add('Any');
+  return 'Any';
+}
+
+// builds a ClassDef for an object and pushes nested classes before itself
+function buildClass(
+  obj: Record<string, unknown>,
+  className: string,
+  classes: ClassDef[],
+  usedNames: Set<string>,
+  imports: Set<string>,
+): void {
+  const fields: string[] = [];
+  for (const [key, val] of Object.entries(obj)) {
+    const pyType = resolveType(val, key, classes, usedNames, imports);
+    fields.push(`    ${safePyName(key)}: ${pyType}`);
+  }
+  // push after nested classes so definitions always appear before their references
+  classes.push({ name: className, fields });
+}
+
+function generatePythonDataclasses(json: unknown): string {
+  if (json === null || Array.isArray(json) || typeof json !== 'object') {
+    throw new Error('Root JSON value must be an object');
+  }
+
+  const classes: ClassDef[] = [];
+  const usedNames = new Set<string>();
+  const imports = new Set<string>();
+
+  // reserve 'Root' so nested keys can't collide with it
+  usedNames.add('Root');
+  buildClass(
+    json as Record<string, unknown>,
+    'Root',
+    classes,
+    usedNames,
+    imports,
+  );
+
+  // build import line — only include what was actually used
+  const typingImports: string[] = [];
+  for (const name of ['List', 'Any', 'Optional']) {
+    if (imports.has(name)) typingImports.push(name);
+  }
+
+  const lines: string[] = ['from dataclasses import dataclass'];
+  if (typingImports.length > 0) {
+    lines.push(`from typing import ${typingImports.join(', ')}`);
+  }
+
+  for (const cls of classes) {
+    lines.push('');
+    lines.push('');
+    lines.push('@dataclass');
+    lines.push(`class ${cls.name}:`);
+    if (cls.fields.length === 0) {
+      lines.push('    pass');
+    } else {
+      for (const f of cls.fields) {
+        lines.push(f);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export const JsonToPythonBoxSource = {
+  defaultDisabled: true,
+  name: 'JSON to Python',
+  description: 'Generate Python @dataclass definitions from a JSON sample.',
+  defaultInput: '{"id":1,"name":"Bob","tags":["a"]} ::pydataclass',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'pydataclass', 'jsontopython')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      const errorBox = new BoxBuilder(
+        'JSON to Python',
+        'Error: invalid JSON — could not parse input.',
+      )
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'python' })
+        .setPriority(this.priority)
+        .build();
+      return [errorBox];
+    }
+
+    let output: string;
+    try {
+      output = generatePythonDataclasses(parsed);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      const errorBox = new BoxBuilder('JSON to Python', `Error: ${msg}`)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'python' })
+        .setPriority(this.priority)
+        .build();
+      return [errorBox];
+    }
+
+    const box = new BoxBuilder('JSON to Python', output)
+      .setTemplate(CodeBoxTemplate)
+      .setOptions({ language: 'python' })
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default JsonToPythonBoxSource;

--- a/src/modules/boxSources/__test__/JsonToPythonBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonToPythonBoxSource.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonToPythonBoxSource } from '../JsonToPythonBoxSource';
+
+describe('JsonToPythonBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no trigger option is provided', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"id":1}', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"id":1}', {
+        yaml: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should generate a dataclass for a flat object with ::pydataclass', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"id":1,"name":"Bob"}',
+        {
+          pydataclass: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('@dataclass');
+      expect(out).toContain('class Root:');
+      expect(out).toContain('id: int');
+      expect(out).toContain('name: str');
+    });
+
+    it('should trigger with ::jsontopython option', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"id":1}', {
+        jsontopython: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('class Root:');
+    });
+
+    it('should map float numbers to float type', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"price":1.5}', {
+        pydataclass: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('price: float');
+    });
+
+    it('should map boolean values to bool type', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"ok":true}', {
+        pydataclass: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('ok: bool');
+    });
+
+    it('should map arrays of strings to List[str]', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"tags":["a"]}',
+        {
+          pydataclass: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('from typing import');
+      expect(out).toContain('List');
+      expect(out).toContain('tags: List[str]');
+    });
+
+    it('should map empty arrays to List[Any]', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"items":[]}', {
+        pydataclass: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('items: List[Any]');
+    });
+
+    it('should map null values to Optional[Any]', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"value":null}',
+        {
+          pydataclass: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('value: Optional[Any]');
+    });
+
+    it('should generate nested dataclass for nested objects', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"meta":{"ok":true}}',
+        {
+          pydataclass: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      // nested class must appear before Root
+      const metaIdx = out.indexOf('class Meta:');
+      const rootIdx = out.indexOf('class Root:');
+      expect(metaIdx).toBeGreaterThanOrEqual(0);
+      expect(rootIdx).toBeGreaterThan(metaIdx);
+      expect(out).toContain('ok: bool');
+      expect(out).toContain('meta: Meta');
+    });
+
+    it('should de-duplicate class names when two keys normalise to the same PascalCase', async () => {
+      // 'my_data' → MyData, 'myData' → Mydata — both normalise similarly; must produce distinct names
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"my_data":{"x":1},"myData":{"y":2}}',
+        { pydataclass: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const out = boxes[0].props.plaintextOutput;
+      // collect all class names defined in the output
+      const classNames = [...out.matchAll(/^class (\w+):/gm)].map((m) => m[1]);
+      // all class names must be unique
+      const unique = new Set(classNames);
+      expect(unique.size).toBe(classNames.length);
+      // at least 3 classes: two nested + Root
+      expect(classNames.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should return an error box for invalid JSON', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{bad', {
+        pydataclass: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/error/i);
+    });
+
+    it('should include from dataclasses import dataclass in output', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"x":1}', {
+        pydataclass: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain(
+        'from dataclasses import dataclass',
+      );
+    });
+
+    it('should use CodeBoxTemplate with python language option', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes('{"x":1}', {
+        pydataclass: true,
+      });
+      expect(boxes[0].props.options?.language).toBe('python');
+    });
+
+    it('escapes python reserved words and digit-leading keys', async () => {
+      const boxes = await JsonToPythonBoxSource.generateBoxes(
+        '{"class":1,"for":2,"1abc":3}',
+        { pydataclass: true },
+      );
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('class_: int');
+      expect(out).toContain('for_: int');
+      expect(out).toContain('f_1abc: int');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import JsonToPythonBoxSource from './JsonToPythonBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  JsonToPythonBoxSource,
 ];


### PR DESCRIPTION
### Box Source: JSON to Python (Convert)

Adds the `JSON to Python` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `{`

#### Options:
- `::jsontopython`, `::pydataclass`

#### Description:
Generate Python @dataclass definitions from a JSON sample.

#### Usage Examples:
- **Input**: `{"id":1,"name":"Bob","tags":["a"]} ::pydataclass`
- **Output Box (`JSON to Python`)**:
```
from dataclasses import dataclass
from typing import List


@dataclass
class Root:
    id: int
    name: str
    tags: List[str]
```
