### PR TITLE
feat(Stats): add Statistics BoxSource

### DIFF
--- a/src/modules/boxSources/StatsBoxSource.ts
+++ b/src/modules/boxSources/StatsBoxSource.ts
@@ -1,0 +1,149 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+// cap on the number of parsed values to bound sort/computation time
+const MAX_NUMBERS = 10_000;
+
+// valid numeric token: integer, decimal, or scientific notation
+const NUMBER_RE = /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/;
+
+// builds "k: v\n..." plaintext from a key-value record
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// formats a float to at most 6 significant decimal places, stripping trailing zeros
+function fmt(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  // toPrecision can produce e-notation; use toFixed for reasonable range
+  const s = n.toFixed(6);
+  // strip trailing zeros after the decimal point
+  const stripped = s.replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
+  // a tiny non-zero value rounds to "0" at 6 decimals — fall back to
+  // significant-figure notation so it isn't shown as exactly zero
+  if (stripped === '0' && n !== 0) return n.toPrecision(4);
+  return stripped;
+}
+
+// computes population variance of an array with a known mean
+function populationVariance(nums: number[], mean: number): number {
+  const sumSqDiff = nums.reduce((acc, x) => acc + (x - mean) ** 2, 0);
+  return sumSqDiff / nums.length;
+}
+
+// returns the median of a pre-sorted array
+function median(sorted: number[]): number {
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid];
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+// returns the mode(s) as a formatted string; 'none' when all values are unique
+function modeString(nums: number[]): string {
+  const freq = new Map<number, number>();
+  for (const n of nums) {
+    freq.set(n, (freq.get(n) ?? 0) + 1);
+  }
+  const maxFreq = Math.max(...freq.values());
+  if (maxFreq === 1) return 'none';
+  const modes = [...freq.entries()]
+    .filter(([, count]) => count === maxFreq)
+    .map(([val]) => val)
+    .sort((a, b) => a - b);
+  return modes.map(fmt).join(', ');
+}
+
+function makeErrorBox(message: string, priority: number): Box {
+  const kv = { Note: message };
+  return new BoxBuilder('Statistics', kvToPlaintext(kv))
+    .setTemplate(KeyValueBoxTemplate)
+    .setOptions(kv)
+    .setPriority(priority)
+    .build();
+}
+
+export const StatsBoxSource = {
+  defaultDisabled: true,
+  name: 'Statistics',
+  description:
+    'Descriptive statistics (mean, median, mode, stddev, etc.) of a list of numbers.',
+  defaultInput: '2, 4, 4, 4, 5, 5, 7, 9 ::stats',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'stats', 'statistics')) return [];
+
+    const raw = trim(input).slice(0, MAX_INPUT);
+
+    // split on commas and/or whitespace, discard empty tokens
+    const tokens = raw.split(/[\s,]+/).filter(Boolean);
+
+    if (tokens.length === 0) {
+      return [makeErrorBox('A list of numbers is required.', this.priority)];
+    }
+
+    const nums: number[] = [];
+    for (const token of tokens.slice(0, MAX_NUMBERS)) {
+      if (!NUMBER_RE.test(token)) {
+        return [makeErrorBox('A list of numbers is required.', this.priority)];
+      }
+      const n = Number.parseFloat(token);
+      if (!Number.isFinite(n)) {
+        return [makeErrorBox('A list of numbers is required.', this.priority)];
+      }
+      nums.push(n);
+    }
+
+    if (nums.length === 0) {
+      return [makeErrorBox('A list of numbers is required.', this.priority)];
+    }
+
+    const sorted = [...nums].sort((a, b) => a - b);
+    const count = nums.length;
+    const sum = nums.reduce((acc, x) => acc + x, 0);
+    const mean = sum / count;
+    const med = median(sorted);
+    const mode = modeString(nums);
+    const min = sorted[0];
+    const max = sorted[sorted.length - 1];
+    const range = max - min;
+    const variance = populationVariance(nums, mean);
+    const stdDev = Math.sqrt(variance);
+
+    const kv: Record<string, string> = {
+      Count: String(count),
+      Sum: fmt(sum),
+      Mean: fmt(mean),
+      Median: fmt(med),
+      Mode: mode,
+      Min: fmt(min),
+      Max: fmt(max),
+      Range: fmt(range),
+      Variance: fmt(variance),
+      'Std Dev (pop)': fmt(stdDev),
+      'Std Dev (sample)':
+        count > 1 ? fmt(Math.sqrt((variance * count) / (count - 1))) : 'n/a',
+    };
+
+    return [
+      new BoxBuilder('Statistics', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default StatsBoxSource;

--- a/src/modules/boxSources/__test__/StatsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/StatsBoxSource.test.ts
@@ -1,0 +1,129 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { StatsBoxSource } from '../StatsBoxSource';
+
+describe('StatsBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option key is provided', async () => {
+      const boxes = await StatsBoxSource.generateBoxes(
+        '2, 4, 4, 4, 5, 5, 7, 9',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option key is provided', async () => {
+      const boxes = await StatsBoxSource.generateBoxes('1, 2, 3', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('computes classic Wikipedia example: 2 4 4 4 5 5 7 9', async () => {
+      // population stddev = 2, variance = 4, mean = 5, median = 4.5, mode = 4
+      const boxes = await StatsBoxSource.generateBoxes(
+        '2, 4, 4, 4, 5, 5, 7, 9',
+        {
+          stats: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Statistics');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Count).toBe('8');
+      expect(opts.Sum).toBe('40');
+      expect(opts.Mean).toBe('5');
+      expect(opts.Median).toBe('4.5');
+      expect(opts.Mode).toBe('4');
+      expect(opts.Min).toBe('2');
+      expect(opts.Max).toBe('9');
+      expect(opts.Range).toBe('7');
+      expect(opts.Variance).toBe('4');
+      expect(opts['Std Dev (pop)']).toBe('2');
+    });
+
+    it('accepts ::statistics alias', async () => {
+      const boxes = await StatsBoxSource.generateBoxes('1, 2, 3', {
+        statistics: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('handles single-value input', async () => {
+      const boxes = await StatsBoxSource.generateBoxes('5', { stats: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Count).toBe('1');
+      expect(opts.Mean).toBe('5');
+      expect(opts['Std Dev (pop)']).toBe('0');
+      expect(opts['Std Dev (sample)']).toBe('n/a');
+      expect(opts.Variance).toBe('0');
+    });
+
+    it('computes correct median for even-length list: 1 2 3 4', async () => {
+      const boxes = await StatsBoxSource.generateBoxes('1, 2, 3, 4', {
+        stats: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Median).toBe('2.5');
+    });
+
+    it('reports all modes for multimodal input: 1 1 2 2', async () => {
+      const boxes = await StatsBoxSource.generateBoxes('1, 1, 2, 2', {
+        stats: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      // mode string should contain both 1 and 2
+      expect(opts.Mode).toContain('1');
+      expect(opts.Mode).toContain('2');
+    });
+
+    it('returns "none" when all values are unique: 1 2 3', async () => {
+      const boxes = await StatsBoxSource.generateBoxes('1, 2, 3', {
+        stats: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mode).toBe('none');
+    });
+
+    it('handles decimal inputs: 1.5 2.5 → mean 2', async () => {
+      const boxes = await StatsBoxSource.generateBoxes('1.5, 2.5', {
+        stats: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Mean).toBe('2');
+    });
+
+    it('returns error box for non-numeric input: a, b', async () => {
+      const boxes = await StatsBoxSource.generateBoxes('a, b', { stats: true });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Note).toMatch(/numbers/i);
+    });
+
+    it('handles space-separated input without commas', async () => {
+      const boxes = await StatsBoxSource.generateBoxes('3 6 9', {
+        stats: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Count).toBe('3');
+      expect(opts.Mean).toBe('6');
+    });
+
+    it('plaintextOutput is non-empty and contains key: value lines', async () => {
+      const boxes = await StatsBoxSource.generateBoxes(
+        '2, 4, 4, 4, 5, 5, 7, 9',
+        {
+          stats: true,
+        },
+      );
+      const text = boxes[0].props.plaintextOutput;
+      expect(text).toContain('Mean: 5');
+      expect(text).toContain('Std Dev (pop): 2');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -35,6 +35,7 @@ import SnowflakeBoxSource from './SnowflakeBoxSource';
 import SortLinesBoxSource from './SortLinesBoxSource';
 import SoundexBoxSource from './SoundexBoxSource';
 import SpeedConvertBoxSource from './SpeedConvertBoxSource';
+import StatsBoxSource from './StatsBoxSource';
 import SubnetBoxSource from './SubnetBoxSource';
 import TemperatureBoxSource from './TemperatureBoxSource';
 import TextReverseBoxSource from './TextReverseBoxSource';
@@ -96,6 +97,7 @@ export const boxSources: BoxSource[] = [
   SortLinesBoxSource,
   SoundexBoxSource,
   SpeedConvertBoxSource,
+  StatsBoxSource,
   SubnetBoxSource,
   TemperatureBoxSource,
   TextReverseBoxSource,


### PR DESCRIPTION
### Box Source: Statistics (Calculate)

Adds the `Statistics` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `2, 4, 4, 4, 5, 5, 7, 9 ::stats`

#### Options:
- `::statistics`, `::stats`

#### Description:
Descriptive statistics (mean, median, mode, stddev, etc.) of a list of numbers.

#### Usage Examples:
- **Input**:
```
2, 4, 4, 4, 5, 5, 7, 9 ::stats
```
- **Output Box (`Statistics`)**:
```
Count: 8
Sum: 40
Mean: 5
Median: 4.5
Mode: 4
Min: 2
Max: 9
Range: 7
Variance: 4
Std Dev (pop): 2
Std Dev (sample): 2.13809
```
