### PR TITLE
feat(Properties): add Properties / JSON BoxSource

### DIFF
--- a/src/modules/boxSources/PropertiesBoxSource.ts
+++ b/src/modules/boxSources/PropertiesBoxSource.ts
@@ -1,0 +1,161 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// keys that would allow prototype pollution if set on a plain object
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+// unescape minimal backslash sequences from .properties values
+function unescapeValue(raw: string): string {
+  return raw
+    .replace(/\\n/g, '\n')
+    .replace(/\\t/g, '\t')
+    .replace(/\\\\/g, '\\')
+    .replace(/\\=/g, '=');
+}
+
+// parse a .properties file into a null-prototype flat object
+function parseProperties(text: string): Record<string, string> {
+  const result = Object.create(null) as Record<string, string>;
+
+  for (const line of text.split('\n')) {
+    const stripped = line.trimStart();
+
+    // skip blank lines and comments
+    if (!stripped || stripped[0] === '#' || stripped[0] === '!') continue;
+
+    // split on first =, :, or whitespace acting as separator
+    const eqIdx = stripped.search(/[=:\s]/);
+    if (eqIdx === -1) {
+      // key with no value
+      const key = stripped.trim();
+      if (!FORBIDDEN_KEYS.has(key)) {
+        result[key] = '';
+      }
+      continue;
+    }
+
+    const key = stripped.slice(0, eqIdx).trim();
+    if (FORBIDDEN_KEYS.has(key)) continue;
+
+    // consume the separator character itself
+    const afterSep = stripped.slice(eqIdx);
+    // strip the separator and any surrounding whitespace
+    const value = afterSep.replace(/^[=:\s]\s*/, '');
+    result[key] = unescapeValue(value.trimEnd());
+  }
+
+  return result;
+}
+
+// serialize a flat record to .properties format
+function stringifyProperties(obj: Record<string, unknown>): string {
+  return Object.keys(obj)
+    .filter((key) => !FORBIDDEN_KEYS.has(key) && Object.hasOwn(obj, key))
+    .map((key) => {
+      const raw = obj[key];
+      const value = typeof raw === 'string' ? raw : JSON.stringify(raw);
+      return `${key}=${value}`;
+    })
+    .join('\n');
+}
+
+export const PropertiesBoxSource = {
+  defaultDisabled: true,
+  name: 'Properties / JSON',
+  description:
+    'Convert a Java .properties file to JSON, or a flat JSON object to .properties.',
+  defaultInput: 'server.host=localhost\nserver.port=8080 ::properties',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'properties', 'propertiesjson')) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const trimmed = trim(input);
+    if (!trimmed) return [];
+
+    const boxes: Box[] = [];
+
+    // direction: JSON → properties when input looks like a JSON object
+    if (trimmed.startsWith('{')) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        boxes.push(
+          new BoxBuilder(
+            'JSON → Properties',
+            `Parse error: input starts with '{' but is not valid JSON`,
+          )
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        );
+        return boxes;
+      }
+
+      if (
+        parsed === null ||
+        typeof parsed !== 'object' ||
+        Array.isArray(parsed)
+      ) {
+        boxes.push(
+          new BoxBuilder(
+            'JSON → Properties',
+            'Error: expected a JSON object (not an array or primitive)',
+          )
+            .setTemplate(CodeBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        );
+        return boxes;
+      }
+
+      const output = stringifyProperties(parsed as Record<string, unknown>);
+      boxes.push(
+        new BoxBuilder('JSON → Properties', output)
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+      return boxes;
+    }
+
+    // default direction: properties → JSON
+    try {
+      const obj = parseProperties(trimmed);
+      const output = JSON.stringify(obj, null, 2);
+      boxes.push(
+        new BoxBuilder('Properties → JSON', output)
+          .setOptions({ language: 'json' })
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    } catch (e) {
+      boxes.push(
+        new BoxBuilder(
+          'Properties → JSON',
+          `Parse error: ${e instanceof Error ? e.message : String(e)}`,
+        )
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default PropertiesBoxSource;

--- a/src/modules/boxSources/__test__/PropertiesBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PropertiesBoxSource.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { PropertiesBoxSource } from '../PropertiesBoxSource';
+
+describe('PropertiesBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return [] when no matching option is provided', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes(
+        'server.host=localhost',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return [] when unrelated options are provided', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes(
+        'server.host=localhost',
+        { json: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert properties to JSON with flat dotted keys', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes(
+        'server.host=localhost\nserver.port=8080',
+        { properties: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Properties → JSON');
+
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      // flat keys — dotted keys must NOT be nested
+      expect(parsed['server.host']).toBe('localhost');
+      expect(parsed['server.port']).toBe('8080');
+      expect(parsed).not.toHaveProperty('server');
+    });
+
+    it('should skip comment lines (# and !) and handle colon separators', async () => {
+      const input = '# comment\nname: app\n! bang comment\nkey=val';
+      const boxes = await PropertiesBoxSource.generateBoxes(input, {
+        properties: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+      expect(parsed).toEqual({ name: 'app', key: 'val' });
+    });
+
+    it('should convert JSON object to .properties format', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes(
+        '{"a":"1","b":"2"}',
+        { properties: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → Properties');
+      expect(boxes[0].props.plaintextOutput).toContain('a=1');
+      expect(boxes[0].props.plaintextOutput).toContain('b=2');
+    });
+
+    it('should skip __proto__ key to prevent prototype pollution', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes('__proto__=evil', {
+        properties: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      const parsed = JSON.parse(boxes[0].props.plaintextOutput);
+
+      // the forbidden key must not appear in the parsed output
+      expect(Object.hasOwn(parsed, '__proto__')).toBe(false);
+      // prototype must not have been polluted
+      // biome-ignore lint/suspicious/noExplicitAny: verifying prototype pollution guard
+      expect(({} as any).polluted).toBeUndefined();
+      // the evil value must not have reached Object.prototype
+      expect(Object.prototype).not.toHaveProperty('polluted');
+    });
+
+    it('should not crash on array-like input and return a properties→JSON box', async () => {
+      // '[1,2]' does not start with '{', so treated as properties→JSON
+      const boxes = await PropertiesBoxSource.generateBoxes('[1,2]', {
+        properties: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // no crash; output is valid JSON (even if empty object)
+      expect(() => JSON.parse(boxes[0].props.plaintextOutput)).not.toThrow();
+    });
+
+    it('should return an error box for JSON-looking input that is invalid JSON', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes('{bad', {
+        properties: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('JSON → Properties');
+      expect(boxes[0].props.plaintextOutput).toMatch(/parse error/i);
+    });
+
+    it('should round-trip flat keys: properties → JSON → properties', async () => {
+      const original = 'app.name=magic\napp.version=1.0';
+
+      const toJsonBoxes = await PropertiesBoxSource.generateBoxes(original, {
+        properties: true,
+      });
+      expect(toJsonBoxes).toHaveLength(1);
+
+      const jsonStr = toJsonBoxes[0].props.plaintextOutput;
+      const toPropsBoxes = await PropertiesBoxSource.generateBoxes(jsonStr, {
+        properties: true,
+      });
+      expect(toPropsBoxes).toHaveLength(1);
+
+      const output = toPropsBoxes[0].props.plaintextOutput;
+      expect(output).toContain('app.name=magic');
+      expect(output).toContain('app.version=1.0');
+    });
+
+    it('should trigger on ::propertiesjson option as well', async () => {
+      const boxes = await PropertiesBoxSource.generateBoxes('key=value', {
+        propertiesjson: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -27,6 +27,7 @@ import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
+import PropertiesBoxSource from './PropertiesBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  PropertiesBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Properties / JSON (Convert)

Adds the `Properties / JSON` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `server.host=localhost
server.port=8080 ::properties`

#### Options:
- `::properties`, `::propertiesjson`

#### Description:
Convert a Java .properties file to JSON, or a flat JSON object to .properties.

#### Usage Examples:
- **Input**:
```
server.host=localhost
server.port=8080
::properties
```
- **Output Box (`Properties → JSON`)**:
```
{
  "server.host": "localhost",
  "server.port": "8080"
}
```
