### PR TITLE
feat(JsonToTypescript): add JSON to TypeScript BoxSource

### DIFF
--- a/src/modules/boxSources/JsonToTypescriptBoxSource.ts
+++ b/src/modules/boxSources/JsonToTypescriptBoxSource.ts
@@ -1,0 +1,138 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// reserved keys that would cause prototype pollution if written into a plain object
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+// returns a valid TS identifier check — keys containing spaces or special chars need quoting
+function needsQuoting(key: string): boolean {
+  return !/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) || UNSAFE_KEYS.has(key);
+}
+
+// converts a string to PascalCase for use as an interface name
+function toPascalCase(str: string): string {
+  return str
+    .replace(/[^A-Za-z0-9]+(.)/g, (_, ch: string) => ch.toUpperCase())
+    .replace(/^[a-z]/, (c) => c.toUpperCase());
+}
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+interface InterfaceDef {
+  name: string;
+  body: string;
+}
+
+// coerce a candidate name into a valid TS identifier, then make it unique so
+// keys that collide after PascalCase (e.g. my_data and myData) don't emit two
+// interfaces with the same name
+function uniqueIdentifier(name: string, used: Set<string>): string {
+  let base = name.replace(/[^A-Za-z0-9$]/g, '').replace(/^[0-9]/, '_$&');
+  if (base.length === 0) base = 'Anon';
+  let candidate = base;
+  let n = 2;
+  while (used.has(candidate)) {
+    candidate = `${base}${n}`;
+    n++;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
+// infers the TypeScript type string for a JSON value, collecting nested interface definitions
+function inferType(
+  value: JsonValue,
+  name: string,
+  defs: InterfaceDef[],
+  used: Set<string>,
+): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return 'string';
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'boolean') return 'boolean';
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return 'unknown[]';
+    const elementType = inferType(value[0], `${name}Item`, defs, used);
+    return `${elementType}[]`;
+  }
+
+  // object — emit a named interface with a guaranteed-unique, valid identifier
+  const ifaceName = uniqueIdentifier(name, used);
+  const lines: string[] = [];
+
+  for (const key of Object.keys(value as JsonObject)) {
+    const fieldValue = (value as JsonObject)[key];
+    const fieldTypeName = toPascalCase(key);
+    const fieldType = inferType(fieldValue, fieldTypeName, defs, used);
+    const formattedKey = needsQuoting(key) ? `'${key}'` : key;
+    lines.push(`  ${formattedKey}: ${fieldType};`);
+  }
+
+  defs.push({ name: ifaceName, body: lines.join('\n') });
+  return ifaceName;
+}
+
+// generates all TypeScript interface declarations from a parsed JSON object
+function generateInterfaces(parsed: JsonValue): string {
+  const defs: InterfaceDef[] = [];
+  inferType(parsed, 'Root', defs, new Set<string>());
+
+  // emit nested interfaces before the root so references are declared first
+  return defs.map((d) => `interface ${d.name} {\n${d.body}\n}`).join('\n\n');
+}
+
+export const JsonToTypescriptBoxSource = {
+  defaultDisabled: true,
+  name: 'JSON to TypeScript',
+  description: 'Generate a TypeScript interface from a JSON sample.',
+  defaultInput:
+    '{"id":1,"name":"Bob","tags":["a"],"meta":{"ok":true}} ::tsinterface',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'tsinterface', 'jsontots')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+
+    let parsed: JsonValue;
+    try {
+      parsed = JSON.parse(trimmed) as JsonValue;
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return [
+        new BoxBuilder(
+          'JSON to TypeScript',
+          `// invalid JSON — cannot generate TypeScript interface\n// ${message}`,
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const output = generateInterfaces(parsed);
+    return [
+      new BoxBuilder('JSON to TypeScript', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonToTypescriptBoxSource;

--- a/src/modules/boxSources/__test__/JsonToTypescriptBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonToTypescriptBoxSource.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonToTypescriptBoxSource } from '../JsonToTypescriptBoxSource';
+
+describe('JsonToTypescriptBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no matching option is provided', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"id":1}',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes('{"id":1}', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should generate a Root interface with primitive fields via ::tsinterface', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"id":1,"name":"Bob"}',
+        { tsinterface: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('interface Root {');
+      expect(output).toContain('id: number;');
+      expect(output).toContain('name: string;');
+    });
+
+    it('should also trigger via ::jsontots option key', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"active":true}',
+        { jsontots: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('interface Root {');
+    });
+
+    it('should emit a nested interface for object values', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"meta":{"ok":true}}',
+        { tsinterface: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('interface Meta {');
+      expect(output).toContain('ok: boolean;');
+      expect(output).toContain('meta: Meta;');
+    });
+
+    it('should type string arrays correctly', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"tags":["a","b"]}',
+        { tsinterface: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('tags: string[];');
+    });
+
+    it('should type empty arrays as unknown[]', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes('{"xs":[]}', {
+        tsinterface: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('xs: unknown[];');
+    });
+
+    it('should return an error box for invalid JSON', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes('{bad}', {
+        tsinterface: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      expect(output.toLowerCase()).toContain('invalid');
+    });
+
+    it('should handle null field values', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"nothing":null}',
+        { tsinterface: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain('nothing: null;');
+    });
+
+    it('should quote keys that are not valid identifiers', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"my-key":1}',
+        { tsinterface: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain("'my-key': number;");
+    });
+
+    it('disambiguates interface names that collide after PascalCase', async () => {
+      const boxes = await JsonToTypescriptBoxSource.generateBoxes(
+        '{"my_data":{"x":1},"myData":{"y":"a"}}',
+        { tsinterface: true },
+      );
+      const out = boxes[0].props.plaintextOutput;
+      // two distinct interfaces, no duplicate name
+      expect(out).toContain('interface MyData {');
+      expect(out).toContain('interface MyData2 {');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import JsonToTypescriptBoxSource from './JsonToTypescriptBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  JsonToTypescriptBoxSource,
 ];


### PR DESCRIPTION
### Box Source: JSON to TypeScript (Convert)

Adds the `JSON to TypeScript` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `{`

#### Options:
- `::jsontots`, `::tsinterface`

#### Description:
Generate a TypeScript interface from a JSON sample.

#### Usage Examples:
- **Input**: `{"id":1,"name":"Bob","tags":["a"],"meta":{"ok":true}} ::tsinterface`
- **Output Box (`JSON to TypeScript`)**:
```
interface Meta {
  ok: boolean;
}

interface Root {
  id: number;
  name: string;
  tags: string[];
  meta: Meta;
}
```
