### PR TITLE
feat(Soundex): add Soundex BoxSource

### DIFF
--- a/src/modules/boxSources/SoundexBoxSource.ts
+++ b/src/modules/boxSources/SoundexBoxSource.ts
@@ -1,0 +1,129 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// digit table for consonant groups per American Soundex standard
+const SOUNDEX_TABLE: Record<string, string> = {
+  B: '1',
+  F: '1',
+  P: '1',
+  V: '1',
+  C: '2',
+  G: '2',
+  J: '2',
+  K: '2',
+  Q: '2',
+  S: '2',
+  X: '2',
+  Z: '2',
+  D: '3',
+  T: '3',
+  L: '4',
+  M: '5',
+  N: '5',
+  R: '6',
+};
+
+// vowels that reset adjacency tracking (produce no digit)
+const VOWELS = new Set(['A', 'E', 'I', 'O', 'U', 'Y']);
+
+/** Computes the American Soundex code for a single word. Returns null for words with no leading letter. */
+function soundex(word: string): string | null {
+  const letters = word.toUpperCase().replace(/[^A-Z]/g, '');
+  if (letters.length === 0) {
+    return null;
+  }
+
+  const first = letters[0];
+  const firstDigit = SOUNDEX_TABLE[first] ?? '';
+
+  // initialize prev to firstDigit so the first letter's own code is never
+  // double-counted when the same consonant group appears next
+  let prev = firstDigit;
+  let digits = '';
+
+  for (let i = 1; i < letters.length && digits.length < 3; i++) {
+    const ch = letters[i];
+
+    // H and W are transparent — skip without resetting adjacency
+    if (ch === 'H' || ch === 'W') {
+      continue;
+    }
+
+    if (VOWELS.has(ch)) {
+      // vowels break adjacency so the next same-digit consonant is recorded
+      prev = '';
+      continue;
+    }
+
+    const digit = SOUNDEX_TABLE[ch] ?? '';
+    if (digit !== prev) {
+      digits += digit;
+      prev = digit;
+    }
+  }
+
+  return (first + digits.padEnd(3, '0')).slice(0, 4);
+}
+
+export const SoundexBoxSource = {
+  defaultDisabled: true,
+  name: 'Soundex',
+  description:
+    'Compute the American Soundex phonetic code for each word in the input.',
+  defaultInput: 'Robert ::soundex',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'soundex')) {
+      return [];
+    }
+
+    if (!isString(input) || trim(input).length === 0) {
+      return [];
+    }
+
+    if (input.length > MAX_INPUT) {
+      return [];
+    }
+
+    const tokens = input.split(/\s+/).filter((t) => t.length > 0);
+
+    const lines: string[] = [];
+    for (const token of tokens) {
+      // only process tokens that begin with an ASCII letter
+      if (!/^[A-Za-z]/.test(token)) {
+        continue;
+      }
+      const code = soundex(token);
+      if (code !== null) {
+        lines.push(`${token} → ${code}`);
+      }
+    }
+
+    if (lines.length === 0) {
+      return [];
+    }
+
+    const output = lines.join('\n');
+
+    return [
+      new BoxBuilder('Soundex', output)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(Priority)
+        .build(),
+    ];
+  },
+};
+
+export default SoundexBoxSource;

--- a/src/modules/boxSources/__test__/SoundexBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/SoundexBoxSource.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { SoundexBoxSource } from '../SoundexBoxSource';
+
+describe('SoundexBoxSource', () => {
+  describe('generateBoxes - option guard', () => {
+    it('returns empty array when no soundex option is provided', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input with soundex option', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('', { soundex: true });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('   ', {
+        soundex: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - single word canonical vectors', () => {
+    const cases: [string, string][] = [
+      ['Robert', 'R163'],
+      ['Rupert', 'R163'],
+      ['Rubin', 'R150'],
+      ['Ashcraft', 'A261'],
+      ['Tymczak', 'T522'],
+      ['Pfister', 'P236'],
+      ['Honeyman', 'H555'],
+    ];
+
+    for (const [word, expected] of cases) {
+      it(`${word} → ${expected}`, async () => {
+        const boxes = await SoundexBoxSource.generateBoxes(word, {
+          soundex: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.plaintextOutput).toContain(expected);
+      });
+    }
+  });
+
+  describe('generateBoxes - multi-word input', () => {
+    it('formats each word on its own line', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert Rupert', {
+        soundex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'Robert → R163\nRupert → R163',
+      );
+    });
+  });
+
+  describe('generateBoxes - non-letter tokens are skipped', () => {
+    it('skips tokens that do not start with a letter', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('123 Robert', {
+        soundex: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Robert → R163');
+    });
+
+    it('returns empty array when all tokens are non-letter', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('123 456', {
+        soundex: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('box props', () => {
+    it('box name is Soundex', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert', {
+        soundex: true,
+      });
+      expect(boxes[0].props.name).toBe('Soundex');
+    });
+
+    it('showExpandButton is false', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert', {
+        soundex: true,
+      });
+      expect(boxes[0].props.showExpandButton).toBe(false);
+    });
+
+    it('priority is set', async () => {
+      const boxes = await SoundexBoxSource.generateBoxes('Robert', {
+        soundex: true,
+      });
+      expect(typeof boxes[0].props.priority).toBe('number');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(SoundexBoxSource.name).toBe('Soundex');
+      expect(typeof SoundexBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -29,6 +29,7 @@ import SemverBoxSource from './SemverBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import SnowflakeBoxSource from './SnowflakeBoxSource';
 import SortLinesBoxSource from './SortLinesBoxSource';
+import SoundexBoxSource from './SoundexBoxSource';
 import SpeedConvertBoxSource from './SpeedConvertBoxSource';
 import SubnetBoxSource from './SubnetBoxSource';
 import TemperatureBoxSource from './TemperatureBoxSource';
@@ -82,6 +83,7 @@ export const boxSources: BoxSource[] = [
   SemverBoxSource,
   SnowflakeBoxSource,
   SortLinesBoxSource,
+  SoundexBoxSource,
   SpeedConvertBoxSource,
   SubnetBoxSource,
   TemperatureBoxSource,


### PR DESCRIPTION
### Box Source: Soundex (Analyze)

Adds the `Soundex` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `Robert ::soundex`

#### Options:
- `::soundex`

#### Description:
Compute the American Soundex phonetic code for each word in the input.

#### Usage Examples:
- **Input**:
```
Robert ::soundex
```
- **Output Box (`Soundex`)**:
```
Robert → R163
```

### Soundex

將英文單字轉換成 **American Soundex** 語音編碼（phonetic code），讓發音相近但拼法不同的單字得到相同的代碼，常用於姓名比對、模糊搜尋（fuzzy search）與去除拼字差異。

例如：

| Input | Soundex |
|-------|----------|
| Robert | `R163` |
| Rupert | `R163` |
| Ashcraft | `A261` |
| Ashcroft | `A261` |

第一個字母會保留，其餘字母依發音轉換為數字，最後產生固定四個字元的編碼。
