### PR TITLE
feat(Jsonl): add JSONL BoxSource

### DIFF
--- a/src/modules/boxSources/JsonlBoxSource.ts
+++ b/src/modules/boxSources/JsonlBoxSource.ts
@@ -1,0 +1,111 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// converts a JSON array to JSONL (one compact JSON element per line)
+function arrayToJsonl(arr: unknown[]): string {
+  return arr.map((item) => JSON.stringify(item)).join('\n');
+}
+
+// converts JSONL lines to a pretty-printed JSON array; throws on invalid lines
+function jsonlToArray(input: string): unknown[] {
+  const lines = input
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  return lines.map((line, idx) => {
+    try {
+      return JSON.parse(line);
+    } catch {
+      throw new Error(`line ${idx + 1}: ${JSON.stringify(line)}`);
+    }
+  });
+}
+
+export const JsonlBoxSource = {
+  defaultDisabled: true,
+  name: 'JSONL',
+  description:
+    'Convert a JSON array to JSONL (one object per line) or JSONL back to a JSON array. ::jsonl',
+  defaultInput: '[{"a":1},{"a":2}] ::jsonl',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'jsonl', 'ndjson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    if (!trimmed) return [];
+
+    // array → jsonl direction
+    if (trimmed.startsWith('[')) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        return [
+          new BoxBuilder('JSONL', `Parse error: invalid JSON array`)
+            .setTemplate(CodeBoxTemplate)
+            .setOptions({ language: 'json' })
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      if (!Array.isArray(parsed)) {
+        return [
+          new BoxBuilder('JSONL', 'Parse error: input is not a JSON array')
+            .setTemplate(CodeBoxTemplate)
+            .setOptions({ language: 'json' })
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      const output = arrayToJsonl(parsed);
+      return [
+        new BoxBuilder('JSONL', output)
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'json' })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // jsonl → array direction
+    let arr: unknown[];
+    try {
+      arr = jsonlToArray(trimmed);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return [
+        new BoxBuilder('JSONL', `Parse error: ${msg}`)
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'json' })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const output = JSON.stringify(arr, null, 2);
+    return [
+      new BoxBuilder('JSONL', output)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'json' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default JsonlBoxSource;

--- a/src/modules/boxSources/__test__/JsonlBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JsonlBoxSource.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { JsonlBoxSource } from '../JsonlBoxSource';
+
+describe('JsonlBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no option is provided', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1}]', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when unrelated option is provided', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1}]', {
+        yaml: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert JSON array to JSONL (compact, one per line)', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1},{"a":2}]', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('{"a":1}\n{"a":2}');
+    });
+
+    it('should convert JSON array to JSONL via ::ndjson option', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1},{"a":2}]', {
+        ndjson: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('{"a":1}\n{"a":2}');
+    });
+
+    it('should convert JSONL to pretty-printed JSON array', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('{"a":1}\n{"a":2}', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual([{ a: 1 }, { a: 2 }]);
+    });
+
+    it('should skip blank lines when converting JSONL to array', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('{"a":1}\n\n{"a":2}\n', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toHaveLength(2);
+      expect(parsed).toEqual([{ a: 1 }, { a: 2 }]);
+    });
+
+    it('should handle scalar values in array → JSONL', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[1,2,3]', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1\n2\n3');
+    });
+
+    it('should handle scalar JSONL → array', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('1\n2\n3', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual([1, 2, 3]);
+    });
+
+    it('should return error box for invalid JSON array input', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[bad', { jsonl: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/parse error/i);
+    });
+
+    it('should return error box mentioning the failing line number for invalid JSONL', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('{"a":1}\n{bad', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/line 2/i);
+    });
+
+    it('should preserve data through array → jsonl → array round-trip', async () => {
+      const original = [
+        { x: 1, y: 'hello' },
+        { x: 2, y: 'world' },
+      ];
+      const input = JSON.stringify(original);
+
+      // array → jsonl
+      const jsonlBoxes = await JsonlBoxSource.generateBoxes(input, {
+        jsonl: true,
+      });
+      expect(jsonlBoxes).toHaveLength(1);
+      const jsonlOutput = jsonlBoxes[0].props.plaintextOutput;
+
+      // jsonl → array
+      const arrayBoxes = await JsonlBoxSource.generateBoxes(jsonlOutput, {
+        jsonl: true,
+      });
+      expect(arrayBoxes).toHaveLength(1);
+      const roundTripped = JSON.parse(arrayBoxes[0].props.plaintextOutput);
+      expect(roundTripped).toEqual(original);
+    });
+
+    it('should use CodeBoxTemplate with language set to json', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1}]', {
+        jsonl: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.language).toBe('json');
+    });
+
+    it('should set priority on the box', async () => {
+      const boxes = await JsonlBoxSource.generateBoxes('[{"a":1}]', {
+        jsonl: true,
+      });
+      expect(boxes[0].props.priority).toBe(JsonlBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import JsonlBoxSource from './JsonlBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  JsonlBoxSource,
 ];


### PR DESCRIPTION
### Box Source: JSONL (Convert)

Adds the `JSONL` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `[{"a":1},{"a":2}] ::jsonl`

#### Options:
- `::jsonl`, `::ndjson`

#### Description:
Convert a JSON array to JSONL (one object per line) or JSONL back to a JSON array. ::jsonl

#### Usage Examples:
- **Input**: `[{"a":1},{"a":2}] ::jsonl`
- **Output Box (`JSONL`)**:
```
{"a":1}
{"a":2}
```
