### PR TITLE
feat(PercentEncode): add Percent Encode BoxSource

### DIFF
--- a/src/modules/boxSources/PercentEncodeBoxSource.ts
+++ b/src/modules/boxSources/PercentEncodeBoxSource.ts
@@ -1,0 +1,76 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// RFC 3986 sub-delimiters that encodeURIComponent leaves unescaped
+const escapeRfc3986Extras = (s: string): string =>
+  s.replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+
+export const PercentEncodeBoxSource = {
+  defaultDisabled: true,
+  name: 'Percent Encode',
+  description:
+    'Percent-encode a string for use in a URL (or decode it). ::percentencode / ::percentdecode.',
+  defaultInput: 'a b&c=日本 ::percentencode',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'percentencode', 'urlencode');
+    const wantDecode = hasOptionKeys(options, 'percentdecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    if (wantEncode) {
+      // encode as a URI component, then additionally escape RFC 3986 sub-delims
+      const encoded = escapeRfc3986Extras(encodeURIComponent(input));
+      return [
+        new BoxBuilder('Percent Encode', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(Priority)
+          .build(),
+      ];
+    }
+
+    // decode path: propagate URIError as a descriptive box
+    try {
+      const decoded = decodeURIComponent(input);
+      return [
+        new BoxBuilder('Percent Decode', decoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(Priority)
+          .build(),
+      ];
+    } catch (e) {
+      if (e instanceof URIError) {
+        return [
+          new BoxBuilder(
+            'Percent Decode',
+            'Invalid percent-encoding: the input contains malformed sequences.',
+          )
+            .setTemplate(DefaultBoxTemplate)
+            .setShowExpandButton(false)
+            .setPriority(Priority)
+            .build(),
+        ];
+      }
+      throw e;
+    }
+  },
+};
+
+export default PercentEncodeBoxSource;

--- a/src/modules/boxSources/__test__/PercentEncodeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PercentEncodeBoxSource.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import { PercentEncodeBoxSource } from '../PercentEncodeBoxSource';
+
+describe('PercentEncodeBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a b&c=', null);
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a b&c=', {
+        sha256: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+
+    it('returns [] for empty input even with option', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('', {
+        percentencode: true,
+      });
+      expect(boxes).toEqual([]);
+    });
+  });
+
+  describe('encode — ::percentencode', () => {
+    it('encodes spaces and special chars', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a b&c=', {
+        percentencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a%20b%26c%3D');
+    });
+
+    it('strictly escapes RFC 3986 sub-delims: ! ( ) * that encodeURIComponent misses', async () => {
+      // encodeURIComponent leaves ! ' ( ) * unescaped; we must escape them too
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a(b)*c!', {
+        percentencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a%28b%29%2Ac%21');
+    });
+
+    it("strictly escapes single-quote '", async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes("it's", {
+        percentencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('it%27s');
+    });
+
+    it('encodes unicode characters', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('日本', {
+        percentencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('%E6%97%A5%E6%9C%AC');
+    });
+
+    it('accepts ::urlencode alias', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a b', {
+        urlencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a%20b');
+    });
+
+    it('box name is "Percent Encode"', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('x', {
+        percentencode: true,
+      });
+      expect(boxes[0].props.name).toBe('Percent Encode');
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('x', {
+        percentencode: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('decode — ::percentdecode', () => {
+    it('decodes a percent-encoded string', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('a%20b%26c%3D', {
+        percentdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a b&c=');
+    });
+
+    it('returns a descriptive box on malformed input', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('%ZZ', {
+        percentdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(
+        /invalid percent-encoding/i,
+      );
+    });
+
+    it('box name is "Percent Decode"', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('hello', {
+        percentdecode: true,
+      });
+      expect(boxes[0].props.name).toBe('Percent Decode');
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await PercentEncodeBoxSource.generateBoxes('hello', {
+        percentdecode: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encodes then decodes back to the original', async () => {
+      const original = 'hello world! (test)';
+      const encoded = await PercentEncodeBoxSource.generateBoxes(original, {
+        percentencode: true,
+      });
+      const encodedStr = encoded[0].props.plaintextOutput;
+
+      const decoded = await PercentEncodeBoxSource.generateBoxes(encodedStr, {
+        percentdecode: true,
+      });
+      expect(decoded[0].props.plaintextOutput).toBe(original);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -26,6 +26,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PercentEncodeBoxSource from './PercentEncodeBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  PercentEncodeBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Percent Encode (Encode)

Adds the `Percent Encode` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `a b&c=日本 ::percentencode`

#### Options:
- `::percentdecode`, `::percentencode`, `::urlencode`

#### Description:
Percent-encode a string for use in a URL (or decode it). ::percentencode / ::percentdecode.

#### Usage Examples:
- **Input**:
```
a b&c=日本
::percentencode
```
- **Output Box (`Percent Encode`)**:
```
a%20b%26c%3D%E6%97%A5%E6%9C%AC
```
