### PR TITLE
feat(Polybius): add Polybius Square BoxSource

### DIFF
--- a/src/modules/boxSources/PolybiusBoxSource.ts
+++ b/src/modules/boxSources/PolybiusBoxSource.ts
@@ -1,0 +1,110 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// 5x5 grid, row-major; I and J share cell — J is excluded, mapped to I before lookup
+const SQUARE = 'ABCDEFGHIKLMNOPQRSTUVWXYZ'; // 25 chars, no 'J'
+
+/** encodes a single letter to its two-digit Polybius coordinate string */
+function encodeChar(ch: string): string {
+  const normalized = ch === 'J' ? 'I' : ch;
+  const idx = SQUARE.indexOf(normalized);
+  if (idx === -1) return '';
+  const row = Math.floor(idx / 5) + 1;
+  const col = (idx % 5) + 1;
+  return `${row}${col}`;
+}
+
+/** encodes plaintext to space-separated Polybius pairs, dropping non-letters */
+function encode(input: string): string {
+  const pairs: string[] = [];
+  for (const ch of input.toUpperCase()) {
+    const pair = encodeChar(ch);
+    if (pair !== '') {
+      pairs.push(pair);
+    }
+  }
+  return pairs.join(' ');
+}
+
+/** decodes space-separated Polybius pairs back to uppercase letters; invalid pair → '?' */
+function decode(input: string): string {
+  const tokens = input.trim().split(/\s+/);
+  return tokens
+    .map((token) => {
+      if (token.length !== 2) return '?';
+      const row = Number.parseInt(token[0], 10);
+      const col = Number.parseInt(token[1], 10);
+      if (
+        Number.isNaN(row) ||
+        Number.isNaN(col) ||
+        row < 1 ||
+        row > 5 ||
+        col < 1 ||
+        col > 5
+      ) {
+        return '?';
+      }
+      const idx = (row - 1) * 5 + (col - 1);
+      return SQUARE[idx] ?? '?';
+    })
+    .join('');
+}
+
+export const PolybiusBoxSource = {
+  defaultDisabled: true,
+  name: 'Polybius Square',
+  description:
+    'Polybius square cipher (5x5, I/J combined). ::polybius to encode; ::polybiusdecode to decode.',
+  defaultInput: 'HELLO ::polybius',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(options, 'polybius', 'polybiusencode');
+    const wantDecode = hasOptionKeys(options, 'polybiusdecode');
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = encode(input);
+      boxes.push(
+        new BoxBuilder('Polybius Square (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decode(input);
+      boxes.push(
+        new BoxBuilder('Polybius Square (Decode)', decoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default PolybiusBoxSource;

--- a/src/modules/boxSources/__test__/PolybiusBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PolybiusBoxSource.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import { PolybiusBoxSource } from '../PolybiusBoxSource';
+
+describe('PolybiusBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(PolybiusBoxSource.name).toBe('Polybius Square');
+      expect(PolybiusBoxSource.tag).toBe('#');
+      expect(PolybiusBoxSource.kind).toBe('Encode');
+      expect(typeof PolybiusBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes — option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::polybius', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('   ', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes — encode', () => {
+    it('encodes HELLO correctly via ::polybius', async () => {
+      // H=idx7→23, E=idx4→15, L=idx10→31, L→31, O=idx13→34 (J removed)
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Polybius Square (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('23 15 31 31 34');
+    });
+
+    it('encodes HELLO correctly via ::polybiusencode', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {
+        polybiusencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('23 15 31 31 34');
+    });
+
+    it('maps J to I before encoding (JUMP)', async () => {
+      // J→I=idx8→24, U=idx19→45, M=idx11→32, P=idx14→35
+      const boxes = await PolybiusBoxSource.generateBoxes('JUMP', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('24 45 32 35');
+    });
+
+    it('handles lowercase input by uppercasing', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('hello', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('23 15 31 31 34');
+    });
+
+    it('drops non-letter characters', async () => {
+      // only letters are encoded; spaces and punctuation are dropped
+      const boxes = await PolybiusBoxSource.generateBoxes('HI!', {
+        polybius: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // H=23, I=24
+      expect(boxes[0].props.plaintextOutput).toBe('23 24');
+    });
+  });
+
+  describe('generateBoxes — decode', () => {
+    it('decodes "23 15 31 31 34" back to HELLO', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('23 15 31 31 34', {
+        polybiusdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Polybius Square (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('HELLO');
+    });
+
+    it('returns ? for invalid pairs', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('99 00', {
+        polybiusdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('??');
+    });
+  });
+
+  describe('generateBoxes — round-trip', () => {
+    it('round-trips POLYBIUS through encode then decode', async () => {
+      const [encBox] = await PolybiusBoxSource.generateBoxes('POLYBIUS', {
+        polybius: true,
+      });
+      const encoded = encBox.props.plaintextOutput;
+
+      const [decBox] = await PolybiusBoxSource.generateBoxes(encoded, {
+        polybiusdecode: true,
+      });
+      // note: B→I path: no J in POLYBIUS, so round-trip is lossless
+      expect(decBox.props.plaintextOutput).toBe('POLYBIUS');
+    });
+  });
+
+  describe('generateBoxes — both options produce two boxes', () => {
+    it('returns 2 boxes when both ::polybius and ::polybiusdecode are set', async () => {
+      // input is valid for encode; decode of "HELLO" treats each char as a token → '?????'
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {
+        polybius: true,
+        polybiusdecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0].props.name).toBe('Polybius Square (Encode)');
+      expect(boxes[1].props.name).toBe('Polybius Square (Decode)');
+    });
+  });
+
+  describe('generateBoxes — showExpandButton', () => {
+    it('sets showExpandButton to false on encode box', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('HELLO', {
+        polybius: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('sets showExpandButton to false on decode box', async () => {
+      const boxes = await PolybiusBoxSource.generateBoxes('23 15 31 31 34', {
+        polybiusdecode: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PolybiusBoxSource from './PolybiusBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  PolybiusBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Polybius Square (Encode)

Adds the `Polybius Square` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `HELLO ::polybius`

#### Options:
- `::polybius`, `::polybiusdecode`, `::polybiusencode`

#### Description:
Polybius square cipher (5x5, I/J combined). ::polybius to encode; ::polybiusdecode to decode.

#### Usage Examples:
- **Input**:
```
HELLO
::polybius
```
- **Output Box (`Polybius Square (Encode)`)**:
```
23 15 31 31 34
```
