### PR TITLE
feat(Quadratic): add Quadratic Solver BoxSource

### DIFF
--- a/src/modules/boxSources/QuadraticBoxSource.ts
+++ b/src/modules/boxSources/QuadraticBoxSource.ts
@@ -1,0 +1,174 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// strip trailing zeros and decimal point from a fixed-notation string
+function stripTrailingZeros(s: string): string {
+  return s.replace(/\.?0+$/, '');
+}
+
+// format a number to at most 6 decimal places, keeping integers exact
+function formatNum(n: number): string {
+  if (Number.isInteger(n)) return n.toString();
+  return stripTrailingZeros(n.toFixed(6));
+}
+
+// build plaintext k:v representation for headless consumers
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// token pattern: optional sign, digits with optional decimal and/or exponent
+const NUM_RE = /[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/g;
+
+export const QuadraticBoxSource = {
+  defaultDisabled: true,
+  name: 'Quadratic Solver',
+  description: 'Solve ax² + bx + c = 0. Input the three coefficients: "a b c".',
+  defaultInput: '1 -3 2 ::quadratic',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'quadratic', 'quad')) return [];
+
+    const raw = trim(input);
+    if (!raw || raw.length > 200) return [];
+
+    const tokens = raw.match(NUM_RE);
+
+    // return an informational box when input cannot be parsed to exactly 3 numbers
+    if (!tokens || tokens.length !== 3) {
+      const kv: Record<string, string> = {
+        Error: 'Expected exactly three coefficients a, b, c (e.g. "1 -3 2").',
+        Usage: 'Solves ax² + bx + c = 0',
+      };
+      return [
+        new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const a = Number.parseFloat(tokens[0]);
+    const b = Number.parseFloat(tokens[1]);
+    const c = Number.parseFloat(tokens[2]);
+
+    // reject coefficients that overflow float64 (e.g. 1e309 → Infinity),
+    // which would propagate NaN into the roots
+    if (!Number.isFinite(a) || !Number.isFinite(b) || !Number.isFinite(c)) {
+      const kv: Record<string, string> = {
+        Error: 'Coefficients must be finite numbers.',
+      };
+      return [
+        new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const equation = `${formatNum(a)}x² + ${formatNum(b)}x + ${formatNum(c)} = 0`;
+
+    // degenerate or linear case when a == 0
+    if (a === 0) {
+      if (b === 0) {
+        const kv: Record<string, string> = {
+          Equation: equation,
+          Error: 'Degenerate: a = 0 and b = 0. No variable to solve for.',
+        };
+        return [
+          new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+            .setOptions(kv)
+            .setTemplate(KeyValueBoxTemplate)
+            .setPriority(this.priority)
+            .build(),
+        ];
+      }
+      // linear: bx + c = 0 → x = -c / b
+      const root = -c / b;
+      const kv: Record<string, string> = {
+        Equation: equation,
+        Note: 'a = 0 — solving as linear equation bx + c = 0',
+        'Linear root': formatNum(root),
+      };
+      return [
+        new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const discriminant = b * b - 4 * a * c;
+
+    if (discriminant > 0) {
+      const sqrtD = Math.sqrt(discriminant);
+      // root ordering: larger root first ((-b + √D) / 2a when a > 0)
+      const root1 = (-b + sqrtD) / (2 * a);
+      const root2 = (-b - sqrtD) / (2 * a);
+      const kv: Record<string, string> = {
+        Equation: equation,
+        Discriminant: formatNum(discriminant),
+        'Root 1': formatNum(root1),
+        'Root 2': formatNum(root2),
+      };
+      return [
+        new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    if (discriminant === 0) {
+      const root = -b / (2 * a);
+      const kv: Record<string, string> = {
+        Equation: equation,
+        Discriminant: '0',
+        Root: formatNum(root),
+      };
+      return [
+        new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+          .setOptions(kv)
+          .setTemplate(KeyValueBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // discriminant < 0: two complex conjugate roots
+    const realPart = -b / (2 * a);
+    // use the magnitude for display so the ± formatting never yields "+ -1i"
+    const imagPart = Math.abs(Math.sqrt(-discriminant) / (2 * a));
+    const kv: Record<string, string> = {
+      Equation: equation,
+      Discriminant: formatNum(discriminant),
+      'Root 1': `${formatNum(realPart)} + ${formatNum(imagPart)}i`,
+      'Root 2': `${formatNum(realPart)} - ${formatNum(imagPart)}i`,
+    };
+    return [
+      new BoxBuilder('Quadratic Solver', kvToPlaintext(kv))
+        .setOptions(kv)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default QuadraticBoxSource;

--- a/src/modules/boxSources/__test__/QuadraticBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/QuadraticBoxSource.test.ts
@@ -1,0 +1,143 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { QuadraticBoxSource } from '../QuadraticBoxSource';
+
+describe('QuadraticBoxSource', () => {
+  describe('no option key', () => {
+    it('returns [] when options are null', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when ::quadratic / ::quad are absent', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', {
+        other: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('two distinct real roots — x²-3x+2=0 → 2, 1', () => {
+    it('produces one box with Root 1=2 and Root 2=1', async () => {
+      // (x-1)(x-2)=0: roots 1 and 2. (-b+√D)/2a = (3+1)/2 = 2 is Root 1
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Root 1']).toBe('2');
+      expect(kv['Root 2']).toBe('1');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', {
+        quadratic: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', {
+        quadratic: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('accepts ::quad alias', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -3 2', {
+        quad: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Root 1']).toBe('2');
+      expect(kv['Root 2']).toBe('1');
+    });
+  });
+
+  describe('double root — x²-2x+1=0 → 1', () => {
+    it('has Discriminant 0 and a single Root key', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -2 1', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Discriminant).toBe('0');
+      expect(kv.Root).toBe('1');
+      // no split roots
+      expect(kv['Root 1']).toBeUndefined();
+      expect(kv['Root 2']).toBeUndefined();
+    });
+  });
+
+  describe('complex roots — x²+1=0 → ±i', () => {
+    it('produces 0 + 1i and 0 - 1i', async () => {
+      // D = 0-4 = -4; real = 0, imag = 2/2 = 1
+      const boxes = await QuadraticBoxSource.generateBoxes('1 0 1', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Root 1']).toBe('0 + 1i');
+      expect(kv['Root 2']).toBe('0 - 1i');
+    });
+  });
+
+  describe('two distinct real roots — x²-5x+6=0 → 3, 2', () => {
+    it('returns Root 1=3 Root 2=2', async () => {
+      // (x-2)(x-3)=0: (-b+√D)/2a = (5+1)/2 = 3
+      const boxes = await QuadraticBoxSource.generateBoxes('1 -5 6', {
+        quadratic: true,
+      });
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Root 1']).toBe('3');
+      expect(kv['Root 2']).toBe('2');
+    });
+  });
+
+  describe('linear fallback — a=0, 2x-4=0 → root 2', () => {
+    it('returns Linear root 2 for "0 2 -4"', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('0 2 -4', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv['Linear root']).toBe('2');
+    });
+  });
+
+  describe('degenerate case — a=0 b=0', () => {
+    it('returns an error box for "0 0 5"', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('0 0 5', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns an error box for non-numeric "a b c"', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('a b c', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+
+    it('returns an error box for too few coefficients "1 2"', async () => {
+      const boxes = await QuadraticBoxSource.generateBoxes('1 2', {
+        quadratic: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const kv = boxes[0].props.options as Record<string, string>;
+      expect(kv.Error).toBeTruthy();
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import QuadraticBoxSource from './QuadraticBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  QuadraticBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Quadratic Solver (Calculate)

Adds the `Quadratic Solver` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `1 -3 2 ::quadratic`

#### Options:
- `::quad`, `::quadratic`

#### Description:
Solve ax² + bx + c = 0. Input the three coefficients: "a b c".

#### Usage Examples:
- **Input**:
```
1 -3 2
::quadratic
```
- **Output Box (`Quadratic Solver`)**:
```
Equation: 1x² + -3x + 2 = 0
Discriminant: 1
Root 1: 2
Root 2: 1
```
