### PR TITLE
feat(JulianDay): add Julian Day BoxSource

### DIFF
--- a/src/modules/boxSources/JulianDayBoxSource.ts
+++ b/src/modules/boxSources/JulianDayBoxSource.ts
@@ -1,0 +1,174 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+const DAY_NAMES = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+];
+
+// standard gregorian-to-jdn algorithm (julian day number at noon)
+function gregorianToJDN(year: number, month: number, day: number): number {
+  const a = Math.floor((14 - month) / 12);
+  const y = year + 4800 - a;
+  const m = month + 12 * a - 3;
+  return (
+    day +
+    Math.floor((153 * m + 2) / 5) +
+    365 * y +
+    Math.floor(y / 4) -
+    Math.floor(y / 100) +
+    Math.floor(y / 400) -
+    32045
+  );
+}
+
+// inverse jdn algorithm — returns [year, month, day] in proleptic gregorian
+function jdnToGregorian(jdn: number): [number, number, number] {
+  const a = jdn + 32044;
+  const b = Math.floor((4 * a + 3) / 146097);
+  const c = a - Math.floor((146097 * b) / 4);
+  const d = Math.floor((4 * c + 3) / 1461);
+  const e = c - Math.floor((1461 * d) / 4);
+  const m = Math.floor((5 * e + 2) / 153);
+  const day = e - Math.floor((153 * m + 2) / 5) + 1;
+  const month = m + 3 - 12 * Math.floor(m / 10);
+  const year = 100 * b + d - 4800 + Math.floor(m / 10);
+  return [year, month, day];
+}
+
+// jdn % 7 → 0=Monday … 6=Sunday (verified: JDN 2451545 = 2000-01-01 = Saturday = index 5)
+function dayOfWeekFromJDN(jdn: number): string {
+  return DAY_NAMES[((jdn % 7) + 7) % 7];
+}
+
+function padDate(year: number, month: number, day: number): string {
+  const y =
+    year < 0
+      ? `-${String(Math.abs(year)).padStart(4, '0')}`
+      : String(year).padStart(4, '0');
+  return `${y}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const JulianDayBoxSource = {
+  defaultDisabled: true,
+  name: 'Julian Day',
+  description:
+    'Convert a Gregorian date (YYYY-MM-DD) to its Julian Day Number, or a JDN back to a date.',
+  defaultInput: '2000-01-01 ::julianday',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'julianday', 'jdn')) return [];
+
+    const trimmed = trim(input);
+    if (trimmed.length === 0 || trimmed.length > 40) return [];
+
+    // plain number (possibly with decimal, possibly negative) → treat as jdn
+    const jdnPattern = /^-?\d{1,7}(\.\d+)?$/;
+    if (jdnPattern.test(trimmed)) {
+      const jdn = Math.floor(Number.parseFloat(trimmed));
+      const [year, month, day] = jdnToGregorian(jdn);
+      const dateStr = padDate(year, month, day);
+      const dow = dayOfWeekFromJDN(jdn);
+
+      const kv: Record<string, string> = {
+        'Julian Day Number': String(jdn),
+        Date: dateStr,
+        'Day of Week': dow,
+      };
+      const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    // gregorian date → jdn
+    const datePattern = /^(-?\d{1,6})-(\d{1,2})-(\d{1,2})$/;
+    const match = datePattern.exec(trimmed);
+    if (match) {
+      const year = Number.parseInt(match[1], 10);
+      const month = Number.parseInt(match[2], 10);
+      const day = Number.parseInt(match[3], 10);
+
+      const isLeap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+      const monthDays = [
+        31,
+        isLeap ? 29 : 28,
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+      ];
+      const maxDay = month >= 1 && month <= 12 ? monthDays[month - 1] : 0;
+      if (month < 1 || month > 12 || day < 1 || day > maxDay) {
+        const kv: Record<string, string> = {
+          Error:
+            'Invalid date — month must be 1–12 and day valid for the month.',
+        };
+        const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build();
+        return [box];
+      }
+
+      const jdn = gregorianToJDN(year, month, day);
+      const dow = dayOfWeekFromJDN(jdn);
+      const kv: Record<string, string> = {
+        Date: padDate(year, month, day),
+        'Julian Day Number': String(jdn),
+        'Day of Week': dow,
+      };
+      const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    // unrecognised format — return an informational box
+    const kv: Record<string, string> = {
+      Error: `Unrecognised input. Expected YYYY-MM-DD or an integer JDN.`,
+      'Date format': 'YYYY-MM-DD (e.g. 2000-01-01)',
+      'JDN format': 'integer (e.g. 2451545)',
+    };
+    const box = new BoxBuilder('Julian Day', kvToPlaintext(kv))
+      .setTemplate(KeyValueBoxTemplate)
+      .setOptions(kv)
+      .setPriority(Priority)
+      .build();
+    return [box];
+  },
+};
+
+export default JulianDayBoxSource;

--- a/src/modules/boxSources/__test__/JulianDayBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/JulianDayBoxSource.test.ts
@@ -1,0 +1,195 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+import { JulianDayBoxSource } from '../JulianDayBoxSource';
+
+describe('JulianDayBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for an unrelated option', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — date → JDN (::julianday)', () => {
+    it('converts 2000-01-01 to JDN 2451545 (J2000 epoch)', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Julian Day Number': '2451545',
+      });
+    });
+
+    it('converts 1970-01-01 to JDN 2440588 (Unix epoch)', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('1970-01-01', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Julian Day Number': '2440588',
+      });
+    });
+
+    it('converts -4713-11-24 to JDN 0 (epoch of the JDN calendar)', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('-4713-11-24', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Julian Day Number': '0',
+      });
+    });
+
+    it('reports Saturday for 2000-01-01', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        julianday: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Day of Week': 'Saturday',
+      });
+    });
+
+    it('includes the input date in the output', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        julianday: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Date: '2000-01-01' });
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        julianday: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets correct priority', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        julianday: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes — date → JDN (::jdn alias)', () => {
+    it('accepts ::jdn option', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-01-01', {
+        jdn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'Julian Day Number': '2451545',
+      });
+    });
+  });
+
+  describe('generateBoxes — JDN → date (reverse)', () => {
+    it('converts JDN 2451545 back to 2000-01-01', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2451545', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Date: '2000-01-01' });
+    });
+
+    it('converts JDN 2440588 back to 1970-01-01', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2440588', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Date: '1970-01-01' });
+    });
+
+    it('JDN 2451545 round-trip preserves JDN in output', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2451545', {
+        julianday: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Julian Day Number': '2451545',
+      });
+    });
+
+    it('JDN 0 round-trip returns -4713-11-24', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('0', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Date: '-4713-11-24' });
+    });
+
+    it('JDN 2451545 day of week is Saturday', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2451545', {
+        julianday: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({
+        'Day of Week': 'Saturday',
+      });
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns a box with an error for unrecognised text "hello"', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('hello', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // the error box should mention the expected format
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Date format'] ?? opts.Error).toBeTruthy();
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input longer than 40 chars', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes(
+        '2000-01-01-extra-padding-that-is-way-too-long',
+        { julianday: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns an error box for out-of-range month', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2000-13-01', {
+        julianday: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeTruthy();
+    });
+  });
+
+  describe('source metadata', () => {
+    it('has the correct name', () => {
+      expect(JulianDayBoxSource.name).toBe('Julian Day');
+    });
+
+    it('has a non-empty description', () => {
+      expect(JulianDayBoxSource.description.length).toBeGreaterThan(0);
+    });
+
+    it('has defaultInput containing ::julianday', () => {
+      expect(JulianDayBoxSource.defaultInput).toContain('::julianday');
+    });
+
+    it('rejects an overflow day-of-month (2025-02-31)', async () => {
+      const boxes = await JulianDayBoxSource.generateBoxes('2025-02-31', {
+        julianday: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/invalid date/i);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -19,6 +19,7 @@ import GcdLcmBoxSource from './GcdLcmBoxSource';
 import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
+import JulianDayBoxSource from './JulianDayBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  JulianDayBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Julian Day (Convert)

Adds the `Julian Day` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `2000-01-01 ::julianday`

#### Options:
- `::jdn`, `::julianday`

#### Description:
Convert a Gregorian date (YYYY-MM-DD) to its Julian Day Number, or a JDN back to a date.

#### Usage Examples:
- **Input**: `2000-01-01 ::julianday`
- **Output Box (`Julian Day`)**:
```
Date: 2000-01-01
Julian Day Number: 2451545
Day of Week: Saturday
```
