### PR TITLE
feat(MimeType): add MIME Type BoxSource

### DIFF
--- a/src/modules/boxSources/MimeTypeBoxSource.ts
+++ b/src/modules/boxSources/MimeTypeBoxSource.ts
@@ -1,0 +1,202 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// extension (no dot, lowercase) -> mime type
+const EXT_TO_MIME: Record<string, string> = {
+  // text
+  txt: 'text/plain',
+  html: 'text/html',
+  htm: 'text/html',
+  css: 'text/css',
+  csv: 'text/csv',
+  md: 'text/markdown',
+  rtf: 'text/rtf',
+  ics: 'text/calendar',
+  vcf: 'text/vcard',
+  xml: 'text/xml',
+  // javascript / json / data
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  ts: 'text/typescript',
+  tsx: 'text/typescript',
+  jsx: 'text/jsx',
+  json: 'application/json',
+  yaml: 'application/yaml',
+  yml: 'application/yaml',
+  toml: 'application/toml',
+  sql: 'application/sql',
+  // documents
+  pdf: 'application/pdf',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls: 'application/vnd.ms-excel',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ppt: 'application/vnd.ms-powerpoint',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  odt: 'application/vnd.oasis.opendocument.text',
+  ods: 'application/vnd.oasis.opendocument.spreadsheet',
+  odp: 'application/vnd.oasis.opendocument.presentation',
+  epub: 'application/epub+zip',
+  mobi: 'application/x-mobipocket-ebook',
+  // images
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  ico: 'image/x-icon',
+  bmp: 'image/bmp',
+  tiff: 'image/tiff',
+  avif: 'image/avif',
+  heic: 'image/heic',
+  // audio
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  flac: 'audio/flac',
+  aac: 'audio/aac',
+  // video
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  mkv: 'video/x-matroska',
+  // archives
+  zip: 'application/zip',
+  gz: 'application/gzip',
+  tar: 'application/x-tar',
+  rar: 'application/vnd.rar',
+  '7z': 'application/x-7z-compressed',
+  bz2: 'application/x-bzip2',
+  // fonts
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  ttf: 'font/ttf',
+  otf: 'font/otf',
+  eot: 'application/vnd.ms-fontobject',
+  // binaries / executables
+  bin: 'application/octet-stream',
+  exe: 'application/x-msdownload',
+  apk: 'application/vnd.android.package-archive',
+  deb: 'application/vnd.debian.binary-package',
+  dmg: 'application/x-apple-diskimage',
+  iso: 'application/x-iso9660-image',
+  wasm: 'application/wasm',
+  // scripts / source
+  sh: 'application/x-sh',
+  py: 'text/x-python',
+  rb: 'application/x-ruby',
+  go: 'text/x-go',
+  rs: 'text/x-rust',
+  c: 'text/x-c',
+  cpp: 'text/x-c++',
+  java: 'text/x-java-source',
+  php: 'application/x-httpd-php',
+};
+
+// build reverse map once at module load
+const MIME_TO_EXTS: Map<string, string[]> = new Map();
+for (const [ext, mime] of Object.entries(EXT_TO_MIME)) {
+  const existing = MIME_TO_EXTS.get(mime);
+  if (existing) {
+    existing.push(ext);
+  } else {
+    MIME_TO_EXTS.set(mime, [ext]);
+  }
+}
+
+// extract the extension from a raw input string (filename, path, or bare extension)
+function extractExtension(raw: string): string {
+  const base = raw.includes('.') ? raw.slice(raw.lastIndexOf('.') + 1) : raw;
+  return base.toLowerCase();
+}
+
+// derive the broad category from a mime type string (e.g. 'image' from 'image/png')
+function mimeCategory(mime: string): string {
+  return mime.split('/')[0] ?? 'unknown';
+}
+
+export const MimeTypeBoxSource = {
+  defaultDisabled: true,
+  name: 'MIME Type',
+  description:
+    'Look up the MIME type for a file extension, or extensions for a MIME type.',
+  defaultInput: 'png ::mimetype',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'mimetype', 'mime')) return [];
+
+    const normalized = trim(input);
+    if (!normalized) return [];
+
+    // if input contains '/' treat it as a mime type -> reverse lookup
+    if (normalized.includes('/')) {
+      const mime = normalized.toLowerCase();
+      const exts = MIME_TO_EXTS.get(mime);
+      const extensionsValue = exts ? exts.join(', ') : 'none known';
+
+      const kv: Record<string, string> = {
+        'MIME Type': mime,
+        Extensions: extensionsValue,
+      };
+      const plaintext = `MIME Type: ${mime}\nExtensions: ${extensionsValue}`;
+
+      return [
+        new BoxBuilder('MIME Type', plaintext)
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // forward lookup: extension -> mime type
+    const ext = extractExtension(normalized);
+    const mime = EXT_TO_MIME[ext];
+
+    if (!mime) {
+      const kv: Record<string, string> = {
+        Extension: ext,
+        'MIME Type': 'unknown',
+        Category: 'unknown',
+      };
+      const plaintext = `Extension: ${ext}\nMIME Type: unknown\nCategory: unknown`;
+
+      return [
+        new BoxBuilder('MIME Type', plaintext)
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const kv: Record<string, string> = {
+      Extension: ext,
+      'MIME Type': mime,
+      Category: mimeCategory(mime),
+    };
+    const plaintext = `Extension: ${ext}\nMIME Type: ${mime}\nCategory: ${mimeCategory(mime)}`;
+
+    return [
+      new BoxBuilder('MIME Type', plaintext)
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default MimeTypeBoxSource;

--- a/src/modules/boxSources/__test__/MimeTypeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MimeTypeBoxSource.test.ts
@@ -1,0 +1,143 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { MimeTypeBoxSource } from '../MimeTypeBoxSource';
+
+describe('MimeTypeBoxSource', () => {
+  describe('no trigger option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is provided', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('forward lookup (extension -> mime)', () => {
+    it('resolves bare extension png to image/png with correct category', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'MIME Type': 'image/png',
+        Category: 'image',
+        Extension: 'png',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('resolves extension with leading dot (.json)', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('.json', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'MIME Type': 'application/json',
+        Extension: 'json',
+      });
+    });
+
+    it('extracts extension from a compound filename (archive.tar.gz)', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('archive.tar.gz', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'MIME Type': 'application/gzip',
+        Extension: 'gz',
+      });
+    });
+
+    it('is case-insensitive for extension input (PNG uppercase)', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('PNG', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'MIME Type': 'image/png',
+      });
+    });
+
+    it('returns unknown box for unrecognised extension xyzzy', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('xyzzy', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Extension: 'xyzzy',
+        'MIME Type': 'unknown',
+        Category: 'unknown',
+      });
+    });
+  });
+
+  describe('reverse lookup (mime -> extensions)', () => {
+    it('returns extensions for a known mime type (image/png)', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('image/png', {
+        mimetype: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const exts: string = boxes[0].props.options?.Extensions as string;
+      expect(exts).toContain('png');
+    });
+
+    it('lists multiple extensions for text/html', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('text/html', {
+        mimetype: true,
+      });
+      const exts: string = boxes[0].props.options?.Extensions as string;
+      expect(exts).toContain('html');
+      expect(exts).toContain('htm');
+    });
+
+    it('returns "none known" for an unrecognised mime type', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes(
+        'application/x-unknown-format',
+        { mimetype: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Extensions).toBe('none known');
+    });
+  });
+
+  describe('::mime alias', () => {
+    it('triggers on ::mime option key', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        mime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        'MIME Type': 'image/png',
+      });
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets priority to 10', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        mimetype: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('sets box name to "MIME Type"', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        mimetype: true,
+      });
+      expect(boxes[0].props.name).toBe('MIME Type');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await MimeTypeBoxSource.generateBoxes('png', {
+        mimetype: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -20,6 +20,7 @@ import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
+import MimeTypeBoxSource from './MimeTypeBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  MimeTypeBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: MIME Type (Analyze)

Adds the `MIME Type` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `png ::mimetype`

#### Options:
- `::mime`, `::mimetype`

#### Description:
Look up the MIME type for a file extension, or extensions for a MIME type.

#### Usage Examples:
- **Input**:
```
png
::mimetype
```
- **Output Box (`MIME Type`)**:
```
Extension: png
MIME Type: image/png
Category: image
```
