### PR TITLE
feat(NumberToCurrency): add Currency Format BoxSource

### DIFF
--- a/src/modules/boxSources/NumberToCurrencyBoxSource.ts
+++ b/src/modules/boxSources/NumberToCurrencyBoxSource.ts
@@ -1,0 +1,107 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length guard against pathological strings
+const MAX_INPUT_LENGTH = 50;
+
+// ISO 4217 currency code must be exactly 3 letters
+const CURRENCY_CODE_RE = /^[A-Za-z]{3}$/;
+
+// only accept plain decimal numbers (no exponents, no currency symbols)
+const NUMBER_RE = /^-?\d+(\.\d+)?$/;
+
+function resolveCurrencyCode(raw: string | boolean | null): string {
+  if (typeof raw === 'string' && CURRENCY_CODE_RE.test(raw)) {
+    return raw.toUpperCase();
+  }
+  return 'USD';
+}
+
+export const NumberToCurrencyBoxSource = {
+  defaultDisabled: true,
+  name: 'Currency Format',
+  description:
+    'Format a number as currency. Use ::currency=EUR for a specific ISO 4217 code (default USD).',
+  defaultInput: '1234567.5 ::currency',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'currency')) return [];
+
+    const text = trim(input);
+    if (!text || text.length > MAX_INPUT_LENGTH) return [];
+    if (!NUMBER_RE.test(text)) return [];
+
+    const n = Number.parseFloat(text);
+    if (!Number.isFinite(n)) return [];
+
+    const rawCode = extractOptionKeys(options, 'currency');
+    // a present but malformed code (e.g. "US", "dollars") is an error; a bare
+    // flag / missing value defaults to USD. Intl accepts any well-formed
+    // 3-letter code, so this is the only reachable "invalid code" path.
+    if (
+      typeof rawCode === 'string' &&
+      rawCode.length > 0 &&
+      !CURRENCY_CODE_RE.test(rawCode)
+    ) {
+      const errorOutput = `Invalid currency code: "${rawCode}"`;
+      return [
+        new BoxBuilder('Currency Format', errorOutput)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: errorOutput })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+    const code = resolveCurrencyCode(rawCode ?? null);
+
+    // belt-and-suspenders: an unknown code throws RangeError from Intl.NumberFormat
+    let formatter: Intl.NumberFormat;
+    try {
+      formatter = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: code,
+      });
+    } catch {
+      // invalid ISO 4217 code — surface an error box rather than silently falling back
+      const errorOutput = `Invalid currency code: "${code}"`;
+      return [
+        new BoxBuilder('Currency Format', errorOutput)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: errorOutput })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const formatted = formatter.format(n);
+
+    // plain grouped number without currency symbol
+    const plain = new Intl.NumberFormat('en-US').format(n);
+
+    const output: Record<string, string> = {
+      Formatted: formatted,
+      Currency: code,
+      Plain: plain,
+    };
+
+    return [
+      new BoxBuilder('Currency Format', formatted)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberToCurrencyBoxSource;

--- a/src/modules/boxSources/__test__/NumberToCurrencyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberToCurrencyBoxSource.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { NumberToCurrencyBoxSource } from '../NumberToCurrencyBoxSource';
+
+describe('NumberToCurrencyBoxSource', () => {
+  it('returns [] when ::currency option is absent', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes(
+      '1234567.5',
+      null,
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('formats with USD by default when ::currency has no value', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('1234567.5', {
+      currency: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Formatted).toBe('$1,234,567.50');
+    expect(opts.Currency).toBe('USD');
+    expect(opts.Plain).toBe('1,234,567.5');
+  });
+
+  it('formats with EUR when ::currency=EUR', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('1000', {
+      currency: 'EUR',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Formatted).toBe('€1,000.00');
+    expect(opts.Currency).toBe('EUR');
+  });
+
+  it('formats with JPY (0 decimals, rounds) when ::currency=JPY', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('1234.5', {
+      currency: 'JPY',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Formatted).toBe('¥1,235');
+    expect(opts.Currency).toBe('JPY');
+  });
+
+  it('returns an error box for an invalid currency code', async () => {
+    // a malformed (non-3-letter) code makes Intl throw; a well-formed but
+    // unknown 3-letter code like ZZZ is accepted by Intl, so use 'US'
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('100', {
+      currency: 'US',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Error).toMatch(/invalid currency code/i);
+    expect(opts.Error).toContain('US');
+  });
+
+  it('returns [] for non-numeric input', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('abc', {
+      currency: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for empty input', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('', {
+      currency: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for input exceeding max length', async () => {
+    const long = '1'.repeat(51);
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes(long, {
+      currency: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('handles negative numbers', async () => {
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('-500', {
+      currency: true,
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Formatted).toBe('-$500.00');
+    expect(opts.Currency).toBe('USD');
+  });
+
+  it('uses boxTemplate KeyValueBoxTemplate', async () => {
+    const { KeyValueBoxTemplate } = await import('@components/BoxTemplate');
+    const boxes = await NumberToCurrencyBoxSource.generateBoxes('1', {
+      currency: true,
+    });
+    expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -22,6 +22,7 @@ import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberToCurrencyBoxSource from './NumberToCurrencyBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  NumberToCurrencyBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Currency Format (Convert)

Adds the `Currency Format` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1234567.5 ::currency`

#### Options:
- `::currency`

#### Description:
Format a number as currency. Use ::currency=EUR for a specific ISO 4217 code (default USD).

#### Usage Examples:
- **Input**:
```
1234567.5
::currency
```
- **Output Box (`Currency Format`)**:
```
$1,234,567.50
```
