### PR TITLE
feat(Pbkdf2): add PBKDF2 BoxSource

### DIFF
--- a/src/modules/boxSources/Pbkdf2BoxSource.ts
+++ b/src/modules/boxSources/Pbkdf2BoxSource.ts
@@ -1,0 +1,152 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max iterations capped to prevent UI freezes from absurdly large values
+const MAX_ITERATIONS = 1_000_000;
+const DEFAULT_ITERATIONS = 100_000;
+const DEFAULT_DKLEN = 32;
+const MAX_DKLEN = 256;
+
+function bufToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// clamp a numeric value within [min, max], falling back to fallback when non-numeric
+function clampNumericOption(
+  raw: string | boolean | null,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (typeof raw !== 'string') return fallback;
+  const n = parseInt(raw, 10);
+  if (Number.isNaN(n)) return fallback;
+  return Math.min(Math.max(n, min), max);
+}
+
+// converts a key-value record to a human-readable plaintext listing
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const Pbkdf2BoxSource = {
+  defaultDisabled: true,
+  name: 'PBKDF2',
+  description:
+    'Derive key bits from a password via PBKDF2 (HMAC-SHA256). Input is the salt; ::pbkdf2=<password>. Options ::iterations=<n>, ::dklen=<bytes>.',
+  defaultInput: 'salt ::pbkdf2=password',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const password = extractOptionKeys(options, 'pbkdf2');
+
+    // no ::pbkdf2 option at all — not our trigger
+    if (password === null) return [];
+
+    // bare ::pbkdf2 without a value — show usage hint
+    if (typeof password !== 'string') {
+      return [
+        new BoxBuilder('PBKDF2', 'provide a password, e.g. ::pbkdf2=secret')
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // guard against non-secure contexts where crypto.subtle is unavailable
+    if (typeof crypto === 'undefined' || !crypto?.subtle) {
+      return [
+        new BoxBuilder(
+          'PBKDF2',
+          'PBKDF2 requires a secure context (HTTPS). crypto.subtle is not available.',
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const iterationsRaw = extractOptionKeys(options, 'iterations');
+    const dklenRaw = extractOptionKeys(options, 'dklen');
+
+    const iterations = clampNumericOption(
+      iterationsRaw,
+      DEFAULT_ITERATIONS,
+      1,
+      MAX_ITERATIONS,
+    );
+    const dklen = clampNumericOption(dklenRaw, DEFAULT_DKLEN, 1, MAX_DKLEN);
+
+    const encoder = new TextEncoder();
+    const passwordBytes = encoder.encode(password);
+    const saltBytes = encoder.encode(input);
+
+    try {
+      const baseKey = await crypto.subtle.importKey(
+        'raw',
+        passwordBytes,
+        'PBKDF2',
+        false,
+        ['deriveBits'],
+      );
+
+      const derivedBits = await crypto.subtle.deriveBits(
+        {
+          name: 'PBKDF2',
+          salt: saltBytes,
+          iterations,
+          hash: 'SHA-256',
+        },
+        baseKey,
+        dklen * 8,
+      );
+
+      const hexKey = bufToHex(derivedBits);
+
+      // password is intentionally excluded from the output — it's a secret
+      const kv: Record<string, string> = {
+        'Derived Key (hex)': hexKey,
+        Salt: input,
+        Iterations: String(iterations),
+        'Key Length (bytes)': String(dklen),
+        Hash: 'SHA-256',
+      };
+
+      return [
+        new BoxBuilder('PBKDF2', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return [
+        new BoxBuilder('PBKDF2', `Key derivation failed: ${message}`)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+  },
+};
+
+export default Pbkdf2BoxSource;

--- a/src/modules/boxSources/__test__/Pbkdf2BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Pbkdf2BoxSource.test.ts
@@ -1,0 +1,162 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Pbkdf2BoxSource } from '../Pbkdf2BoxSource';
+
+describe('Pbkdf2BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - bare ::pbkdf2 (no password value)', () => {
+    it('returns a usage hint box when ::pbkdf2 is boolean true', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/provide a password/i);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+
+  describe('generateBoxes - PBKDF2-HMAC-SHA256 known vectors', () => {
+    // RFC 6070 test vectors translated to SHA-256 (SHA-256 canonical vectors)
+    it('derives correct key for password=password, salt=salt, c=1, dklen=32', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+        iterations: '1',
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Derived Key (hex)']).toBe(
+        '120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b',
+      );
+      expect(opts.Salt).toBe('salt');
+      expect(opts.Iterations).toBe('1');
+      expect(opts['Key Length (bytes)']).toBe('32');
+      expect(opts.Hash).toBe('SHA-256');
+    });
+
+    it('derives correct key for password=password, salt=salt, c=2, dklen=32', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+        iterations: '2',
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Derived Key (hex)']).toBe(
+        'ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43',
+      );
+    });
+
+    it('custom dklen=16 returns first 16 bytes of c=1 vector', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+        iterations: '1',
+        dklen: '16',
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // first 32 hex chars = 16 bytes
+      expect(opts['Derived Key (hex)']).toBe(
+        '120fb6cffcf8b32c43e7225256c4f837',
+      );
+      expect(opts['Key Length (bytes)']).toBe('16');
+    });
+  });
+
+  describe('generateBoxes - password redaction', () => {
+    it('does not echo the password in plaintextOutput', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+        iterations: '1',
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).not.toContain('password');
+    });
+
+    it('does not include the password in options', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+        iterations: '1',
+      });
+
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      // none of the option values should be the literal password string
+      const values = Object.values(opts);
+      expect(values).not.toContain('password');
+      // the option key 'pbkdf2' must not be present in output options
+      expect(Object.keys(opts)).not.toContain('pbkdf2');
+    });
+  });
+
+  describe('generateBoxes - non-secure context fallback', () => {
+    const originalCrypto = globalThis.crypto;
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: { subtle: undefined },
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+        writable: true,
+      });
+    });
+
+    it('returns an informational box when crypto.subtle is unavailable', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/secure context/i);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+
+  describe('generateBoxes - default iterations and dklen', () => {
+    it('uses default iterations=100000 and dklen=32 when not specified', async () => {
+      const boxes = await Pbkdf2BoxSource.generateBoxes('salt', {
+        pbkdf2: 'password',
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Iterations).toBe('100000');
+      expect(opts['Key Length (bytes)']).toBe('32');
+      // derived key should be 64 hex chars (32 bytes)
+      expect(opts['Derived Key (hex)']).toHaveLength(64);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Pbkdf2BoxSource.name).toBe('PBKDF2');
+      expect(Pbkdf2BoxSource.tag).toBe('#');
+      expect(Pbkdf2BoxSource.kind).toBe('Encode');
+      expect(typeof Pbkdf2BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -26,6 +26,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import Pbkdf2BoxSource from './Pbkdf2BoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  Pbkdf2BoxSource,
 ];


### PR DESCRIPTION
### Box Source: PBKDF2 (Encode)

Adds the `PBKDF2` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `salt ::pbkdf2=password`

#### Options:
- None

#### Description:
Derive key bits from a password via PBKDF2 (HMAC-SHA256). Input is the salt; ::pbkdf2=<password>. Options ::iterations=<n>, ::dklen=<bytes>.

#### Usage Examples:
- **Input**:
```
salt
::pbkdf2=password
```
- **Output Box (`PBKDF2`)**:
```
Derived Key (hex): 0394a2ede332c9a13eb82e9b24631604c31df978b4e2f0fbd2c549944f9d79a5
Salt: salt
Iterations: 100000
Key Length (bytes): 32
Hash: SHA-256
```
