### PR TITLE
feat(Popcount): add Popcount BoxSource

### DIFF
--- a/src/modules/boxSources/PopcountBoxSource.ts
+++ b/src/modules/boxSources/PopcountBoxSource.ts
@@ -1,0 +1,136 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// maximum input string length to accept (guards against pathological inputs)
+const MAX_INPUT_LEN = 5000;
+
+// count set bits via iterative bit-scan (BigInt safe, no overflow)
+function popcount(n: bigint): bigint {
+  let count = 0n;
+  let v = n;
+  while (v > 0n) {
+    count += v & 1n;
+    v >>= 1n;
+  }
+  return count;
+}
+
+// number of trailing zero bits; defined as 0 for the value 0
+function trailingZeros(n: bigint): bigint {
+  if (n === 0n) return 0n;
+  let count = 0n;
+  let v = n;
+  while ((v & 1n) === 0n) {
+    count++;
+    v >>= 1n;
+  }
+  return count;
+}
+
+// position of the highest set bit (bit length); 0 for the value 0
+function bitLength(n: bigint): number {
+  if (n === 0n) return 0;
+  return n.toString(2).length;
+}
+
+// render k:v pairs as a plaintext string for plaintextOutput
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const PopcountBoxSource = {
+  defaultDisabled: true,
+  name: 'Popcount',
+  description:
+    'Count set bits (population count) and bit length of a non-negative integer.',
+  defaultInput: '255 ::popcount',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'popcount', 'bitcount')) return [];
+
+    const raw = trim(input);
+
+    // guard against unreasonably large strings
+    if (raw.length > MAX_INPUT_LEN) {
+      const kv = { Error: 'Input too long (max 5000 chars).' };
+      return [
+        new BoxBuilder('Popcount', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // accept decimal, 0x hex, or 0b binary — all non-negative
+    const isDecimal = /^\d+$/.test(raw);
+    const isHex = /^0x[0-9a-f]+$/i.test(raw);
+    const isBinary = /^0b[01]+$/i.test(raw);
+
+    if (!isDecimal && !isHex && !isBinary) {
+      const kv = {
+        Error:
+          'A non-negative integer (decimal, 0x hex, or 0b binary) is required.',
+      };
+      return [
+        new BoxBuilder('Popcount', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    let n: bigint;
+    try {
+      n = BigInt(raw);
+    } catch {
+      const kv = {
+        Error:
+          'A non-negative integer (decimal, 0x hex, or 0b binary) is required.',
+      };
+      return [
+        new BoxBuilder('Popcount', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const setBits = popcount(n);
+    const bitLen = bitLength(n);
+    const trailing = trailingZeros(n);
+
+    const kv: Record<string, string> = {
+      Decimal: n.toString(10),
+      Binary: `0b${n.toString(2)}`,
+      Hex: `0x${n.toString(16)}`,
+      'Set Bits': setBits.toString(),
+      'Bit Length': bitLen.toString(),
+      'Trailing Zeros': trailing.toString(),
+    };
+
+    return [
+      new BoxBuilder('Popcount', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PopcountBoxSource;

--- a/src/modules/boxSources/__test__/PopcountBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PopcountBoxSource.test.ts
@@ -1,0 +1,251 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { PopcountBoxSource } from '../PopcountBoxSource';
+
+describe('PopcountBoxSource', () => {
+  describe('option gate', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::popcount option', () => {
+    it('activates on ::popcount', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('activates on ::bitcount', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        bitcount: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('255 (0xff = 11111111)', () => {
+    it('has Set Bits = 8', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('8');
+    });
+
+    it('has Bit Length = 8', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Bit Length']).toBe('8');
+    });
+
+    it('has Trailing Zeros = 0', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('0');
+    });
+
+    it('has correct Decimal, Binary, Hex fields', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      const opts = boxes[0].props.options;
+      expect(opts?.Decimal).toBe('255');
+      expect(opts?.Binary).toBe('0b11111111');
+      expect(opts?.Hex).toBe('0xff');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('255', {
+        popcount: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+
+  describe('0 edge case', () => {
+    it('has Set Bits = 0', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('0');
+    });
+
+    it('has Bit Length = 0', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Bit Length']).toBe('0');
+    });
+
+    it('has Trailing Zeros = 0', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('0');
+    });
+  });
+
+  describe('8 (0b1000)', () => {
+    it('has Set Bits = 1', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('8', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('1');
+    });
+
+    it('has Trailing Zeros = 3', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('8', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('3');
+    });
+  });
+
+  describe('hex input 0xff', () => {
+    it('has Set Bits = 8', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0xff', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('8');
+    });
+  });
+
+  describe('binary input 0b1010', () => {
+    it('has Set Bits = 2', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0b1010', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('2');
+    });
+
+    it('has Trailing Zeros = 1', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('0b1010', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('1');
+    });
+  });
+
+  describe('64-bit all-ones: 0xffffffffffffffff', () => {
+    it('has Set Bits = 64 (BigInt — no overflow)', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes(
+        '0xffffffffffffffff',
+        {
+          popcount: true,
+        },
+      );
+      expect(boxes[0].props.options?.['Set Bits']).toBe('64');
+    });
+
+    it('has Bit Length = 64', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes(
+        '0xffffffffffffffff',
+        {
+          popcount: true,
+        },
+      );
+      expect(boxes[0].props.options?.['Bit Length']).toBe('64');
+    });
+
+    it('has Trailing Zeros = 0', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes(
+        '0xffffffffffffffff',
+        {
+          popcount: true,
+        },
+      );
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('0');
+    });
+  });
+
+  describe('power of two: 1024 (0b10000000000)', () => {
+    it('has Set Bits = 1', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('1024', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Set Bits']).toBe('1');
+    });
+
+    it('has Bit Length = 11', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('1024', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Bit Length']).toBe('11');
+    });
+
+    it('has Trailing Zeros = 10', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('1024', {
+        popcount: true,
+      });
+      expect(boxes[0].props.options?.['Trailing Zeros']).toBe('10');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('returns an error box for "abc"', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('abc', {
+        popcount: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeTruthy();
+    });
+
+    it('returns an error box for "-5"', async () => {
+      // -5 starts with '-', not matched by decimal/hex/binary patterns → error box
+      const boxes = await PopcountBoxSource.generateBoxes('-5', {
+        popcount: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeTruthy();
+    });
+
+    it('returns an error box for empty string', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('', {
+        popcount: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeTruthy();
+    });
+  });
+
+  describe('box metadata', () => {
+    it('box name is Popcount', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('1', {
+        popcount: true,
+      });
+      expect(boxes[0].props.name).toBe('Popcount');
+    });
+
+    it('priority matches source priority', async () => {
+      const boxes = await PopcountBoxSource.generateBoxes('1', {
+        popcount: true,
+      });
+      expect(boxes[0].props.priority).toBe(PopcountBoxSource.priority);
+    });
+  });
+
+  describe('static metadata', () => {
+    it('has expected name, tag, kind', () => {
+      expect(PopcountBoxSource.name).toBe('Popcount');
+      expect(PopcountBoxSource.tag).toBe('#');
+      expect(PopcountBoxSource.kind).toBe('Calculate');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PopcountBoxSource from './PopcountBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  PopcountBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Popcount (Calculate)

Adds the `Popcount` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `255 ::popcount`

#### Options:
- `::bitcount`, `::popcount`

#### Description:
Count set bits (population count) and bit length of a non-negative integer.

#### Usage Examples:
- **Input**:
```
255
::popcount
```
- **Output Box (`Popcount`)**:
```
Decimal: 255
Binary: 0b11111111
Hex: 0xff
Set Bits: 8
Bit Length: 8
Trailing Zeros: 0
```
