### PR TITLE
feat(PigLatin): add Pig Latin BoxSource

### DIFF
--- a/src/modules/boxSources/PigLatinBoxSource.ts
+++ b/src/modules/boxSources/PigLatinBoxSource.ts
@@ -1,0 +1,87 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+const VOWELS = /[aeiou]/i;
+// matches a contiguous run of ASCII letters (a word token to transform)
+const WORD_RE = /[a-zA-Z]+/g;
+
+// moves the leading consonant cluster to the end and appends 'ay'.
+// 'y' is treated as a vowel only when it is not the first letter.
+function convertWord(word: string): string {
+  // words starting with a vowel get 'way' appended
+  if (VOWELS.test(word[0])) {
+    return `${word}way`;
+  }
+
+  // find the split index: first vowel, treating y as vowel after position 0
+  let splitAt = word.length; // fallback: all consonants (e.g. "rhythm" has y)
+  for (let i = 0; i < word.length; i++) {
+    const ch = word[i].toLowerCase();
+    if (VOWELS.test(ch) || (i > 0 && ch === 'y')) {
+      splitAt = i;
+      break;
+    }
+  }
+
+  const cluster = word.slice(0, splitAt);
+  const remainder = word.slice(splitAt);
+  return `${remainder}${cluster}ay`;
+}
+
+// preserves title-case: if the original started with an uppercase letter, capitalize
+// the result's first letter and lowercase the rest.
+function applyCase(original: string, converted: string): string {
+  if (original.length === 0 || converted.length === 0) return converted;
+  const firstOriginal = original[0];
+  if (firstOriginal >= 'A' && firstOriginal <= 'Z') {
+    return converted[0].toUpperCase() + converted.slice(1).toLowerCase();
+  }
+  return converted;
+}
+
+function toPigLatin(input: string): string {
+  return input.replace(WORD_RE, (word) => {
+    const converted = convertWord(word.toLowerCase());
+    return applyCase(word, converted);
+  });
+}
+
+export const PigLatinBoxSource = {
+  defaultDisabled: true,
+  name: 'Pig Latin',
+  description: 'Convert English text to Pig Latin.',
+  defaultInput: 'hello world ::piglatin',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'piglatin', 'piglatinencode')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const result = toPigLatin(input);
+
+    return [
+      new BoxBuilder('Pig Latin', result)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PigLatinBoxSource;

--- a/src/modules/boxSources/__test__/PigLatinBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PigLatinBoxSource.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { PigLatinBoxSource } from '../PigLatinBoxSource';
+
+describe('PigLatinBoxSource', () => {
+  describe('no option → empty', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('empty input → empty', () => {
+    it('returns [] when input is empty string', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when input is whitespace only', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('   ', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('consonant-start words', () => {
+    it("converts 'hello' → 'ellohay'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ellohay');
+    });
+
+    it("converts 'world' → 'orldway'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('world', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('orldway');
+    });
+  });
+
+  describe('vowel-start words', () => {
+    it("converts 'apple' → 'appleway'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('apple', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('appleway');
+    });
+  });
+
+  describe('sentence', () => {
+    it("converts 'hello world' → 'ellohay orldway'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello world', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ellohay orldway');
+    });
+  });
+
+  describe('capitalization', () => {
+    it("converts 'Hello' → 'Ellohay'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('Hello', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Ellohay');
+    });
+  });
+
+  describe('punctuation', () => {
+    it("keeps trailing punctuation in place: 'hello!' → 'ellohay!'", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello!', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ellohay!');
+    });
+  });
+
+  describe('y as vowel', () => {
+    it("converts 'rhythm' → 'ythmrhay' (y treated as vowel after position 0)", async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('rhythm', {
+        piglatin: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ythmrhay');
+    });
+  });
+
+  describe('piglatinencode alias', () => {
+    it('also triggers on ::piglatinencode option', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello', {
+        piglatinencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('ellohay');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('box has correct name', async () => {
+      const boxes = await PigLatinBoxSource.generateBoxes('hello world', {
+        piglatin: true,
+      });
+      expect(boxes[0].props.name).toBe('Pig Latin');
+    });
+  });
+
+  describe('static properties', () => {
+    it('has expected metadata', () => {
+      expect(PigLatinBoxSource.name).toBe('Pig Latin');
+      expect(PigLatinBoxSource.kind).toBe('Transform');
+      expect(typeof PigLatinBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PigLatinBoxSource from './PigLatinBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  PigLatinBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Pig Latin (Transform)

Adds the `Pig Latin` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `hello world ::piglatin`

#### Options:
- `::piglatin`, `::piglatinencode`

#### Description:
Convert English text to Pig Latin.

#### Usage Examples:
- **Input**:
```
hello world
::piglatin
```
- **Output Box (`Pig Latin`)**:
```
ellohay orldway
```
