### PR TITLE
feat(LineNumbers): add Line Numbers BoxSource

### DIFF
--- a/src/modules/boxSources/LineNumbersBoxSource.ts
+++ b/src/modules/boxSources/LineNumbersBoxSource.ts
@@ -1,0 +1,79 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// right-pad a number string with leading spaces to reach the desired width
+function padNumber(n: number, width: number): string {
+  return String(n).padStart(width, ' ');
+}
+
+// add line numbers to text, optionally starting at a custom index
+function addLineNumbers(input: string, start: number): string {
+  const lines = input.split('\n').map((line) => line.replace(/\r$/, ''));
+  const end = start + lines.length - 1;
+  const width = String(end).length;
+  return lines
+    .map((line, i) => `${padNumber(start + i, width)} | ${line}`)
+    .join('\n');
+}
+
+// strip a leading line-number prefix of the form: optional-spaces digits optional-spaces [|│:] optional-space
+function stripLineNumbers(input: string): string {
+  // require a separator so plain "42 value" lines aren't mangled
+  const PREFIX_RE = /^\s*\d+\s*[|│:.]\s?/;
+  return input
+    .split('\n')
+    .map((line) => line.replace(PREFIX_RE, ''))
+    .join('\n');
+}
+
+export const LineNumbersBoxSource = {
+  defaultDisabled: true,
+  name: 'Line Numbers',
+  description:
+    'Add line numbers to text (::linenumbers, optional ::linenumbers=<start>) or strip them (::stripnumbers).',
+  defaultInput: 'first\nsecond\nthird ::linenumbers',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantAdd = hasOptionKeys(options, 'linenumbers', 'numberlines');
+    const wantStrip = hasOptionKeys(options, 'stripnumbers');
+    if (!wantAdd && !wantStrip) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    let output: string;
+
+    if (wantAdd) {
+      const rawValue = extractOptionKeys(options, 'linenumbers', 'numberlines');
+      // parse the numeric start value; default to 1 if absent or invalid
+      const parsedStart =
+        typeof rawValue === 'string'
+          ? Number.parseInt(rawValue, 10)
+          : Number.NaN;
+      const start =
+        Number.isFinite(parsedStart) && parsedStart >= 0 ? parsedStart : 1;
+      output = addLineNumbers(input, start);
+    } else {
+      output = stripLineNumbers(input);
+    }
+
+    return [
+      new BoxBuilder('Line Numbers', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LineNumbersBoxSource;

--- a/src/modules/boxSources/__test__/LineNumbersBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LineNumbersBoxSource.test.ts
@@ -1,0 +1,171 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { LineNumbersBoxSource } from '../LineNumbersBoxSource';
+
+describe('LineNumbersBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LineNumbersBoxSource.name).toBe('Line Numbers');
+      expect(LineNumbersBoxSource.tag).toBe('#');
+      expect(LineNumbersBoxSource.kind).toBe('Transform');
+      expect(typeof LineNumbersBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - guard conditions', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\nsecond\nthird',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\nsecond\nthird',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input string with ::linenumbers', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('', {
+        linenumbers: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for input exceeding MAX_INPUT', async () => {
+      const huge = 'a'.repeat(100_001);
+      const boxes = await LineNumbersBoxSource.generateBoxes(huge, {
+        linenumbers: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - add line numbers (::linenumbers)', () => {
+    it('numbers three lines starting at 1 with width 1', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\nsecond\nthird',
+        { linenumbers: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '1 | first\n2 | second\n3 | third',
+      );
+    });
+
+    it('uses CodeBoxTemplate', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('hello', {
+        linenumbers: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+
+    it('sets box name to "Line Numbers"', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('hello', {
+        linenumbers: true,
+      });
+      expect(boxes[0].props.name).toBe('Line Numbers');
+    });
+
+    it('sets priority from the source', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('hello', {
+        linenumbers: true,
+      });
+      expect(boxes[0].props.priority).toBe(LineNumbersBoxSource.priority);
+    });
+
+    it('accepts ::numberlines as alias for ::linenumbers', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\nsecond\nthird',
+        { numberlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '1 | first\n2 | second\n3 | third',
+      );
+    });
+
+    it('supports custom start index via ::linenumbers=10', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\nsecond\nthird',
+        { linenumbers: '10' },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '10 | first\n11 | second\n12 | third',
+      );
+    });
+
+    it('right-aligns with space padding when max width is 2 (10 lines from 1)', async () => {
+      const input = Array.from({ length: 10 }, (_, i) =>
+        String.fromCharCode(97 + i),
+      ).join('\n');
+      const boxes = await LineNumbersBoxSource.generateBoxes(input, {
+        linenumbers: true,
+      });
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      // line 1 should be ' 1 | a' (leading space, width 2)
+      expect(lines[0]).toBe(' 1 | a');
+      // line 10 should be '10 | j' (no leading space)
+      expect(lines[9]).toBe('10 | j');
+    });
+
+    it('strips trailing \\r from each line before numbering', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        'first\r\nsecond\r\nthird',
+        { linenumbers: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '1 | first\n2 | second\n3 | third',
+      );
+    });
+
+    it('falls back to start=1 when ::linenumbers value is not a valid integer', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('a\nb', {
+        linenumbers: 'abc',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('1 | a\n2 | b');
+    });
+
+    it('falls back to start=1 when ::linenumbers is boolean true', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes('a\nb', {
+        linenumbers: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('1 | a\n2 | b');
+    });
+  });
+
+  describe('generateBoxes - strip line numbers (::stripnumbers)', () => {
+    it('strips leading "N | " prefix from each line', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        '1 | first\n2 | second',
+        { stripnumbers: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('first\nsecond');
+    });
+
+    it('strips wide number prefix with space-padded numbers', async () => {
+      const boxes = await LineNumbersBoxSource.generateBoxes(
+        ' 1 | first\n 2 | second\n10 | tenth',
+        { stripnumbers: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('first\nsecond\ntenth');
+    });
+
+    it('round-trips add then strip back to original', async () => {
+      const original = 'alpha\nbeta\ngamma';
+      const numbered = await LineNumbersBoxSource.generateBoxes(original, {
+        linenumbers: true,
+      });
+      const stripped = await LineNumbersBoxSource.generateBoxes(
+        numbered[0].props.plaintextOutput,
+        { stripnumbers: true },
+      );
+      expect(stripped[0].props.plaintextOutput).toBe(original);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -1,10 +1,6 @@
 import type { BoxSource } from '../BoxSource';
 import A1Z26BoxSource from './A1Z26BoxSource';
 import AsciiTableBoxSource from './AsciiTableBoxSource';
-import {
-  Base64DecodeBoxSource,
-  Base64EncodeBoxSource,
-} from './Base64BoxSource';
 import BinaryTextBoxSource from './BinaryTextBoxSource';
 import BmiBoxSource from './BmiBoxSource';
 import ColorBoxSource from './ColorBoxSource';
@@ -21,6 +17,7 @@ import HashBoxSource from './HashBoxSource';
 import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LineNumbersBoxSource from './LineNumbersBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
@@ -40,14 +37,14 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
-import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
-import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
@@ -86,6 +83,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   HaversineBoxSource,
+  LineNumbersBoxSource,
   LineToolsBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,


### PR DESCRIPTION
### Box Source: Line Numbers (Transform)

Adds the `Line Numbers` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `first
second
third ::linenumbers`

#### Options:
- `::linenumbers`, `::numberlines`, `::stripnumbers`

#### Description:
Add line numbers to text (::linenumbers, optional ::linenumbers=<start>) or strip them (::stripnumbers).

#### Usage Examples:
- **Input**: `first
second
third ::linenumbers`
- **Output Box (`Line Numbers`)**:
```
1 | first
2 | second
3 | third
```
