### PR TITLE
feat(Levenshtein): add Levenshtein BoxSource

### DIFF
--- a/src/modules/boxSources/LevenshteinBoxSource.ts
+++ b/src/modules/boxSources/LevenshteinBoxSource.ts
@@ -1,0 +1,114 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+// the DP is O(n*m); cap total input so the worst case (two ~500-char
+// strings → 250k cells) stays well under a frame budget
+const MAX_INPUT = 1_000;
+
+// two-row DP: O(n*m) time, O(min(n,m)) space
+function levenshtein(a: string, b: string): number {
+  // ensure `a` is the shorter string so we allocate the smaller row
+  if (a.length > b.length) {
+    return levenshtein(b, a);
+  }
+
+  const m = a.length;
+  const n = b.length;
+
+  let prev = new Array<number>(m + 1);
+  let curr = new Array<number>(m + 1);
+
+  for (let i = 0; i <= m; i++) {
+    prev[i] = i;
+  }
+
+  for (let j = 1; j <= n; j++) {
+    curr[0] = j;
+    for (let i = 1; i <= m; i++) {
+      if (a.charCodeAt(i - 1) === b.charCodeAt(j - 1)) {
+        curr[i] = prev[i - 1];
+      } else {
+        curr[i] =
+          1 +
+          Math.min(
+            prev[i - 1], // substitution
+            prev[i], // deletion
+            curr[i - 1], // insertion
+          );
+      }
+    }
+    // swap rows without allocation
+    const tmp = prev;
+    prev = curr;
+    curr = tmp;
+  }
+
+  return prev[m];
+}
+
+export const LevenshteinBoxSource = {
+  defaultDisabled: true,
+  name: 'Levenshtein',
+  description:
+    'Compute the Levenshtein edit distance between two newline-separated strings.',
+  defaultInput: 'kitten\nsitting ::levenshtein',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'levenshtein', 'editdistance')) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
+
+    // split input into exactly two strings on the first newline
+    const newlineIdx = input.indexOf('\n');
+    if (newlineIdx === -1) {
+      return [
+        new BoxBuilder(
+          'Levenshtein',
+          'Two newline-separated strings are required (e.g. "abc\\nxyz ::levenshtein").',
+        )
+          .setTemplate(KeyValueBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const a = input.slice(0, newlineIdx);
+    const b = input.slice(newlineIdx + 1);
+
+    const distance = levenshtein(a, b);
+    const maxLen = Math.max(a.length, b.length);
+    // similarity is 1 when both strings are empty
+    const similarity = maxLen === 0 ? 1 : 1 - distance / maxLen;
+    const similarityPct = `${(similarity * 100).toFixed(1)}%`;
+
+    const output: Record<string, string> = {
+      Distance: String(distance),
+      Similarity: similarityPct,
+      'Length A': String(a.length),
+      'Length B': String(b.length),
+    };
+
+    const plaintextOutput = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Levenshtein', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LevenshteinBoxSource;

--- a/src/modules/boxSources/__test__/LevenshteinBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LevenshteinBoxSource.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { LevenshteinBoxSource } from '../LevenshteinBoxSource';
+
+describe('LevenshteinBoxSource', () => {
+  describe('generateBoxes - option gate', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes(
+        'kitten\nsitting',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes(
+        'kitten\nsitting',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ::levenshtein trigger', () => {
+    it('kitten vs sitting yields distance 3', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes(
+        'kitten\nsitting',
+        { levenshtein: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Distance).toBe('3');
+    });
+
+    it('identical strings yield distance 0 and similarity 100.0%', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes('abc\nabc', {
+        levenshtein: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.Distance).toBe('0');
+      expect(opts?.Similarity).toBe('100.0%');
+    });
+
+    it('fully different strings of equal length yield distance 3 and similarity 0.0%', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes('abc\nxyz', {
+        levenshtein: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.Distance).toBe('3');
+      expect(opts?.Similarity).toBe('0.0%');
+    });
+
+    it('flaw vs lawn yields distance 2', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes('flaw\nlawn', {
+        levenshtein: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Distance).toBe('2');
+    });
+  });
+
+  describe('generateBoxes - ::editdistance alias', () => {
+    it('accepts ::editdistance option', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes(
+        'kitten\nsitting',
+        { editdistance: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Distance).toBe('3');
+    });
+  });
+
+  describe('generateBoxes - single line without newline', () => {
+    it('returns an informational box when input has no newline', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes('abc', {
+        levenshtein: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/two.*strings.*required/i);
+    });
+  });
+
+  describe('generateBoxes - length fields', () => {
+    it('reports correct Length A and Length B', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes(
+        'kitten\nsitting',
+        { levenshtein: true },
+      );
+      const opts = boxes[0].props.options;
+      expect(opts?.['Length A']).toBe('6');
+      expect(opts?.['Length B']).toBe('7');
+    });
+  });
+
+  describe('generateBoxes - both-empty edge case', () => {
+    it('both empty strings yield distance 0 and similarity 100.0%', async () => {
+      const boxes = await LevenshteinBoxSource.generateBoxes('\n', {
+        levenshtein: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.Distance).toBe('0');
+      expect(opts?.Similarity).toBe('100.0%');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LevenshteinBoxSource.name).toBe('Levenshtein');
+      expect(LevenshteinBoxSource.tag).toBe('#');
+      expect(LevenshteinBoxSource.kind).toBe('Analyze');
+      expect(typeof LevenshteinBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -21,6 +21,7 @@ import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LevenshteinBoxSource from './LevenshteinBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  LevenshteinBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Levenshtein (Analyze)

Adds the `Levenshtein` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `kitten
sitting ::levenshtein`

#### Options:
- `::editdistance`, `::levenshtein`

#### Description:
Compute the Levenshtein edit distance between two newline-separated strings.

#### Usage Examples:
- **Input**: `kitten
sitting ::levenshtein`
- **Output Box (`Levenshtein`)**:
```
Distance: 3
Similarity: 57.1%
Length A: 6
Length B: 7
```
