### PR TITLE
feat(NumberToWords): add Number to Words BoxSource

### DIFF
--- a/src/modules/boxSources/NumberToWordsBoxSource.ts
+++ b/src/modules/boxSources/NumberToWordsBoxSource.ts
@@ -1,0 +1,159 @@
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max digit length we're willing to handle (~10^39 would overflow quintillions scale)
+const MAX_INPUT_LENGTH = 40;
+
+const ones = [
+  '',
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten',
+  'eleven',
+  'twelve',
+  'thirteen',
+  'fourteen',
+  'fifteen',
+  'sixteen',
+  'seventeen',
+  'eighteen',
+  'nineteen',
+];
+
+const tens = [
+  '',
+  '',
+  'twenty',
+  'thirty',
+  'forty',
+  'fifty',
+  'sixty',
+  'seventy',
+  'eighty',
+  'ninety',
+];
+
+// named scale groups in ascending order (each covers 3 decimal digits)
+const scales = [
+  '',
+  'thousand',
+  'million',
+  'billion',
+  'trillion',
+  'quadrillion',
+  'quintillion',
+];
+
+// convert a value in [0, 999] to english words
+function convertHundreds(n: number): string {
+  if (n === 0) return '';
+
+  const parts: string[] = [];
+
+  if (n >= 100) {
+    parts.push(`${ones[Math.floor(n / 100)]} hundred`);
+    n %= 100;
+  }
+
+  if (n >= 20) {
+    const t = tens[Math.floor(n / 10)];
+    const o = ones[n % 10];
+    parts.push(o ? `${t}-${o}` : t);
+  } else if (n > 0) {
+    parts.push(ones[n]);
+  }
+
+  return parts.join(' ');
+}
+
+// convert a non-negative BigInt to english words
+function bigIntToWords(n: bigint): string {
+  if (n === 0n) return 'zero';
+
+  const groupSize = 1000n;
+  const groups: number[] = [];
+
+  let remaining = n;
+  while (remaining > 0n) {
+    groups.push(Number(remaining % groupSize));
+    remaining /= groupSize;
+  }
+
+  if (groups.length > scales.length) {
+    // number exceeds quintillions — reject
+    return '';
+  }
+
+  const parts: string[] = [];
+  for (let i = groups.length - 1; i >= 0; i--) {
+    const g = groups[i];
+    if (g === 0) continue;
+
+    const words = convertHundreds(g);
+    const scale = scales[i];
+    parts.push(scale ? `${words} ${scale}` : words);
+  }
+
+  return parts.join(' ');
+}
+
+export const NumberToWordsBoxSource = {
+  defaultDisabled: true,
+  name: 'Number to Words',
+  description: 'Spell an integer in English words.',
+  defaultInput: '1234 ::numwords',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'numwords')) return [];
+
+    const raw = trim(input);
+
+    // reject overly long strings before BigInt parsing
+    if (raw.length > MAX_INPUT_LENGTH) return [];
+
+    if (!/^-?\d+$/.test(raw)) return [];
+
+    const negative = raw.startsWith('-');
+    const digits = negative ? raw.slice(1) : raw;
+
+    const words = bigIntToWords(BigInt(digits));
+    if (!words) {
+      return [
+        new BoxBuilder(
+          'Number to Words',
+          'number exceeds the maximum supported scale (999 quintillion)',
+        )
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const output = negative ? `negative ${words}` : words;
+
+    return [
+      new BoxBuilder('Number to Words', output)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default NumberToWordsBoxSource;

--- a/src/modules/boxSources/__test__/NumberToWordsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/NumberToWordsBoxSource.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { NumberToWordsBoxSource } from '../NumberToWordsBoxSource';
+
+describe('NumberToWordsBoxSource', () => {
+  describe('generateBoxes — option guard', () => {
+    it('returns [] when ::numwords option is absent', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('1234', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is an empty object', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('1234', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — valid integers', () => {
+    async function words(input: string): Promise<string> {
+      const boxes = await NumberToWordsBoxSource.generateBoxes(input, {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(1);
+      return boxes[0].props.plaintextOutput;
+    }
+
+    it('converts 0 to "zero"', async () => {
+      expect(await words('0')).toBe('zero');
+    });
+
+    it('converts 21 to "twenty-one"', async () => {
+      expect(await words('21')).toBe('twenty-one');
+    });
+
+    it('converts 100 to "one hundred"', async () => {
+      expect(await words('100')).toBe('one hundred');
+    });
+
+    it('converts 1234 to "one thousand two hundred thirty-four"', async () => {
+      expect(await words('1234')).toBe('one thousand two hundred thirty-four');
+    });
+
+    it('converts 1000000 to "one million"', async () => {
+      expect(await words('1000000')).toBe('one million');
+    });
+
+    it('converts -42 to "negative forty-two"', async () => {
+      expect(await words('-42')).toBe('negative forty-two');
+    });
+  });
+
+  describe('generateBoxes — invalid input', () => {
+    it('returns [] for non-numeric input "abc"', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('abc', {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for decimal "1.5"', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('1.5', {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty string', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('', {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — box metadata', () => {
+    it('sets name, showExpandButton false, and correct priority', async () => {
+      const boxes = await NumberToWordsBoxSource.generateBoxes('5', {
+        numwords: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { props, boxTemplate } = boxes[0];
+      expect(props.name).toBe('Number to Words');
+      expect(props.priority).toBe(10);
+      expect(props.showExpandButton).toBe(false);
+      expect(boxTemplate).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -22,6 +22,7 @@ import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import NumberToWordsBoxSource from './NumberToWordsBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  NumberToWordsBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Number to Words (Convert)

Adds the `Number to Words` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1234 ::numwords`

#### Options:
- `::numwords`

#### Description:
Spell an integer in English words.

#### Usage Examples:
- **Input**:
```
1234
::numwords
```
- **Output Box (`Number to Words`)**:
```
one thousand two hundred thirty-four
```
