### PR TITLE
feat(ShannonEntropy): add Shannon Entropy BoxSource

### DIFF
--- a/src/modules/boxSources/ShannonEntropyBoxSource.ts
+++ b/src/modules/boxSources/ShannonEntropyBoxSource.ts
@@ -1,0 +1,85 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// compute Shannon entropy (bits per symbol) by iterating code points
+function computeEntropy(input: string): {
+  entropy: number;
+  length: number;
+  uniqueSymbols: number;
+  totalBits: number;
+} {
+  const freq = new Map<string, number>();
+  let n = 0;
+  for (const cp of input) {
+    freq.set(cp, (freq.get(cp) ?? 0) + 1);
+    n++;
+  }
+
+  let h = 0;
+  for (const count of freq.values()) {
+    const p = count / n;
+    h -= p * Math.log2(p);
+  }
+
+  return {
+    entropy: h,
+    length: n,
+    uniqueSymbols: freq.size,
+    totalBits: Math.round(h * n),
+  };
+}
+
+export const ShannonEntropyBoxSource = {
+  defaultDisabled: true,
+  name: 'Shannon Entropy',
+  description:
+    'Compute the Shannon entropy (bits per symbol) of the input text.',
+  defaultInput: 'aaaabbbbcccd ::entropy',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'entropy', 'shannon')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const { entropy, length, uniqueSymbols, totalBits } = computeEntropy(input);
+
+    const entropyStr = `${entropy.toFixed(3)} bits/symbol`;
+    const lengthStr = `${length} symbols`;
+    const uniqueStr = `${uniqueSymbols}`;
+    const totalBitsStr = `${totalBits}`;
+
+    // plaintext k:v lines for the box content
+    const content = `Entropy: ${entropyStr}
+Length: ${lengthStr}
+Unique Symbols: ${uniqueStr}
+Total Bits: ${totalBitsStr}`;
+
+    const output: Record<string, string> = {
+      Entropy: entropyStr,
+      Length: lengthStr,
+      'Unique Symbols': uniqueStr,
+      'Total Bits': totalBitsStr,
+    };
+
+    return [
+      new BoxBuilder('Shannon Entropy', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(output)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ShannonEntropyBoxSource;

--- a/src/modules/boxSources/__test__/ShannonEntropyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ShannonEntropyBoxSource.test.ts
@@ -1,0 +1,96 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { ShannonEntropyBoxSource } from '../ShannonEntropyBoxSource';
+
+describe('ShannonEntropyBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no matching option key', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('', {
+        entropy: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('single distinct symbol → 0.000 bits/symbol', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('aaaa', {
+        entropy: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Entropy).toBe('0.000 bits/symbol');
+      expect(opts['Unique Symbols']).toBe('1');
+    });
+
+    it("'ab' → 1.000 bits/symbol, 2 unique symbols", async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('ab', {
+        entropy: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Entropy).toBe('1.000 bits/symbol');
+      expect(opts['Unique Symbols']).toBe('2');
+      expect(opts.Length).toBe('2 symbols');
+      expect(opts['Total Bits']).toBe('2');
+    });
+
+    // a=4, b=4, c=3, d=1, N=12 → H ≈ 1.855 bits/symbol, total bits = round(1.855*12) = 22
+    it("'aaaabbbbcccd' → 1.855 bits/symbol", async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes(
+        'aaaabbbbcccd',
+        { entropy: true },
+      );
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Entropy).toBe('1.855 bits/symbol');
+      expect(opts['Unique Symbols']).toBe('4');
+      expect(opts.Length).toBe('12 symbols');
+      expect(opts['Total Bits']).toBe('22');
+    });
+
+    it("'abcd' (4 equal) → 2.000 bits/symbol", async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('abcd', {
+        entropy: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Entropy).toBe('2.000 bits/symbol');
+      expect(opts['Unique Symbols']).toBe('4');
+    });
+
+    it('::shannon alias triggers the box', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('ab', {
+        shannon: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Entropy).toBe('1.000 bits/symbol');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('ab', {
+        entropy: true,
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('ab', {
+        entropy: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('box name is Shannon Entropy', async () => {
+      const boxes = await ShannonEntropyBoxSource.generateBoxes('ab', {
+        entropy: true,
+      });
+      expect(boxes[0].props.name).toBe('Shannon Entropy');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -30,6 +30,7 @@ import PowerConvertBoxSource from './PowerConvertBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
+import ShannonEntropyBoxSource from './ShannonEntropyBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import SnowflakeBoxSource from './SnowflakeBoxSource';
 import SortLinesBoxSource from './SortLinesBoxSource';
@@ -92,6 +93,7 @@ export const boxSources: BoxSource[] = [
   LineToolsBoxSource,
   PowerConvertBoxSource,
   SemverBoxSource,
+  ShannonEntropyBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,
   SoundexBoxSource,


### PR DESCRIPTION
### Box Source: Shannon Entropy (Analyze)

Adds the `Shannon Entropy` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `aaaabbbbcccd ::entropy`

#### Options:
- `::entropy`, `::shannon`

#### Description:
Compute the Shannon entropy (bits per symbol) of the input text.

#### Usage Examples:
- **Input**:
```
aaaabbbbcccd ::entropy
```
- **Output Box (`Shannon Entropy`)**:
```
Entropy: 1.855 bits/symbol
Length: 12 symbols
Unique Symbols: 4
Total Bits: 22
```
