### PR TITLE
feat(MetricVolume): add Volume Convert BoxSource

### DIFF
--- a/src/modules/boxSources/MetricVolumeBoxSource.ts
+++ b/src/modules/boxSources/MetricVolumeBoxSource.ts
@@ -1,0 +1,130 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// unit aliases (normalized) → liters
+const TO_L: Record<string, number> = {
+  l: 1,
+  ml: 0.001,
+  cl: 0.01,
+  dl: 0.1,
+  kl: 1000,
+  m3: 1000,
+  cm3: 0.001,
+  mm3: 1e-6,
+  dm3: 1,
+  ft3: 28.316846592,
+  in3: 0.016387064,
+  yd3: 764.554857984,
+  usgal: 3.785411784,
+  gal: 3.785411784,
+  impgal: 4.54609,
+  usqt: 0.946352946,
+  uspt: 0.473176473,
+};
+
+const SUPPORTED_UNITS = Object.keys(TO_L).join(', ');
+
+// max input length to prevent abuse
+const MAX_INPUT_LENGTH = 64;
+
+// formats the value as an integer string when exact, or 6-decimal trimmed float
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// builds the plaintext kv string for KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// normalizes a unit string: lowercase, ³→3, ^3→3, collapse whitespace
+function normalizeUnit(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/³/g, '3')
+    .replace(/\^3/g, '3')
+    .replace(/\s+/g, '');
+}
+
+export const MetricVolumeBoxSource = {
+  defaultDisabled: true,
+  name: 'Volume Convert',
+  description: 'Convert a volume between m³, L, mL, ft³, gallons, and more.',
+  defaultInput: '1 m3 ::cubicvolume',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'cubicvolume', 'volumeconvert')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT_LENGTH) return [];
+
+    // expect "<number> <unit>", split on first whitespace boundary
+    const spaceIdx = raw.search(/\s+/);
+    if (spaceIdx === -1) {
+      return [buildErrorBox()];
+    }
+
+    const numStr = raw.slice(0, spaceIdx);
+    const unitRaw = raw.slice(spaceIdx).trim();
+
+    const value = Number.parseFloat(numStr);
+    if (Number.isNaN(value)) {
+      return [buildErrorBox()];
+    }
+
+    const unit = normalizeUnit(unitRaw);
+    const factor = TO_L[unit];
+    if (factor === undefined) {
+      return [buildErrorBox()];
+    }
+
+    const liters = value * factor;
+
+    const kv: Record<string, string> = {
+      Input: `${formatValue(value)} ${unitRaw}`,
+      L: formatValue(liters),
+      mL: formatValue(liters * 1000),
+      'm³': formatValue(liters / 1000),
+      'cm³': formatValue(liters * 1000),
+      'ft³': formatValue(liters / 28.316846592),
+      'in³': formatValue(liters / 0.016387064),
+      'US gal': formatValue(liters / 3.785411784),
+      'imp gal': formatValue(liters / 4.54609),
+    };
+
+    return [
+      new BoxBuilder('Volume Convert', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+function buildErrorBox(): Box {
+  const kv = {
+    Error: 'Invalid input. Expected: <number> <unit>',
+    Supported: SUPPORTED_UNITS,
+  };
+  return new BoxBuilder('Volume Convert', kvToPlaintext(kv))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(kv)
+    .setPriority(Priority)
+    .build();
+}
+
+export default MetricVolumeBoxSource;

--- a/src/modules/boxSources/__test__/MetricVolumeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MetricVolumeBoxSource.test.ts
@@ -1,0 +1,145 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { MetricVolumeBoxSource } from '../MetricVolumeBoxSource';
+
+describe('MetricVolumeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are provided', async () => {
+      const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::volumeconvert option key', async () => {
+      const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+        volumeconvert: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    describe('1 m³ = 1000 L', () => {
+      it('converts 1 m3 to 1000 L', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+          cubicvolume: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.name).toBe('Volume Convert');
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+        expect(boxes[0].props.options?.L).toBe('1000');
+      });
+
+      it('converts 1 m3 to 1000000 mL', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+          cubicvolume: true,
+        });
+        expect(boxes[0].props.options?.mL).toBe('1000000');
+      });
+
+      it('converts 1 m3 to 1000000 cm³', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+          cubicvolume: true,
+        });
+        expect(boxes[0].props.options?.['cm³']).toBe('1000000');
+      });
+    });
+
+    describe('1 L conversions', () => {
+      it('converts 1 L to 1000 mL', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 l', {
+          cubicvolume: true,
+        });
+        expect(boxes[0].props.options?.mL).toBe('1000');
+      });
+
+      it('converts 1 L to 0.001 m³', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 l', {
+          cubicvolume: true,
+        });
+        expect(boxes[0].props.options?.['m³']).toBe('0.001');
+      });
+    });
+
+    describe('1 ft³ ≈ 28.316847 L', () => {
+      it('converts 1 ft3 and L starts with 28.31684', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 ft3', {
+          cubicvolume: true,
+        });
+        const l = boxes[0].props.options?.L;
+        expect(String(l)).toMatch(/^28\.31684/);
+      });
+    });
+
+    describe('1 usgal ≈ 3.785412 L', () => {
+      it('converts 1 usgal and L starts with 3.78541', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 usgal', {
+          cubicvolume: true,
+        });
+        const l = boxes[0].props.options?.L;
+        expect(String(l)).toMatch(/^3\.78541/);
+      });
+    });
+
+    describe('superscript ³ support', () => {
+      it('converts "1 m³" (unicode superscript) to 1000 L', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m³', {
+          cubicvolume: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.L).toBe('1000');
+      });
+    });
+
+    describe('1 impgal ≈ 4.54609 L', () => {
+      it('converts 1 impgal and L equals 4.54609', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 impgal', {
+          cubicvolume: true,
+        });
+        const l = boxes[0].props.options?.L;
+        expect(String(l)).toMatch(/^4\.54609/);
+      });
+    });
+
+    describe('invalid input', () => {
+      it('returns an error box for bare "abc"', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('abc', {
+          cubicvolume: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Error).toBeDefined();
+      });
+
+      it('returns an error box for "5 foo" (unknown unit)', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('5 foo', {
+          cubicvolume: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Error).toBeDefined();
+      });
+    });
+
+    describe('box metadata', () => {
+      it('sets priority to 10', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+          cubicvolume: true,
+        });
+        expect(boxes[0].props.priority).toBe(10);
+      });
+
+      it('sets plaintextOutput as k:v lines', async () => {
+        const boxes = await MetricVolumeBoxSource.generateBoxes('1 m3', {
+          cubicvolume: true,
+        });
+        const text = boxes[0].props.plaintextOutput;
+        expect(text).toContain('L: 1000');
+        expect(text).toContain('mL: 1000000');
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -20,6 +20,7 @@ import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
+import MetricVolumeBoxSource from './MetricVolumeBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  MetricVolumeBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Volume Convert (Convert)

Adds the `Volume Convert` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1 m3 ::cubicvolume`

#### Options:
- `::cubicvolume`, `::volumeconvert`

#### Description:
Convert a volume between m³, L, mL, ft³, gallons, and more.

#### Usage Examples:
- **Input**:
```
1 m3
::cubicvolume
```
- **Output Box (`Volume Convert`)**:
```
Input: 1 m3
L: 1000
mL: 1000000
m³: 1
cm³: 1000000
ft³: 35.314667
in³: 61023.744095
US gal: 264.172052
imp gal: 219.969248
```
