### PR TITLE
feat(PrimeCheck): add Prime Check BoxSource

### DIFF
--- a/src/modules/boxSources/PrimeCheckBoxSource.ts
+++ b/src/modules/boxSources/PrimeCheckBoxSource.ts
@@ -1,0 +1,141 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// cap to prevent trial division from running too long: sqrt(10^13) ≈ 3.16e6 iterations
+// cap at 10^10: a single O(sqrt n) trial-division pass is ~100k iterations
+// (~1ms); next/prev-prime probe many candidates, so a higher cap risks a
+// multi-hundred-ms freeze on slower devices
+const MAX_VALUE = 10_000_000_000n;
+
+// bound the next/prev prime search to avoid indefinite scanning
+const MAX_PRIME_SEARCH_STEPS = 100_000n;
+
+// renders a key-value record as "key: value" lines for plaintext consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// trial division primality test using BigInt; correct for all n >= 0
+function isPrime(n: bigint): boolean {
+  if (n < 2n) return false;
+  if (n < 4n) return true;
+  if (n % 2n === 0n) return false;
+  for (let i = 3n; i * i <= n; i += 2n) {
+    if (n % i === 0n) return false;
+  }
+  return true;
+}
+
+// returns the smallest prime factor of n (n must be composite and >= 2)
+function smallestFactor(n: bigint): bigint {
+  if (n % 2n === 0n) return 2n;
+  for (let i = 3n; i * i <= n; i += 2n) {
+    if (n % i === 0n) return i;
+  }
+  // n is prime; caller is responsible for not reaching here
+  return n;
+}
+
+// finds the next prime strictly greater than n; returns null if search bound exceeded
+function nextPrime(n: bigint): bigint | null {
+  let candidate = n + 1n;
+  const limit = n + MAX_PRIME_SEARCH_STEPS;
+  while (candidate <= limit) {
+    if (isPrime(candidate)) return candidate;
+    candidate++;
+  }
+  return null;
+}
+
+// finds the largest prime strictly less than n; returns null if n <= 2 (none exists)
+function prevPrime(n: bigint): bigint | null {
+  if (n <= 2n) return null;
+  let candidate = n - 1n;
+  const limit = n > MAX_PRIME_SEARCH_STEPS ? n - MAX_PRIME_SEARCH_STEPS : 2n;
+  while (candidate >= limit) {
+    if (isPrime(candidate)) return candidate;
+    candidate--;
+  }
+  return null;
+}
+
+export const PrimeCheckBoxSource = {
+  defaultDisabled: true,
+  name: 'Prime Check',
+  description:
+    'Test whether an integer is prime, and find the next and previous primes (up to 10^13).',
+  defaultInput: '97 ::isprime',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'isprime', 'prime')) return [];
+
+    const raw = trim(input);
+
+    // reject strings that are too long or not pure digits
+    if (raw.length > 16 || !/^\d+$/.test(raw)) {
+      const kv: Record<string, string> = {
+        Error: 'Input must be a non-negative integer with at most 16 digits.',
+      };
+      return [
+        new BoxBuilder('Prime Check', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const n = BigInt(raw);
+
+    if (n > MAX_VALUE) {
+      const kv: Record<string, string> = {
+        Error: `Value exceeds maximum of ${MAX_VALUE.toLocaleString()} (10^10). Use a smaller number.`,
+      };
+      return [
+        new BoxBuilder('Prime Check', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const prime = isPrime(n);
+    const next = nextPrime(n);
+    const prev = prevPrime(n);
+
+    const kv: Record<string, string> = {
+      Number: n.toString(),
+      'Is Prime': prime ? 'true' : 'false',
+      'Next Prime': next !== null ? next.toString() : 'search limit exceeded',
+      'Previous Prime': prev !== null ? prev.toString() : 'none',
+    };
+
+    // include the smallest factor only for composite numbers >= 2
+    if (!prime && n >= 2n) {
+      kv['Smallest Factor'] = smallestFactor(n).toString();
+    }
+
+    return [
+      new BoxBuilder('Prime Check', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PrimeCheckBoxSource;

--- a/src/modules/boxSources/__test__/PrimeCheckBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PrimeCheckBoxSource.test.ts
@@ -1,0 +1,184 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { PrimeCheckBoxSource } from '../PrimeCheckBoxSource';
+
+describe('PrimeCheckBoxSource', () => {
+  describe('generateBoxes - trigger guard', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated option is provided', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::isprime option', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('triggers on ::prime option', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        prime: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+
+  describe('generateBoxes - known prime 97', () => {
+    it('correctly identifies 97 as prime with next=101 and prev=89', async () => {
+      // verified: 97 is prime, next prime is 101, previous prime is 89
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('true');
+      expect(options?.['Next Prime']).toBe('101');
+      expect(options?.['Previous Prime']).toBe('89');
+      expect(options?.['Smallest Factor']).toBeUndefined();
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets correct priority', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes - composite 100', () => {
+    it('correctly identifies 100 as composite with factor 2, next=101, prev=97', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('100', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('false');
+      expect(options?.['Next Prime']).toBe('101');
+      expect(options?.['Previous Prime']).toBe('97');
+      expect(options?.['Smallest Factor']).toBe('2');
+    });
+  });
+
+  describe('generateBoxes - boundary: 2', () => {
+    it('correctly identifies 2 as prime with prev=none and next=3', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('2', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('true');
+      expect(options?.['Previous Prime']).toBe('none');
+      expect(options?.['Next Prime']).toBe('3');
+    });
+  });
+
+  describe('generateBoxes - boundary: 1', () => {
+    it('correctly identifies 1 as not prime and next prime is 2', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('1', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('false');
+      expect(options?.['Next Prime']).toBe('2');
+      // 1 < 2, so no previous prime
+      expect(options?.['Previous Prime']).toBe('none');
+    });
+  });
+
+  describe('generateBoxes - Carmichael number 561', () => {
+    it('correctly identifies 561 as composite via trial division (not fooled like Fermat)', async () => {
+      // 561 = 3 × 11 × 17; a Carmichael number — Fermat primality would wrongly pass it
+      const boxes = await PrimeCheckBoxSource.generateBoxes('561', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('false');
+      expect(options?.['Smallest Factor']).toBe('3');
+    });
+  });
+
+  describe('generateBoxes - large prime 1000000007', () => {
+    it('correctly identifies 10^9+7 as prime', async () => {
+      // 1000000007 is the famous prime used in competitive programming
+      const boxes = await PrimeCheckBoxSource.generateBoxes('1000000007', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('true');
+      expect(options?.Number).toBe('1000000007');
+    });
+  });
+
+  describe('generateBoxes - out-of-range input', () => {
+    it('returns an error box for value exceeding 10^13', async () => {
+      // 100000000000000 = 10^14, which exceeds MAX_VALUE
+      const boxes = await PrimeCheckBoxSource.generateBoxes('100000000000000', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeDefined();
+    });
+  });
+
+  describe('generateBoxes - invalid input', () => {
+    it('returns an error box for non-numeric input', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('abc', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeDefined();
+    });
+
+    it('returns an error box for negative number string', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('-7', {
+        isprime: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Error).toBeDefined();
+    });
+  });
+
+  describe('box structure', () => {
+    it('box name is "Prime Check"', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      expect(boxes[0].props.name).toBe('Prime Check');
+    });
+
+    it('plaintextOutput contains key: value lines', async () => {
+      const boxes = await PrimeCheckBoxSource.generateBoxes('97', {
+        isprime: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Is Prime: true');
+      expect(text).toContain('Next Prime: 101');
+      expect(text).toContain('Previous Prime: 89');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PrimeCheckBoxSource from './PrimeCheckBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  PrimeCheckBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Prime Check (Calculate)

Adds the `Prime Check` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `97 ::isprime`

#### Options:
- `::isprime`, `::prime`

#### Description:
Test whether an integer is prime, and find the next and previous primes (up to 10^13).

#### Usage Examples:
- **Input**:
```
97
::isprime
```
- **Output Box (`Prime Check`)**:
```
Number: 97
Is Prime: true
Next Prime: 101
Previous Prime: 89
```
