### PR TITLE
feat(Slugify): add Slugify BoxSource

### DIFF
--- a/src/modules/boxSources/SlugifyBoxSource.ts
+++ b/src/modules/boxSources/SlugifyBoxSource.ts
@@ -1,0 +1,54 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// every nonspacing combining mark (diacritics produced by NFKD decomposition);
+// \p{Mn} covers Latin, Greek, Cyrillic and the extended/supplement blocks
+const COMBINING_MARKS = /\p{Mn}/gu;
+
+// converts text to a lowercase, hyphen-separated URL slug with diacritics removed
+function slugify(input: string): string {
+  return input
+    .normalize('NFKD')
+    .replace(COMBINING_MARKS, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export const SlugifyBoxSource = {
+  defaultDisabled: true,
+  name: 'Slugify',
+  description:
+    'Convert text into a lowercase, hyphen-separated URL slug (diacritics removed).',
+  defaultInput: 'Héllo World! Foo_Bar ::slug',
+  tag: '/',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'slug')) return [];
+    if (!isString(input) || trim(input).length === 0) return [];
+
+    const slug = slugify(input);
+
+    // if the entire input collapses to empty after stripping non-latin chars, skip
+    if (slug.length === 0) return [];
+
+    return [
+      new BoxBuilder('Slugify', slug)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default SlugifyBoxSource;

--- a/src/modules/boxSources/__test__/SlugifyBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SlugifyBoxSource.test.ts
@@ -1,0 +1,66 @@
+import { SlugifyBoxSource } from '@modules/boxSources/SlugifyBoxSource';
+import { describe, expect, it } from 'vitest';
+
+describe('SlugifyBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when ::slug option is absent', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes(
+        'Héllo World! Foo_Bar',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::slug option', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('', { slug: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('   ', { slug: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('converts accented text with punctuation and underscores', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes(
+        'Héllo World! Foo_Bar',
+        { slug: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hello-world-foo-bar');
+    });
+
+    it('collapses special characters between words correctly', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('  C++  & Rust!! ', {
+        slug: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('c-rust');
+    });
+
+    it('drops non-latin characters and collapses remaining segments', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('日本語 test', {
+        slug: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('test');
+    });
+
+    it('returns [] when input reduces to empty after slugification', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('日本語!!!', {
+        slug: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('produces no leading, trailing, or double hyphens', async () => {
+      const boxes = await SlugifyBoxSource.generateBoxes('--Hello--World--', {
+        slug: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const slug = boxes[0].props.plaintextOutput as string;
+      expect(slug).not.toMatch(/^-|-$|--/);
+      expect(slug).toBe('hello-world');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -27,6 +27,7 @@ import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import SemverBoxSource from './SemverBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SlugifyBoxSource from './SlugifyBoxSource';
 import SnowflakeBoxSource from './SnowflakeBoxSource';
 import SortLinesBoxSource from './SortLinesBoxSource';
 import SpeedConvertBoxSource from './SpeedConvertBoxSource';
@@ -80,6 +81,7 @@ export const boxSources: BoxSource[] = [
   GcdLcmBoxSource,
   LineToolsBoxSource,
   SemverBoxSource,
+  SlugifyBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,
   SpeedConvertBoxSource,


### PR DESCRIPTION
### Box Source: Slugify (Convert)

Adds the `Slugify` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `/`
- **Default Input**: `Héllo World! Foo_Bar ::slug`

#### Options:
- `::slug`

#### Description:
Convert text into a lowercase, hyphen-separated URL slug (diacritics removed).

#### Usage Examples:
- **Input**:
```
Héllo World! Foo_Bar ::slug
```
- **Output Box (`Slugify`)**:
```
hello-world-foo-bar
```
