### PR TITLE
feat(QuotedPrintable): add Quoted-Printable BoxSource

### DIFF
--- a/src/modules/boxSources/QuotedPrintableBoxSource.ts
+++ b/src/modules/boxSources/QuotedPrintableBoxSource.ts
@@ -1,0 +1,126 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// printable ASCII range excluding '=' (0x3D): codepoints 33–60 and 62–126 pass through as-is.
+// space (32) and tab (9) also pass through literally.
+// all other bytes, including newlines and non-ASCII, are encoded as =XX (uppercase hex).
+// soft line-break wrapping (76-column limit) is intentionally omitted for determinism.
+function encodeQP(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  const parts: string[] = [];
+  for (const byte of bytes) {
+    if (
+      (byte >= 33 && byte <= 60) ||
+      (byte >= 62 && byte <= 126) ||
+      byte === 9 ||
+      byte === 32
+    ) {
+      parts.push(String.fromCharCode(byte));
+    } else {
+      parts.push(`=${byte.toString(16).toUpperCase().padStart(2, '0')}`);
+    }
+  }
+  return parts.join('');
+}
+
+// decodes quoted-printable: =XX → byte, soft line breaks (=\r\n or =\n) → removed,
+// bare characters → their UTF-8 byte. invalid =XX sequences are passed through literally (lenient).
+function decodeQP(input: string): string {
+  const bytes: number[] = [];
+  let i = 0;
+  while (i < input.length) {
+    if (input[i] === '=') {
+      // soft line break: =\r\n or =\n
+      if (input[i + 1] === '\r' && input[i + 2] === '\n') {
+        i += 3;
+        continue;
+      }
+      if (input[i + 1] === '\n') {
+        i += 2;
+        continue;
+      }
+      // encoded byte: = followed by exactly 2 hex digits
+      const hex = input.slice(i + 1, i + 3);
+      if (/^[0-9A-Fa-f]{2}$/.test(hex)) {
+        bytes.push(Number.parseInt(hex, 16));
+        i += 3;
+        continue;
+      }
+      // lenient: not a valid sequence, emit the '=' literally
+      bytes.push(0x3d);
+      i++;
+    } else {
+      bytes.push(input.charCodeAt(i));
+      i++;
+    }
+  }
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+export const QuotedPrintableBoxSource = {
+  defaultDisabled: true,
+  name: 'Quoted-Printable',
+  description:
+    'Encode/decode MIME Quoted-Printable. ::quotedprintable to encode, ::qpdecode to decode.',
+  defaultInput: 'Héllo World ::quotedprintable',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEncode = hasOptionKeys(
+      options,
+      'quotedprintable',
+      'qp',
+      'qpencode',
+    );
+    const wantDecode = hasOptionKeys(
+      options,
+      'qpdecode',
+      'quotedprintabledecode',
+    );
+    if (!wantEncode && !wantDecode) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (wantEncode) {
+      const encoded = encodeQP(input);
+      boxes.push(
+        new BoxBuilder('Quoted-Printable (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (wantDecode) {
+      const decoded = decodeQP(input);
+      boxes.push(
+        new BoxBuilder('Quoted-Printable (Decode)', decoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default QuotedPrintableBoxSource;

--- a/src/modules/boxSources/__test__/QuotedPrintableBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/QuotedPrintableBoxSource.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { QuotedPrintableBoxSource } from '../QuotedPrintableBoxSource';
+
+describe('QuotedPrintableBoxSource', () => {
+  describe('no option / guard conditions', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('Héllo', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('Héllo', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input with encode option', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('', {
+        quotedprintable: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('   ', {
+        quotedprintable: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode', () => {
+    it('encodes Héllo → H=C3=A9llo (é = UTF-8 C3 A9)', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('Héllo', {
+        quotedprintable: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Quoted-Printable (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('H=C3=A9llo');
+    });
+
+    it('encodes = sign as =3D', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('=', {
+        quotedprintable: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('=3D');
+    });
+
+    it('leaves space literal in "a b"', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('a b', {
+        qp: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a b');
+    });
+
+    it('accepts ::qpencode alias', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('Hi', {
+        qpencode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hi');
+    });
+  });
+
+  describe('decode', () => {
+    it('decodes H=C3=A9llo → Héllo', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('H=C3=A9llo', {
+        qpdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Quoted-Printable (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('Héllo');
+    });
+
+    it('removes soft line break =\\r\\n', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes(
+        'abc=\r\ndef',
+        { qpdecode: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('abcdef');
+    });
+
+    it('removes soft line break =\\n', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('abc=\ndef', {
+        qpdecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('abcdef');
+    });
+
+    it('accepts ::quotedprintabledecode alias', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('Hello', {
+        quotedprintabledecode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hello');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('encode then decode returns the original string', async () => {
+      const original = 'Symbols: =, é, 日本! ✓';
+      const encBoxes = await QuotedPrintableBoxSource.generateBoxes(original, {
+        quotedprintable: true,
+      });
+      expect(encBoxes).toHaveLength(1);
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await QuotedPrintableBoxSource.generateBoxes(encoded, {
+        qpdecode: true,
+      });
+      expect(decBoxes).toHaveLength(1);
+      expect(decBoxes[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('both options produce 2 boxes', () => {
+    it('returns encode box and decode box when both options are set', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('Hello', {
+        quotedprintable: true,
+        qpdecode: true,
+      });
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Quoted-Printable (Encode)');
+      expect(names).toContain('Quoted-Printable (Decode)');
+    });
+  });
+
+  describe('box template and metadata', () => {
+    it('does not show expand button', async () => {
+      const boxes = await QuotedPrintableBoxSource.generateBoxes('test', {
+        quotedprintable: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('has expected static properties', () => {
+      expect(QuotedPrintableBoxSource.name).toBe('Quoted-Printable');
+      expect(QuotedPrintableBoxSource.tag).toBe('#');
+      expect(QuotedPrintableBoxSource.kind).toBe('Encode');
+      expect(typeof QuotedPrintableBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -27,6 +27,7 @@ import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
+import QuotedPrintableBoxSource from './QuotedPrintableBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  QuotedPrintableBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Quoted-Printable (Encode)

Adds the `Quoted-Printable` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `Héllo World ::quotedprintable`

#### Options:
- `::`, `::qp`, `::qpdecode`, `::qpencode`, `::quotedprintable`, `::quotedprintabledecode`

#### Description:
Encode/decode MIME Quoted-Printable. ::quotedprintable to encode, ::qpdecode to decode.

#### Usage Examples:
- **Input**:
```
Héllo World
::quotedprintable
```
- **Output Box (`Quoted-Printable (Encode)`)**:
```
H=C3=A9llo World
```
