### PR TITLE
feat(LeetSpeak): add Leetspeak BoxSource

### DIFF
--- a/src/modules/boxSources/LeetSpeakBoxSource.ts
+++ b/src/modules/boxSources/LeetSpeakBoxSource.ts
@@ -1,0 +1,93 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// basic leet substitutions — encode direction (letter → digit/symbol)
+const TO_LEET: Record<string, string> = {
+  a: '4',
+  b: '8',
+  e: '3',
+  g: '6',
+  i: '1',
+  l: '1',
+  o: '0',
+  s: '5',
+  t: '7',
+  z: '2',
+};
+
+// reverse map — digit → letter. '1' is ambiguous (both 'i' and 'l' encode to '1');
+// 'l' wins because it is defined after 'i' in TO_LEET and overwrites it here.
+const FROM_LEET: Record<string, string> = Object.fromEntries(
+  Object.entries(TO_LEET).map(([letter, digit]) => [digit, letter]),
+);
+
+function encode(input: string): string {
+  return input
+    .toLowerCase()
+    .split('')
+    .map((ch) => TO_LEET[ch] ?? ch)
+    .join('');
+}
+
+function decode(input: string): string {
+  return input
+    .split('')
+    .map((ch) => FROM_LEET[ch] ?? ch)
+    .join('');
+}
+
+export const LeetSpeakBoxSource = {
+  defaultDisabled: true,
+  name: 'Leetspeak',
+  description:
+    'Convert text to leetspeak (h4ck3r) or decode it back. ::leet to encode, ::leetdecode to decode.',
+  defaultInput: 'leet ::leet',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'leet', 'leetspeak', '1337');
+    const wantDecode = hasOptionKeys(options, 'leetdecode', 'unleet');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      boxes.push(
+        new BoxBuilder('Leetspeak (Encode)', encode(input))
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      // decode is approximate — '1' maps to 'l' (not 'i'); other ambiguities may apply
+      boxes.push(
+        new BoxBuilder('Leetspeak (Decode)', decode(input))
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default LeetSpeakBoxSource;

--- a/src/modules/boxSources/__test__/LeetSpeakBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LeetSpeakBoxSource.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import { LeetSpeakBoxSource } from '../LeetSpeakBoxSource';
+
+describe('LeetSpeakBoxSource', () => {
+  describe('no matching option', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty input', () => {
+    it('returns [] for empty string with ::leet', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('', { leet: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::leet', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('   ', {
+        leet: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ::leet', () => {
+    // l→1, e→3, e→3, t→7
+    it('encodes "leet" → "1337"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Leetspeak (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('1337');
+    });
+
+    // h passes through, a→4, c passes through, k passes through, e→3, r passes through
+    it('encodes "hacker" → "h4ck3r"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('hacker', {
+        leet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('h4ck3r');
+    });
+
+    // e→3, l→1, i→1, t→7, e→3
+    it('encodes "elite" → "31173" (both l and i map to 1)', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('elite', {
+        leet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('31173');
+    });
+
+    it('preserves non-letter characters: "a b!" → "4 8!"', async () => {
+      // a→4, space passes through, b→8, !  passes through
+      const boxes = await LeetSpeakBoxSource.generateBoxes('a b!', {
+        leet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('4 8!');
+    });
+
+    it('accepts ::leetspeak alias', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leetspeak: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('1337');
+    });
+
+    it('accepts ::1337 alias', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        '1337': true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('1337');
+    });
+
+    it('priority is set on the box', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+      });
+      expect(boxes[0].props.priority).toBe(LeetSpeakBoxSource.priority);
+    });
+  });
+
+  describe('decode — ::leetdecode', () => {
+    // 1→i (ambiguous; 'i' is the canonical choice), 3→e, 3→e, 7→t
+    it('decodes "1337" → "leet"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('1337', {
+        leetdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Leetspeak (Decode)');
+      // '1' maps to 'l' (l overwrites i in the reverse map) — documented approximation
+      expect(boxes[0].props.plaintextOutput).toBe('leet');
+    });
+
+    it('decodes "h4ck3r" → "hacker"', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('h4ck3r', {
+        leetdecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hacker');
+    });
+
+    it('accepts ::unleet alias', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('h4ck3r', {
+        unleet: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('hacker');
+    });
+  });
+
+  describe('both encode and decode options', () => {
+    it('returns 2 boxes when both ::leet and ::leetdecode are set', async () => {
+      const boxes = await LeetSpeakBoxSource.generateBoxes('leet', {
+        leet: true,
+        leetdecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Leetspeak (Encode)');
+      expect(names).toContain('Leetspeak (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LeetSpeakBoxSource.name).toBe('Leetspeak');
+      expect(LeetSpeakBoxSource.tag).toBe('#');
+      expect(LeetSpeakBoxSource.kind).toBe('Transform');
+      expect(typeof LeetSpeakBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,10 +1,6 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -21,6 +17,7 @@ import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LeetSpeakBoxSource from './LeetSpeakBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -86,6 +83,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   HaversineBoxSource,
+  LeetSpeakBoxSource,
   LineToolsBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,


### PR DESCRIPTION
### Box Source: Leetspeak (Transform)

Adds the `Leetspeak` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `leet ::leet`

#### Options:
- `::1337`, `::leet`, `::leetdecode`, `::leetspeak`, `::unleet`

#### Description:
Convert text to leetspeak (h4ck3r) or decode it back. ::leet to encode, ::leetdecode to decode.

#### Usage Examples:
- **Input**: `leet ::leet`
- **Output Box (`Leetspeak (Encode)`)**:
```
1337
```
