### PR TITLE
feat(NumberFormat): add Number Format BoxSource

### DIFF
--- a/src/modules/boxSources/NumberFormatBoxSource.ts
+++ b/src/modules/boxSources/NumberFormatBoxSource.ts
@@ -1,0 +1,65 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// matches an optional minus sign followed by digits and an optional decimal part
+const numberPattern = /^-?\d+(\.\d+)?$/;
+
+export const NumberFormatBoxSource = {
+  defaultDisabled: true,
+  name: 'Number Format',
+  description:
+    'Format a number with thousands separators, scientific, and compact notation.',
+  defaultInput: '1234567.89 ::numformat',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'numformat', 'numfmt')) return [];
+
+    const raw = trim(input);
+    // no legitimate number literal is this long; bound regex + Intl work
+    if (raw.length > 100) return [];
+    if (!numberPattern.test(raw)) return [];
+
+    const n = Number.parseFloat(raw);
+
+    // group via BigInt for integers (exact for any size) and keep all decimals
+    // for fractions (toLocaleString defaults to rounding at 3 places)
+    const grouped = raw.includes('.')
+      ? n.toLocaleString('en-US', { maximumFractionDigits: 20 })
+      : BigInt(raw).toLocaleString('en-US');
+    const compact = new Intl.NumberFormat('en-US', {
+      notation: 'compact',
+    }).format(n);
+    const scientific = n.toExponential();
+
+    const output: Record<string, string> = {
+      Grouped: grouped,
+      Compact: compact,
+      Scientific: scientific,
+      Plain: raw,
+    };
+
+    const plaintextOutput = Object.entries(output)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Number Format', plaintextOutput)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberFormatBoxSource;

--- a/src/modules/boxSources/__test__/NumberFormatBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberFormatBoxSource.test.ts
@@ -1,0 +1,86 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { NumberFormatBoxSource } from '../NumberFormatBoxSource';
+
+describe('NumberFormatBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no trigger option is provided', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1234567.89');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('abc', {
+        numformat: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('formats 1234567.89 with ::numformat', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1234567.89', {
+        numformat: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Number Format');
+      expect(boxes[0].props.options).toMatchObject({
+        Grouped: '1,234,567.89',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('formats 1000000 into compact 1M and grouped 1,000,000', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1000000', {
+        numfmt: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Grouped: '1,000,000',
+        Compact: '1M',
+      });
+    });
+
+    it('formats negative number -5000', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('-5000', {
+        numformat: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Grouped: '-5,000',
+      });
+    });
+
+    it('sets correct priority', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1234567', {
+        numformat: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('includes Scientific and Plain keys', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1234567', {
+        numformat: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Scientific).toBe('1.234567e+6');
+      expect(opts.Plain).toBe('1234567');
+    });
+
+    it('does not round fractional digits in Grouped', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes('1234.56789', {
+        numformat: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Grouped).toBe('1,234.56789');
+    });
+
+    it('preserves precision of very large integers via BigInt', async () => {
+      const boxes = await NumberFormatBoxSource.generateBoxes(
+        '123456789012345678901234567890',
+        { numformat: true },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Grouped).toBe('123,456,789,012,345,678,901,234,567,890');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -22,6 +22,7 @@ import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberFormatBoxSource from './NumberFormatBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  NumberFormatBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Number Format (Convert)

Adds the `Number Format` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1234567.89 ::numformat`

#### Options:
- `::numfmt`, `::numformat`

#### Description:
Format a number with thousands separators, scientific, and compact notation.

#### Usage Examples:
- **Input**:
```
1234567.89
::numformat
```
- **Output Box (`Number Format`)**:
```
Grouped: 1,234,567.89
Compact: 1.2M
Scientific: 1.23456789e+6
Plain: 1234567.89
```
