### PR TITLE
feat(ReverseText): add Reverse Text BoxSource

### DIFF
--- a/src/modules/boxSources/ReverseTextBoxSource.ts
+++ b/src/modules/boxSources/ReverseTextBoxSource.ts
@@ -34,7 +34,7 @@ export const ReverseTextBoxSource = {
   defaultDisabled: true,
   name: 'Reverse Text',
   description:
-    'Reverse text by characters (default), words (::reverse=words), or lines (::reverse=lines).',
+    'Reverse text by characters (default), words (::reverse=words|word|w), or lines (::reverse=lines).',
   defaultInput: 'hello world ::reverse',
   tag: '#',
   kind: 'Transform',
@@ -51,7 +51,7 @@ export const ReverseTextBoxSource = {
     const mode = extractOptionKeys(options, 'reverse');
 
     let output: string;
-    if (mode === 'words') {
+    if (mode === 'words' || mode === 'word' || mode === 'w') {
       output = reverseWords(input);
     } else if (mode === 'lines') {
       output = reverseLines(input);

--- a/src/modules/boxSources/ReverseTextBoxSource.ts
+++ b/src/modules/boxSources/ReverseTextBoxSource.ts
@@ -1,0 +1,72 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// reverse a string by grapheme cluster so emoji with modifiers/ZWJ/flags
+// (e.g. 👍🏽, 🇺🇸) stay intact; fall back to code-point reversal if the
+// Intl.Segmenter API is unavailable (still safe for simple emoji like 😀)
+function reverseChars(str: string): string {
+  if (typeof Intl?.Segmenter === 'function') {
+    const segmenter = new Intl.Segmenter();
+    return [...segmenter.segment(str)]
+      .map((s) => s.segment)
+      .reverse()
+      .join('');
+  }
+  return [...str].reverse().join('');
+}
+
+// reverse word order; multiple whitespace runs collapse to a single space
+function reverseWords(str: string): string {
+  return str.split(/\s+/).reverse().join(' ');
+}
+
+// reverse line order; normalize CRLF to LF first
+function reverseLines(str: string): string {
+  return str.replace(/\r\n/g, '\n').split('\n').reverse().join('\n');
+}
+
+export const ReverseTextBoxSource = {
+  defaultDisabled: true,
+  name: 'Reverse Text',
+  description:
+    'Reverse text by characters (default), words (::reverse=words), or lines (::reverse=lines).',
+  defaultInput: 'hello world ::reverse',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'reverse')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const mode = extractOptionKeys(options, 'reverse');
+
+    let output: string;
+    if (mode === 'words') {
+      output = reverseWords(input);
+    } else if (mode === 'lines') {
+      output = reverseLines(input);
+    } else {
+      // default: chars (handles true/empty/'chars'/any other value)
+      output = reverseChars(input);
+    }
+
+    const box = new BoxBuilder('Reverse Text', output)
+      .setTemplate(CodeBoxTemplate)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default ReverseTextBoxSource;

--- a/src/modules/boxSources/__test__/ReverseTextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ReverseTextBoxSource.test.ts
@@ -92,10 +92,26 @@ describe('ReverseTextBoxSource', () => {
   });
 
   describe('words mode', () => {
-    it('reverses word order', async () => {
+    it('reverses word order with words option', async () => {
       const boxes = await ReverseTextBoxSource.generateBoxes(
         'hello world foo',
         { reverse: 'words' },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('foo world hello');
+    });
+
+    it('reverses word order with word option', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes(
+        'hello world foo',
+        { reverse: 'word' },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('foo world hello');
+    });
+
+    it('reverses word order with w option', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes(
+        'hello world foo',
+        { reverse: 'w' },
       );
       expect(boxes[0].props.plaintextOutput).toBe('foo world hello');
     });

--- a/src/modules/boxSources/__test__/ReverseTextBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ReverseTextBoxSource.test.ts
@@ -1,0 +1,137 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ReverseTextBoxSource } from '../ReverseTextBoxSource';
+
+describe('ReverseTextBoxSource', () => {
+  describe('trigger conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('hello', {
+        qr: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('', {
+        reverse: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('chars mode (default)', () => {
+    it('reverses ascii string by characters', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('hello', {
+        reverse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('olleh');
+    });
+
+    it('reverses mixed string with spaces', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('abc 123', {
+        reverse: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('321 cba');
+    });
+
+    it('reverses unicode precomposed char correctly (é as one code point)', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('café', {
+        reverse: true,
+      });
+      // é (U+00E9) is a single precomposed code point; must stay intact
+      expect(boxes[0].props.plaintextOutput).toBe('éfac');
+    });
+
+    it('is code-point safe: emoji stays intact (a😀b → b😀a)', async () => {
+      // verify the invariant the test depends on
+      expect([...'a😀b'].reverse().join('')).toBe('b😀a');
+
+      const boxes = await ReverseTextBoxSource.generateBoxes('a😀b', {
+        reverse: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('b😀a');
+    });
+
+    it('is grapheme-safe: skin-tone emoji (👍🏽) stays intact', async () => {
+      const input = '👍🏽';
+      const boxes = await ReverseTextBoxSource.generateBoxes(input, {
+        reverse: true,
+      });
+      // a single grapheme cluster reverses to itself (not split into base +
+      // modifier) thanks to Intl.Segmenter
+      expect(boxes[0].props.plaintextOutput).toBe('👍🏽');
+    });
+
+    it('reverses multiple grapheme clusters as whole units', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('a👍🏽b', {
+        reverse: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('b👍🏽a');
+    });
+
+    it('uses CodeBoxTemplate', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('hello', {
+        reverse: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+
+    it('sets the box name to "Reverse Text"', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('hello', {
+        reverse: true,
+      });
+      expect(boxes[0].props.name).toBe('Reverse Text');
+    });
+  });
+
+  describe('words mode', () => {
+    it('reverses word order', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes(
+        'hello world foo',
+        { reverse: 'words' },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('foo world hello');
+    });
+
+    it('collapses multiple spaces between words', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('a  b   c', {
+        reverse: 'words',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('c b a');
+    });
+  });
+
+  describe('lines mode', () => {
+    it('reverses line order', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes(
+        'line1\nline2\nline3',
+        { reverse: 'lines' },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('line3\nline2\nline1');
+    });
+
+    it('normalizes CRLF before reversing lines', async () => {
+      const boxes = await ReverseTextBoxSource.generateBoxes('a\r\nb\r\nc', {
+        reverse: 'lines',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('c\nb\na');
+    });
+  });
+
+  describe('input length guard', () => {
+    it('returns [] when input exceeds MAX_INPUT', async () => {
+      const huge = 'x'.repeat(100_001);
+      const boxes = await ReverseTextBoxSource.generateBoxes(huge, {
+        reverse: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -29,6 +29,7 @@ import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import ReverseTextBoxSource from './ReverseTextBoxSource';
 import SemverBoxSource from './SemverBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import SnowflakeBoxSource from './SnowflakeBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  ReverseTextBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Reverse Text (Transform)

Adds the `Reverse Text` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `hello world ::reverse`

#### Options:
- `::reverse`
- `::reverse=words` / `::reverse=word` / `::reverse=w`
- `::reverse=lines`

#### Description:
Reverse text by characters (default), words (::reverse=words|word|w), or lines (::reverse=lines).

#### Usage Examples:
- **Input**:
```
hello world ::reverse
```
- **Output Box (`Reverse Text`)**:
```
dlrow olleh
```

Closes #454