### PR TITLE
feat(LoanPayment): add Loan Payment BoxSource

### DIFF
--- a/src/modules/boxSources/LoanPaymentBoxSource.ts
+++ b/src/modules/boxSources/LoanPaymentBoxSource.ts
@@ -1,0 +1,118 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// convert a key-value record to plaintext lines for box plaintextOutput
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// standard amortizing loan: P * r * (1+r)^n / ((1+r)^n - 1)
+function computeMonthlyPayment(
+  principal: number,
+  annualRatePercent: number,
+  years: number,
+): number {
+  const r = annualRatePercent / 100 / 12;
+  const n = years * 12;
+  if (r === 0) {
+    return principal / n;
+  }
+  const factor = (1 + r) ** n;
+  return (principal * r * factor) / (factor - 1);
+}
+
+export const LoanPaymentBoxSource = {
+  defaultDisabled: true,
+  name: 'Loan Payment',
+  description:
+    'Compute the monthly payment of an amortizing loan. Input: "<principal> <annualRate%> <years>".',
+  defaultInput: '200000 5 30 ::loan',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'loan', 'mortgage')) return [];
+
+    const text = trim(input);
+    if (text.length > 100) return [];
+
+    // split on whitespace and/or commas to get the three numeric tokens
+    const parts = text.split(/[\s,]+/).filter(Boolean);
+
+    if (parts.length !== 3) {
+      const errorKv = {
+        'Expected input': '<principal> <annualRate%> <years>',
+        Example: '200000 5 30',
+      };
+      return [
+        new BoxBuilder('Loan Payment', kvToPlaintext(errorKv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(errorKv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const principal = Number.parseFloat(parts[0]);
+    const annualRate = Number.parseFloat(parts[1]);
+    const years = Number.parseFloat(parts[2]);
+
+    if (
+      Number.isNaN(principal) ||
+      Number.isNaN(annualRate) ||
+      Number.isNaN(years) ||
+      principal <= 0 ||
+      years <= 0 ||
+      annualRate < 0
+    ) {
+      const errorKv = {
+        'Expected input': '<principal> <annualRate%> <years>',
+        Example: '200000 5 30',
+      };
+      return [
+        new BoxBuilder('Loan Payment', kvToPlaintext(errorKv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(errorKv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const monthlyPayment = computeMonthlyPayment(principal, annualRate, years);
+    const n = years * 12;
+    const totalPaid = monthlyPayment * n;
+    const totalInterest = totalPaid - principal;
+
+    const round2 = (v: number) => Math.round(v * 100) / 100;
+
+    const kv: Record<string, string> = {
+      Principal: round2(principal).toFixed(2),
+      'Annual Rate': `${annualRate}%`,
+      Term: `${years} year${years !== 1 ? 's' : ''}`,
+      'Monthly Payment': round2(monthlyPayment).toFixed(2),
+      'Total Paid': round2(totalPaid).toFixed(2),
+      'Total Interest': round2(totalInterest).toFixed(2),
+      Payments: Number.isInteger(n) ? n.toString() : n.toFixed(2),
+    };
+
+    return [
+      new BoxBuilder('Loan Payment', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default LoanPaymentBoxSource;

--- a/src/modules/boxSources/__test__/LoanPaymentBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/LoanPaymentBoxSource.test.ts
@@ -1,0 +1,126 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { LoanPaymentBoxSource } from '../LoanPaymentBoxSource';
+
+describe('LoanPaymentBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option key is present', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes(
+        '200000 5 30',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is present', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5 30', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('computes $200k / 5% APR / 30yr → monthly payment ≈ 1073.64', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5 30', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const box = boxes[0];
+      expect(box.props.name).toBe('Loan Payment');
+      expect(box.props.priority).toBe(10);
+      expect(box.boxTemplate).toBe(KeyValueBoxTemplate);
+
+      const opts = box.props.options as Record<string, string>;
+      expect(opts['Monthly Payment']).toMatch(/^1073\.6/);
+      expect(opts['Total Paid']).toBe('386511.57');
+      expect(opts['Total Interest']).toBe('186511.57');
+      expect(opts.Payments).toBe('360');
+      expect(opts.Principal).toBe('200000.00');
+      expect(opts['Annual Rate']).toBe('5%');
+      expect(opts.Term).toBe('30 years');
+    });
+
+    it('accepts ::mortgage option key', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5 30', {
+        mortgage: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Monthly Payment']).toMatch(/^1073\.6/);
+    });
+
+    it('computes zero-interest loan: 1200 / 0% / 1yr → 100/mo', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('1200 0 1', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Monthly Payment']).toBe('100.00');
+      expect(opts['Total Paid']).toBe('1200.00');
+      expect(opts['Total Interest']).toBe('0.00');
+    });
+
+    it('computes $100k / 6% APR / 15yr → monthly payment ≈ 843.86', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('100000 6 15', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Monthly Payment']).toMatch(/^843\.8/);
+    });
+
+    it('returns an error box when arg count is wrong (too few)', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Expected input']).toBeDefined();
+    });
+
+    it('returns an error box when args are non-numeric', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('a b c', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Expected input']).toBeDefined();
+    });
+
+    it('returns an error box when principal is zero or negative', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('0 5 30', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Expected input']).toBeDefined();
+    });
+
+    it('returns an error box when years is zero or negative', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5 0', {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Expected input']).toBeDefined();
+    });
+
+    it('returns [] for input exceeding 100 characters', async () => {
+      const long = `${'2'.repeat(101)} 5 30`;
+      const boxes = await LoanPaymentBoxSource.generateBoxes(long, {
+        loan: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('plaintext output contains key: value lines', async () => {
+      const boxes = await LoanPaymentBoxSource.generateBoxes('200000 5 30', {
+        loan: true,
+      });
+      const plaintext = boxes[0].props.plaintextOutput;
+      expect(plaintext).toContain('Monthly Payment: 1073.6');
+      expect(plaintext).toContain('Principal: 200000.00');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -22,6 +22,7 @@ import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
+import LoanPaymentBoxSource from './LoanPaymentBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  LoanPaymentBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Loan Payment (Calculate)

Adds the `Loan Payment` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `200000 5 30 ::loan`

#### Options:
- `::loan`, `::mortgage`

#### Description:
Compute the monthly payment of an amortizing loan. Input: "<principal> <annualRate%> <years>".

#### Usage Examples:
- **Input**:
```
200000 5 30
::loan
```
- **Output Box (`Loan Payment`)**:
```
Principal: 200000.00
Annual Rate: 5%
Term: 30 years
Monthly Payment: 1073.64
Total Paid: 386511.57
Total Interest: 186511.57
Payments: 360
```
