### PR TITLE
feat(NumberSpell): add Number to Words BoxSource

### DIFF
--- a/src/modules/boxSources/NumberSpellBoxSource.ts
+++ b/src/modules/boxSources/NumberSpellBoxSource.ts
@@ -1,0 +1,148 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// short-scale word tables
+const ONES = [
+  'zero',
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten',
+  'eleven',
+  'twelve',
+  'thirteen',
+  'fourteen',
+  'fifteen',
+  'sixteen',
+  'seventeen',
+  'eighteen',
+  'nineteen',
+];
+
+const TENS = [
+  '',
+  '',
+  'twenty',
+  'thirty',
+  'forty',
+  'fifty',
+  'sixty',
+  'seventy',
+  'eighty',
+  'ninety',
+];
+
+// named powers in ascending order (index 0 = 10^3, 1 = 10^6, ...)
+// short-scale group names; 13 entries cover up to 42 digits (> the 40 cap)
+const SCALE = [
+  'thousand',
+  'million',
+  'billion',
+  'trillion',
+  'quadrillion',
+  'quintillion',
+  'sextillion',
+  'septillion',
+  'octillion',
+  'nonillion',
+  'decillion',
+  'undecillion',
+  'duodecillion',
+];
+
+// spell a value in [0, 999]; caller guarantees this range
+function spellHundreds(n: number): string {
+  if (n < 20) return ONES[n];
+  if (n < 100) {
+    const tens = TENS[Math.floor(n / 10)];
+    const unit = n % 10;
+    return unit === 0 ? tens : `${tens}-${ONES[unit]}`;
+  }
+  const hundreds = Math.floor(n / 100);
+  const remainder = n % 100;
+  const base = `${ONES[hundreds]} hundred`;
+  return remainder === 0 ? base : `${base} ${spellHundreds(remainder)}`;
+}
+
+// split a BigInt into groups of 1000, lowest first
+function splitGroups(n: bigint): number[] {
+  const groups: number[] = [];
+  const thousand = 1000n;
+  while (n > 0n) {
+    groups.push(Number(n % thousand));
+    n = n / thousand;
+  }
+  return groups;
+}
+
+// spell a non-negative BigInt as english words
+function spellBigInt(n: bigint): string {
+  if (n === 0n) return 'zero';
+
+  const groups = splitGroups(n);
+  const parts: string[] = [];
+
+  for (let i = groups.length - 1; i >= 0; i--) {
+    const g = groups[i];
+    if (g === 0) continue;
+    const words = spellHundreds(g);
+    if (i === 0) {
+      parts.push(words);
+    } else {
+      parts.push(`${words} ${SCALE[i - 1]}`);
+    }
+  }
+
+  return parts.join(' ');
+}
+
+export const NumberSpellBoxSource = {
+  defaultDisabled: true,
+  name: 'Number to Words',
+  description: 'Spell an integer in English words.',
+  defaultInput: '1234567 ::spell',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'spell', 'numwords')) return [];
+    // bound work before the regex (a valid number is well under this)
+    if (input.length > 100) return [];
+
+    const raw = trim(input);
+
+    // validate: optional leading minus followed by digits only, max 40 digits
+    if (!/^-?\d+$/.test(raw)) return [];
+    const digits = raw.startsWith('-') ? raw.slice(1) : raw;
+    if (digits.length > 40) return [];
+
+    const value = BigInt(raw);
+    const negative = value < 0n;
+    const spelled = spellBigInt(negative ? -value : value);
+    const output = negative ? `negative ${spelled}` : spelled;
+
+    return [
+      new BoxBuilder('Number to Words', output)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberSpellBoxSource;

--- a/src/modules/boxSources/__test__/NumberSpellBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberSpellBoxSource.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import { NumberSpellBoxSource } from '../NumberSpellBoxSource';
+
+describe('NumberSpellBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no trigger option is present', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('42', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for non-integer input', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('abc', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for decimal input', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('1.5', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('spells zero', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('0', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('zero');
+    });
+
+    it('spells single digit seven', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('7', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('seven');
+    });
+
+    it('hyphenates compound tens: 42', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('42', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('forty-two');
+    });
+
+    it('spells round hundred: 100', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('100', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('one hundred');
+    });
+
+    it('spells hundred-and-one (American style, no "and"): 101', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('101', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('one hundred one');
+    });
+
+    it('spells 1234567 exactly', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('1234567', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'one million two hundred thirty-four thousand five hundred sixty-seven',
+      );
+    });
+
+    it('spells negative numbers', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('-5', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('negative five');
+    });
+
+    it('spells one billion', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('1000000000', {
+        spell: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('one billion');
+    });
+
+    it('also triggers on ::numwords option key', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('42', {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('forty-two');
+    });
+
+    it('sets correct box name and priority', async () => {
+      const boxes = await NumberSpellBoxSource.generateBoxes('7', {
+        spell: true,
+      });
+      expect(boxes[0].props.name).toBe('Number to Words');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('spells a 25-digit number without emitting "undefined"', async () => {
+      // 10^24 needs a scale word beyond sextillion (septillion)
+      const boxes = await NumberSpellBoxSource.generateBoxes(
+        `1${'0'.repeat(24)}`,
+        { spell: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('one septillion');
+      expect(boxes[0].props.plaintextOutput).not.toContain('undefined');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -22,6 +22,7 @@ import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberSpellBoxSource from './NumberSpellBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  NumberSpellBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Number to Words (Convert)

Adds the `Number to Words` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1234567 ::spell`

#### Options:
- `::numwords`, `::spell`

#### Description:
Spell an integer in English words.

#### Usage Examples:
- **Input**:
```
1234567
::spell
```
- **Output Box (`Number to Words`)**:
```
one million two hundred thirty-four thousand five hundred sixty-seven
```
