### PR TITLE
feat(ModPow): add Modular Exponentiation BoxSource

### DIFF
--- a/src/modules/boxSources/ModPowBoxSource.ts
+++ b/src/modules/boxSources/ModPowBoxSource.ts
@@ -1,0 +1,109 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// builds "k: v\n..." plaintext from a key-value record
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+function makeErrorBox(message: string, priority: number): Box {
+  const kv = { Note: message };
+  return new BoxBuilder('Modular Exponentiation', kvToPlaintext(kv))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(kv)
+    .setPriority(priority)
+    .build();
+}
+
+// square-and-multiply: computes (base ^ exp) mod mod in O(log exp) multiplications
+function modPow(base: bigint, exp: bigint, mod: bigint): bigint {
+  // normalise base into [0, mod) to handle negative inputs
+  base = ((base % mod) + mod) % mod;
+  let result = 1n;
+  while (exp > 0n) {
+    if (exp & 1n) {
+      result = (result * base) % mod;
+    }
+    base = (base * base) % mod;
+    exp >>= 1n;
+  }
+  return result;
+}
+
+export const ModPowBoxSource = {
+  defaultDisabled: true,
+  name: 'Modular Exponentiation',
+  description:
+    'Compute (base ^ exponent) mod modulus efficiently. Input: "base exponent modulus".',
+  defaultInput: '4 13 497 ::modpow',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'modpow', 'powmod')) return [];
+
+    const raw = trim(input).slice(0, 5000);
+
+    // split on whitespace and/or commas
+    const tokens = raw.split(/[\s,]+/).filter(Boolean);
+
+    if (tokens.length !== 3 || tokens.some((t) => !/^-?\d+$/.test(t))) {
+      return [
+        makeErrorBox(
+          'Expected exactly 3 integers: base exponent modulus.',
+          this.priority,
+        ),
+      ];
+    }
+
+    // cap operand magnitude: square-and-multiply does O(log exp) BigInt
+    // multiplications over the modulus; huge operands would stall the main
+    // thread synchronously on every keystroke (input is the URL ?input= param)
+    if (tokens.some((t) => t.replace(/^-/, '').length > 100)) {
+      return [
+        makeErrorBox('Each operand must be at most 100 digits.', this.priority),
+      ];
+    }
+
+    const base = BigInt(tokens[0]);
+    const exponent = BigInt(tokens[1]);
+    const modulus = BigInt(tokens[2]);
+
+    if (exponent < 0n) {
+      return [makeErrorBox('Exponent must be >= 0.', this.priority)];
+    }
+
+    if (modulus <= 0n) {
+      return [makeErrorBox('Modulus must be > 0.', this.priority)];
+    }
+
+    const result = modPow(base, exponent, modulus);
+
+    const kv: Record<string, string> = {
+      Base: String(base),
+      Exponent: String(exponent),
+      Modulus: String(modulus),
+      Result: String(result),
+    };
+
+    return [
+      new BoxBuilder('Modular Exponentiation', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ModPowBoxSource;

--- a/src/modules/boxSources/__test__/ModPowBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ModPowBoxSource.test.ts
@@ -1,0 +1,159 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ModPowBoxSource } from '../ModPowBoxSource';
+
+describe('ModPowBoxSource', () => {
+  describe('generateBoxes — gating', () => {
+    it('returns [] when no matching option is present', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('4 13 497', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are present', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('4 13 497', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — classic RSA example', () => {
+    it('computes 4^13 mod 497 = 445 via ::modpow', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('4 13 497', {
+        modpow: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Modular Exponentiation');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.options).toMatchObject({ Result: '445' });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('computes 4^13 mod 497 = 445 via ::powmod alias', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('4 13 497', {
+        powmod: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({ Result: '445' });
+    });
+  });
+
+  describe('generateBoxes — correctness cases', () => {
+    it('computes 2^10 mod 1000 = 24', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('2 10 1000', {
+        modpow: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Result: '24' });
+    });
+
+    it('computes 3^0 mod 7 = 1 (anything^0 = 1)', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('3 0 7', {
+        modpow: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Result: '1' });
+    });
+
+    it('computes 5^3 mod 1 = 0 (all values mod 1 = 0)', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('5 3 1', {
+        modpow: true,
+      });
+      expect(boxes[0].props.options).toMatchObject({ Result: '0' });
+    });
+
+    it('handles negative base: -2^3 mod 5 = 2', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('-2 3 5', {
+        modpow: true,
+      });
+      // (-8 mod 5) normalised to [0,5) = 2
+      expect(boxes[0].props.options).toMatchObject({ Result: '2' });
+    });
+  });
+
+  describe('generateBoxes — huge exponent (performance)', () => {
+    it('computes 2^1000000 mod 1000000007 without hanging', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes(
+        '2 1000000 1000000007',
+        { modpow: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const result = BigInt(
+        (boxes[0].props.options as Record<string, string>).Result,
+      );
+      expect(result).toBeGreaterThanOrEqual(0n);
+      expect(result).toBeLessThan(1000000007n);
+    });
+  });
+
+  describe('generateBoxes — error cases', () => {
+    it('returns an error box when fewer than 3 tokens are given', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('4 13', {
+        modpow: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Note: expect.stringContaining('3 integers'),
+      });
+    });
+
+    it('returns an error box when modulus is 0', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('4 13 0', {
+        modpow: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Note: expect.stringContaining('Modulus'),
+      });
+    });
+
+    it('returns an error box when exponent is negative', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('4 -1 7', {
+        modpow: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Note: expect.stringContaining('Exponent'),
+      });
+    });
+  });
+
+  describe('generateBoxes — output shape', () => {
+    it('box options contain Base, Exponent, Modulus, Result keys', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('4 13 497', {
+        modpow: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts).toHaveProperty('Base', '4');
+      expect(opts).toHaveProperty('Exponent', '13');
+      expect(opts).toHaveProperty('Modulus', '497');
+      expect(opts).toHaveProperty('Result', '445');
+    });
+
+    it('plaintextOutput contains all key:value pairs', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('4 13 497', {
+        modpow: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Result: 445');
+    });
+
+    it('rejects operands longer than 100 digits (DoS guard)', async () => {
+      const huge = '9'.repeat(200);
+      const boxes = await ModPowBoxSource.generateBoxes(`2 ${huge} ${huge}`, {
+        modpow: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toMatch(/100 digits/);
+    });
+
+    it('plaintextOutput keeps the base/exponent/modulus lines', async () => {
+      const boxes = await ModPowBoxSource.generateBoxes('4 13 497', {
+        modpow: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Base: 4');
+      expect(text).toContain('Exponent: 13');
+      expect(text).toContain('Modulus: 497');
+      expect(text).toContain('Result: 445');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -20,6 +20,7 @@ import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
+import ModPowBoxSource from './ModPowBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  ModPowBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Modular Exponentiation (Calculate)

Adds the `Modular Exponentiation` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `4 13 497 ::modpow`

#### Options:
- `::modpow`, `::powmod`

#### Description:
Compute (base ^ exponent) mod modulus efficiently. Input: "base exponent modulus".

#### Usage Examples:
- **Input**:
```
4 13 497
::modpow
```
- **Output Box (`Modular Exponentiation`)**:
```
Base: 4
Exponent: 13
Modulus: 497
Result: 445
```
