### PR TITLE
feat(NumberBase): add Number Base BoxSource

### DIFF
--- a/src/modules/boxSources/NumberBaseBoxSource.ts
+++ b/src/modules/boxSources/NumberBaseBoxSource.ts
@@ -1,0 +1,87 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// parse a string as a bigint, supporting 0x/0o/0b/decimal prefixes and a leading minus sign
+function parseIntegerInput(raw: string): bigint | null {
+  const s = trim(raw);
+  if (s === '' || s === '-') return null;
+
+  const negative = s.startsWith('-');
+  const abs = negative ? s.slice(1) : s;
+
+  // bound the digit count: BigInt parse/format is O(n^2) for non-power-of-two
+  // bases, so an unbounded string would freeze the main thread (DoS)
+  if (abs.length > 1024) return null;
+
+  // BigInt() treats a leading zero as decimal, so rewrite classic C-style octal
+  // (e.g. 0755) to the explicit 0o form before parsing
+  const normalized = /^0[0-7]+$/.test(abs) ? `0o${abs.slice(1)}` : abs;
+
+  // BigInt() natively handles 0x/0o/0b/decimal literals
+  try {
+    const value = BigInt(normalized);
+    return negative ? -value : value;
+  } catch {
+    return null;
+  }
+}
+
+// format a bigint in the requested base with the standard prefix, preserving sign
+function formatBigInt(value: bigint, radix: number, prefix: string): string {
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+  const digits = abs.toString(radix);
+  return negative ? `-${prefix}${digits}` : `${prefix}${digits}`;
+}
+
+export const NumberBaseBoxSource = {
+  defaultDisabled: true,
+  name: 'Number Base',
+  description:
+    'Convert an integer between decimal, hexadecimal, octal and binary. Input may be prefixed 0x / 0o / 0b.',
+  defaultInput: '255 ::base',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'base')) return [];
+
+    const value = parseIntegerInput(input);
+    if (value === null) return [];
+
+    const decimal = value.toString(10);
+    const hex = formatBigInt(value, 16, '0x');
+    const octal = formatBigInt(value, 8, '0o');
+    const binary = formatBigInt(value, 2, '0b');
+
+    const output: Record<string, string> = {
+      Decimal: decimal,
+      Hexadecimal: hex,
+      Octal: octal,
+      Binary: binary,
+    };
+
+    // plaintext output joins key=value pairs for copy/TUI display
+    const plaintextOutput = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Number Base', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberBaseBoxSource;

--- a/src/modules/boxSources/__test__/NumberBaseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberBaseBoxSource.test.ts
@@ -1,0 +1,105 @@
+import { NumberBaseBoxSource } from '@modules/boxSources/NumberBaseBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('NumberBaseBoxSource', () => {
+  it('returns [] when ::base option is absent', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('255', null);
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('converts decimal 255 to all bases', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('255', {
+      base: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const { options } = boxes[0].props;
+    expect(options).toEqual({
+      Decimal: '255',
+      Hexadecimal: '0xff',
+      Octal: '0o377',
+      Binary: '0b11111111',
+    });
+  });
+
+  it('converts hex literal 0xff (same result as decimal 255)', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('0xff', {
+      base: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.options).toEqual({
+      Decimal: '255',
+      Hexadecimal: '0xff',
+      Octal: '0o377',
+      Binary: '0b11111111',
+    });
+  });
+
+  it('converts binary literal 0b1010', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('0b1010', {
+      base: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect((boxes[0].props.options as Record<string, string>).Decimal).toBe(
+      '10',
+    );
+  });
+
+  it('returns [] for non-integer input', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('hello', {
+      base: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('handles large values beyond Number.MAX_SAFE_INTEGER exactly', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes(
+      '0xffffffffffffffff',
+      { base: true },
+    );
+    expect(boxes).toHaveLength(1);
+    expect((boxes[0].props.options as Record<string, string>).Decimal).toBe(
+      '18446744073709551615',
+    );
+  });
+
+  it('converts negative decimal', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('-255', {
+      base: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Decimal).toBe('-255');
+    expect(opts.Hexadecimal).toBe('-0xff');
+    expect(opts.Octal).toBe('-0o377');
+    expect(opts.Binary).toBe('-0b11111111');
+  });
+
+  it('sets box name to "Number Base"', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('1', { base: true });
+    expect(boxes[0].props.name).toBe('Number Base');
+  });
+
+  it('treats classic leading-zero input as octal (0755 -> 493)', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('0755', {
+      base: true,
+    });
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Decimal).toBe('493');
+    expect(opts.Hexadecimal).toBe('0x1ed');
+  });
+
+  it('rejects oversized input to avoid quadratic BigInt work (DoS guard)', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('9'.repeat(2000), {
+      base: true,
+    });
+    expect(boxes).toHaveLength(0);
+  });
+
+  it('handles zero', async () => {
+    const boxes = await NumberBaseBoxSource.generateBoxes('0', { base: true });
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Decimal).toBe('0');
+    expect(opts.Hexadecimal).toBe('0x0');
+    expect(opts.Binary).toBe('0b0');
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -22,6 +22,7 @@ import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberBaseBoxSource from './NumberBaseBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  NumberBaseBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Number Base (Convert)

Adds the `Number Base` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `255 ::base`

#### Options:
- `::base`

#### Description:
Convert an integer between decimal, hexadecimal, octal and binary. Input may be prefixed 0x / 0o / 0b.

#### Usage Examples:
- **Input**:
```
255
::base
```
- **Output Box (`Number Base`)**:
```
Decimal: 255
Hexadecimal: 0xff
Octal: 0o377
Binary: 0b11111111
```
