### PR TITLE
feat(PortLookup): add FTP-DATA BoxSource

### DIFF
--- a/src/modules/boxSources/PortLookupBoxSource.ts
+++ b/src/modules/boxSources/PortLookupBoxSource.ts
@@ -1,0 +1,156 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// curated well-known ports (IANA / common). number -> {service, description}
+const PORTS: Record<number, { name: string; desc: string }> = {
+  20: { name: 'FTP-DATA', desc: 'File Transfer (data)' },
+  21: { name: 'FTP', desc: 'File Transfer (control)' },
+  22: { name: 'SSH', desc: 'Secure Shell' },
+  23: { name: 'Telnet', desc: 'Telnet' },
+  25: { name: 'SMTP', desc: 'Simple Mail Transfer' },
+  53: { name: 'DNS', desc: 'Domain Name System' },
+  67: { name: 'DHCP', desc: 'DHCP server' },
+  68: { name: 'DHCP', desc: 'DHCP client' },
+  80: { name: 'HTTP', desc: 'Hypertext Transfer' },
+  110: { name: 'POP3', desc: 'Post Office Protocol v3' },
+  123: { name: 'NTP', desc: 'Network Time Protocol' },
+  143: { name: 'IMAP', desc: 'Internet Message Access' },
+  161: { name: 'SNMP', desc: 'Simple Network Management' },
+  389: { name: 'LDAP', desc: 'Lightweight Directory Access' },
+  443: { name: 'HTTPS', desc: 'HTTP over TLS' },
+  445: { name: 'SMB', desc: 'Microsoft-DS / SMB' },
+  465: { name: 'SMTPS', desc: 'SMTP over TLS' },
+  587: { name: 'SMTP', desc: 'Mail submission' },
+  636: { name: 'LDAPS', desc: 'LDAP over TLS' },
+  993: { name: 'IMAPS', desc: 'IMAP over TLS' },
+  995: { name: 'POP3S', desc: 'POP3 over TLS' },
+  1433: { name: 'MSSQL', desc: 'Microsoft SQL Server' },
+  1521: { name: 'Oracle', desc: 'Oracle database' },
+  3306: { name: 'MySQL', desc: 'MySQL database' },
+  3389: { name: 'RDP', desc: 'Remote Desktop' },
+  5432: { name: 'PostgreSQL', desc: 'PostgreSQL database' },
+  5672: { name: 'AMQP', desc: 'RabbitMQ / AMQP' },
+  6379: { name: 'Redis', desc: 'Redis' },
+  8080: { name: 'HTTP-alt', desc: 'HTTP alternate' },
+  8443: { name: 'HTTPS-alt', desc: 'HTTPS alternate' },
+  9200: { name: 'Elasticsearch', desc: 'Elasticsearch' },
+  27017: { name: 'MongoDB', desc: 'MongoDB' },
+};
+
+// returns the IANA range label for a valid port number
+function portRange(n: number): string {
+  if (n <= 1023) return 'well-known';
+  if (n <= 49151) return 'registered';
+  return 'dynamic/private';
+}
+
+// builds the plaintext k:v representation used by KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const PortLookupBoxSource = {
+  defaultDisabled: true,
+  name: 'Port Lookup',
+  description: 'Look up a well-known port number or service name. ::port',
+  defaultInput: '443 ::port',
+  tag: '#',
+  kind: 'Decode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'port', 'portlookup')) return [];
+
+    const query = trim(input).slice(0, 32);
+
+    if (/^\d+$/.test(query)) {
+      // number → service lookup
+      const n = Number.parseInt(query, 10);
+
+      if (n < 0 || n > 65535) {
+        const kv: Record<string, string> = {
+          Port: query,
+          Service: 'invalid — out of range (0–65535)',
+          Description: '',
+          Range: 'n/a',
+        };
+        return [
+          new BoxBuilder('Port Lookup', kvToPlaintext(kv))
+            .setTemplate(KeyValueBoxTemplate)
+            .setOptions(kv)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+
+      const entry = PORTS[n];
+      const range = portRange(n);
+
+      const kv: Record<string, string> = entry
+        ? {
+            Port: String(n),
+            Service: entry.name,
+            Description: entry.desc,
+            Range: range,
+          }
+        : {
+            Port: String(n),
+            Service: 'unassigned / not a well-known port',
+            Description: '',
+            Range: range,
+          };
+
+      return [
+        new BoxBuilder('Port Lookup', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // name → port(s) lookup (case-insensitive)
+    const needle = query.toLowerCase();
+    const matches = Object.entries(PORTS)
+      .filter(([, v]) => v.name.toLowerCase() === needle)
+      .map(([port]) => port);
+
+    if (matches.length > 0) {
+      const kv: Record<string, string> = {
+        Service: query,
+        'Port(s)': matches.join(', '),
+      };
+      return [
+        new BoxBuilder('Port Lookup', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // no match found — return an informational box
+    const kv: Record<string, string> = {
+      Service: query,
+      'Port(s)': 'no match in well-known port table',
+    };
+    return [
+      new BoxBuilder('Port Lookup', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PortLookupBoxSource;

--- a/src/modules/boxSources/__test__/PortLookupBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PortLookupBoxSource.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import { PortLookupBoxSource } from '../PortLookupBoxSource';
+
+describe('PortLookupBoxSource', () => {
+  describe('option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('number → service lookup', () => {
+    it('443 resolves to HTTPS with TLS in description and well-known range', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toBe('HTTPS');
+      expect(opts.Description).toMatch(/TLS/i);
+      expect(opts.Range).toBe('well-known');
+      expect(opts.Port).toBe('443');
+    });
+
+    it('80 resolves to HTTP', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('80', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toBe('HTTP');
+      expect(opts.Range).toBe('well-known');
+    });
+
+    it('22 resolves to SSH', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('22', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toBe('SSH');
+    });
+
+    it('::portlookup alias also triggers lookup', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('22', {
+        portlookup: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toBe('SSH');
+    });
+
+    it('valid but unassigned port 12345 returns unassigned service and registered range', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('12345', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toMatch(/unassigned/i);
+      expect(opts.Range).toBe('registered');
+    });
+
+    it('out-of-range port 70000 returns an invalid box', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('70000', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Service).toMatch(/invalid|out of range/i);
+    });
+
+    it('dynamic/private range port 50000 shows correct range', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('50000', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Range).toBe('dynamic/private');
+    });
+  });
+
+  describe('name → port(s) lookup', () => {
+    it('"https" resolves to port 443', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('https', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Port(s)']).toContain('443');
+    });
+
+    it('"http" resolves to port 80', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('http', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Port(s)']).toContain('80');
+    });
+
+    it('"HTTPS" is case-insensitive and resolves to 443', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('HTTPS', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Port(s)']).toContain('443');
+    });
+
+    it('"hello!" returns a no-match box', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('hello!', {
+        port: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Port(s)']).toMatch(/no match/i);
+    });
+  });
+
+  describe('box structure', () => {
+    it('box is named "Port Lookup"', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', {
+        port: true,
+      });
+      expect(boxes[0].props.name).toBe('Port Lookup');
+    });
+
+    it('plaintextOutput contains key:value pairs', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', {
+        port: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('Service: HTTPS');
+    });
+
+    it('boxTemplate is set (KeyValueBoxTemplate)', async () => {
+      const boxes = await PortLookupBoxSource.generateBoxes('443', {
+        port: true,
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(PortLookupBoxSource.name).toBe('Port Lookup');
+      expect(PortLookupBoxSource.tag).toBe('#');
+      expect(PortLookupBoxSource.kind).toBe('Decode');
+      expect(typeof PortLookupBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -26,6 +26,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PortLookupBoxSource from './PortLookupBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  PortLookupBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Port Lookup (Decode)

Adds the `Port Lookup` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Decode`
- **Tag**: `#`
- **Default Input**: `443 ::port`

#### Options:
- `::port`, `::portlookup`

#### Description:
Look up a well-known port number or service name. ::port

#### Usage Examples:
- **Input**:
```
443
::port
```
- **Output Box (`Port Lookup`)**:
```
Port: 443
Service: HTTPS
Description: HTTP over TLS
Range: well-known
```
