### PR TITLE
feat(PrimeFactor): add Prime Factorization BoxSource

### DIFF
--- a/src/modules/boxSources/PrimeFactorBoxSource.ts
+++ b/src/modules/boxSources/PrimeFactorBoxSource.ts
@@ -1,0 +1,130 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_VALUE = 1_000_000_000_000n; // 10^12
+
+// builds "k: v\n..." plaintext from a key-value record
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// trial-division factorization; only called when n >= 2 and n <= MAX_VALUE
+function primeFactors(n: bigint): Map<bigint, number> {
+  const factors = new Map<bigint, number>();
+
+  // divide out all 2s
+  while (n % 2n === 0n) {
+    factors.set(2n, (factors.get(2n) ?? 0) + 1);
+    n /= 2n;
+  }
+
+  // odd divisors from 3 up to sqrt(n)
+  for (let i = 3n; i * i <= n; i += 2n) {
+    while (n % i === 0n) {
+      factors.set(i, (factors.get(i) ?? 0) + 1);
+      n /= i;
+    }
+  }
+
+  // remaining factor is prime
+  if (n > 1n) {
+    factors.set(n, (factors.get(n) ?? 0) + 1);
+  }
+
+  return factors;
+}
+
+// formats the factorization map as e.g. "2^3 × 3^2 × 5"
+function formatFactorization(factors: Map<bigint, number>): string {
+  return [...factors.entries()]
+    .map(([p, exp]) => (exp === 1 ? String(p) : `${p}^${exp}`))
+    .join(' × ');
+}
+
+function makeErrorBox(message: string, priority: number): Box {
+  const kv = { Note: message };
+  return new BoxBuilder('Prime Factorization', kvToPlaintext(kv))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(kv)
+    .setPriority(priority)
+    .build();
+}
+
+export const PrimeFactorBoxSource = {
+  defaultDisabled: true,
+  name: 'Prime Factorization',
+  description: 'Factor an integer into its prime factors (up to 10^12).',
+  defaultInput: '360 ::factor',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'factor', 'factorize', 'primefactor')) {
+      return [];
+    }
+
+    const raw = trim(input);
+
+    // reject non-digit strings or strings too long to factor in the browser
+    if (!/^\d+$/.test(raw)) {
+      return [
+        makeErrorBox(
+          'Input must be a positive integer (digits only).',
+          this.priority,
+        ),
+      ];
+    }
+
+    // cap at 13 digits so sqrt stays within ~1 M iterations
+    if (raw.length > 13) {
+      return [
+        makeErrorBox(
+          'Number is too large to factor in the browser. Maximum supported value is 10^12.',
+          this.priority,
+        ),
+      ];
+    }
+
+    const n = BigInt(raw);
+
+    if (n < 2n || n > MAX_VALUE) {
+      return [
+        makeErrorBox(
+          'Input must be an integer between 2 and 10^12.',
+          this.priority,
+        ),
+      ];
+    }
+
+    const factors = primeFactors(n);
+    const factorizationStr = formatFactorization(factors);
+    const primeList = [...factors.keys()].map(String).join(', ');
+    const isPrime = factors.size === 1 && [...factors.values()][0] === 1;
+
+    const kv: Record<string, string> = {
+      Number: raw,
+      Factorization: factorizationStr,
+      'Prime Factors': primeList,
+      'Is Prime': String(isPrime),
+    };
+
+    return [
+      new BoxBuilder('Prime Factorization', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PrimeFactorBoxSource;

--- a/src/modules/boxSources/__test__/PrimeFactorBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PrimeFactorBoxSource.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+
+import { PrimeFactorBoxSource } from '../PrimeFactorBoxSource';
+
+describe('PrimeFactorBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('360', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('360', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::factor trigger', () => {
+    it('360 = 2^3 × 3^2 × 5', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('360', {
+        factor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Factorization).toBe('2^3 × 3^2 × 5');
+      expect(options?.['Prime Factors']).toBe('2, 3, 5');
+      expect(options?.['Is Prime']).toBe('false');
+      expect(options?.Number).toBe('360');
+    });
+
+    it('17 is prime', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('17', {
+        factor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Factorization).toBe('17');
+      expect(options?.['Is Prime']).toBe('true');
+    });
+
+    it('12 = 2^2 × 3', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('12', {
+        factor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Factorization).toBe('2^2 × 3');
+    });
+
+    it('1024 = 2^10', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('1024', {
+        factor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.Factorization).toBe('2^10');
+      expect(options?.['Is Prime']).toBe('false');
+    });
+  });
+
+  describe('::factorize and ::primefactor triggers', () => {
+    it('accepts ::factorize', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('7', {
+        factorize: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.['Is Prime']).toBe('true');
+    });
+
+    it('accepts ::primefactor', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('6', {
+        primefactor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options?.Factorization).toBe('2 × 3');
+    });
+  });
+
+  describe('boundary and error cases', () => {
+    it('1 is out of range → explanatory box', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('1', {
+        factor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const note = boxes[0].props.options?.Note as string;
+      expect(note).toMatch(/between 2 and/i);
+    });
+
+    it('too large (10^13) → explanatory box', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('10000000000000', {
+        factor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const note = boxes[0].props.options?.Note as string;
+      expect(note).toMatch(/too large/i);
+    });
+
+    it('invalid "abc" → explanatory box', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('abc', {
+        factor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const note = boxes[0].props.options?.Note as string;
+      expect(note).toMatch(/positive integer/i);
+    });
+
+    it('large prime near cap (999999999989) is prime', async () => {
+      // 999999999989 is a known prime < 10^12; sqrt ≈ 999999 — stays within budget
+      const boxes = await PrimeFactorBoxSource.generateBoxes('999999999989', {
+        factor: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const { options } = boxes[0].props;
+      expect(options?.['Is Prime']).toBe('true');
+      expect(options?.Factorization).toBe('999999999989');
+    }, 10_000); // allow up to 10 s for the trial division
+  });
+
+  describe('box shape', () => {
+    it('box name is "Prime Factorization"', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('360', {
+        factor: true,
+      });
+      expect(boxes[0].props.name).toBe('Prime Factorization');
+    });
+
+    it('priority equals source priority', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('360', {
+        factor: true,
+      });
+      expect(boxes[0].props.priority).toBe(PrimeFactorBoxSource.priority);
+    });
+
+    it('plaintextOutput is non-empty k:v text (no JSON, no empty string)', async () => {
+      const boxes = await PrimeFactorBoxSource.generateBoxes('360', {
+        factor: true,
+      });
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toBeTruthy();
+      expect(text).not.toBe('');
+      // should contain at least one "key: value" pair
+      expect(text).toMatch(/\w+: .+/);
+      // must not be JSON
+      expect(() => JSON.parse(text)).toThrow();
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PrimeFactorBoxSource from './PrimeFactorBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  PrimeFactorBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Prime Factorization (Calculate)

Adds the `Prime Factorization` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `360 ::factor`

#### Options:
- `::factor`, `::factorize`, `::primefactor`

#### Description:
Factor an integer into its prime factors (up to 10^12).

#### Usage Examples:
- **Input**:
```
360
::factor
```
- **Output Box (`Prime Factorization`)**:
```
Number: 360
Factorization: 2^3 × 3^2 × 5
Prime Factors: 2, 3, 5
Is Prime: false
```
