### PR TITLE
feat(KelvinToRgb): add Color Temperature BoxSource

### DIFF
--- a/src/modules/boxSources/KelvinToRgbBoxSource.ts
+++ b/src/modules/boxSources/KelvinToRgbBoxSource.ts
@@ -1,0 +1,118 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// min/max valid kelvin range per the Tanner Helland approximation
+const MIN_KELVIN = 1000;
+const MAX_KELVIN = 40000;
+
+interface RgbColor {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// clamp a float to [0, 255] and round to integer
+function clampChannel(value: number): number {
+  return Math.round(Math.min(255, Math.max(0, value)));
+}
+
+// Tanner Helland algorithm: convert a Kelvin temperature to approximate RGB
+// https://tannerhelland.com/2012/09/18/convert-temperature-rgb-algorithm-code.html
+function kelvinToRgb(kelvin: number): RgbColor {
+  const temp = kelvin / 100;
+
+  let r: number;
+  if (temp <= 66) {
+    r = 255;
+  } else {
+    r = 329.698727446 * (temp - 60) ** -0.1332047592;
+  }
+
+  let g: number;
+  if (temp <= 66) {
+    g = 99.4708025861 * Math.log(temp) - 161.1195681661;
+  } else {
+    g = 288.1221695283 * (temp - 60) ** -0.0755148492;
+  }
+
+  let b: number;
+  if (temp >= 66) {
+    b = 255;
+  } else if (temp <= 19) {
+    b = 0;
+  } else {
+    b = 138.5177312231 * Math.log(temp - 10) - 305.0447927307;
+  }
+
+  return { r: clampChannel(r), g: clampChannel(g), b: clampChannel(b) };
+}
+
+// format a channel byte as a two-digit hex string
+function toHex(channel: number): string {
+  return channel.toString(16).padStart(2, '0');
+}
+
+export const KelvinToRgbBoxSource = {
+  defaultDisabled: true,
+  name: 'Color Temperature',
+  description:
+    'Convert a color temperature in Kelvin (1000–40000) to an approximate RGB/hex color.',
+  defaultInput: '6500 ::kelvin',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'kelvin', 'colortemp')) return [];
+
+    const raw = trim(input).replace(/[Kk]$/, '').trim();
+
+    // input too long or not a plain integer
+    if (raw.length > 8 || !/^\d+$/.test(raw)) {
+      return [
+        new BoxBuilder(
+          'Color Temperature',
+          'Please provide a valid Kelvin value (e.g. 6500 ::kelvin)',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({
+            Error: 'A numeric Kelvin value is required (1000–40000)',
+          })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const rawK = Number.parseInt(raw, 10);
+    const kelvin = Math.min(MAX_KELVIN, Math.max(MIN_KELVIN, rawK));
+
+    const { r, g, b } = kelvinToRgb(kelvin);
+    const hex = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+
+    const kv = {
+      Kelvin: `${kelvin}K`,
+      RGB: `rgb(${r}, ${g}, ${b})`,
+      Hex: hex,
+    };
+    const plaintext = Object.entries(kv)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Color Temperature', plaintext)
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default KelvinToRgbBoxSource;

--- a/src/modules/boxSources/__test__/KelvinToRgbBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/KelvinToRgbBoxSource.test.ts
@@ -1,0 +1,172 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { KelvinToRgbBoxSource } from '../KelvinToRgbBoxSource';
+
+// Tanner Helland formula replicated to compute expected channel values in tests
+function clamp(v: number): number {
+  return Math.round(Math.min(255, Math.max(0, v)));
+}
+
+function kelvinToRgb(kelvin: number): { r: number; g: number; b: number } {
+  const temp = kelvin / 100;
+
+  const r =
+    temp <= 66 ? 255 : clamp(329.698727446 * (temp - 60) ** -0.1332047592);
+
+  const g =
+    temp <= 66
+      ? clamp(99.4708025861 * Math.log(temp) - 161.1195681661)
+      : clamp(288.1221695283 * (temp - 60) ** -0.0755148492);
+
+  const b =
+    temp >= 66
+      ? 255
+      : temp <= 19
+        ? 0
+        : clamp(138.5177312231 * Math.log(temp - 10) - 305.0447927307);
+
+  return { r, g, b };
+}
+
+describe('KelvinToRgbBoxSource', () => {
+  describe('generateBoxes — option guard', () => {
+    it('returns [] when no matching option key is present', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('6500', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option keys are present', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('6500', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — valid input via ::kelvin', () => {
+    it('6500K — near white: R===255 and Hex starts with #ff', async () => {
+      const { r, g, b } = kelvinToRgb(6500);
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('6500', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('6500K');
+      expect(opts.RGB).toBe(`rgb(${r}, ${g}, ${b})`);
+      // R channel must be 255 for 6500K (temp<=66)
+      expect(r).toBe(255);
+      // G and B are high for daylight white
+      expect(g).toBeGreaterThanOrEqual(240);
+      expect(b).toBeGreaterThanOrEqual(240);
+      expect(opts.Hex).toMatch(/^#ff/);
+    });
+
+    it('1000K — very warm: R===255, B===0', async () => {
+      const { r, b } = kelvinToRgb(1000);
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('1000', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('1000K');
+      // 1000K: temp=10, <=66 → R=255; temp<=19 → B=0
+      expect(r).toBe(255);
+      expect(b).toBe(0);
+      expect(opts.RGB).toMatch(/^rgb\(255,/);
+      expect(opts.RGB).toMatch(/, 0\)$/);
+    });
+
+    it('40000K — cool: B===255, R<255', async () => {
+      const { r, b } = kelvinToRgb(40000);
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('40000', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('40000K');
+      // 40000K: temp=400 >66 → B=255; R is reduced
+      expect(b).toBe(255);
+      expect(r).toBeLessThan(255);
+      expect(opts.Hex).toMatch(/ff$/); // ends with ff for blue channel
+    });
+
+    it('2700K — incandescent: R===255, G and B lower than R', async () => {
+      const { r, g, b } = kelvinToRgb(2700);
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('2700', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(r).toBe(255);
+      expect(g).toBeLessThan(r);
+      expect(b).toBeLessThan(r);
+    });
+
+    it('trailing K suffix "5000K" is parsed as 5000', async () => {
+      const { r, g, b } = kelvinToRgb(5000);
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('5000K', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('5000K');
+      expect(opts.RGB).toBe(`rgb(${r}, ${g}, ${b})`);
+    });
+  });
+
+  describe('generateBoxes — ::colortemp alias', () => {
+    it('accepts ::colortemp option key', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('6500', {
+        colortemp: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('6500K');
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('non-numeric input returns an error box mentioning Kelvin', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('abc', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // error box should mention Kelvin in its message
+      const combined = JSON.stringify(opts).toLowerCase();
+      expect(combined).toContain('kelvin');
+    });
+
+    it('empty string returns an error box mentioning Kelvin', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      const combined = JSON.stringify(opts).toLowerCase();
+      expect(combined).toContain('kelvin');
+    });
+  });
+
+  describe('generateBoxes — clamping', () => {
+    it('value below 1000 is clamped to 1000', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('500', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('1000K');
+    });
+
+    it('value above 40000 is clamped to 40000', async () => {
+      const boxes = await KelvinToRgbBoxSource.generateBoxes('99999', {
+        kelvin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Kelvin).toBe('40000K');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,10 +1,6 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -21,6 +17,7 @@ import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import KelvinToRgbBoxSource from './KelvinToRgbBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -86,6 +83,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   HaversineBoxSource,
+  KelvinToRgbBoxSource,
   LineToolsBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,


### PR DESCRIPTION
### Box Source: Color Temperature (Convert)

Adds the `Color Temperature` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `6500 ::kelvin`

#### Options:
- `::colortemp`, `::kelvin`

#### Description:
Convert a color temperature in Kelvin (1000–40000) to an approximate RGB/hex color.

#### Usage Examples:
- **Input**: `6500 ::kelvin`
- **Output Box (`Color Temperature`)**:
```
Kelvin: 6500K
RGB: rgb(255, 254, 250)
Hex: #fffefa
```
