### PR TITLE
feat(NoteFrequency): add Musical Note BoxSource

### DIFF
--- a/src/modules/boxSources/NoteFrequencyBoxSource.ts
+++ b/src/modules/boxSources/NoteFrequencyBoxSource.ts
@@ -1,0 +1,159 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// standard 12-TET pitch class mapping: C=0, C#/Db=1, ..., B=11
+const NOTE_NAMES = [
+  'C',
+  'C#',
+  'D',
+  'D#',
+  'E',
+  'F',
+  'F#',
+  'G',
+  'G#',
+  'A',
+  'A#',
+  'B',
+];
+
+const PITCH_CLASS: Record<string, number> = {
+  C: 0,
+  D: 2,
+  E: 4,
+  F: 5,
+  G: 7,
+  A: 9,
+  B: 11,
+};
+
+// regex for a note name with optional accidental and octave
+const NOTE_PATTERN = /^([A-Ga-g])(#|b)?(-?\d+)$/;
+
+// regex for a bare numeric frequency (Hz)
+const FREQ_PATTERN = /^\d+(\.\d+)?$/;
+
+function noteToMidi(
+  noteLetter: string,
+  accidental: string | undefined,
+  octave: number,
+): number {
+  const base = PITCH_CLASS[noteLetter.toUpperCase()];
+  const shift = accidental === '#' ? 1 : accidental === 'b' ? -1 : 0;
+  // midi middle-C (C4) = 60; formula: (octave+1)*12 + pitchClass
+  return (octave + 1) * 12 + base + shift;
+}
+
+function midiToFreq(midi: number): number {
+  return 440 * 2 ** ((midi - 69) / 12);
+}
+
+function midiToNoteName(midi: number): string {
+  const pitchClass = ((midi % 12) + 12) % 12;
+  const octave = Math.floor(midi / 12) - 1;
+  return `${NOTE_NAMES[pitchClass]}${octave}`;
+}
+
+// build a plaintext representation of key:value pairs for KeyValueBoxTemplate fallback
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const NoteFrequencyBoxSource = {
+  defaultDisabled: true,
+  name: 'Musical Note',
+  description:
+    'Convert a musical note (e.g. A4) to its frequency in Hz, or a frequency to the nearest note (A4=440, 12-TET).',
+  defaultInput: 'A4 ::note',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'note', 'pitch')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > 32) return [];
+
+    // note name → frequency
+    const noteMatch = NOTE_PATTERN.exec(raw);
+    if (noteMatch) {
+      const [, letter, accidental, octaveStr] = noteMatch;
+      const octave = Number.parseInt(octaveStr, 10);
+      const midi = noteToMidi(letter, accidental, octave);
+      const freq = midiToFreq(midi);
+      const freqStr = freq.toFixed(2);
+      const noteName = midiToNoteName(midi);
+
+      const pairs: Record<string, string> = {
+        Note: noteName,
+        Frequency: `${freqStr} Hz`,
+        MIDI: String(midi),
+      };
+
+      return [
+        new BoxBuilder('Musical Note', kvToPlaintext(pairs))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(pairs)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // frequency (Hz) → nearest note
+    const freqMatch = FREQ_PATTERN.exec(raw);
+    if (freqMatch) {
+      const freq = Number.parseFloat(raw);
+      if (freq <= 0) return [];
+
+      const midiExact = 69 + 12 * Math.log2(freq / 440);
+      const midi = Math.round(midiExact);
+      const noteName = midiToNoteName(midi);
+      const noteFreq = midiToFreq(midi);
+      const cents = Math.round((midiExact - midi) * 100);
+      const centsStr = cents >= 0 ? `+${cents}` : String(cents);
+
+      const pairs: Record<string, string> = {
+        Frequency: `${freq} Hz`,
+        'Nearest Note': noteName,
+        'Note Frequency': `${noteFreq.toFixed(2)} Hz`,
+        Cents: centsStr,
+        MIDI: String(midi),
+      };
+
+      return [
+        new BoxBuilder('Musical Note', kvToPlaintext(pairs))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(pairs)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // unrecognized input — explain accepted formats
+    const helpText =
+      'Enter a note name (e.g. A4, C#5, Bb3) or a frequency in Hz (e.g. 440).';
+    const pairs: Record<string, string> = {
+      Format: helpText,
+    };
+
+    return [
+      new BoxBuilder('Musical Note', kvToPlaintext(pairs))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(pairs)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NoteFrequencyBoxSource;

--- a/src/modules/boxSources/__test__/NoteFrequencyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NoteFrequencyBoxSource.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import { NoteFrequencyBoxSource } from '../NoteFrequencyBoxSource';
+
+describe('NoteFrequencyBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no option key is present', async () => {
+      const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('note name → frequency', () => {
+      it('A4 → 440 Hz, MIDI 69', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', {
+          note: true,
+        });
+        expect(boxes).toHaveLength(1);
+
+        const opts = boxes[0].props.options as Record<string, string>;
+        // frequency should be 440.00 Hz
+        expect(opts.Frequency).toMatch(/^440/);
+        expect(opts.MIDI).toBe('69');
+      });
+
+      it('C4 → ~261.63 Hz (middle C)', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('C4', {
+          note: true,
+        });
+        expect(boxes).toHaveLength(1);
+
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Frequency).toMatch(/^261\.6/);
+        expect(opts.MIDI).toBe('60');
+      });
+
+      it('A5 → 880 Hz', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A5', {
+          note: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Frequency).toMatch(/^880/);
+      });
+
+      it('A3 → 220 Hz', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A3', {
+          note: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Frequency).toMatch(/^220/);
+      });
+
+      it('C#5 and Db5 produce the same frequency (~554.37 Hz)', async () => {
+        const sharpBoxes = await NoteFrequencyBoxSource.generateBoxes('C#5', {
+          note: true,
+        });
+        const flatBoxes = await NoteFrequencyBoxSource.generateBoxes('Db5', {
+          note: true,
+        });
+
+        const sharpOpts = sharpBoxes[0].props.options as Record<string, string>;
+        const flatOpts = flatBoxes[0].props.options as Record<string, string>;
+
+        // both should start with 554.3
+        expect(sharpOpts.Frequency).toMatch(/^554\.3/);
+        expect(flatOpts.Frequency).toMatch(/^554\.3/);
+        // same MIDI number
+        expect(sharpOpts.MIDI).toBe(flatOpts.MIDI);
+      });
+
+      it('accepts ::pitch option', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', {
+          pitch: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Frequency).toMatch(/^440/);
+      });
+
+      it('box name is "Musical Note"', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', {
+          note: true,
+        });
+        expect(boxes[0].props.name).toBe('Musical Note');
+      });
+
+      it('plaintextOutput contains key:value pairs', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('A4', {
+          note: true,
+        });
+        expect(boxes[0].props.plaintextOutput).toContain('Frequency:');
+        expect(boxes[0].props.plaintextOutput).toContain('MIDI:');
+      });
+    });
+
+    describe('frequency (Hz) → nearest note', () => {
+      it('440 Hz → Nearest Note A4, Cents 0', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('440', {
+          note: true,
+        });
+        expect(boxes).toHaveLength(1);
+
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Nearest Note']).toBe('A4');
+        expect(opts.Cents).toBe('+0');
+        expect(opts.MIDI).toBe('69');
+      });
+
+      it('261.63 Hz → Nearest Note C4', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('261.63', {
+          note: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Nearest Note']).toBe('C4');
+      });
+
+      it('450 Hz → Nearest Note A4, positive cents deviation', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('450', {
+          note: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Nearest Note']).toBe('A4');
+        // 450 Hz is above 440 Hz so cents should be positive
+        const cents = Number.parseInt(opts.Cents, 10);
+        expect(cents).toBeGreaterThan(0);
+        // approximately +39 cents
+        expect(cents).toBeGreaterThanOrEqual(38);
+        expect(cents).toBeLessThanOrEqual(40);
+      });
+
+      it('frequency result includes Note Frequency field', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('440', {
+          note: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts['Note Frequency']).toMatch(/^440/);
+      });
+    });
+
+    describe('invalid / unrecognized input', () => {
+      it('unrecognized text produces a help box', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes('hello', {
+          note: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Format).toBeTruthy();
+      });
+
+      it('input longer than 32 chars returns []', async () => {
+        const boxes = await NoteFrequencyBoxSource.generateBoxes(
+          'A4 some very long extra text that exceeds',
+          { note: true },
+        );
+        expect(boxes).toHaveLength(0);
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -24,6 +24,7 @@ import K8sSecretBoxSource from './K8sSecretBoxSource';
 import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
+import NoteFrequencyBoxSource from './NoteFrequencyBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  NoteFrequencyBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Musical Note (Convert)

Adds the `Musical Note` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `A4 ::note`

#### Options:
- `::note`, `::pitch`

#### Description:
Convert a musical note (e.g. A4) to its frequency in Hz, or a frequency to the nearest note (A4=440, 12-TET).

#### Usage Examples:
- **Input**:
```
A4
::note
```
- **Output Box (`Musical Note`)**:
```
Note: A4
Frequency: 440.00 Hz
MIDI: 69
```
