### PR TITLE
feat(Morse): add Morse Code BoxSource

### DIFF
--- a/src/modules/boxSources/MorseBoxSource.ts
+++ b/src/modules/boxSources/MorseBoxSource.ts
@@ -1,0 +1,154 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// maps each character to its ITU-R M.1677-1 morse representation
+const CHAR_TO_MORSE: Record<string, string> = {
+  A: '.-',
+  B: '-...',
+  C: '-.-.',
+  D: '-..',
+  E: '.',
+  F: '..-.',
+  G: '--.',
+  H: '....',
+  I: '..',
+  J: '.---',
+  K: '-.-',
+  L: '.-..',
+  M: '--',
+  N: '-.',
+  O: '---',
+  P: '.--.',
+  Q: '--.-',
+  R: '.-.',
+  S: '...',
+  T: '-',
+  U: '..-',
+  V: '...-',
+  W: '.--',
+  X: '-..-',
+  Y: '-.--',
+  Z: '--..',
+  '0': '-----',
+  '1': '.----',
+  '2': '..---',
+  '3': '...--',
+  '4': '....-',
+  '5': '.....',
+  '6': '-....',
+  '7': '--...',
+  '8': '---..',
+  '9': '----.',
+  '.': '.-.-.-',
+  ',': '--..--',
+  '?': '..--..',
+  "'": '.----.',
+  '!': '-.-.--',
+  '/': '-..-.',
+  '(': '-.--.',
+  ')': '-.--.-',
+  '&': '.-...',
+  ':': '---...',
+  ';': '-.-.-.',
+  '=': '-...-',
+  '+': '.-.-.',
+  '-': '-....-',
+  _: '..--.-',
+  '"': '.-..-.',
+  $: '...-..-',
+  '@': '.--.-.',
+};
+
+// invert CHAR_TO_MORSE for decoding
+const MORSE_TO_CHAR: Record<string, string> = Object.fromEntries(
+  Object.entries(CHAR_TO_MORSE).map(([ch, code]) => [code, ch]),
+);
+
+// encode plaintext to morse; words separated by ' / ', letters by ' '
+function encodeMorse(input: string): string {
+  return input
+    .toUpperCase()
+    .split(/\s+/)
+    .filter((word) => word.length > 0)
+    .map((word) =>
+      word
+        .split('')
+        .map((ch) => CHAR_TO_MORSE[ch] ?? '?')
+        .join(' '),
+    )
+    .join(' / ');
+}
+
+// decode morse to plaintext; word groups separated by ' / ', codes by ' '
+function decodeMorse(input: string): string {
+  return input
+    .split(' / ')
+    .map((wordGroup) =>
+      wordGroup
+        .trim()
+        .split(' ')
+        .filter((code) => code.length > 0)
+        .map((code) => MORSE_TO_CHAR[code] ?? '?')
+        .join(''),
+    )
+    .join(' ');
+}
+
+export const MorseBoxSource = {
+  defaultDisabled: true,
+  name: 'Morse Code',
+  description:
+    'Encode text to International Morse code or decode Morse back to text.',
+  defaultInput: 'SOS ::morse',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'morse', 'morseencode');
+    const wantDecode = hasOptionKeys(options, 'morsedecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = encodeMorse(input);
+      boxes.push(
+        new BoxBuilder('Morse Code (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decodeMorse(input);
+      boxes.push(
+        new BoxBuilder('Morse Code (Decode)', decoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default MorseBoxSource;

--- a/src/modules/boxSources/__test__/MorseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MorseBoxSource.test.ts
@@ -1,0 +1,128 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { MorseBoxSource } from '../MorseBoxSource';
+
+describe('MorseBoxSource', () => {
+  describe('no option → empty', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('SOS', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('SOS', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty input → empty', () => {
+    it('returns empty array for whitespace-only input with encode option', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('   ', { morse: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty string with decode option', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('', {
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode (::morse)', () => {
+    it('encodes SOS correctly', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('SOS', { morse: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+      expect(boxes[0].props.name).toBe('Morse Code (Encode)');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('encodes HELLO correctly', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('HELLO', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('.... . .-.. .-.. ---');
+    });
+
+    it('separates words with " / "', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('HI BYE', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('.... .. / -... -.-- .');
+    });
+
+    it('is case-insensitive (lowercase input)', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('sos', { morse: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+    });
+
+    it('also triggers on ::morseencode option', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('SOS', {
+        morseencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+    });
+  });
+
+  describe('decode (::morsedecode)', () => {
+    it('decodes SOS correctly', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('... --- ...', {
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('SOS');
+      expect(boxes[0].props.name).toBe('Morse Code (Decode)');
+    });
+
+    it('decodes multi-word morse separated by " / "', async () => {
+      const boxes = await MorseBoxSource.generateBoxes(
+        '.... .. / -... -.-- .',
+        { morsedecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('HI BYE');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encode then decode returns original text', async () => {
+      const original = 'HELLO WORLD';
+      const encoded = await MorseBoxSource.generateBoxes(original, {
+        morse: true,
+      });
+      const morseText = encoded[0].props.plaintextOutput;
+
+      const decoded = await MorseBoxSource.generateBoxes(morseText, {
+        morsedecode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('both options → 2 boxes', () => {
+    it('returns encode box then decode box when both options are set', async () => {
+      const boxes = await MorseBoxSource.generateBoxes('SOS', {
+        morse: true,
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Morse Code (Encode)');
+      expect(boxes[1].props.name).toBe('Morse Code (Decode)');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(MorseBoxSource.name).toBe('Morse Code');
+      expect(MorseBoxSource.tag).toBe('#');
+      expect(MorseBoxSource.kind).toBe('Encode');
+      expect(typeof MorseBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -20,6 +20,7 @@ import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
+import MorseBoxSource from './MorseBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  MorseBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Morse Code (Encode)

Adds the `Morse Code` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `SOS ::morse`

#### Options:
- `::morse`, `::morsedecode`, `::morseencode`

#### Description:
Encode text to International Morse code or decode Morse back to text.

#### Usage Examples:
- **Input**:
```
SOS
::morse
```
- **Output Box (`Morse Code (Encode)`)**:
```
... --- ...
```
