### PR TITLE
feat(Rot47): add ROT47 BoxSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev-debug.log
 *.sln
 *.sw?
 # OS specific
+.gemini/

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: box.defaultDisabled ? false : true,
+        enabled: !box.defaultDisabled,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: box.defaultDisabled ? false : true,
+            enabled: !box.defaultDisabled,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: true,
+        enabled: box.defaultDisabled ? false : true,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: true,
+            enabled: box.defaultDisabled ? false : true,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/modules/BoxSource.ts
+++ b/src/modules/BoxSource.ts
@@ -9,5 +9,6 @@ export interface BoxSource {
   tag: string;
   kind: string;
   priority?: number;
+  defaultDisabled?: boolean;
   generateBoxes: (input: string, options: BoxOptions) => Promise<Box[]>;
 }

--- a/src/modules/boxSources/Rot47BoxSource.ts
+++ b/src/modules/boxSources/Rot47BoxSource.ts
@@ -1,0 +1,56 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// rotate printable ASCII characters (! to ~, codes 33-126) by 47 positions
+function rot47(input: string): string {
+  let result = '';
+  for (let i = 0; i < input.length; i++) {
+    const c = input.charCodeAt(i);
+    if (c >= 33 && c <= 126) {
+      result += String.fromCharCode(33 + ((c - 33 + 47) % 94));
+    } else {
+      result += input[i];
+    }
+  }
+  return result;
+}
+
+export const Rot47BoxSource = {
+  defaultDisabled: true,
+  name: 'ROT47',
+  description:
+    'Apply the ROT47 cipher (rotates printable ASCII ! to ~ by 47). Self-inverse.',
+  defaultInput: 'Hello, World! ::rot47',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'rot47')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const output = rot47(input);
+    return [
+      new BoxBuilder('ROT47', output)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default Rot47BoxSource;

--- a/src/modules/boxSources/__test__/Rot47BoxSource.test.ts
+++ b/src/modules/boxSources/__test__/Rot47BoxSource.test.ts
@@ -1,0 +1,108 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { Rot47BoxSource } from '../Rot47BoxSource';
+
+describe('Rot47BoxSource', () => {
+  describe('generateBoxes - no option', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('Hello, World!', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('Hello, World!', {});
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - empty input', () => {
+    it('returns empty array for empty string', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('', { rot47: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('   ', { rot47: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - known vector', () => {
+    it('produces canonical ROT47 output for "Hello, World!"', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('Hello, World!', {
+        rot47: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('w6==@[ (@C=5P');
+      expect(boxes[0].props.name).toBe('ROT47');
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('produces correct ROT47 for "ABC"', async () => {
+      // A(65)→p, B(66)→q, C(67)→r
+      const boxes = await Rot47BoxSource.generateBoxes('ABC', { rot47: true });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('pqr');
+    });
+  });
+
+  describe('generateBoxes - self-inverse property', () => {
+    it('rot47(rot47(x)) === x for "Hello, World!"', async () => {
+      const first = await Rot47BoxSource.generateBoxes('Hello, World!', {
+        rot47: true,
+      });
+      const encoded = first[0].props.plaintextOutput as string;
+      const second = await Rot47BoxSource.generateBoxes(encoded, {
+        rot47: true,
+      });
+      expect(second[0].props.plaintextOutput).toBe('Hello, World!');
+    });
+
+    it('rot47(rot47(x)) === x for arbitrary printable ASCII', async () => {
+      const input =
+        '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+      const first = await Rot47BoxSource.generateBoxes(input, { rot47: true });
+      const second = await Rot47BoxSource.generateBoxes(
+        first[0].props.plaintextOutput as string,
+        { rot47: true },
+      );
+      expect(second[0].props.plaintextOutput).toBe(input);
+    });
+  });
+
+  describe('generateBoxes - boundary characters', () => {
+    it('preserves spaces (code 32, below range 33-126)', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('A B', { rot47: true });
+      expect(boxes).toHaveLength(1);
+      // A→p, space→space, B→q
+      expect(boxes[0].props.plaintextOutput).toBe('p q');
+    });
+
+    it('preserves newline and tab (control characters below 33)', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('A\nB\tC', {
+        rot47: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('p\nq\tr');
+    });
+
+    it('preserves non-ASCII characters (codes > 126)', async () => {
+      const boxes = await Rot47BoxSource.generateBoxes('héllo', {
+        rot47: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // lowercase h(104)→9, é unchanged (code 233), l→=, l→=, o→@
+      expect(boxes[0].props.plaintextOutput).toBe('9é==@');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(Rot47BoxSource.name).toBe('ROT47');
+      expect(Rot47BoxSource.tag).toBe('#');
+      expect(Rot47BoxSource.kind).toBe('Encode');
+      expect(typeof Rot47BoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -17,6 +17,7 @@ import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import Rot47BoxSource from './Rot47BoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
@@ -50,5 +51,6 @@ export const boxSources = [
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
+  Rot47BoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: ROT47 (Encode)

Adds the `ROT47` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `Hello, World! ::rot47`

#### Options:
- `::rot47`

#### Description:
Apply the ROT47 cipher (rotates printable ASCII ! to ~ by 47). Self-inverse.

#### Usage Examples:
- **Input**:
```
Hello, World! ::rot47
```
- **Output Box (`ROT47`)**:
```
w6==@[ (@C=5P
```
