### PR TITLE
feat(RomanNumeral): add Roman Numeral BoxSource

### DIFF
--- a/src/modules/boxSources/RomanNumeralBoxSource.ts
+++ b/src/modules/boxSources/RomanNumeralBoxSource.ts
@@ -1,0 +1,99 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// ordered pairs used for the standard subtractive algorithm
+const ROMAN_TABLE: [number, string][] = [
+  [1000, 'M'],
+  [900, 'CM'],
+  [500, 'D'],
+  [400, 'CD'],
+  [100, 'C'],
+  [90, 'XC'],
+  [50, 'L'],
+  [40, 'XL'],
+  [10, 'X'],
+  [9, 'IX'],
+  [5, 'V'],
+  [4, 'IV'],
+  [1, 'I'],
+];
+
+// strict regex that only accepts valid subtractive-form roman numerals
+const ROMAN_REGEX = /^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$/;
+
+function toRoman(n: number): string {
+  let result = '';
+  let remaining = n;
+  for (const [value, numeral] of ROMAN_TABLE) {
+    while (remaining >= value) {
+      result += numeral;
+      remaining -= value;
+    }
+  }
+  return result;
+}
+
+function fromRoman(s: string): number {
+  let result = 0;
+  let i = 0;
+  for (const [value, numeral] of ROMAN_TABLE) {
+    while (s.startsWith(numeral, i)) {
+      result += value;
+      i += numeral.length;
+    }
+  }
+  return result;
+}
+
+export const RomanNumeralBoxSource = {
+  defaultDisabled: true,
+  name: 'Roman Numeral',
+  description:
+    'Convert an integer (1-3999) to a Roman numeral, or a Roman numeral back to an integer.',
+  defaultInput: '2024 ::roman',
+  tag: 'Ⅼ',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'roman')) return [];
+
+    const s = trim(input);
+
+    if (/^[0-9]+$/.test(s)) {
+      const n = Number.parseInt(s, 10);
+      if (n < 1 || n > 3999) return [];
+      const roman = toRoman(n);
+      return [
+        new BoxBuilder('Roman Numeral', roman)
+          .setTemplate(DefaultBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const upper = s.toUpperCase();
+    // ensure the string is non-empty and matches valid subtractive form
+    if (upper.length > 0 && ROMAN_REGEX.test(upper)) {
+      const n = fromRoman(upper);
+      if (n === 0) return [];
+      return [
+        new BoxBuilder('Roman Numeral', String(n))
+          .setTemplate(DefaultBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    return [];
+  },
+};
+
+export default RomanNumeralBoxSource;

--- a/src/modules/boxSources/__test__/RomanNumeralBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/RomanNumeralBoxSource.test.ts
@@ -1,0 +1,78 @@
+import { RomanNumeralBoxSource } from '@modules/boxSources/RomanNumeralBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('RomanNumeralBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::roman option is absent', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('2024', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts 2024 to MMXXIV', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('2024', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('MMXXIV');
+    });
+
+    it('converts 4 to IV', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('4', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('IV');
+    });
+
+    it('converts 3999 to MMMCMXCIX', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('3999', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('MMMCMXCIX');
+    });
+
+    it('converts lowercase roman mmxxiv to 2024', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('mmxxiv', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('2024');
+    });
+
+    it('returns [] for 0 (out of range)', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('0', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for 4000 (out of range)', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('4000', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for IIII (invalid subtractive form)', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('IIII', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for arbitrary non-roman string', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('hello', {
+        roman: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('box name is Roman Numeral', async () => {
+      const boxes = await RomanNumeralBoxSource.generateBoxes('2024', {
+        roman: true,
+      });
+      expect(boxes[0].props.name).toBe('Roman Numeral');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -29,6 +29,7 @@ import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import RomanNumeralBoxSource from './RomanNumeralBoxSource';
 import SemverBoxSource from './SemverBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import SnowflakeBoxSource from './SnowflakeBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  RomanNumeralBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Roman Numeral (Convert)

Adds the `Roman Numeral` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `Ⅼ`
- **Default Input**: `2024 ::roman`

#### Options:
- `::roman`

#### Description:
Convert an integer (1-3999) to a Roman numeral, or a Roman numeral back to an integer.

#### Usage Examples:
- **Input**:
```
2024 ::roman
```
- **Output Box (`Roman Numeral`)**:
```
MMXXIV
```
