### PR TITLE
feat(PxRem): add px / rem BoxSource

### DIFF
--- a/src/modules/boxSources/PxRemBoxSource.ts
+++ b/src/modules/boxSources/PxRemBoxSource.ts
@@ -1,0 +1,72 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const DEFAULT_BASE = 16;
+
+// round to ~10 sig figs and strip trailing zeros without leaking scientific
+// notation (Number().toString() renormalizes e.g. 1e10 → "10000000000")
+function formatNumber(n: number): string {
+  return Number(n.toPrecision(10)).toString();
+}
+
+export const PxRemBoxSource = {
+  defaultDisabled: true,
+  name: 'px / rem',
+  description:
+    'Convert between px and rem given a root font size (default 16). e.g. "24px ::pxrem" or "1.5rem ::pxrem".',
+  defaultInput: '24px ::pxrem',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'pxrem', 'rempx')) return [];
+
+    // resolve base font size from option value, falling back to DEFAULT_BASE
+    const rawBase = extractOptionKeys(options, 'pxrem', 'rempx');
+    const base =
+      typeof rawBase === 'string' && rawBase !== ''
+        ? Number.parseFloat(rawBase)
+        : DEFAULT_BASE;
+    if (!Number.isFinite(base) || base <= 0) return [];
+
+    const trimmed = trim(input);
+    const match = /^(-?\d+(?:\.\d+)?)\s*(px|rem)?$/i.exec(trimmed);
+    if (!match) return [];
+
+    const value = Number.parseFloat(match[1]);
+    const unit = (match[2] ?? 'px').toLowerCase();
+
+    let pxValue: number;
+    let remValue: number;
+
+    if (unit === 'rem') {
+      remValue = value;
+      pxValue = value * base;
+    } else {
+      // treat unitless or explicit px as px
+      pxValue = value;
+      remValue = value / base;
+    }
+
+    return [
+      new BoxBuilder('px / rem', formatNumber(pxValue))
+        .setOptions({
+          px: formatNumber(pxValue),
+          rem: formatNumber(remValue),
+          Base: `${formatNumber(base)}px`,
+        })
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default PxRemBoxSource;

--- a/src/modules/boxSources/__test__/PxRemBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/PxRemBoxSource.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { PxRemBoxSource } from '../PxRemBoxSource';
+
+describe('PxRemBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no option key is present', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('24px', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array when options object lacks pxrem/rempx', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('24px', { foo: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should convert px to rem with default base (24px → rem 1.5)', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('24px', { pxrem: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.px).toBe('24');
+      expect(opts?.rem).toBe('1.5');
+      expect(opts?.Base).toBe('16px');
+    });
+
+    it('should convert rem to px with default base (1.5rem → px 24)', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('1.5rem', {
+        pxrem: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.px).toBe('24');
+      expect(opts?.rem).toBe('1.5');
+      expect(opts?.Base).toBe('16px');
+    });
+
+    it('should use custom base from option value (20px + ::pxrem=10 → rem 2)', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('20px', { pxrem: '10' });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.px).toBe('20');
+      expect(opts?.rem).toBe('2');
+      expect(opts?.Base).toBe('10px');
+    });
+
+    it('should treat unitless input as px (32 + ::pxrem → rem 2)', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('32', { pxrem: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.px).toBe('32');
+      expect(opts?.rem).toBe('2');
+    });
+
+    it('should return empty array for non-numeric input', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('abc', { pxrem: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should work with rempx option key', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('1rem', { rempx: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options;
+      expect(opts?.px).toBe('16');
+      expect(opts?.rem).toBe('1');
+    });
+
+    it('should use KeyValueBoxTemplate', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('24px', { pxrem: true });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+
+    it('should set priority from source priority', async () => {
+      const boxes = await PxRemBoxSource.generateBoxes('24px', { pxrem: true });
+      expect(boxes[0].props.priority).toBe(PxRemBoxSource.priority);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import PxRemBoxSource from './PxRemBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  PxRemBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: px / rem (Convert)

Adds the `px / rem` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `24px ::pxrem`

#### Options:
- `::pxrem`, `::rempx`

#### Description:
Convert between px and rem given a root font size (default 16). e.g. "24px ::pxrem" or "1.5rem ::pxrem".

#### Usage Examples:
- **Input**:
```
24px
::pxrem
```
- **Output Box (`px / rem`)**:
```
24
```
