### PR TITLE
feat(PowerConvert): add Power Convert BoxSource

### DIFF
--- a/src/modules/boxSources/PowerConvertBoxSource.ts
+++ b/src/modules/boxSources/PowerConvertBoxSource.ts
@@ -1,0 +1,120 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// watts per unit — used for all conversions via W as intermediate
+const TO_W: Record<string, number> = {
+  w: 1,
+  kw: 1000,
+  mw: 1e6,
+  hp: 745.6998715822702, // mechanical horsepower (NIST)
+  ps: 735.49875, // metric horsepower
+  'btu/h': 0.29307107017,
+  btuh: 0.29307107017,
+};
+
+// display labels for each output unit, in order
+const OUTPUT_UNITS: { key: string; label: string }[] = [
+  { key: 'w', label: 'W' },
+  { key: 'kw', label: 'kW' },
+  { key: 'mw', label: 'MW' },
+  { key: 'hp', label: 'hp' },
+  { key: 'ps', label: 'PS' },
+  { key: 'btu/h', label: 'BTU/h' },
+];
+
+// formats a converted value: exact integer if whole, else 6 decimal places stripped of trailing zeros
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// builds a plaintext "key: value" block suitable for headless rendering
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+const PARSE_RE = /^(-?\d+(?:\.\d+)?)\s*([a-zA-Z/]+)$/;
+const SUPPORTED_UNITS = 'W, kW, MW, hp, PS, BTU/h';
+
+export const PowerConvertBoxSource = {
+  defaultDisabled: true,
+  name: 'Power Convert',
+  description: `Convert power between ${SUPPORTED_UNITS}.`,
+  defaultInput: '100 hp ::power',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'power')) return [];
+
+    const raw = trim(input).slice(0, 64);
+    const match = PARSE_RE.exec(raw);
+
+    if (!match) {
+      // invalid — return a box listing supported units
+      const pairs = {
+        Error: 'Invalid format. Expected: <number> <unit>',
+        'Supported units': SUPPORTED_UNITS,
+      };
+      return [
+        new BoxBuilder('Power Convert', kvToPlaintext(pairs))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(pairs)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitKey = match[2].toLowerCase();
+    const factor = TO_W[unitKey];
+
+    if (factor === undefined) {
+      // unknown unit — return a box listing supported units
+      const pairs = {
+        Error: `Unknown unit: ${match[2]}`,
+        'Supported units': SUPPORTED_UNITS,
+      };
+      return [
+        new BoxBuilder('Power Convert', kvToPlaintext(pairs))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(pairs)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const watts = value * factor;
+
+    // build ordered key-value pairs for all output units + the original input
+    const kvPairs: Record<string, string> = {
+      Input: raw,
+    };
+
+    for (const { key, label } of OUTPUT_UNITS) {
+      kvPairs[label] = formatValue(watts / TO_W[key]);
+    }
+
+    const plaintext = kvToPlaintext(kvPairs);
+
+    return [
+      new BoxBuilder('Power Convert', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvPairs)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PowerConvertBoxSource;

--- a/src/modules/boxSources/__test__/PowerConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PowerConvertBoxSource.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { PowerConvertBoxSource } from '../PowerConvertBoxSource';
+
+describe('PowerConvertBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when ::power option is absent', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('100 hp', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options object has no power key', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('100 hp', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert 1 hp to correct watt value', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1 hp', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 mechanical hp = 745.6998715822702 W → rounded to 6 dp → 745.699872
+      expect(opts.W).toBe('745.699872');
+      expect(opts.kW).toBe('0.7457');
+    });
+
+    it('should convert 1000 W to exactly 1 kW', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1000 W', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.kW).toBe('1');
+    });
+
+    it('should convert 1 kW to correct hp value', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1 kW', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1000 / 745.6998715822702 = 1.341022...
+      expect(opts.hp).toBe('1.341022');
+    });
+
+    it('should convert 1 PS to correct watt value', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1 PS', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 1 PS = 735.49875 W (exact)
+      expect(opts.W).toBe('735.49875');
+    });
+
+    it('should include Input key in options', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1 hp', {
+        power: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('1 hp');
+    });
+
+    it('should return a box with supported units for fully invalid input', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('abc', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toContain('W');
+      expect(opts['Supported units']).toContain('hp');
+    });
+
+    it('should return a box with supported units for unknown unit', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('5 foo', {
+        power: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toContain('W');
+      expect(opts['Supported units']).toContain('PS');
+    });
+
+    it('should produce a non-empty plaintextOutput', async () => {
+      const boxes = await PowerConvertBoxSource.generateBoxes('1 hp', {
+        power: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toContain('W: 745.699872');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  PowerConvertBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Power Convert (Convert)

Adds the `Power Convert` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `100 hp ::power`

#### Options:
- `::power`

#### Description:
Convert power between W, kW, MW, hp, PS, BTU/h.

#### Usage Examples:
- **Input**:
```
100 hp
::power
```
- **Output Box (`Power Convert`)**:
```
Input: 100 hp
W: 74569.987158
kW: 74.569987
MW: 0.07457
hp: 100
PS: 101.386967
BTU/h: 254443.357766
```
