### PR TITLE
feat(OnColor): add Readable Text Color BoxSource

### DIFF
--- a/src/modules/boxSources/OnColorBoxSource.ts
+++ b/src/modules/boxSources/OnColorBoxSource.ts
@@ -1,0 +1,135 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_HEX_INPUT = 32;
+
+// expands a 3-digit shorthand hex (e.g. #rgb) to 6-digit form
+function expandShortHex(hex: string): string {
+  return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+}
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// parses #RGB or #RRGGBB hex strings; returns null for anything else
+function parseHex(input: string): { rgb: Rgb; normalized: string } | null {
+  const cleaned = input.trim().toLowerCase();
+  const short = /^#([0-9a-f]{3})$/.exec(cleaned);
+  if (short) {
+    const full = expandShortHex(cleaned);
+    return {
+      rgb: {
+        r: Number.parseInt(full.slice(1, 3), 16),
+        g: Number.parseInt(full.slice(3, 5), 16),
+        b: Number.parseInt(full.slice(5, 7), 16),
+      },
+      normalized: full,
+    };
+  }
+  const long = /^#([0-9a-f]{6})$/.exec(cleaned);
+  if (long) {
+    return {
+      rgb: {
+        r: Number.parseInt(cleaned.slice(1, 3), 16),
+        g: Number.parseInt(cleaned.slice(3, 5), 16),
+        b: Number.parseInt(cleaned.slice(5, 7), 16),
+      },
+      normalized: cleaned,
+    };
+  }
+  return null;
+}
+
+// converts a single 8-bit channel to its WCAG linearized value
+function linearizeChannel(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+// computes WCAG 2.1 relative luminance for an sRGB color
+function relativeLuminance({ r, g, b }: Rgb): number {
+  return (
+    0.2126 * linearizeChannel(r) +
+    0.7152 * linearizeChannel(g) +
+    0.0722 * linearizeChannel(b)
+  );
+}
+
+// formats a contrast ratio as "X.XX:1", dropping decimals when exact
+function formatRatio(ratio: number): string {
+  const rounded = Math.round(ratio * 100) / 100;
+  return `${rounded % 1 === 0 ? rounded.toFixed(0) : rounded}:1`;
+}
+
+export const OnColorBoxSource = {
+  defaultDisabled: true,
+  name: 'Readable Text Color',
+  description:
+    'Given a background hex color, pick the readable foreground (black or white) and the WCAG contrast.',
+  defaultInput: '#3498db ::oncolor',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'oncolor', 'textcolor')) return [];
+
+    const raw = trim(input).slice(0, MAX_HEX_INPUT);
+    const parsed = parseHex(raw);
+
+    if (!parsed) {
+      const errorText = 'A valid hex color is required (e.g. #3498db or #fff)';
+      return [
+        new BoxBuilder('Readable Text Color', errorText)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: errorText })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { rgb, normalized } = parsed;
+    const L = relativeLuminance(rgb);
+
+    // WCAG contrast ratio: (lighter + 0.05) / (darker + 0.05)
+    const blackRatio = (L + 0.05) / 0.05;
+    const whiteRatio = 1.05 / (L + 0.05);
+
+    const foreground = blackRatio >= whiteRatio ? '#000000' : '#ffffff';
+    const ratio = Math.max(blackRatio, whiteRatio);
+    const contrastStr = formatRatio(ratio);
+    const wcagAA = ratio >= 4.5 ? 'pass' : 'fail';
+    const wcagAAA = ratio >= 7 ? 'pass' : 'fail';
+
+    const kvOptions: Record<string, string> = {
+      Background: normalized,
+      Foreground: foreground,
+      Contrast: contrastStr,
+      'WCAG AA': wcagAA,
+      'WCAG AAA': wcagAAA,
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Readable Text Color', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default OnColorBoxSource;

--- a/src/modules/boxSources/__test__/OnColorBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/OnColorBoxSource.test.ts
@@ -1,0 +1,222 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { OnColorBoxSource } from '../OnColorBoxSource';
+
+describe('OnColorBoxSource', () => {
+  describe('guard conditions', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when an unrelated option is set', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('white background (#ffffff)', () => {
+    it('produces one box', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('foreground is black (#000000) because black has higher contrast on white', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Foreground).toBe('#000000');
+    });
+
+    it('contrast is 21:1 (maximum possible)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Contrast).toBe('21:1');
+    });
+
+    it('WCAG AA and AAA both pass', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['WCAG AA']).toBe('pass');
+      expect(opts['WCAG AAA']).toBe('pass');
+    });
+
+    it('background is normalized to #ffffff', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Background).toBe('#ffffff');
+    });
+  });
+
+  describe('black background (#000000)', () => {
+    it('foreground is white (#ffffff)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#000000', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Foreground).toBe('#ffffff');
+    });
+
+    it('contrast is 21:1', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#000000', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Contrast).toBe('21:1');
+    });
+  });
+
+  describe('mid blue (#3498db)', () => {
+    // luminance ~0.283; vs black ~6.66, vs white ~3.15 → black wins
+    it('foreground is #000000 (black has higher contrast)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#3498db', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Foreground).toBe('#000000');
+    });
+
+    it('contrast matches the higher ratio (black wins at ~6.66:1)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#3498db', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Contrast).toBe('6.66:1');
+    });
+
+    it('WCAG AA passes (>= 4.5), WCAG AAA fails (< 7)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#3498db', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['WCAG AA']).toBe('pass');
+      expect(opts['WCAG AAA']).toBe('fail');
+    });
+  });
+
+  describe('mid grey (#777777)', () => {
+    // luminance ~0.184; vs black ~4.69, vs white ~4.48 → black wins narrowly
+    it('produces a valid foreground (black or white)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#777777', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(['#000000', '#ffffff']).toContain(opts.Foreground);
+    });
+
+    it('contrast equals the higher of the two ratios', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#777777', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // expected: black wins at ~4.69:1
+      expect(opts.Contrast).toBe('4.69:1');
+    });
+  });
+
+  describe('invalid color input', () => {
+    it('xyz triggers an error box (not empty array)', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('xyz', {
+        oncolor: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('error box mentions that a hex color is required', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('xyz', {
+        oncolor: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text.toLowerCase()).toMatch(/hex color/);
+    });
+
+    it('bare color name without hash returns an error box', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('red', {
+        oncolor: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('shorthand hex (#fff)', () => {
+    it('expands #fff to #ffffff and picks black foreground', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#fff', {
+        oncolor: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Background).toBe('#ffffff');
+      expect(opts.Foreground).toBe('#000000');
+      expect(opts.Contrast).toBe('21:1');
+    });
+  });
+
+  describe('::textcolor alias', () => {
+    it('triggers with ::textcolor option', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        textcolor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Foreground).toBe('#000000');
+    });
+  });
+
+  describe('box shape', () => {
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('box name is "Readable Text Color"', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      expect(boxes[0].props.name).toBe('Readable Text Color');
+    });
+
+    it('plaintext output contains k:v lines', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Background: #ffffff');
+      expect(text).toContain('Foreground: #000000');
+      expect(text).toContain('Contrast: 21:1');
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await OnColorBoxSource.generateBoxes('#ffffff', {
+        oncolor: true,
+      });
+      expect(boxes[0].props.priority).toBe(OnColorBoxSource.priority);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(OnColorBoxSource.name).toBe('Readable Text Color');
+      expect(OnColorBoxSource.tag).toBe('#');
+      expect(OnColorBoxSource.kind).toBe('Analyze');
+      expect(typeof OnColorBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -25,6 +25,7 @@ import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import OnColorBoxSource from './OnColorBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  OnColorBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Readable Text Color (Analyze)

Adds the `Readable Text Color` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `#3498db ::oncolor`

#### Options:
- `::oncolor`, `::textcolor`

#### Description:
Given a background hex color, pick the readable foreground (black or white) and the WCAG contrast.

#### Usage Examples:
- **Input**:
```
#3498db
::oncolor
```
- **Output Box (`Readable Text Color`)**:
```
Background: #3498db
Foreground: #000000
Contrast: 6.66:1
WCAG AA: pass
WCAG AAA: fail
```
