### PR TITLE
feat(Snowflake): add Snowflake BoxSource

### DIFF
--- a/src/modules/boxSources/SnowflakeBoxSource.ts
+++ b/src/modules/boxSources/SnowflakeBoxSource.ts
@@ -1,0 +1,73 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// epochs: discord = 2015-01-01T00:00:00Z, twitter = 2010-11-04T01:42:54.657Z
+const DISCORD_EPOCH = 1420070400000n;
+const TWITTER_EPOCH = 1288834974657n;
+
+// u64 max (18446744073709551615) is exactly 20 decimal digits
+const MAX_SNOWFLAKE_LENGTH = 20;
+const MAX_SNOWFLAKE = 18446744073709551615n;
+
+export const SnowflakeBoxSource = {
+  defaultDisabled: true,
+  name: 'Snowflake',
+  description:
+    'Parse a Snowflake ID (Discord/Twitter) into its timestamp and components.',
+  defaultInput: '175928847299117063 ::snowflake',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'snowflake')) return [];
+
+    const raw = trim(input);
+    if (!/^\d+$/.test(raw) || raw.length > MAX_SNOWFLAKE_LENGTH) return [];
+
+    const id = BigInt(raw);
+    if (id > MAX_SNOWFLAKE) return [];
+
+    const epochOption = extractOptionKeys(options, 'snowflake', 'epoch');
+    const useTwitter = epochOption === 'twitter';
+    const epoch = useTwitter ? TWITTER_EPOCH : DISCORD_EPOCH;
+    const epochLabel = useTwitter ? 'Twitter' : 'Discord';
+
+    const timestampMs = Number((id >> 22n) + epoch);
+    const timestamp = new Date(timestampMs).toISOString();
+    // the 5+5 internal bits mean different things per platform
+    const highId = ((id >> 17n) & 0x1fn).toString();
+    const lowId = ((id >> 12n) & 0x1fn).toString();
+    const increment = (id & 0xfffn).toString();
+
+    const kvOptions: Record<string, string> = {
+      Timestamp: timestamp,
+      'Unix (ms)': timestampMs.toString(),
+      [useTwitter ? 'Datacenter ID' : 'Worker ID']: highId,
+      [useTwitter ? 'Worker ID' : 'Process ID']: lowId,
+      Increment: increment,
+      Epoch: epochLabel,
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Snowflake', plaintext)
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default SnowflakeBoxSource;

--- a/src/modules/boxSources/__test__/SnowflakeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SnowflakeBoxSource.test.ts
@@ -1,0 +1,118 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { SnowflakeBoxSource } from '../SnowflakeBoxSource';
+
+describe('SnowflakeBoxSource', () => {
+  describe('no ::snowflake option', () => {
+    it('returns [] when options are null', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '175928847299117063',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when ::snowflake key is absent', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '175928847299117063',
+        { other: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('discord epoch (default)', () => {
+    // verified: 175928847299117063n >> 22n = 41944705796n
+    // 41944705796 + 1420070400000 = 1462015105796 → 2016-04-30T11:18:25.796Z
+    // worker: (id >> 17n) & 0x1fn = 1n, process: (id >> 12n) & 0x1fn = 0n, increment: id & 0xfffn = 7n
+    it('parses discord snowflake into correct components', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '175928847299117063',
+        { snowflake: true },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Timestamp).toBe('2016-04-30T11:18:25.796Z');
+      expect(options?.['Unix (ms)']).toBe('1462015105796');
+      expect(options?.['Worker ID']).toBe('1');
+      expect(options?.['Process ID']).toBe('0');
+      expect(options?.Increment).toBe('7');
+      expect(options?.Epoch).toBe('Discord');
+    });
+
+    it('uses KeyValueBoxTemplate', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '175928847299117063',
+        { snowflake: true },
+      );
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+
+    it('sets priority', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '175928847299117063',
+        { snowflake: true },
+      );
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('twitter epoch via ::snowflake=twitter', () => {
+    it('reports Epoch as Twitter and returns a plausible date', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '1234567890123456789',
+        { snowflake: 'twitter' },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const { options } = boxes[0].props;
+      expect(options?.Epoch).toBe('Twitter');
+
+      // plausibility: twitter launched 2006, snowflakes appeared ~2010; date must be after epoch
+      const ts = Number(options?.['Unix (ms)']);
+      expect(ts).toBeGreaterThan(1288834974657); // after twitter epoch
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns [] for non-numeric input', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes('abc', {
+        snowflake: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty string', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes('', {
+        snowflake: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding max length', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '12345678901234567890123456', // 26 digits, over cap
+        { snowflake: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for mixed alphanumeric input', async () => {
+      const boxes = await SnowflakeBoxSource.generateBoxes('175928abc', {
+        snowflake: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('rejects values above the 64-bit range (would crash toISOString)', async () => {
+      // 21 digits, > u64 max
+      const boxes = await SnowflakeBoxSource.generateBoxes(
+        '999999999999999999999',
+        { snowflake: true },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -21,6 +21,7 @@ import PasswordBoxSource from './PasswordBoxSource';
 import RandomIntegerBoxSource from './RandomIntegerBoxSource';
 import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
+import SnowflakeBoxSource from './SnowflakeBoxSource';
 import SortLinesBoxSource from './SortLinesBoxSource';
 import SpeedConvertBoxSource from './SpeedConvertBoxSource';
 import SubnetBoxSource from './SubnetBoxSource';
@@ -64,6 +65,7 @@ export const boxSources = [
   A1Z26BoxSource,
   AsciiTableBoxSource,
   BmiBoxSource,
+  SnowflakeBoxSource,
   SortLinesBoxSource,
   SpeedConvertBoxSource,
   SubnetBoxSource,


### PR DESCRIPTION
### Box Source: Snowflake (Analyze)

Adds the `Snowflake` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `175928847299117063 ::snowflake`

#### Options:
- `::snowflake`

#### Description:
Parse a Snowflake ID (Discord/Twitter) into its timestamp and components.

#### Usage Examples:
- **Input**:
```
175928847299117063 ::snowflake
```
- **Output Box (`Snowflake`)**:
```
Timestamp: 2016-04-30T11:18:25.796Z
Unix (ms): 1462015105796
Worker ID: 1
Process ID: 0
Increment: 7
Epoch: Discord
```
