### PR TITLE
feat(RegexEscape): add Regex Escape BoxSource

### DIFF
--- a/src/modules/boxSources/RegexEscapeBoxSource.ts
+++ b/src/modules/boxSources/RegexEscapeBoxSource.ts
@@ -1,0 +1,44 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// MDN-recommended pattern: escapes all regex metacharacters with a backslash
+function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export const RegexEscapeBoxSource = {
+  defaultDisabled: true,
+  name: 'Regex Escape',
+  description:
+    'Escape a literal string so it can be used inside a regular expression.',
+  defaultInput: 'a.b*c (x?) ::regexescape',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'regexescape', 'reescape')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const escaped = escapeRegex(input);
+
+    return [
+      new BoxBuilder('Regex Escape', escaped)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default RegexEscapeBoxSource;

--- a/src/modules/boxSources/__test__/RegexEscapeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/RegexEscapeBoxSource.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { RegexEscapeBoxSource } from '../RegexEscapeBoxSource';
+
+describe('RegexEscapeBoxSource', () => {
+  describe('generateBoxes - gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('a.b*c', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('a.b*c', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input string', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - escaping', () => {
+    it('escapes . and * in "a.b*c"', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('a.b*c', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\\.b\\*c');
+    });
+
+    it('escapes ( ? ) in "(x?)"', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('(x?)', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('\\(x\\?\\)');
+    });
+
+    it('escapes + but leaves = unchanged in "1+1=2"', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('1+1=2', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1\\+1=2');
+    });
+
+    it('escapes $ and . in "price: $5.00"', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('price: $5.00', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('price: \\$5\\.00');
+    });
+
+    it('escapes backslash in "a\\b"', async () => {
+      // input is a-backslash-b (2 chars between a and b)
+      const boxes = await RegexEscapeBoxSource.generateBoxes('a\\b', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // output: a\\b (escaped backslash)
+      expect(boxes[0].props.plaintextOutput).toBe('a\\\\b');
+    });
+
+    it('leaves plain text unchanged when no special chars', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('hello', {
+        regexescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+  });
+
+  describe('generateBoxes - alias trigger', () => {
+    it('accepts ::reescape as an alias', async () => {
+      const boxes = await RegexEscapeBoxSource.generateBoxes('a.b', {
+        reescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\\.b');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(RegexEscapeBoxSource.name).toBe('Regex Escape');
+      expect(RegexEscapeBoxSource.tag).toBe('#');
+      expect(RegexEscapeBoxSource.kind).toBe('Encode');
+      expect(typeof RegexEscapeBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -25,6 +25,7 @@ import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import RegexEscapeBoxSource from './RegexEscapeBoxSource';
 import SemverBoxSource from './SemverBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import SnowflakeBoxSource from './SnowflakeBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  RegexEscapeBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Regex Escape (Encode)

Adds the `Regex Escape` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `a.b*c (x?) ::regexescape`

#### Options:
- `::reescape`, `::regexescape`

#### Description:
Escape a literal string so it can be used inside a regular expression.

#### Usage Examples:
- **Input**:
```
a.b*c (x?) ::regexescape
```
- **Output Box (`Regex Escape`)**:
```
a\.b\*c \(x\?\)
```
