### PR TITLE
feat(PressureConvert): add Pressure Convert BoxSource

### DIFF
--- a/src/modules/boxSources/PressureConvertBoxSource.ts
+++ b/src/modules/boxSources/PressureConvertBoxSource.ts
@@ -1,0 +1,126 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 64;
+
+// unit -> pascals conversion factors
+const TO_PA: Record<string, number> = {
+  pa: 1,
+  kpa: 1000,
+  hpa: 100,
+  mpa: 1e6,
+  bar: 100000,
+  mbar: 100,
+  psi: 6894.757293168,
+  atm: 101325,
+  mmhg: 133.322387415,
+  torr: 101325 / 760,
+};
+
+// output unit labels in display order
+const OUTPUT_UNITS: Array<[string, string]> = [
+  ['Pa', 'pa'],
+  ['hPa', 'hpa'],
+  ['kPa', 'kpa'],
+  ['MPa', 'mpa'],
+  ['bar', 'bar'],
+  ['mbar', 'mbar'],
+  ['psi', 'psi'],
+  ['atm', 'atm'],
+  ['mmHg', 'mmhg'],
+  ['Torr', 'torr'],
+];
+
+// formats a number as integer when exact, otherwise rounds to 6 decimal places
+function formatValue(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return String(Number.parseFloat(n.toFixed(6)));
+}
+
+// build the plaintext representation of a key-value record
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+const PARSE_RE = /^(-?\d+(?:\.\d+)?)\s*([a-zA-Z]+)$/;
+
+const SUPPORTED_UNITS = Object.keys(TO_PA)
+  .map((u) => u.toUpperCase())
+  .join(', ');
+
+export const PressureConvertBoxSource = {
+  defaultDisabled: true,
+  name: 'Pressure Convert',
+  description:
+    'Convert a pressure between Pa, kPa, bar, psi, atm, mmHg, and Torr.',
+  defaultInput: '1 atm ::pressure',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'pressure')) return [];
+
+    const trimmed = trim(input).slice(0, MAX_INPUT);
+    const match = PARSE_RE.exec(trimmed);
+
+    if (!match) {
+      const kv = {
+        Note: `invalid format — use "<number> <unit>"`,
+        'Supported units': SUPPORTED_UNITS,
+      };
+      return [
+        new BoxBuilder('Pressure Convert', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = Number.parseFloat(match[1]);
+    const unitKey = match[2].toLowerCase();
+
+    if (!(unitKey in TO_PA)) {
+      const kv = {
+        Note: `unknown unit "${match[2]}"`,
+        'Supported units': SUPPORTED_UNITS,
+      };
+      return [
+        new BoxBuilder('Pressure Convert', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const pa = value * TO_PA[unitKey];
+
+    const kv: Record<string, string> = {
+      Input: trimmed,
+    };
+
+    for (const [label, key] of OUTPUT_UNITS) {
+      kv[label] = formatValue(pa / TO_PA[key]);
+    }
+
+    return [
+      new BoxBuilder('Pressure Convert', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PressureConvertBoxSource;

--- a/src/modules/boxSources/__test__/PressureConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PressureConvertBoxSource.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { PressureConvertBoxSource } from '../PressureConvertBoxSource';
+
+describe('PressureConvertBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when ::pressure option is absent', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes('1 atm', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when options is empty object (no pressure key)', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes('1 atm', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert 1 atm correctly', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes('1 atm', {
+        pressure: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Pa).toBe('101325');
+      expect(opts.kPa).toBe('101.325');
+      expect(opts.bar).toBe('1.01325');
+      // 101325 / 6894.757293168 ≈ 14.695949
+      expect(opts.psi).toBe('14.695949');
+      expect(opts.atm).toBe('1');
+      // mmHg uses NIST factor 133.322387415 Pa — not exactly 101325/760, so ≈ 759.999892
+      expect(opts.mmHg).toBe('759.999892');
+      // Torr is defined as exactly 101325/760 Pa, so 1 atm = 760 Torr exactly
+      expect(opts.Torr).toBe('760');
+    });
+
+    it('should convert 1 bar correctly', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes('1 bar', {
+        pressure: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Pa).toBe('100000');
+      expect(opts.kPa).toBe('100');
+    });
+
+    it('should convert 14.6959 psi close to 1 atm', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes(
+        '14.6959 psi',
+        {
+          pressure: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      // 14.6959 psi should yield atm ≈ 1 (within 0.01%)
+      const atm = Number.parseFloat(opts.atm);
+      expect(atm).toBeCloseTo(1, 3);
+    });
+
+    it('should convert 760 mmHg close to 1 atm', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes('760 mmHg', {
+        pressure: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.atm).toBe('1');
+    });
+
+    it('should handle uppercase unit (ATM)', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes('1 ATM', {
+        pressure: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Pa).toBe('101325');
+    });
+
+    it('should return an error box for completely invalid input', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes('abc', {
+        pressure: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toBeDefined();
+    });
+
+    it('should return an error box for unknown unit', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes('5 foo', {
+        pressure: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Supported units']).toBeDefined();
+    });
+
+    it('should include Input field in successful conversion', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes('1 atm', {
+        pressure: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Input).toBe('1 atm');
+    });
+
+    it('should set KeyValueBoxTemplate on the box', async () => {
+      const boxes = await PressureConvertBoxSource.generateBoxes('1 atm', {
+        pressure: true,
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PressureConvertBoxSource from './PressureConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  PressureConvertBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Pressure Convert (Convert)

Adds the `Pressure Convert` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `1 atm ::pressure`

#### Options:
- `::pressure`

#### Description:
Convert a pressure between Pa, kPa, bar, psi, atm, mmHg, and Torr.

#### Usage Examples:
- **Input**:
```
1 atm
::pressure
```
- **Output Box (`Pressure Convert`)**:
```
Input: 1 atm
Pa: 101325
hPa: 1013.25
kPa: 101.325
MPa: 0.101325
bar: 1.01325
mbar: 1013.25
psi: 14.695949
atm: 1
mmHg: 759.999892
Torr: 760
```
