### PR TITLE
feat(LengthConvert): add Length Convert BoxSource

### DIFF
--- a/src/modules/boxSources/LengthConvertBoxSource.ts
+++ b/src/modules/boxSources/LengthConvertBoxSource.ts
@@ -1,0 +1,127 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit -> meters conversion factor
+const TO_M: Record<string, number> = {
+  mm: 0.001,
+  cm: 0.01,
+  m: 1,
+  km: 1000,
+  in: 0.0254,
+  ft: 0.3048,
+  yd: 0.9144,
+  mi: 1609.344,
+  nmi: 1852,
+};
+
+// display order for output keys
+const UNIT_ORDER = ['mm', 'cm', 'm', 'km', 'in', 'ft', 'yd', 'mi', 'nmi'];
+
+const PARSE_RE = /^(-?\d+(?:\.\d+)?)\s*([a-z]+)$/i;
+
+// format a number to up to 6 significant figures, stripping trailing zeros
+function formatValue(n: number): string {
+  // handle exact integers cleanly (sig-figs would corrupt large exact values)
+  if (Number.isInteger(n)) return String(n);
+
+  // round to 6 decimal places, then strip trailing zeros
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// render key/value pairs as `k: v` lines for the headless/TUI plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const LengthConvertBoxSource = {
+  defaultDisabled: true,
+  name: 'Length Convert',
+  description:
+    'Convert a length between units. e.g. "1 mi ::length" or "5 km ::length=mi".',
+  defaultInput: '1 mi ::length',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'length')) return [];
+
+    const raw = trim(input).slice(0, 64);
+    const match = PARSE_RE.exec(raw);
+
+    if (!match) {
+      // invalid format — return an explanatory box
+      const kv: Record<string, string> = {
+        Error: 'Invalid format. Expected: <number> <unit>',
+        'Supported Units': UNIT_ORDER.join(', '),
+        Example: '1 mi, 5.5 km, -2.5 ft',
+      };
+      return [
+        new BoxBuilder('Length Convert', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitRaw = match[2].toLowerCase();
+
+    if (!(unitRaw in TO_M)) {
+      // unknown unit — return an explanatory box
+      const kv: Record<string, string> = {
+        Error: `Unknown unit: "${unitRaw}"`,
+        'Supported Units': UNIT_ORDER.join(', '),
+        Example: '1 mi, 5.5 km, -2.5 ft',
+      };
+      return [
+        new BoxBuilder('Length Convert', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const meters = value * TO_M[unitRaw];
+
+    // optional target unit from option value, e.g. ::length=km
+    const targetRaw = extractOptionKeys(options, 'length');
+    const target =
+      typeof targetRaw === 'string' && targetRaw.toLowerCase() in TO_M
+        ? targetRaw.toLowerCase()
+        : null;
+
+    const kv: Record<string, string> = {
+      Input: `${formatValue(value)} ${unitRaw}`,
+    };
+
+    for (const unit of UNIT_ORDER) {
+      kv[unit] = formatValue(meters / TO_M[unit]);
+    }
+
+    if (target !== null) {
+      kv.Result = `${formatValue(meters / TO_M[target])} ${target}`;
+    }
+
+    return [
+      new BoxBuilder('Length Convert', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LengthConvertBoxSource;

--- a/src/modules/boxSources/__test__/LengthConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LengthConvertBoxSource.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { LengthConvertBoxSource } from '../LengthConvertBoxSource';
+
+describe('LengthConvertBoxSource', () => {
+  it('returns [] when no ::length option', async () => {
+    const boxes = await LengthConvertBoxSource.generateBoxes('1 mi', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('returns [] when unrelated option is given', async () => {
+    const boxes = await LengthConvertBoxSource.generateBoxes('1 mi', {
+      base64: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  describe('1 mi ::length', () => {
+    it('produces one box with correct conversions', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('1 mi', {
+        length: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 mi = 1609.344 m exactly
+      expect(opts.m).toBe('1609.344');
+      // 1 mi = 1.609344 km exactly
+      expect(opts.km).toBe('1.609344');
+      // 1 mi = 5280 ft exactly
+      expect(opts.ft).toBe('5280');
+      // 1 mi = 1760 yd exactly
+      expect(opts.yd).toBe('1760');
+    });
+  });
+
+  describe('1000 m ::length', () => {
+    it('converts to km=1 and mi≈0.621371', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('1000 m', {
+        length: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.km).toBe('1');
+      // 1000 / 1609.344 ≈ 0.621371...
+      expect(Number.parseFloat(opts.mi)).toBeCloseTo(0.621371, 5);
+    });
+  });
+
+  describe('5 km ::length=mi', () => {
+    it('includes a Result key with the target unit value', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('5 km', {
+        length: 'mi',
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Result).toContain('mi');
+      // 5 km = 5000 m; 5000 / 1609.344 ≈ 3.10686
+      expect(Number.parseFloat(opts.Result)).toBeCloseTo(3.10686, 4);
+    });
+  });
+
+  describe('1 in ::length', () => {
+    it('converts to cm=2.54', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('1 in', {
+        length: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.cm).toBe('2.54');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('returns an error box for non-numeric input "abc"', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('abc', {
+        length: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeTruthy();
+      expect(opts['Supported Units']).toContain('mi');
+    });
+
+    it('returns an error box for unknown unit "5 furlong"', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('5 furlong', {
+        length: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/furlong/i);
+      expect(opts['Supported Units']).toContain('km');
+    });
+  });
+
+  describe('Input key is normalized', () => {
+    it('includes Input key with parsed value and unit', async () => {
+      const boxes = await LengthConvertBoxSource.generateBoxes('1 mi', {
+        length: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('1 mi');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,10 +1,6 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -21,6 +17,7 @@ import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LengthConvertBoxSource from './LengthConvertBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -86,6 +83,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   HaversineBoxSource,
+  LengthConvertBoxSource,
   LineToolsBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,


### PR DESCRIPTION
### Box Source: Length Convert (Convert)

Adds the `Length Convert` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1 mi ::length`

#### Options:
- `::length`

#### Description:
Convert a length between units. e.g. "1 mi ::length" or "5 km ::length=mi".

#### Usage Examples:
- **Input**: `1 mi ::length`
- **Output Box (`Length Convert`)**:
```
Input: 1 mi
mm: 1609344
cm: 160934.4
m: 1609.344
km: 1.609344
in: 63360
ft: 5280
yd: 1760
mi: 1
nmi: 0.868976
```
