### PR TITLE
feat(Punycode): add Punycode BoxSource

### DIFF
--- a/src/modules/boxSources/PunycodeBoxSource.ts
+++ b/src/modules/boxSources/PunycodeBoxSource.ts
@@ -1,0 +1,240 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 10_000;
+
+// RFC 3492 bootstring constants
+const BASE = 36;
+const TMIN = 1;
+const TMAX = 26;
+const SKEW = 38;
+const DAMP = 700;
+const INITIAL_BIAS = 72;
+const INITIAL_N = 128;
+const DELIMITER = '-';
+
+// adapts bias after each encoded delta per RFC 3492 §6.1
+function adaptBias(
+  delta: number,
+  numPoints: number,
+  firstTime: boolean,
+): number {
+  let d = firstTime ? Math.floor(delta / DAMP) : delta >> 1;
+  d += Math.floor(d / numPoints);
+  let k = 0;
+  while (d > ((BASE - TMIN) * TMAX) >> 1) {
+    d = Math.floor(d / (BASE - TMIN));
+    k += BASE;
+  }
+  return Math.floor(k + ((BASE - TMIN + 1) * d) / (d + SKEW));
+}
+
+// maps a digit value to its ASCII character per RFC 3492 §5
+function digitToBasic(digit: number): number {
+  return digit < 26 ? digit + 97 : digit + 22; // a-z then 0-9
+}
+
+// maps a basic code point to its digit value; -1 if not valid
+function basicToDigit(cp: number): number {
+  if (cp >= 48 && cp <= 57) return cp - 22; // 0-9 → 26-35
+  if (cp >= 65 && cp <= 90) return cp - 65; // A-Z → 0-25
+  if (cp >= 97 && cp <= 122) return cp - 97; // a-z → 0-25
+  return -1;
+}
+
+// encodes a single Punycode label (no xn-- prefix) per RFC 3492 §6.3
+function punycodeEncode(input: number[]): string {
+  const n = input.length;
+  let bias = INITIAL_BIAS;
+  let delta = 0;
+  let currentN = INITIAL_N;
+  let h = 0;
+  let b = 0;
+  const output: number[] = [];
+
+  for (const cp of input) {
+    if (cp < INITIAL_N) {
+      output.push(cp);
+      h++;
+      b++;
+    }
+  }
+
+  if (b > 0) output.push(DELIMITER.charCodeAt(0));
+
+  while (h < n) {
+    // find the next larger non-basic code point
+    let m = Number.MAX_SAFE_INTEGER;
+    for (const cp of input) {
+      if (cp >= currentN && cp < m) m = cp;
+    }
+
+    delta += (m - currentN) * (h + 1);
+    currentN = m;
+
+    for (const cp of input) {
+      if (cp < currentN) delta++;
+      if (cp === currentN) {
+        // encode delta as generalized variable-length integer
+        let q = delta;
+        for (let k = BASE; ; k += BASE) {
+          const t =
+            k <= bias + TMIN ? TMIN : k >= bias + TMAX ? TMAX : k - bias;
+          if (q < t) break;
+          output.push(digitToBasic(t + ((q - t) % (BASE - t))));
+          q = Math.floor((q - t) / (BASE - t));
+        }
+        output.push(digitToBasic(q));
+        bias = adaptBias(delta, h + 1, h === b);
+        delta = 0;
+        h++;
+      }
+    }
+
+    delta++;
+    currentN++;
+  }
+
+  return String.fromCharCode(...output);
+}
+
+// decodes a Punycode-encoded label (without xn-- prefix) per RFC 3492 §6.2
+function punycodeDecode(input: string): string {
+  const output: number[] = [];
+  let bias = INITIAL_BIAS;
+  let i = 0;
+  let currentN = INITIAL_N;
+
+  const delimIdx = input.lastIndexOf(DELIMITER);
+  const basic = delimIdx < 0 ? '' : input.slice(0, delimIdx);
+  const extended = delimIdx < 0 ? input : input.slice(delimIdx + 1);
+
+  for (let j = 0; j < basic.length; j++) {
+    output.push(basic.charCodeAt(j));
+  }
+
+  let idx = 0;
+  while (idx < extended.length) {
+    const oldi = i;
+    let w = 1;
+    for (let k = BASE; ; k += BASE) {
+      if (idx >= extended.length) throw new RangeError('invalid punycode');
+      const digit = basicToDigit(extended.charCodeAt(idx++));
+      if (digit < 0) throw new RangeError('invalid punycode');
+      i += digit * w;
+      const t = k <= bias + TMIN ? TMIN : k >= bias + TMAX ? TMAX : k - bias;
+      if (digit < t) break;
+      w *= BASE - t;
+    }
+    const len = output.length + 1;
+    bias = adaptBias(i - oldi, len, oldi === 0);
+    currentN += Math.floor(i / len);
+    i %= len;
+    output.splice(i, 0, currentN);
+    i++;
+  }
+
+  return String.fromCodePoint(...output);
+}
+
+// returns true if every character in the string is ASCII (< 128)
+function isAsciiOnly(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) >= 128) return false;
+  }
+  return true;
+}
+
+// converts a domain to ASCII Punycode form (IDNA ToASCII per label)
+function toAscii(domain: string): string {
+  return domain
+    .toLowerCase()
+    .split('.')
+    .map((label) => {
+      if (isAsciiOnly(label)) return label;
+      const codePoints = [...label].map((ch) => ch.codePointAt(0) as number);
+      return `xn--${punycodeEncode(codePoints)}`;
+    })
+    .join('.');
+}
+
+// converts an ASCII Punycode domain back to its Unicode form
+function toUnicode(domain: string): string {
+  return domain
+    .split('.')
+    .map((label) => {
+      if (label.toLowerCase().startsWith('xn--')) {
+        return punycodeDecode(label.slice(4));
+      }
+      return label;
+    })
+    .join('.');
+}
+
+export const PunycodeBoxSource = {
+  defaultDisabled: true,
+  name: 'Punycode',
+  description:
+    'Convert an internationalized domain name to/from its Punycode (xn--) ASCII form.',
+  defaultInput: 'münchen.de ::punycode',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantToAscii = hasOptionKeys(
+      options,
+      'punycode',
+      'punycodeencode',
+      'idn',
+    );
+    const wantToUnicode = hasOptionKeys(options, 'punycodedecode', 'idndecode');
+    if (!wantToAscii && !wantToUnicode) return [];
+    if (input.length > MAX_INPUT) return [];
+
+    const domain = trim(input);
+    const boxes: Box[] = [];
+
+    if (wantToAscii) {
+      let result: string;
+      try {
+        result = toAscii(domain);
+      } catch {
+        result = 'Invalid domain: unable to encode to Punycode.';
+      }
+      boxes.push(
+        new BoxBuilder('Punycode (ToASCII)', result)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantToUnicode) {
+      let result: string;
+      try {
+        result = toUnicode(domain);
+      } catch {
+        result = 'Invalid domain: unable to decode from Punycode.';
+      }
+      boxes.push(
+        new BoxBuilder('Punycode (ToUnicode)', result)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default PunycodeBoxSource;

--- a/src/modules/boxSources/__test__/PunycodeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PunycodeBoxSource.test.ts
@@ -1,0 +1,137 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { PunycodeBoxSource } from '../PunycodeBoxSource';
+
+describe('PunycodeBoxSource', () => {
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(PunycodeBoxSource.name).toBe('Punycode');
+      expect(PunycodeBoxSource.tag).toBe('#');
+      expect(PunycodeBoxSource.kind).toBe('Encode');
+      expect(typeof PunycodeBoxSource.priority).toBe('number');
+    });
+  });
+
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no punycode option is provided', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - ToASCII (::punycode)', () => {
+    it('encodes münchen.de to xn--mnchen-3ya.de', async () => {
+      // ground truth: new URL('http://münchen.de').hostname === 'xn--mnchen-3ya.de'
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', {
+        punycode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Punycode (ToASCII)');
+      expect(boxes[0].props.plaintextOutput).toBe('xn--mnchen-3ya.de');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('encodes bücher.com to xn--bcher-kva.com', async () => {
+      // ground truth: new URL('http://bücher.com').hostname === 'xn--bcher-kva.com'
+      const boxes = await PunycodeBoxSource.generateBoxes('bücher.com', {
+        punycode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('xn--bcher-kva.com');
+    });
+
+    it('leaves pure-ASCII domain unchanged', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('example.com', {
+        punycode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('example.com');
+    });
+
+    it('accepts ::punycodeencode alias', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', {
+        punycodeencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('xn--mnchen-3ya.de');
+    });
+
+    it('accepts ::idn alias', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', {
+        idn: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('xn--mnchen-3ya.de');
+    });
+  });
+
+  describe('generateBoxes - ToUnicode (::punycodedecode)', () => {
+    it('decodes xn--mnchen-3ya.de to münchen.de', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('xn--mnchen-3ya.de', {
+        punycodedecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Punycode (ToUnicode)');
+      expect(boxes[0].props.plaintextOutput).toBe('münchen.de');
+    });
+
+    it('leaves non-xn-- labels unchanged during decode', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('example.com', {
+        punycodedecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('example.com');
+    });
+
+    it('accepts ::idndecode alias', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('xn--mnchen-3ya.de', {
+        idndecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('münchen.de');
+    });
+  });
+
+  describe('generateBoxes - round-trip', () => {
+    it('toUnicode(toAscii(münchen.de)) === münchen.de', async () => {
+      const asciiBoxes = await PunycodeBoxSource.generateBoxes('münchen.de', {
+        punycode: true,
+      });
+      const ascii = asciiBoxes[0].props.plaintextOutput;
+      const unicodeBoxes = await PunycodeBoxSource.generateBoxes(ascii, {
+        punycodedecode: true,
+      });
+      expect(unicodeBoxes[0].props.plaintextOutput).toBe('münchen.de');
+    });
+  });
+
+  describe('generateBoxes - both options', () => {
+    it('returns 2 boxes when both ::punycode and ::punycodedecode are set', async () => {
+      const boxes = await PunycodeBoxSource.generateBoxes('münchen.de', {
+        punycode: true,
+        punycodedecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Punycode (ToASCII)');
+      expect(names).toContain('Punycode (ToUnicode)');
+    });
+  });
+
+  describe('generateBoxes - input guard', () => {
+    it('returns empty array when input exceeds MAX_INPUT', async () => {
+      const huge = 'a'.repeat(10_001);
+      const boxes = await PunycodeBoxSource.generateBoxes(huge, {
+        punycode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -27,6 +27,7 @@ import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
+import PunycodeBoxSource from './PunycodeBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  PunycodeBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Punycode (Encode)

Adds the `Punycode` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `münchen.de ::punycode`

#### Options:
- `::`, `::idn`, `::idndecode`, `::punycode`, `::punycodedecode`, `::punycodeencode`

#### Description:
Convert an internationalized domain name to/from its Punycode (xn--) ASCII form.

#### Usage Examples:
- **Input**:
```
münchen.de
::punycode
```
- **Output Box (`Punycode (ToASCII)`)**:
```
xn--mnchen-3ya.de
```
