### PR TITLE
feat(Semver): add Semver BoxSource

### DIFF
--- a/src/modules/boxSources/SemverBoxSource.ts
+++ b/src/modules/boxSources/SemverBoxSource.ts
@@ -1,0 +1,96 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// official semver 2.0.0 regex from https://semver.org/#is-there-a-suggested-regexp-to-check-a-semver-string
+const SEMVER_REGEX =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+interface SemverMatch {
+  major: string;
+  minor: string;
+  patch: string;
+  prerelease: string | null;
+  build: string | null;
+}
+
+function parseSemver(raw: string): SemverMatch | null {
+  // strip optional leading 'v' before matching
+  const normalized = raw.startsWith('v') ? raw.slice(1) : raw;
+  const m = SEMVER_REGEX.exec(normalized);
+  if (!m) return null;
+
+  return {
+    major: m[1],
+    minor: m[2],
+    patch: m[3],
+    prerelease: m[4] ?? null,
+    build: m[5] ?? null,
+  };
+}
+
+export const SemverBoxSource = {
+  defaultDisabled: true,
+  name: 'Semver',
+  description:
+    'Parse and validate a Semantic Version string into its components.',
+  defaultInput: '1.2.3-beta.1+build.5 ::semver',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'semver')) return [];
+
+    const raw = trim(input);
+    const parsed = parseSemver(raw);
+
+    if (!parsed) {
+      const content = `"${raw}" is not a valid semver string`;
+      return [
+        new BoxBuilder('Semver', content)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Valid: 'false', Input: raw })
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const kvOptions: Record<string, string> = {
+      Major: parsed.major,
+      Minor: parsed.minor,
+      Patch: parsed.patch,
+    };
+
+    // omit Prerelease / Build keys entirely when absent (consistent handling)
+    if (parsed.prerelease !== null) {
+      kvOptions.Prerelease = parsed.prerelease;
+    }
+    if (parsed.build !== null) {
+      kvOptions.Build = parsed.build;
+    }
+    kvOptions.Valid = 'true';
+
+    const lines = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Semver', lines)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default SemverBoxSource;

--- a/src/modules/boxSources/__test__/SemverBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SemverBoxSource.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'vitest';
+
+import { SemverBoxSource } from '../SemverBoxSource';
+
+describe('SemverBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::semver option is absent', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('1.2.3');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options is null', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('1.2.3', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('parses a basic semver string', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('1.2.3', {
+        semver: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Major).toBe('1');
+      expect(opts.Minor).toBe('2');
+      expect(opts.Patch).toBe('3');
+      expect(opts.Valid).toBe('true');
+    });
+
+    it('parses prerelease and build metadata', async () => {
+      const boxes = await SemverBoxSource.generateBoxes(
+        '1.2.3-beta.1+build.5',
+        { semver: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Prerelease).toBe('beta.1');
+      expect(opts.Build).toBe('build.5');
+      expect(opts.Valid).toBe('true');
+    });
+
+    it('strips a leading v before parsing', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('v2.0.0', {
+        semver: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Major).toBe('2');
+      expect(opts.Valid).toBe('true');
+    });
+
+    it('returns an invalid box for a non-semver string', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('1.2', {
+        semver: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const content = boxes[0].props.plaintextOutput;
+      expect(content).toMatch(/not a valid semver/i);
+    });
+
+    it('rejects leading zeros in numeric identifiers', async () => {
+      const boxes = await SemverBoxSource.generateBoxes('01.2.3', {
+        semver: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const content = boxes[0].props.plaintextOutput;
+      expect(content).toMatch(/not a valid semver/i);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -20,6 +20,7 @@ import NowBoxSource from './NowBoxSource';
 import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
+import SemverBoxSource from './SemverBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import SnowflakeBoxSource from './SnowflakeBoxSource';
 import SortLinesBoxSource from './SortLinesBoxSource';
@@ -65,6 +66,7 @@ export const boxSources = [
   A1Z26BoxSource,
   AsciiTableBoxSource,
   BmiBoxSource,
+  SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,
   SpeedConvertBoxSource,


### PR DESCRIPTION
### Box Source: Semver (Analyze)

Adds the `Semver` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `1.2.3-beta.1+build.5 ::semver`

#### Options:
- `::semver`

#### Description:
Parse and validate a Semantic Version string into its components.

#### Usage Examples:
- **Input**:
```
1.2.3-beta.1+build.5 ::semver
```
- **Output Box (`Semver`)**:
```
Major: 1
Minor: 2
Patch: 3
Prerelease: beta.1
Build: build.5
Valid: true
```
