### PR TITLE
feat(StripTags): add Strip HTML Tags BoxSource

### DIFF
--- a/src/modules/boxSources/StripTagsBoxSource.ts
+++ b/src/modules/boxSources/StripTagsBoxSource.ts
@@ -1,0 +1,80 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// common named entities; &amp; is handled last (below) to avoid double-decoding
+const ENTITY_MAP: [RegExp, string][] = [
+  [/&lt;/g, '<'],
+  [/&gt;/g, '>'],
+  [/&quot;/g, '"'],
+  [/&#39;|&apos;/g, "'"],
+  [/&nbsp;/g, ' '],
+];
+
+// [^>]* is a negated character class — linear, no catastrophic backtracking
+const TAG_REGEX = /<[^>]*>/g;
+
+// out-of-range code points (> U+10FFFF) would throw, so leave them verbatim
+function fromCodePointSafe(codePoint: number, original: string): string {
+  return codePoint <= 0x10ffff ? String.fromCodePoint(codePoint) : original;
+}
+
+function decodeEntities(text: string): string {
+  let result = text;
+  for (const [pattern, replacement] of ENTITY_MAP) {
+    result = result.replace(pattern, replacement);
+  }
+  // numeric character references (decimal and hex), then &amp; last
+  result = result
+    .replace(/&#x([0-9a-fA-F]+);/g, (m, hex) =>
+      fromCodePointSafe(Number.parseInt(hex, 16), m),
+    )
+    .replace(/&#([0-9]+);/g, (m, dec) =>
+      fromCodePointSafe(Number.parseInt(dec, 10), m),
+    )
+    .replace(/&amp;/g, '&');
+  return result;
+}
+
+function stripTags(input: string): string {
+  return trim(decodeEntities(input.replace(TAG_REGEX, '')));
+}
+
+export const StripTagsBoxSource = {
+  defaultDisabled: true,
+  name: 'Strip HTML Tags',
+  description: 'Remove HTML tags, returning the plain text content.',
+  defaultInput: '<p>Hello <b>world</b></p> ::striptags',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'striptags', 'striphtml')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    const stripped = stripTags(input);
+
+    return [
+      new BoxBuilder('Strip HTML Tags', stripped)
+        .setTemplate(CodeBoxTemplate)
+        .setShowExpandButton(true)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default StripTagsBoxSource;

--- a/src/modules/boxSources/__test__/StripTagsBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/StripTagsBoxSource.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { StripTagsBoxSource } from '../StripTagsBoxSource';
+
+describe('StripTagsBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes(
+        '<p>Hello</p>',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with option', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes('', {
+        striptags: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with option', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes('   ', {
+        striptags: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('strips basic block tags and returns plain text', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes(
+        '<p>Hello <b>world</b></p>',
+        { striptags: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hello world');
+    });
+
+    it('strips anchor tags, keeping inner text', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes(
+        '<a href="x">link</a>',
+        { striptags: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('link');
+    });
+
+    it('decodes &amp; entity', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes(
+        '<p>Tom &amp; Jerry</p>',
+        { striptags: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Tom & Jerry');
+    });
+
+    it('decodes &lt; and &gt; entities in text nodes (no real tags)', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes('&lt;tag&gt;', {
+        striptags: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('<tag>');
+    });
+
+    it('handles self-closing tags', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes('<br/>done', {
+        striptags: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('done');
+    });
+
+    it('triggers on ::striphtml option key as well', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes('<p>Hello</p>', {
+        striphtml: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Hello');
+    });
+
+    it('sets correct box name and priority', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes('<p>Hello</p>', {
+        striptags: true,
+      });
+      expect(boxes[0].props.name).toBe('Strip HTML Tags');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+
+    it('decodes decimal and hex numeric character references', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes(
+        '<p>&#65;&#x42; &#33; C</p>',
+        { striptags: true },
+      );
+      expect(boxes[0].props.plaintextOutput).toBe('AB ! C');
+    });
+
+    it('leaves out-of-range numeric references verbatim (no throw)', async () => {
+      const boxes = await StripTagsBoxSource.generateBoxes('&#x110000;', {
+        striptags: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('&#x110000;');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -35,6 +35,7 @@ import SnowflakeBoxSource from './SnowflakeBoxSource';
 import SortLinesBoxSource from './SortLinesBoxSource';
 import SoundexBoxSource from './SoundexBoxSource';
 import SpeedConvertBoxSource from './SpeedConvertBoxSource';
+import StripTagsBoxSource from './StripTagsBoxSource';
 import SubnetBoxSource from './SubnetBoxSource';
 import TemperatureBoxSource from './TemperatureBoxSource';
 import TextReverseBoxSource from './TextReverseBoxSource';
@@ -96,6 +97,7 @@ export const boxSources: BoxSource[] = [
   SortLinesBoxSource,
   SoundexBoxSource,
   SpeedConvertBoxSource,
+  StripTagsBoxSource,
   SubnetBoxSource,
   TemperatureBoxSource,
   TextReverseBoxSource,


### PR DESCRIPTION
### Box Source: Strip HTML Tags (Transform)

Adds the `Strip HTML Tags` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `<p>Hello <b>world</b></p> ::striptags`

#### Options:
- `::striphtml`, `::striptags`

#### Description:
Remove HTML tags, returning the plain text content.

#### Usage Examples:
- **Input**:
```
<p>Hello <b>world</b></p> ::striptags
```
- **Output Box (`Strip HTML Tags`)**:
```
Hello world
```
