### PR TITLE
feat(NatoPhonetic): add NATO Phonetic BoxSource

### DIFF
--- a/src/modules/boxSources/NatoPhoneticBoxSource.ts
+++ b/src/modules/boxSources/NatoPhoneticBoxSource.ts
@@ -1,0 +1,139 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 10_000;
+
+const NATO: Record<string, string> = {
+  a: 'Alfa',
+  b: 'Bravo',
+  c: 'Charlie',
+  d: 'Delta',
+  e: 'Echo',
+  f: 'Foxtrot',
+  g: 'Golf',
+  h: 'Hotel',
+  i: 'India',
+  j: 'Juliett',
+  k: 'Kilo',
+  l: 'Lima',
+  m: 'Mike',
+  n: 'November',
+  o: 'Oscar',
+  p: 'Papa',
+  q: 'Quebec',
+  r: 'Romeo',
+  s: 'Sierra',
+  t: 'Tango',
+  u: 'Uniform',
+  v: 'Victor',
+  w: 'Whiskey',
+  x: 'X-ray',
+  y: 'Yankee',
+  z: 'Zulu',
+  '0': 'Zero',
+  '1': 'One',
+  '2': 'Two',
+  '3': 'Three',
+  '4': 'Four',
+  '5': 'Five',
+  '6': 'Six',
+  '7': 'Seven',
+  '8': 'Eight',
+  '9': 'Nine',
+};
+
+// reverse map: lowercase nato word → original char (uppercase letter or digit)
+const NATO_REVERSE: Record<string, string> = Object.fromEntries(
+  Object.entries(NATO).map(([char, word]) => [
+    word.toLowerCase(),
+    char === char.toUpperCase() ? char : char.toUpperCase(),
+  ]),
+);
+
+function encodeNato(input: string): string {
+  const tokens: string[] = [];
+  for (const ch of input) {
+    const lower = ch.toLowerCase();
+    if (lower === ' ') {
+      tokens.push('(space)');
+    } else if (NATO[lower] !== undefined) {
+      tokens.push(NATO[lower]);
+    } else {
+      tokens.push(ch);
+    }
+  }
+  return tokens.join(' ');
+}
+
+function decodeNato(input: string): string {
+  const tokens = input.trim().split(/\s+/);
+  const result: string[] = [];
+  for (const token of tokens) {
+    const lower = token.toLowerCase();
+    if (lower === '(space)') {
+      result.push(' ');
+    } else if (NATO_REVERSE[lower] !== undefined) {
+      result.push(NATO_REVERSE[lower]);
+    } else {
+      result.push(token);
+    }
+  }
+  return result.join('');
+}
+
+export const NatoPhoneticBoxSource = {
+  defaultDisabled: true,
+  name: 'NATO Phonetic',
+  description:
+    'Spell text in the NATO phonetic alphabet (Alfa Bravo Charlie). ::nato to encode, ::natodecode to decode.',
+  defaultInput: 'ABC ::nato',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'nato', 'natoencode', 'phonetic');
+    const wantDecode = hasOptionKeys(options, 'natodecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = encodeNato(input);
+      boxes.push(
+        new BoxBuilder('NATO Phonetic (Encode)', encoded)
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decodeNato(input);
+      boxes.push(
+        new BoxBuilder('NATO Phonetic (Decode)', decoded)
+          .setTemplate(CodeBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default NatoPhoneticBoxSource;

--- a/src/modules/boxSources/__test__/NatoPhoneticBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NatoPhoneticBoxSource.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { NatoPhoneticBoxSource } from '../NatoPhoneticBoxSource';
+
+describe('NatoPhoneticBoxSource', () => {
+  describe('generateBoxes — no match cases', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('ABC');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::nato', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::nato', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('   ', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes(
+        'A'.repeat(10_001),
+        { nato: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — ::nato', () => {
+    it('encodes ABC to Alfa Bravo Charlie', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('ABC', {
+        nato: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('NATO Phonetic (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa Bravo Charlie');
+    });
+
+    it('encodes SOS to Sierra Oscar Sierra', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('SOS', {
+        nato: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Sierra Oscar Sierra');
+    });
+
+    it('encodes digit string A1 to Alfa One', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('A1', {
+        nato: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa One');
+    });
+
+    it('encodes lowercase abc same as uppercase', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('abc', {
+        nato: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Alfa Bravo Charlie');
+    });
+
+    it('encodes via ::natoencode alias', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('SOS', {
+        natoencode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Sierra Oscar Sierra');
+    });
+
+    it('encodes via ::phonetic alias', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('SOS', {
+        phonetic: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Sierra Oscar Sierra');
+    });
+
+    it('sets priority and showExpandButton correctly', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('A', {
+        nato: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('decode — ::natodecode', () => {
+    it('decodes Alfa Bravo Charlie to ABC', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes(
+        'Alfa Bravo Charlie',
+        {
+          natodecode: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('NATO Phonetic (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('ABC');
+    });
+
+    it('decodes case-insensitively (alfa bravo → AB)', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('alfa bravo', {
+        natodecode: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AB');
+    });
+
+    it('keeps unrecognized tokens as-is', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes(
+        'Alfa UNKNOWN Charlie',
+        {
+          natodecode: true,
+        },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('AUNKNOWNC');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('HELLO round-trips through encode then decode', async () => {
+      const encoded = await NatoPhoneticBoxSource.generateBoxes('HELLO', {
+        nato: true,
+      });
+      const encodedText = encoded[0].props.plaintextOutput;
+
+      const decoded = await NatoPhoneticBoxSource.generateBoxes(encodedText, {
+        natodecode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe('HELLO');
+    });
+  });
+
+  describe('both options — returns 2 boxes', () => {
+    it('produces encode box and decode box when both options present', async () => {
+      const boxes = await NatoPhoneticBoxSource.generateBoxes('Alfa', {
+        nato: true,
+        natodecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('NATO Phonetic (Encode)');
+      expect(boxes[1].props.name).toBe('NATO Phonetic (Decode)');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -24,6 +24,7 @@ import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
+import NatoPhoneticBoxSource from './NatoPhoneticBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  NatoPhoneticBoxSource,
 ];


### PR DESCRIPTION
### Box Source: NATO Phonetic (Encode)

Adds the `NATO Phonetic` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `ABC ::nato`

#### Options:
- `::nato`, `::natodecode`, `::natoencode`, `::phonetic`

#### Description:
Spell text in the NATO phonetic alphabet (Alfa Bravo Charlie). ::nato to encode, ::natodecode to decode.

#### Usage Examples:
- **Input**:
```
ABC
::nato
```
- **Output Box (`NATO Phonetic (Encode)`)**:
```
Alfa Bravo Charlie
```
