### PR TITLE
feat(PercentChange): add Percent Change BoxSource

### DIFF
--- a/src/modules/boxSources/PercentChangeBoxSource.ts
+++ b/src/modules/boxSources/PercentChangeBoxSource.ts
@@ -1,0 +1,117 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to prevent abuse
+const MAX_INPUT_LENGTH = 100;
+
+// builds the plaintext kv string for KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// formats a number to at most 4 decimal places, stripping trailing zeros
+function formatNumber(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(4).replace(/\.?0+$/, '');
+}
+
+interface ParsedPair {
+  a: number;
+  b: number;
+}
+
+// parses two numbers from input separated by ' to ', comma, or whitespace
+function parsePair(raw: string): ParsedPair | null {
+  // split on ' to ', comma, or one-or-more whitespace characters
+  const parts = raw
+    .split(/\s+to\s+|,\s*|\s+/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  if (parts.length !== 2) return null;
+
+  const a = Number.parseFloat(parts[0]);
+  const b = Number.parseFloat(parts[1]);
+
+  if (Number.isNaN(a) || Number.isNaN(b)) return null;
+
+  return { a, b };
+}
+
+export const PercentChangeBoxSource = {
+  defaultDisabled: true,
+  name: 'Percent Change',
+  description:
+    'Percentage change between two numbers. Input: "<from> to <to>" or "<from> <to>".',
+  defaultInput: '120 to 150 ::pctchange',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'pctchange', 'percentchange')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > MAX_INPUT_LENGTH) return [];
+
+    const pair = parsePair(raw);
+
+    if (pair === null) {
+      const kv = {
+        Usage: 'Enter two numbers: "120 to 150", "120,150", or "120 150"',
+      };
+      return [
+        new BoxBuilder('Percent Change', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { a, b } = pair;
+
+    const change = b - a;
+
+    const percentChange = a === 0 ? null : ((b - a) / a) * 100;
+
+    const direction =
+      change > 0 ? 'increase' : change < 0 ? 'decrease' : 'no change';
+
+    const kv: Record<string, string> = {
+      From: formatNumber(a),
+      To: formatNumber(b),
+      Change: formatNumber(change),
+      'Percent Change':
+        percentChange === null
+          ? 'undefined (from is 0)'
+          : formatNumber(percentChange),
+      Direction: direction,
+      ...(a !== 0
+        ? {
+            Ratio: formatNumber(b / a),
+            Of: `${formatNumber((b / a) * 100)}%`,
+          }
+        : {}),
+    };
+
+    return [
+      new BoxBuilder('Percent Change', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PercentChangeBoxSource;

--- a/src/modules/boxSources/__test__/PercentChangeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PercentChangeBoxSource.test.ts
@@ -1,0 +1,202 @@
+import { expect } from 'vitest';
+
+import { PercentChangeBoxSource } from '../PercentChangeBoxSource';
+
+describe('PercentChangeBoxSource', () => {
+  const opts = (key: string) => ({ [key]: true });
+
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        null,
+      );
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes('120 to 150', {
+        qrcode: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+  });
+
+  describe('::pctchange trigger', () => {
+    it('120 to 150 → Change 30, Percent Change 25, Direction increase', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.From).toBe('120');
+      expect(kv.To).toBe('150');
+      expect(kv.Change).toBe('30');
+      expect(kv['Percent Change']).toBe('25');
+      expect(kv.Direction).toBe('increase');
+    });
+
+    it('150 to 120 → Change -30, Percent Change -20, Direction decrease', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '150 to 120',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Change).toBe('-30');
+      expect(kv['Percent Change']).toBe('-20');
+      expect(kv.Direction).toBe('decrease');
+    });
+
+    it('100 to 100 → Percent Change 0, Direction no change', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '100 to 100',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Percent Change']).toBe('0');
+      expect(kv.Direction).toBe('no change');
+    });
+
+    it('50 to 75 → Percent Change 50', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '50 to 75',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Percent Change']).toBe('50');
+    });
+
+    it('200 to 50 → Percent Change -75', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '200 to 50',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Percent Change']).toBe('-75');
+    });
+  });
+
+  describe('::percentchange alias', () => {
+    it('accepts ::percentchange option key', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        opts('percentchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Percent Change']).toBe('25');
+    });
+  });
+
+  describe('separator variants', () => {
+    it('comma separator "120,150" → same as "120 to 150"', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120,150',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Change).toBe('30');
+      expect(kv['Percent Change']).toBe('25');
+    });
+
+    it('space separator "120 150" → same as "120 to 150"', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 150',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Change).toBe('30');
+      expect(kv['Percent Change']).toBe('25');
+    });
+  });
+
+  describe('division by zero', () => {
+    it('0 to 5 → Percent Change contains "undefined"', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '0 to 5',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Percent Change']).toContain('undefined');
+    });
+
+    it('0 to 5 → no Ratio or Of keys', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '0 to 5',
+        opts('pctchange'),
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Ratio).toBeUndefined();
+      expect(kv.Of).toBeUndefined();
+    });
+  });
+
+  describe('invalid input', () => {
+    it('"hello" → returns a usage hint box', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        'hello',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Usage).toBeTruthy();
+    });
+
+    it('single number → returns a usage hint box', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '42',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Usage).toBeTruthy();
+    });
+
+    it('three numbers → returns a usage hint box', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '1 2 3',
+        opts('pctchange'),
+      );
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Usage).toBeTruthy();
+    });
+  });
+
+  describe('output shape', () => {
+    it('box name is "Percent Change"', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        opts('pctchange'),
+      );
+      expect(boxes[0].props.name).toBe('Percent Change');
+    });
+
+    it('box has Ratio and Of keys when from !== 0', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        opts('pctchange'),
+      );
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Ratio).toBeDefined();
+      expect(kv.Of).toBeDefined();
+    });
+
+    it('plaintextOutput contains key:value lines', async () => {
+      const boxes = await PercentChangeBoxSource.generateBoxes(
+        '120 to 150',
+        opts('pctchange'),
+      );
+      expect(boxes[0].props.plaintextOutput).toContain('Percent Change: 25');
+      expect(boxes[0].props.plaintextOutput).toContain('Change: 30');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PercentChangeBoxSource from './PercentChangeBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  PercentChangeBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Percent Change (Calculate)

Adds the `Percent Change` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `120 to 150 ::pctchange`

#### Options:
- `::pctchange`, `::percentchange`

#### Description:
Percentage change between two numbers. Input: "<from> to <to>" or "<from> <to>".

#### Usage Examples:
- **Input**:
```
120 to 150
::pctchange
```
- **Output Box (`Percent Change`)**:
```
From: 120
To: 150
Change: 30
Percent Change: 25
Direction: increase
Ratio: 1.25
Of: 125%
```
