### PR TITLE
feat(MorseCode): add Morse Code BoxSource

### DIFF
--- a/src/modules/boxSources/MorseCodeBoxSource.ts
+++ b/src/modules/boxSources/MorseCodeBoxSource.ts
@@ -1,0 +1,142 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// ITU-R M.1677-1 morse code table plus common non-standard extensions ($)
+const MORSE_ENCODE: Record<string, string> = {
+  A: '.-',
+  B: '-...',
+  C: '-.-.',
+  D: '-..',
+  E: '.',
+  F: '..-.',
+  G: '--.',
+  H: '....',
+  I: '..',
+  J: '.---',
+  K: '-.-',
+  L: '.-..',
+  M: '--',
+  N: '-.',
+  O: '---',
+  P: '.--.',
+  Q: '--.-',
+  R: '.-.',
+  S: '...',
+  T: '-',
+  U: '..-',
+  V: '...-',
+  W: '.--',
+  X: '-..-',
+  Y: '-.--',
+  Z: '--..',
+  '0': '-----',
+  '1': '.----',
+  '2': '..---',
+  '3': '...--',
+  '4': '....-',
+  '5': '.....',
+  '6': '-....',
+  '7': '--...',
+  '8': '---..',
+  '9': '----.',
+  '.': '.-.-.-',
+  ',': '--..--',
+  '?': '..--..',
+  "'": '.----.',
+  '!': '-.-.--',
+  '/': '-..-.',
+  '(': '-.--.',
+  ')': '-.--.-',
+  '&': '.-...',
+  ':': '---...',
+  ';': '-.-.-.',
+  '=': '-...-',
+  '+': '.-.-.',
+  '-': '-....-',
+  _: '..--.-',
+  '"': '.-..-.',
+  $: '...-..-',
+  '@': '.--.-.',
+};
+
+// reverse map for decoding
+const MORSE_DECODE: Record<string, string> = Object.fromEntries(
+  Object.entries(MORSE_ENCODE).map(([char, code]) => [code, char]),
+);
+
+/** encodes a plain-text string to Morse code. words are separated by ` / `, letters by ` `. */
+function encode(text: string): string {
+  const words = text.toUpperCase().split(/\s+/).filter(Boolean);
+  return words
+    .map((word) =>
+      word
+        .split('')
+        .map((ch) => MORSE_ENCODE[ch])
+        .filter(Boolean)
+        .join(' '),
+    )
+    .filter(Boolean)
+    .join(' / ');
+}
+
+/** decodes a Morse code string back to plain text. words split on ` / `, symbols on space. */
+function decode(morse: string): string {
+  return morse
+    .split(' / ')
+    .map((word) =>
+      word
+        .trim()
+        .split(' ')
+        .map((sym) => MORSE_DECODE[sym] ?? '')
+        .join(''),
+    )
+    .join(' ');
+}
+
+export const MorseCodeBoxSource = {
+  defaultDisabled: true,
+  name: 'Morse Code',
+  description: 'Encode text to Morse code or decode Morse code back to text.',
+  defaultInput: 'SOS ::morse',
+  tag: '·',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'morse', 'morseencode');
+    const wantDecode = hasOptionKeys(options, 'morsedecode');
+    if (!wantEncode && !wantDecode) return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      boxes.push(
+        new BoxBuilder('Morse Code (Encode)', encode(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      boxes.push(
+        new BoxBuilder('Morse Code (Decode)', decode(input))
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default MorseCodeBoxSource;

--- a/src/modules/boxSources/__test__/MorseCodeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/MorseCodeBoxSource.test.ts
@@ -1,0 +1,145 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { MorseCodeBoxSource } from '../MorseCodeBoxSource';
+
+describe('MorseCodeBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(MorseCodeBoxSource.name).toBe('Morse Code');
+      expect(MorseCodeBoxSource.tag).toBe('·');
+      expect(MorseCodeBoxSource.kind).toBe('Encode');
+      expect(typeof MorseCodeBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when options are null', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option keys', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', {
+        sha256: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - encode via ::morse', () => {
+    it('SOS encodes to ... --- ...', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Morse Code (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('HELLO WORLD encodes correctly with word separator', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('HELLO WORLD', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        '.... . .-.. .-.. --- / .-- --- .-. .-.. -..',
+      );
+    });
+
+    it('lowercase input is treated as uppercase', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('sos', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+    });
+
+    it('unknown characters are skipped silently', async () => {
+      // digit 1 is known, tilde is not
+      const boxes = await MorseCodeBoxSource.generateBoxes('A~B', {
+        morse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // ~ skipped; A and B encoded and joined
+      expect(boxes[0].props.plaintextOutput).toBe('.- -...');
+    });
+  });
+
+  describe('generateBoxes - encode via ::morseencode', () => {
+    it('morseencode option also triggers encode box', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', {
+        morseencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Morse Code (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('... --- ...');
+    });
+  });
+
+  describe('generateBoxes - decode via ::morsedecode', () => {
+    it('decodes ... --- ... back to SOS', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('... --- ...', {
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Morse Code (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('SOS');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('decodes HELLO WORLD Morse string correctly', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes(
+        '.... . .-.. .-.. --- / .-- --- .-. .-.. -..',
+        { morsedecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('HELLO WORLD');
+    });
+
+    it('unknown Morse symbols produce empty characters (skipped)', async () => {
+      // '....' is H, '.....' is 5, '......' is unknown
+      const boxes = await MorseCodeBoxSource.generateBoxes('.... ......', {
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // unknown symbol maps to '' so result is just 'H'
+      expect(boxes[0].props.plaintextOutput).toBe('H');
+    });
+  });
+
+  describe('generateBoxes - both encode and decode options together', () => {
+    it('returns two boxes when both morse and morsedecode are set', async () => {
+      const boxes = await MorseCodeBoxSource.generateBoxes('SOS', {
+        morse: true,
+        morsedecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Morse Code (Encode)');
+      expect(names).toContain('Morse Code (Decode)');
+    });
+  });
+
+  describe('generateBoxes - roundtrip', () => {
+    it('encode then decode returns the original uppercased text', async () => {
+      const original = 'MAGIC BOX';
+      const [encodeBox] = await MorseCodeBoxSource.generateBoxes(original, {
+        morse: true,
+      });
+      const [decodeBox] = await MorseCodeBoxSource.generateBoxes(
+        encodeBox.props.plaintextOutput,
+        { morsedecode: true },
+      );
+      expect(decodeBox.props.plaintextOutput).toBe(original);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import JWTBoxSource from './JWTBoxSource';
 import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
+import MorseCodeBoxSource from './MorseCodeBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  MorseCodeBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Morse Code (Encode)

Adds the `Morse Code` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `·`
- **Default Input**: `SOS ::morse`

#### Options:
- `::morse`, `::morsedecode`, `::morseencode`

#### Description:
Encode text to Morse code or decode Morse code back to text.

#### Usage Examples:
- **Input**:
```
SOS
::morse
```
- **Output Box (`Morse Code (Encode)`)**:
```
... --- ...
```
