### PR TITLE
feat(MacAddress): add MAC Address BoxSource

### DIFF
--- a/src/modules/boxSources/MacAddressBoxSource.ts
+++ b/src/modules/boxSources/MacAddressBoxSource.ts
@@ -1,0 +1,166 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to guard against pathological inputs
+const MAX_INPUT_LENGTH = 40;
+
+// renders a key-value record as "key: value" lines for the plaintext output
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+interface MacResult {
+  colon: string;
+  hyphen: string;
+  dot: string;
+  bare: string;
+  oui: string;
+  nic: string;
+  type: string;
+  eui64: string;
+}
+
+// extract exactly 12 hex digits from common MAC formats:
+//   colon:  01:23:45:67:89:ab
+//   hyphen: 01-23-45-67-89-ab
+//   dot:    0123.4567.89ab (Cisco)
+//   bare:   0123456789ab
+function extractHexDigits(raw: string): string | null {
+  const s = raw.toLowerCase();
+
+  // colon or hyphen separated: 6 groups of 2 hex digits
+  if (/^[0-9a-f]{2}([:][0-9a-f]{2}){5}$/.test(s)) {
+    return s.replace(/:/g, '');
+  }
+  if (/^[0-9a-f]{2}([-][0-9a-f]{2}){5}$/.test(s)) {
+    return s.replace(/-/g, '');
+  }
+
+  // Cisco dot notation: 3 groups of 4 hex digits
+  if (/^[0-9a-f]{4}(\.[0-9a-f]{4}){2}$/.test(s)) {
+    return s.replace(/\./g, '');
+  }
+
+  // bare: exactly 12 hex digits
+  if (/^[0-9a-f]{12}$/.test(s)) {
+    return s;
+  }
+
+  return null;
+}
+
+// split 12-char hex string into an array of 6 byte strings (lowercase)
+function toBytes(hex: string): string[] {
+  const bytes: string[] = [];
+  for (let i = 0; i < 12; i += 2) {
+    bytes.push(hex.slice(i, i + 2));
+  }
+  return bytes;
+}
+
+// compute EUI-64 by inserting ff:fe after the OUI and flipping the U/L bit
+function computeEUI64(bytes: string[]): string {
+  const firstByte = Number.parseInt(bytes[0], 16);
+  // flip bit 6 (the U/L bit, 0x02) to indicate universal scope
+  const flipped = (firstByte ^ 0x02).toString(16).padStart(2, '0');
+  const eui64Bytes = [
+    flipped,
+    ...bytes.slice(1, 3),
+    'ff',
+    'fe',
+    ...bytes.slice(3),
+  ];
+  return eui64Bytes.join(':');
+}
+
+function analyzeMac(hex: string): MacResult {
+  const bytes = toBytes(hex);
+
+  const colon = bytes.join(':');
+  const hyphen = bytes.join('-');
+  const dot = `${hex.slice(0, 4)}.${hex.slice(4, 8)}.${hex.slice(8, 12)}`;
+  const bare = hex;
+
+  const oui = bytes.slice(0, 3).join(':');
+  const nic = bytes.slice(3).join(':');
+
+  // read the first byte to determine address type flags
+  const firstByteVal = Number.parseInt(bytes[0], 16);
+  const isMulticast = (firstByteVal & 0x01) !== 0;
+  const isLocallyAdministered = (firstByteVal & 0x02) !== 0;
+
+  const castType = isMulticast ? 'multicast' : 'unicast';
+  const adminType = isLocallyAdministered
+    ? 'locally administered'
+    : 'globally unique';
+  const type = `${castType}, ${adminType}`;
+
+  const eui64 = computeEUI64(bytes);
+
+  return { colon, hyphen, dot, bare, oui, nic, type, eui64 };
+}
+
+export const MacAddressBoxSource = {
+  defaultDisabled: true,
+  name: 'MAC Address',
+  description:
+    'Normalize a MAC address and show its formats, OUI prefix, and flags.',
+  defaultInput: '01:23:45:67:89:ab ::mac',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'mac', 'macaddress')) return [];
+
+    const raw = trim(input).slice(0, MAX_INPUT_LENGTH);
+
+    const hex = extractHexDigits(raw);
+
+    if (hex === null) {
+      const kv: Record<string, string> = {
+        Error:
+          'A valid MAC address is required (e.g. 01:23:45:67:89:ab, 01-23-45-67-89-ab, 0123.4567.89ab, or 0123456789ab).',
+      };
+      return [
+        new BoxBuilder('MAC Address', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const result = analyzeMac(hex);
+
+    const kv: Record<string, string> = {
+      Colon: result.colon,
+      Hyphen: result.hyphen,
+      Dot: result.dot,
+      Bare: result.bare,
+      OUI: result.oui,
+      NIC: result.nic,
+      Type: result.type,
+      'EUI-64': result.eui64,
+    };
+
+    return [
+      new BoxBuilder('MAC Address', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default MacAddressBoxSource;

--- a/src/modules/boxSources/__test__/MacAddressBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MacAddressBoxSource.test.ts
@@ -1,0 +1,217 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { MacAddressBoxSource } from '../MacAddressBoxSource';
+
+describe('MacAddressBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when mac option is absent', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { other: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::macaddress option', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { macaddress: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('colon-separated input', () => {
+    it('normalizes colon format and extracts all fields', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { mac: true },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('01:23:45:67:89:ab');
+      expect(opts.Hyphen).toBe('01-23-45-67-89-ab');
+      expect(opts.Dot).toBe('0123.4567.89ab');
+      expect(opts.Bare).toBe('0123456789ab');
+      expect(opts.OUI).toBe('01:23:45');
+      expect(opts.NIC).toBe('67:89:ab');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { mac: true },
+      );
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('plaintext output contains key: value lines', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { mac: true },
+      );
+      const text = boxes[0].props.plaintextOutput ?? '';
+      expect(text).toContain('Colon: 01:23:45:67:89:ab');
+      expect(text).toContain('OUI: 01:23:45');
+    });
+  });
+
+  describe('format normalization', () => {
+    it('normalizes hyphen format (mixed case) to lowercase colon', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01-23-45-67-89-AB',
+        { mac: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('01:23:45:67:89:ab');
+      expect(opts.Hyphen).toBe('01-23-45-67-89-ab');
+    });
+
+    it('normalizes Cisco dot notation to colon', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('0123.4567.89ab', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('01:23:45:67:89:ab');
+    });
+
+    it('normalizes bare 12-digit hex to colon', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('0123456789ab', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('01:23:45:67:89:ab');
+    });
+
+    it('accepts uppercase in colon format and lowercases output', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        'AA:BB:CC:DD:EE:FF',
+        { mac: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Colon).toBe('aa:bb:cc:dd:ee:ff');
+      expect(opts.Bare).toBe('aabbccddeeff');
+    });
+  });
+
+  describe('type flag bits', () => {
+    it('first byte 0x01 → multicast, globally unique', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:00:00:00:00:00',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toContain('multicast');
+      expect(opts.Type).toContain('globally unique');
+    });
+
+    it('first byte 0x02 → unicast, locally administered', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '02:00:00:00:00:00',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toContain('unicast');
+      expect(opts.Type).toContain('locally administered');
+    });
+
+    it('first byte 0x03 → multicast, locally administered', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '03:00:00:00:00:00',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toContain('multicast');
+      expect(opts.Type).toContain('locally administered');
+    });
+
+    it('first byte 0x00 → unicast, globally unique', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '00:00:00:00:00:00',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Type).toContain('unicast');
+      expect(opts.Type).toContain('globally unique');
+    });
+  });
+
+  describe('EUI-64 expansion', () => {
+    it('inserts ff:fe after OUI and flips U/L bit', async () => {
+      // 00:23:45 → flip U/L (0x02) on first byte → 02:23:45, then insert ff:fe → 02:23:45:ff:fe:67:89:ab
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '00:23:45:67:89:ab',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['EUI-64']).toBe('02:23:45:ff:fe:67:89:ab');
+    });
+
+    it('EUI-64 for 01:23:45:67:89:ab flips bit 1 of first byte', async () => {
+      // first byte 0x01 ^ 0x02 = 0x03
+      const boxes = await MacAddressBoxSource.generateBoxes(
+        '01:23:45:67:89:ab',
+        { mac: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['EUI-64']).toBe('03:23:45:ff:fe:67:89:ab');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns an error box for "hello"', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('hello', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/valid MAC address/i);
+    });
+
+    it('returns an error box for too-short input "01:23:45"', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('01:23:45', {
+        mac: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/valid MAC address/i);
+    });
+
+    it('returns an error box for empty string', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('', { mac: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/valid MAC address/i);
+    });
+
+    it('error box plaintext is not empty', async () => {
+      const boxes = await MacAddressBoxSource.generateBoxes('not-a-mac', {
+        mac: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBeTruthy();
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(MacAddressBoxSource.name).toBe('MAC Address');
+      expect(MacAddressBoxSource.tag).toBe('#');
+      expect(MacAddressBoxSource.kind).toBe('Convert');
+      expect(typeof MacAddressBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -22,6 +22,7 @@ import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
+import MacAddressBoxSource from './MacAddressBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  MacAddressBoxSource,
 ];


### PR DESCRIPTION
### Box Source: MAC Address (Convert)

Adds the `MAC Address` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `01:23:45:67:89:ab ::mac`

#### Options:
- `::mac`, `::macaddress`

#### Description:
Normalize a MAC address and show its formats, OUI prefix, and flags.

#### Usage Examples:
- **Input**:
```
01:23:45:67:89:ab
::mac
```
- **Output Box (`MAC Address`)**:
```
Colon: 01:23:45:67:89:ab
Hyphen: 01-23-45-67-89-ab
Dot: 0123.4567.89ab
Bare: 0123456789ab
OUI: 01:23:45
NIC: 67:89:ab
Type: multicast, globally unique
EUI-64: 03:23:45:ff:fe:67:89:ab
```
