### PR TITLE
feat(LineTools): add Line Tools BoxSource

### DIFF
--- a/src/modules/boxSources/LineToolsBoxSource.ts
+++ b/src/modules/boxSources/LineToolsBoxSource.ts
@@ -1,0 +1,81 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// split into lines, stripping trailing \r (CRLF) and dropping the single empty
+// element a trailing newline would otherwise produce
+function splitLines(input: string): string[] {
+  const lines = input.split('\n').map((line) => line.replace(/\r$/, ''));
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+export const LineToolsBoxSource = {
+  defaultDisabled: true,
+  name: 'Line Tools',
+  description: 'Sort, de-duplicate, or reverse the lines of a text block.',
+  defaultInput: 'banana\napple\ncherry\napple ::sortlines',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantSort = hasOptionKeys(options, 'sortlines');
+    const wantUnique = hasOptionKeys(options, 'uniquelines');
+    const wantReverse = hasOptionKeys(options, 'reverselines');
+
+    if (!wantSort && !wantUnique && !wantReverse) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const lines = splitLines(input);
+    const boxes: Box[] = [];
+
+    if (wantSort) {
+      const sorted = [...lines].sort((a, b) => a.localeCompare(b));
+      boxes.push(
+        new BoxBuilder('Sorted Lines', sorted.join('\n'))
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantUnique) {
+      // keep first occurrence order
+      const seen = new Set<string>();
+      const unique = lines.filter((line) => {
+        if (seen.has(line)) return false;
+        seen.add(line);
+        return true;
+      });
+      boxes.push(
+        new BoxBuilder('Unique Lines', unique.join('\n'))
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantReverse) {
+      const reversed = [...lines].reverse();
+      boxes.push(
+        new BoxBuilder('Reversed Lines', reversed.join('\n'))
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default LineToolsBoxSource;

--- a/src/modules/boxSources/__test__/LineToolsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LineToolsBoxSource.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { LineToolsBoxSource } from '../LineToolsBoxSource';
+
+describe('LineToolsBoxSource', () => {
+  describe('trigger guards', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes(
+        'banana\napple',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes('banana\napple', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes('', {
+        sortlines: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when input exceeds MAX_INPUT', async () => {
+      const big = 'a\n'.repeat(60_000);
+      const boxes = await LineToolsBoxSource.generateBoxes(big, {
+        sortlines: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::sortlines', () => {
+    it('sorts lines ascending by localeCompare', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        { sortlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Sorted Lines');
+      expect(boxes[0].props.plaintextOutput).toBe('apple\nbanana\ncherry');
+    });
+  });
+
+  describe('::uniquelines', () => {
+    it('removes duplicate lines keeping first occurrence order', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes('a\nb\na\nc\nb', {
+        uniquelines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Unique Lines');
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb\nc');
+    });
+  });
+
+  describe('::reverselines', () => {
+    it('reverses the order of lines', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes('1\n2\n3', {
+        reverselines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Reversed Lines');
+      expect(boxes[0].props.plaintextOutput).toBe('3\n2\n1');
+    });
+  });
+
+  describe('combined options', () => {
+    it('returns two boxes for ::sortlines + ::uniquelines', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes('banana\napple', {
+        sortlines: true,
+        uniquelines: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Sorted Lines');
+      expect(names).toContain('Unique Lines');
+    });
+
+    it('returns three boxes when all three options are set', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes(
+        'banana\napple\ncherry',
+        { sortlines: true, uniquelines: true, reverselines: true },
+      );
+      expect(boxes).toHaveLength(3);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Sorted Lines');
+      expect(names).toContain('Unique Lines');
+      expect(names).toContain('Reversed Lines');
+    });
+  });
+
+  describe('CRLF tolerance', () => {
+    it('strips trailing \\r from each line before processing', async () => {
+      const boxes = await LineToolsBoxSource.generateBoxes(
+        'banana\r\napple\r\ncherry\r\n',
+        { sortlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      // trailing empty string after final \n is sorted first, then words
+      const output = boxes[0].props.plaintextOutput as string;
+      expect(output).toContain('apple');
+      expect(output).toContain('banana');
+      expect(output).toContain('cherry');
+      // no \r should remain in output
+      expect(output).not.toContain('\r');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(LineToolsBoxSource.name).toBe('Line Tools');
+      expect(LineToolsBoxSource.tag).toBe('#');
+      expect(LineToolsBoxSource.kind).toBe('Transform');
+      expect(typeof LineToolsBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -16,6 +16,7 @@ import GenerateQRCodeBoxSource from './GenerateQRCodeBoxSource';
 import HashBoxSource from './HashBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
+import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
@@ -71,6 +72,7 @@ export const boxSources: BoxSource[] = [
   AsciiTableBoxSource,
   BinaryTextBoxSource,
   BmiBoxSource,
+  LineToolsBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Line Tools (Transform)

Adds the `Line Tools` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `banana
apple
cherry
apple ::sortlines`

#### Options:
- `::reverselines`, `::sortlines`, `::uniquelines`

#### Description:
Sort, de-duplicate, or reverse the lines of a text block.

#### Usage Examples:
- **Input**: `banana
apple
cherry
apple ::sortlines`
- **Output Box (`Sorted Lines`)**:
```
apple
apple
banana
cherry
```
