### PR TITLE
feat(Ordinal): add Ordinal BoxSource

### DIFF
--- a/src/modules/boxSources/OrdinalBoxSource.ts
+++ b/src/modules/boxSources/OrdinalBoxSource.ts
@@ -1,0 +1,61 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+/** returns the English ordinal suffix for a non-negative integer string */
+function ordinalSuffix(n: number): string {
+  const abs = Math.abs(n);
+  const lastTwo = abs % 100;
+  if (lastTwo >= 11 && lastTwo <= 13) return 'th';
+  switch (abs % 10) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+}
+
+export const OrdinalBoxSource = {
+  defaultDisabled: true,
+  name: 'Ordinal',
+  description: 'Convert an integer to its ordinal form (e.g. 21 → 21st).',
+  defaultInput: '21 ::ordinal',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ordinal')) return [];
+
+    const raw = trim(input);
+    // optional sign + up to 15 digits (stays within Number.MAX_SAFE_INTEGER, so
+    // parseInt doesn't round and the displayed value matches the input)
+    if (!/^-?\d{1,15}$/.test(raw)) return [];
+
+    const n = Number.parseInt(raw, 10);
+    if (Number.isNaN(n)) return [];
+
+    const suffix = ordinalSuffix(n);
+    const ordinal = `${n}${suffix}`;
+
+    return [
+      new BoxBuilder('Ordinal', '')
+        .setOptions({ Ordinal: ordinal, Suffix: suffix })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default OrdinalBoxSource;

--- a/src/modules/boxSources/__test__/OrdinalBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/OrdinalBoxSource.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import { OrdinalBoxSource } from '../OrdinalBoxSource';
+
+describe('OrdinalBoxSource', () => {
+  describe('gate conditions', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when options object lacks ordinal key', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for non-numeric input', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('abc', {
+        ordinal: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for input exceeding 16 digits', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('12345678901234567', {
+        ordinal: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('ordinal output', () => {
+    it('converts 21 to 21st', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', {
+        ordinal: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Ordinal).toBe('21st');
+      expect(boxes[0].props.options?.Suffix).toBe('st');
+    });
+
+    it('converts 1 to 1st', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('1', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('1st');
+      expect(boxes[0].props.options?.Suffix).toBe('st');
+    });
+
+    it('converts 2 to 2nd', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('2', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('2nd');
+      expect(boxes[0].props.options?.Suffix).toBe('nd');
+    });
+
+    it('converts 3 to 3rd', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('3', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('3rd');
+      expect(boxes[0].props.options?.Suffix).toBe('rd');
+    });
+
+    it('converts 4 to 4th', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('4', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('4th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+
+    it('converts 0 to 0th', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('0', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('0th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+  });
+
+  describe('teen exceptions (11–13 always use th)', () => {
+    it('converts 11 to 11th', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('11', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('11th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+
+    it('converts 12 to 12th', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('12', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('12th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+
+    it('converts 13 to 13th', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('13', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('13th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+
+    it('converts 111 to 111th (last two digits 11)', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('111', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('111th');
+      expect(boxes[0].props.options?.Suffix).toBe('th');
+    });
+
+    it('converts 101 to 101st (last two digits 01, not a teen)', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('101', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('101st');
+      expect(boxes[0].props.options?.Suffix).toBe('st');
+    });
+
+    it('converts 22 to 22nd', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('22', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.options?.Ordinal).toBe('22nd');
+      expect(boxes[0].props.options?.Suffix).toBe('nd');
+    });
+  });
+
+  describe('box structure', () => {
+    it('returns exactly one box', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', {
+        ordinal: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('box name is Ordinal', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.name).toBe('Ordinal');
+    });
+
+    it('box priority matches source priority', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('21', {
+        ordinal: true,
+      });
+      expect(boxes[0].props.priority).toBe(OrdinalBoxSource.priority);
+    });
+
+    it('rejects 16-digit input beyond MAX_SAFE_INTEGER (float would round)', async () => {
+      const boxes = await OrdinalBoxSource.generateBoxes('9999999999999991', {
+        ordinal: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -22,6 +22,7 @@ import LineToolsBoxSource from './LineToolsBoxSource';
 import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
+import OrdinalBoxSource from './OrdinalBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  OrdinalBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Ordinal (Convert)

Adds the `Ordinal` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `21 ::ordinal`

#### Options:
- `::ordinal`

#### Description:
Convert an integer to its ordinal form (e.g. 21 → 21st).

#### Usage Examples:
- **Input**:
```
21
::ordinal
```
- **Output Box (`Ordinal`)**:
```

```
