### PR TITLE
feat(NumberBases): add Number Bases BoxSource

### DIFF
--- a/src/modules/boxSources/NumberBasesBoxSource.ts
+++ b/src/modules/boxSources/NumberBasesBoxSource.ts
@@ -1,0 +1,95 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// regex patterns for each supported prefix
+const HEX_RE = /^[0-9a-fA-F]+$/;
+const OCT_RE = /^[0-7]+$/;
+const BIN_RE = /^[01]+$/;
+const DEC_RE = /^[0-9]+$/;
+
+// parse the input string into a BigInt, return undefined on invalid input
+function parseIntoBigInt(raw: string): bigint | undefined {
+  if (raw.length > 256) return undefined;
+
+  const negative = raw.startsWith('-');
+  const unsigned = negative ? raw.slice(1) : raw;
+
+  let value: bigint;
+
+  if (unsigned.startsWith('0x') || unsigned.startsWith('0X')) {
+    const digits = unsigned.slice(2);
+    if (!digits || !HEX_RE.test(digits)) return undefined;
+    value = BigInt(`0x${digits}`);
+  } else if (unsigned.startsWith('0o') || unsigned.startsWith('0O')) {
+    const digits = unsigned.slice(2);
+    if (!digits || !OCT_RE.test(digits)) return undefined;
+    value = BigInt(`0o${digits}`);
+  } else if (unsigned.startsWith('0b') || unsigned.startsWith('0B')) {
+    const digits = unsigned.slice(2);
+    if (!digits || !BIN_RE.test(digits)) return undefined;
+    value = BigInt(`0b${digits}`);
+  } else {
+    if (!unsigned || !DEC_RE.test(unsigned)) return undefined;
+    value = BigInt(unsigned);
+  }
+
+  return negative ? -value : value;
+}
+
+// format a BigInt into the four base representations
+function formatBases(n: bigint): Record<string, string> {
+  const negative = n < 0n;
+  const abs = negative ? -n : n;
+  const sign = negative ? '-' : '';
+
+  return {
+    Decimal: `${sign}${abs.toString(10)}`,
+    Hex: `${sign}0x${abs.toString(16)}`,
+    Octal: `${sign}0o${abs.toString(8)}`,
+    Binary: `${sign}0b${abs.toString(2)}`,
+  };
+}
+
+export const NumberBasesBoxSource = {
+  defaultDisabled: true,
+  name: 'Number Bases',
+  description:
+    'Show an integer in binary, octal, decimal, and hex. Accepts 0x, 0o, 0b prefixes.',
+  defaultInput: '255 ::bases',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'bases', 'numbase')) return [];
+    if (!isString(input)) return [];
+
+    const raw = trim(input);
+    const n = parseIntoBigInt(raw);
+    if (n === undefined) return [];
+
+    const bases = formatBases(n);
+
+    // key/value lines for headless/TUI consumers (not raw JSON)
+    const plaintext = Object.entries(bases)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Number Bases', plaintext)
+        .setOptions(bases)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberBasesBoxSource;

--- a/src/modules/boxSources/__test__/NumberBasesBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberBasesBoxSource.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { NumberBasesBoxSource } from '../NumberBasesBoxSource';
+
+describe('NumberBasesBoxSource', () => {
+  describe('generateBoxes — option gate', () => {
+    it('returns [] when no matching option key is provided', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('255', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option key is provided', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('255', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — decimal input', () => {
+    it('converts 255 to all four bases', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('255', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('255');
+      expect(opts.Hex).toBe('0xff');
+      expect(opts.Octal).toBe('0o377');
+      expect(opts.Binary).toBe('0b11111111');
+    });
+
+    it('converts 0 correctly', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('0', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('0');
+      expect(opts.Hex).toBe('0x0');
+      expect(opts.Octal).toBe('0o0');
+      expect(opts.Binary).toBe('0b0');
+    });
+  });
+
+  describe('generateBoxes — prefixed input', () => {
+    it('parses hex input 0xff', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('0xff', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('255');
+      expect(opts.Hex).toBe('0xff');
+    });
+
+    it('parses binary input 0b1010', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('0b1010', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('10');
+      expect(opts.Hex).toBe('0xa');
+    });
+
+    it('parses octal input 0o17', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('0o17', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('15');
+    });
+
+    it('accepts uppercase prefixes 0X, 0O, 0B', async () => {
+      const hexBoxes = await NumberBasesBoxSource.generateBoxes('0XFF', {
+        bases: true,
+      });
+      expect(
+        (hexBoxes[0].props.options as Record<string, string>).Decimal,
+      ).toBe('255');
+
+      const octBoxes = await NumberBasesBoxSource.generateBoxes('0O17', {
+        bases: true,
+      });
+      expect(
+        (octBoxes[0].props.options as Record<string, string>).Decimal,
+      ).toBe('15');
+
+      const binBoxes = await NumberBasesBoxSource.generateBoxes('0B1010', {
+        bases: true,
+      });
+      expect(
+        (binBoxes[0].props.options as Record<string, string>).Decimal,
+      ).toBe('10');
+    });
+  });
+
+  describe('generateBoxes — negative numbers', () => {
+    it('handles negative decimal -16', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('-16', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('-16');
+      expect(opts.Hex).toBe('-0x10');
+      expect(opts.Octal).toBe('-0o20');
+      expect(opts.Binary).toBe('-0b10000');
+    });
+  });
+
+  describe('generateBoxes — BigInt precision beyond Number', () => {
+    it('handles 9007199254740993 (> 2^53) with exact precision', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes(
+        '9007199254740993',
+        { bases: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Decimal).toBe('9007199254740993');
+      expect(opts.Hex).toBe('0x20000000000001');
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns [] for "xyz"', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('xyz', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for bare prefix "0x" with no digits', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('0x', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for floating point "12.5"', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('12.5', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty string', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('', {
+        bases: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('accepts ::numbase option key as well', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('10', {
+        numbase: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('sets box name to "Number Bases"', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('255', {
+        bases: true,
+      });
+      expect(boxes[0].props.name).toBe('Number Bases');
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await NumberBasesBoxSource.generateBoxes('255', {
+        bases: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -25,6 +25,7 @@ import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberBasesBoxSource from './NumberBasesBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  NumberBasesBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Number Bases (Convert)

Adds the `Number Bases` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `255 ::bases`

#### Options:
- `::bases`, `::numbase`

#### Description:
Show an integer in binary, octal, decimal, and hex. Accepts 0x, 0o, 0b prefixes.

#### Usage Examples:
- **Input**:
```
255
::bases
```
- **Output Box (`Number Bases`)**:
```
Decimal: 255
Hex: 0xff
Octal: 0o377
Binary: 0b11111111
```
