### PR TITLE
feat(MarkdownToc): add Markdown TOC BoxSource

### DIFF
--- a/src/modules/boxSources/MarkdownTocBoxSource.ts
+++ b/src/modules/boxSources/MarkdownTocBoxSource.ts
@@ -1,0 +1,125 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// heading pattern: one to six # chars followed by at least one space and text
+const HEADING_RE = /^(#{1,6})\s+(.+)$/;
+
+// fence delimiter pattern: opening ``` or ~~~ (with optional language tag)
+const FENCE_OPEN_RE = /^(`{3,}|~{3,})/;
+
+/** converts heading text to a github-compatible anchor slug */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+interface Heading {
+  level: number;
+  text: string;
+}
+
+/** parses ATX headings from markdown, skipping lines inside fenced code blocks */
+function parseHeadings(input: string): Heading[] {
+  const headings: Heading[] = [];
+  let inFence = false;
+  let fenceChar = '';
+
+  for (const line of input.split('\n')) {
+    if (inFence) {
+      // exit fence when we see the matching closing delimiter
+      if (line.trimStart().startsWith(fenceChar)) {
+        inFence = false;
+        fenceChar = '';
+      }
+      continue;
+    }
+
+    const fenceMatch = FENCE_OPEN_RE.exec(line.trimStart());
+    if (fenceMatch) {
+      inFence = true;
+      // keep the exact opening run; a closing fence must be at least as long
+      fenceChar = fenceMatch[1];
+      continue;
+    }
+
+    const headingMatch = HEADING_RE.exec(line);
+    if (headingMatch) {
+      const rawText = headingMatch[2];
+      // strip trailing # characters and whitespace (setext-style closers)
+      const text = rawText.replace(/\s+#+\s*$/, '').trim();
+      headings.push({ level: headingMatch[1].length, text });
+    }
+  }
+
+  return headings;
+}
+
+/** builds the nested bullet list string with github-style duplicate slug disambiguation */
+function buildToc(headings: Heading[]): string {
+  const minLevel = headings.reduce((min, h) => Math.min(min, h.level), 6);
+  const slugCount: Record<string, number> = {};
+  const lines: string[] = [];
+
+  for (const { level, text } of headings) {
+    const baseSlug = slugify(text);
+    const count = slugCount[baseSlug] ?? 0;
+    slugCount[baseSlug] = count + 1;
+
+    // first occurrence uses the base slug; subsequent ones append -1, -2, …
+    const slug = count === 0 ? baseSlug : `${baseSlug}-${count}`;
+    const indent = ' '.repeat((level - minLevel) * 2);
+    lines.push(`${indent}- [${text}](#${slug})`);
+  }
+
+  return lines.join('\n');
+}
+
+export const MarkdownTocBoxSource = {
+  defaultDisabled: true,
+  name: 'Markdown TOC',
+  description:
+    'Generate a table of contents (nested bullet list with anchor links) from Markdown headings.',
+  defaultInput: '# Title\n## Section A\n### Sub\n## Section B ::toc',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'toc', 'tableofcontents')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const headings = parseHeadings(input);
+
+    if (headings.length === 0) {
+      return [
+        new BoxBuilder('Markdown TOC', 'No headings found.')
+          .setTemplate(CodeBoxTemplate)
+          .setOptions({ language: 'markdown' })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const toc = buildToc(headings);
+    return [
+      new BoxBuilder('Markdown TOC', toc)
+        .setTemplate(CodeBoxTemplate)
+        .setOptions({ language: 'markdown' })
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default MarkdownTocBoxSource;

--- a/src/modules/boxSources/__test__/MarkdownTocBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MarkdownTocBoxSource.test.ts
@@ -1,0 +1,149 @@
+import { MarkdownTocBoxSource } from '@modules/boxSources/MarkdownTocBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('MarkdownTocBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes(
+        '# Title\n## Section',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no toc/tableofcontents key', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes(
+        '# Title\n## Section',
+        { foo: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with ::toc option', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('', { toc: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('basic toc generation', () => {
+    it('generates a nested toc from h1/h2/h3 headings', async () => {
+      const input = '# Title\n## Section A\n### Sub\n## Section B';
+      const boxes = await MarkdownTocBoxSource.generateBoxes(input, {
+        toc: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Markdown TOC');
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '- [Title](#title)\n  - [Section A](#section-a)\n    - [Sub](#sub)\n  - [Section B](#section-b)',
+      );
+    });
+
+    it('accepts ::tableofcontents as the trigger option', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('# Hello', {
+        tableofcontents: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('- [Hello](#hello)');
+    });
+
+    it('normalizes indentation so shallowest heading is at indent 0', async () => {
+      // starts at h2, so h2 should be indent 0 and h3 indent 2
+      const input = '## A\n### B';
+      const boxes = await MarkdownTocBoxSource.generateBoxes(input, {
+        toc: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('- [A](#a)\n  - [B](#b)');
+    });
+  });
+
+  describe('duplicate heading disambiguation', () => {
+    it('appends -1 to the second occurrence of a duplicate heading', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('## A\n## A', {
+        toc: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('- [A](#a)\n- [A](#a-1)');
+    });
+
+    it('appends -1, -2 for three identical headings', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes(
+        '## A\n## A\n## A',
+        { toc: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '- [A](#a)\n- [A](#a-1)\n- [A](#a-2)',
+      );
+    });
+  });
+
+  describe('fenced code block exclusion', () => {
+    it('ignores headings inside backtick fences', async () => {
+      const input = '```\n# NotAHeading\n```\n# Real';
+      const boxes = await MarkdownTocBoxSource.generateBoxes(input, {
+        toc: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('- [Real](#real)');
+    });
+
+    it('ignores headings inside tilde fences', async () => {
+      const input = '~~~\n# NotAHeading\n~~~\n# Real';
+      const boxes = await MarkdownTocBoxSource.generateBoxes(input, {
+        toc: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('- [Real](#real)');
+    });
+  });
+
+  describe('slug generation', () => {
+    it('strips special characters from slug', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes(
+        '## Hello, World!',
+        { toc: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '- [Hello, World!](#hello-world)',
+      );
+    });
+
+    it('handles headings with numbers', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('## Step 1', {
+        toc: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('- [Step 1](#step-1)');
+    });
+  });
+
+  describe('no headings found', () => {
+    it('returns a box mentioning no headings when input has no ATX headings', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('just text', {
+        toc: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/no headings/i);
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets priority from source priority field', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('# Hi', {
+        toc: true,
+      });
+      expect(boxes[0].props.priority).toBe(MarkdownTocBoxSource.priority);
+    });
+
+    it('sets language option to markdown for CodeBoxTemplate', async () => {
+      const boxes = await MarkdownTocBoxSource.generateBoxes('# Hi', {
+        toc: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ language: 'markdown' });
+    });
+
+    it('does not close a 4-backtick fence with a 3-backtick line', async () => {
+      // the inner 3-backtick line must not end the 4-backtick block
+      const md = '````\n# fake\n```\n# still fake\n````\n# real';
+      const boxes = await MarkdownTocBoxSource.generateBoxes(md, { toc: true });
+      const out = boxes[0].props.plaintextOutput;
+      expect(out).toContain('[real]');
+      expect(out).not.toContain('fake');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -22,6 +22,7 @@ import HaversineBoxSource from './HaversineBoxSource';
 import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
+import MarkdownTocBoxSource from './MarkdownTocBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  MarkdownTocBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Markdown TOC (Transform)

Adds the `Markdown TOC` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `# Title
## Section A
### Sub
## Section B ::toc`

#### Options:
- `::tableofcontents`, `::toc`

#### Description:
Generate a table of contents (nested bullet list with anchor links) from Markdown headings.

#### Usage Examples:
- **Input**:
```
# Title
## Section A
### Sub
## Section B
::toc
```
- **Output Box (`Markdown TOC`)**:
```
- [Title](#title)
  - [Section A](#section-a)
    - [Sub](#sub)
  - [Section B](#section-b)
```
