### PR TITLE
feat(ReverseWords): add Reverse Words BoxSource

### DIFF
--- a/src/modules/boxSources/ReverseWordsBoxSource.ts
+++ b/src/modules/boxSources/ReverseWordsBoxSource.ts
@@ -1,0 +1,47 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// split on runs of whitespace, reverse, and rejoin with a single space
+function reverseWords(input: string): string {
+  return trim(input).split(/\s+/).reverse().join(' ');
+}
+
+export const ReverseWordsBoxSource = {
+  defaultDisabled: true,
+  name: 'Reverse Words',
+  description: 'Reverse the order of words in the input.',
+  defaultInput: 'the quick brown fox ::reversewords',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'reversewords')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const output = reverseWords(input);
+
+    return [
+      new BoxBuilder('Reverse Words', output)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ReverseWordsBoxSource;

--- a/src/modules/boxSources/__test__/ReverseWordsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ReverseWordsBoxSource.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { ReverseWordsBoxSource } from '../ReverseWordsBoxSource';
+
+describe('ReverseWordsBoxSource', () => {
+  describe('generateBoxes - option gate', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await ReverseWordsBoxSource.generateBoxes(
+        'the quick brown fox',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when reversewords option is absent', async () => {
+      const boxes = await ReverseWordsBoxSource.generateBoxes(
+        'the quick brown fox',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input even with reversewords option', async () => {
+      const boxes = await ReverseWordsBoxSource.generateBoxes('', {
+        reversewords: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await ReverseWordsBoxSource.generateBoxes('   ', {
+        reversewords: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - word reversal', () => {
+    it('reverses word order for a normal sentence', async () => {
+      const boxes = await ReverseWordsBoxSource.generateBoxes(
+        'the quick brown fox',
+        { reversewords: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('fox brown quick the');
+    });
+
+    it('collapses multiple spaces between words', async () => {
+      const boxes = await ReverseWordsBoxSource.generateBoxes('a   b', {
+        reversewords: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('b a');
+    });
+
+    it('returns the same word for single-word input', async () => {
+      const boxes = await ReverseWordsBoxSource.generateBoxes('hello', {
+        reversewords: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello');
+    });
+
+    it('double reverse restores original word order', async () => {
+      const original = 'the quick brown fox';
+      const first = await ReverseWordsBoxSource.generateBoxes(original, {
+        reversewords: true,
+      });
+      const reversed = first[0].props.plaintextOutput as string;
+
+      const second = await ReverseWordsBoxSource.generateBoxes(reversed, {
+        reversewords: true,
+      });
+      expect(second[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('generateBoxes - box properties', () => {
+    it('sets the box name to "Reverse Words"', async () => {
+      const boxes = await ReverseWordsBoxSource.generateBoxes(
+        'the quick brown fox',
+        { reversewords: true },
+      );
+      expect(boxes[0].props.name).toBe('Reverse Words');
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await ReverseWordsBoxSource.generateBoxes(
+        'the quick brown fox',
+        { reversewords: true },
+      );
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -25,6 +25,7 @@ import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import ReverseWordsBoxSource from './ReverseWordsBoxSource';
 import SemverBoxSource from './SemverBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import SnowflakeBoxSource from './SnowflakeBoxSource';
@@ -79,6 +80,7 @@ export const boxSources: BoxSource[] = [
   FrequencyBoxSource,
   GcdLcmBoxSource,
   LineToolsBoxSource,
+  ReverseWordsBoxSource,
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,


### PR DESCRIPTION
### Box Source: Reverse Words (Transform)

Adds the `Reverse Words` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `the quick brown fox ::reversewords`

#### Options:
- `::reversewords`

#### Description:
Reverse the order of words in the input.

#### Usage Examples:
- **Input**:
```
the quick brown fox ::reversewords
```
- **Output Box (`Reverse Words`)**:
```
fox brown quick the
```
