### PR TITLE
feat(RailFence): add Rail Fence BoxSource

### DIFF
--- a/src/modules/boxSources/RailFenceBoxSource.ts
+++ b/src/modules/boxSources/RailFenceBoxSource.ts
@@ -1,0 +1,124 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+const DEFAULT_RAILS = 3;
+const MIN_RAILS = 2;
+const MAX_RAILS = 1000;
+
+// parse and clamp the rail count from an option value
+function parseRails(value: string | boolean): number {
+  if (typeof value === 'boolean') return DEFAULT_RAILS;
+  const n = Number.parseInt(value, 10);
+  if (Number.isNaN(n)) return DEFAULT_RAILS;
+  return Math.min(Math.max(n, MIN_RAILS), MAX_RAILS);
+}
+
+// build the zigzag row-index pattern for a given text length and rail count
+function zigzagPattern(length: number, numRails: number): number[] {
+  const pattern: number[] = [];
+  let row = 0;
+  let dir = 1;
+  for (let i = 0; i < length; i++) {
+    pattern.push(row);
+    if (row === 0) dir = 1;
+    else if (row === numRails - 1) dir = -1;
+    row += dir;
+  }
+  return pattern;
+}
+
+function encode(text: string, numRails: number): string {
+  const rails: string[][] = Array.from({ length: numRails }, () => []);
+  const pattern = zigzagPattern(text.length, numRails);
+  for (let i = 0; i < text.length; i++) {
+    rails[pattern[i]].push(text[i]);
+  }
+  return rails.map((r) => r.join('')).join('');
+}
+
+function decode(cipher: string, numRails: number): string {
+  const n = cipher.length;
+  const pattern = zigzagPattern(n, numRails);
+
+  // count how many characters land on each rail
+  const counts = new Array<number>(numRails).fill(0);
+  for (const r of pattern) counts[r]++;
+
+  // slice the ciphertext into per-rail segments in read order
+  const railStrings: string[] = [];
+  let pos = 0;
+  for (let i = 0; i < numRails; i++) {
+    railStrings.push(cipher.slice(pos, pos + counts[i]));
+    pos += counts[i];
+  }
+
+  // read characters back out in zigzag order
+  const railCursors = new Array<number>(numRails).fill(0);
+  let result = '';
+  for (const r of pattern) {
+    result += railStrings[r][railCursors[r]++];
+  }
+  return result;
+}
+
+export const RailFenceBoxSource = {
+  defaultDisabled: true,
+  name: 'Rail Fence',
+  description:
+    'Rail Fence (zigzag) transposition cipher. ::railfence=3 to encode with 3 rails; ::railfencedecode=3 to decode.',
+  defaultInput: 'WEAREDISCOVEREDFLEEATONCE ::railfence=3',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (
+      !hasOptionKeys(options, 'railfence', 'railfenceencode', 'railfencedecode')
+    ) {
+      return [];
+    }
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT) {
+      return [];
+    }
+
+    const encValue = extractOptionKeys(options, 'railfence', 'railfenceencode');
+    const decValue = extractOptionKeys(options, 'railfencedecode');
+
+    const boxes: Box[] = [];
+
+    if (encValue !== null) {
+      const numRails = parseRails(encValue);
+      const encoded = encode(input, numRails);
+      boxes.push(
+        new BoxBuilder('Rail Fence (Encode)', encoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    if (decValue !== null) {
+      const numRails = parseRails(decValue);
+      const decoded = decode(input, numRails);
+      boxes.push(
+        new BoxBuilder('Rail Fence (Decode)', decoded)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      );
+    }
+
+    return boxes;
+  },
+};
+
+export default RailFenceBoxSource;

--- a/src/modules/boxSources/__test__/RailFenceBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/RailFenceBoxSource.test.ts
@@ -1,0 +1,135 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { RailFenceBoxSource } from '../RailFenceBoxSource';
+
+describe('RailFenceBoxSource', () => {
+  describe('gate conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object has no relevant keys', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes('', {
+        railfence: '3',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding MAX_INPUT', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'a'.repeat(100_001),
+        { railfence: '3' },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('encode — canonical 3-rail vector', () => {
+    it('encodes WEAREDISCOVEREDFLEEATONCE with 3 rails to WECRLTEERDSOEEFEAOCAIVDEN', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        { railfence: '3' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Rail Fence (Encode)');
+      expect(boxes[0].props.plaintextOutput).toBe('WECRLTEERDSOEEFEAOCAIVDEN');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+  });
+
+  describe('decode — canonical 3-rail vector', () => {
+    it('decodes WECRLTEERDSOEEFEAOCAIVDEN with 3 rails to WEAREDISCOVEREDFLEEATONCE', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WECRLTEERDSOEEFEAOCAIVDEN',
+        { railfencedecode: '3' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Rail Fence (Decode)');
+      expect(boxes[0].props.plaintextOutput).toBe('WEAREDISCOVEREDFLEEATONCE');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('round-trips HELLO WORLD with 4 rails', async () => {
+      const encBoxes = await RailFenceBoxSource.generateBoxes('HELLO WORLD', {
+        railfence: '4',
+      });
+      expect(encBoxes).toHaveLength(1);
+      const encoded = encBoxes[0].props.plaintextOutput;
+
+      const decBoxes = await RailFenceBoxSource.generateBoxes(encoded, {
+        railfencedecode: '4',
+      });
+      expect(decBoxes).toHaveLength(1);
+      expect(decBoxes[0].props.plaintextOutput).toBe('HELLO WORLD');
+    });
+  });
+
+  describe('N=2 edge case', () => {
+    it('encodes abcdef with 2 rails to acebdf', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes('abcdef', {
+        railfence: '2',
+      });
+      expect(boxes).toHaveLength(1);
+      // rails: a c e / b d f → "ace" + "bdf"
+      expect(boxes[0].props.plaintextOutput).toBe('acebdf');
+    });
+  });
+
+  describe('both encode and decode options', () => {
+    it('returns 2 boxes when both ::railfence and ::railfencedecode are set', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        { railfence: '3', railfencedecode: '3' },
+      );
+      expect(boxes).toHaveLength(2);
+      const names = boxes.map((b) => b.props.name);
+      expect(names).toContain('Rail Fence (Encode)');
+      expect(names).toContain('Rail Fence (Decode)');
+    });
+  });
+
+  describe('rail clamping', () => {
+    it('clamps rail count below MIN to 2', async () => {
+      // rails=1 is invalid; should clamp to 2 and not throw
+      const boxes = await RailFenceBoxSource.generateBoxes('abcdef', {
+        railfence: '1',
+      });
+      expect(boxes).toHaveLength(1);
+      // 2-rail result matches known good output
+      expect(boxes[0].props.plaintextOutput).toBe('acebdf');
+    });
+
+    it('uses default of 3 rails when option value is boolean true', async () => {
+      const boxes = await RailFenceBoxSource.generateBoxes(
+        'WEAREDISCOVEREDFLEEATONCE',
+        { railfence: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('WECRLTEERDSOEEFEAOCAIVDEN');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(RailFenceBoxSource.name).toBe('Rail Fence');
+      expect(RailFenceBoxSource.tag).toBe('#');
+      expect(RailFenceBoxSource.kind).toBe('Encode');
+      expect(typeof RailFenceBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import MathExpressionBoxSource from './MathExpressionBoxSource';
 import MyIPBoxSource from './MyIPBoxSource';
 import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
+import RailFenceBoxSource from './RailFenceBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  RailFenceBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Rail Fence (Encode)

Adds the `Rail Fence` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `WEAREDISCOVEREDFLEEATONCE ::railfence=3`

#### Options:
- `::railfence`, `::railfencedecode`, `::railfenceencode`

#### Description:
Rail Fence (zigzag) transposition cipher. ::railfence=3 to encode with 3 rails; ::railfencedecode=3 to decode.

#### Usage Examples:
- **Input**:
```
WEAREDISCOVEREDFLEEATONCE ::railfence=3
```
- **Output Box (`Rail Fence (Encode)`)**:
```
WECRLTEERDSOEEFEAOCAIVDEN
```
