### PR TITLE
feat(ScientificNotation): add Scientific Notation BoxSource

### DIFF
--- a/src/modules/boxSources/ScientificNotationBoxSource.ts
+++ b/src/modules/boxSources/ScientificNotationBoxSource.ts
@@ -1,0 +1,133 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// valid decimal or scientific notation number (optional sign, digits, optional decimal, optional exponent)
+const NUMBER_RE = /^-?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
+
+// trim trailing zeros after decimal in mantissa, keep at least one digit
+function trimMantissa(mantissa: string): string {
+  if (!mantissa.includes('.')) return mantissa;
+  return mantissa.replace(/\.?0+$/, '');
+}
+
+// format to scientific notation: Xe+Y with trimmed mantissa
+function toScientific(n: number): string {
+  const raw = n.toExponential();
+  // raw is like "1.23450e-4" — split on 'e'
+  const [mantissa, expPart] = raw.split('e');
+  const exp = Number.parseInt(expPart, 10);
+  const sign = exp >= 0 ? '+' : '';
+  return `${trimMantissa(mantissa)}e${sign}${exp}`;
+}
+
+// format to engineering notation: exponent is a multiple of 3
+function toEngineering(n: number): string {
+  if (n === 0) return '0e+0';
+
+  const exp = Math.floor(Math.log10(Math.abs(n)));
+  // round down to nearest multiple of 3
+  const engExp = Math.floor(exp / 3) * 3;
+  const mantissa = n / 10 ** engExp;
+
+  // round to avoid floating-point noise (up to 10 significant digits)
+  const mantissaRounded = Number.parseFloat(mantissa.toPrecision(10));
+  const sign = engExp >= 0 ? '+' : '';
+  return `${trimMantissa(mantissaRounded.toString())}e${sign}${engExp}`;
+}
+
+// produce a plain decimal string without JS auto-exponent notation
+function toDecimal(n: number): string {
+  // Number.toString() uses exponent for very large/small values;
+  // toFixed loses precision for very large numbers, so use a threshold approach
+  const abs = Math.abs(n);
+  if (abs === 0) return '0';
+  // for numbers JS would render in exponent form natively (< 1e-6 or >= 1e21),
+  // reconstruct from toExponential to get full decimal expansion
+  if (abs < 1e-6 || abs >= 1e21) {
+    const [mantissa, expPart] = n.toExponential().split('e');
+    const exp = Number.parseInt(expPart, 10);
+    const digits = mantissa.replace('-', '').replace('.', '');
+    const isNeg = n < 0;
+    const dotPos = 1 + exp; // position of decimal point in digits
+    let result: string;
+    if (dotPos <= 0) {
+      result = `0.${'0'.repeat(-dotPos)}${digits}`;
+    } else if (dotPos >= digits.length) {
+      result = digits + '0'.repeat(dotPos - digits.length);
+    } else {
+      result = `${digits.slice(0, dotPos)}.${digits.slice(dotPos)}`;
+    }
+    return isNeg ? `-${result}` : result;
+  }
+  // for normal range, toString() is fine
+  return n.toString();
+}
+
+export const ScientificNotationBoxSource = {
+  defaultDisabled: true,
+  name: 'Scientific Notation',
+  description: 'Convert a number to/from scientific and engineering notation.',
+  defaultInput: '0.00012345 ::scinote',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'scinote', 'scientific')) return [];
+
+    const raw = trim(input).slice(0, 100);
+
+    if (!NUMBER_RE.test(raw)) {
+      // no setTemplate → DefaultBoxTemplate renders the plaintext message
+      const box = new BoxBuilder(
+        'Scientific Notation',
+        'A valid number is required (e.g. 0.00012345 or 1.5e-3).',
+      )
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    const n = Number.parseFloat(raw);
+
+    if (!Number.isFinite(n)) {
+      const box = new BoxBuilder(
+        'Scientific Notation',
+        'A valid finite number is required.',
+      )
+        .setPriority(this.priority)
+        .build();
+      return [box];
+    }
+
+    const decimal = toDecimal(n);
+    const scientific = toScientific(n);
+    const engineering = toEngineering(n);
+    const eNotation = scientific.toUpperCase();
+
+    // plaintext output is a k:v block for KeyValueBoxTemplate fallback rendering
+    const plaintext = `Decimal: ${decimal}\nScientific: ${scientific}\nEngineering: ${engineering}\nE-notation: ${eNotation}`;
+
+    const box = new BoxBuilder('Scientific Notation', plaintext)
+      .setOptions({
+        Decimal: decimal,
+        Scientific: scientific,
+        Engineering: engineering,
+        'E-notation': eNotation,
+      })
+      .setTemplate(KeyValueBoxTemplate)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default ScientificNotationBoxSource;

--- a/src/modules/boxSources/__test__/ScientificNotationBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ScientificNotationBoxSource.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { ScientificNotationBoxSource } from '../ScientificNotationBoxSource';
+
+describe('ScientificNotationBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no matching option key', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes(
+        '0.00012345',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option is present', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes(
+        '0.00012345',
+        { base64: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('triggers on ::scinote option', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes(
+        '0.00012345',
+        { scinote: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('triggers on ::scientific option', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes(
+        '0.00012345',
+        { scientific: true },
+      );
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('returns error box for invalid input', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes('abc', {
+        scinote: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/valid number/i);
+    });
+
+    it('returns error box for empty input', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes('', {
+        scinote: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/valid number/i);
+    });
+
+    describe('0.00012345', () => {
+      it('produces Scientific = 1.2345e-4', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '0.00012345',
+          { scinote: true },
+        );
+        expect(boxes[0].props.options?.Scientific).toBe('1.2345e-4');
+      });
+
+      it('produces Engineering = 123.45e-6', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '0.00012345',
+          { scinote: true },
+        );
+        expect(boxes[0].props.options?.Engineering).toBe('123.45e-6');
+      });
+
+      it('produces Decimal = 0.00012345', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '0.00012345',
+          { scinote: true },
+        );
+        expect(boxes[0].props.options?.Decimal).toBe('0.00012345');
+      });
+    });
+
+    describe('123456', () => {
+      it('produces Scientific = 1.23456e+5', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '123456',
+          { scinote: true },
+        );
+        expect(boxes[0].props.options?.Scientific).toBe('1.23456e+5');
+      });
+    });
+
+    describe('1.5e3', () => {
+      it('produces Decimal = 1500', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes('1.5e3', {
+          scinote: true,
+        });
+        expect(boxes[0].props.options?.Decimal).toBe('1500');
+      });
+
+      it('produces Scientific = 1.5e+3', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes('1.5e3', {
+          scinote: true,
+        });
+        expect(boxes[0].props.options?.Scientific).toBe('1.5e+3');
+      });
+    });
+
+    describe('1000000', () => {
+      it('produces Engineering with exponent that is a multiple of 3', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '1000000',
+          { scinote: true },
+        );
+        const eng = boxes[0].props.options?.Engineering as string;
+        expect(eng).toBeDefined();
+        // extract exponent value and verify it's a multiple of 3
+        const match = eng.match(/e([+-]\d+)$/);
+        expect(match).not.toBeNull();
+        const expVal = Number.parseInt(match?.[1] ?? '', 10);
+        expect(expVal % 3).toBe(0);
+      });
+
+      it('produces Engineering = 1e+6', async () => {
+        const boxes = await ScientificNotationBoxSource.generateBoxes(
+          '1000000',
+          { scinote: true },
+        );
+        expect(boxes[0].props.options?.Engineering).toBe('1e+6');
+      });
+    });
+
+    it('E-notation is uppercase version of Scientific', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes(
+        '0.00012345',
+        { scinote: true },
+      );
+      const scientific = boxes[0].props.options?.Scientific as string;
+      const eNotation = boxes[0].props.options?.['E-notation'] as string;
+      expect(eNotation).toBe(scientific.toUpperCase());
+    });
+
+    it('sets priority matching source priority', async () => {
+      const boxes = await ScientificNotationBoxSource.generateBoxes('42', {
+        scinote: true,
+      });
+      expect(boxes[0].props.priority).toBe(
+        ScientificNotationBoxSource.priority,
+      );
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -29,6 +29,7 @@ import PasswordBoxSource from './PasswordBoxSource';
 import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import ScientificNotationBoxSource from './ScientificNotationBoxSource';
 import SemverBoxSource from './SemverBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import SnowflakeBoxSource from './SnowflakeBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  ScientificNotationBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Scientific Notation (Convert)

Adds the `Scientific Notation` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `0.00012345 ::scinote`

#### Options:
- `::scientific`, `::scinote`

#### Description:
Convert a number to/from scientific and engineering notation.

#### Usage Examples:
- **Input**:
```
0.00012345 ::scinote
```
- **Output Box (`Scientific Notation`)**:
```
Decimal: 0.00012345
Scientific: 1.2345e-4
Engineering: 123.45e-6
E-notation: 1.2345E-4
```
