### PR TITLE
feat(TextDiff): add Text Diff BoxSource

### DIFF
--- a/src/modules/boxSources/TextDiffBoxSource.ts
+++ b/src/modules/boxSources/TextDiffBoxSource.ts
@@ -1,0 +1,144 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 20_000;
+
+// separator line that splits left and right texts
+const SEPARATOR = '---';
+
+interface DiffResult {
+  added: number;
+  removed: number;
+  lines: string[];
+}
+
+// compute LCS lengths table for two arrays
+function lcsTable(left: string[], right: string[]): number[][] {
+  const m = left.length;
+  const n = right.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array(n + 1).fill(0),
+  );
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (left[i - 1] === right[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+  return dp;
+}
+
+// backtrack LCS table to produce unified-style diff lines (removals before additions)
+function buildDiff(left: string[], right: string[]): DiffResult {
+  const dp = lcsTable(left, right);
+  const lines: string[] = [];
+  let added = 0;
+  let removed = 0;
+  let i = left.length;
+  let j = right.length;
+
+  // collect in reverse then flip
+  const reversed: string[] = [];
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && left[i - 1] === right[j - 1]) {
+      reversed.push(`  ${left[i - 1]}`);
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      reversed.push(`+ ${right[j - 1]}`);
+      added++;
+      j--;
+    } else {
+      reversed.push(`- ${left[i - 1]}`);
+      removed++;
+      i--;
+    }
+  }
+
+  reversed.reverse();
+  lines.push(...reversed);
+
+  return { added, removed, lines };
+}
+
+// the LCS table is O(leftLines * rightLines); bound the line count so a
+// pathological many-short-lines input within MAX_INPUT can't freeze the page
+const MAX_LINES_PER_SIDE = 2_000;
+
+type DiffOutcome =
+  | { ok: true; output: string }
+  | { ok: false; message: string };
+
+function computeDiff(input: string): DiffOutcome {
+  const inputLines = input.split('\n');
+  const sepIdx = inputLines.findIndex((line) => line.trim() === SEPARATOR);
+
+  if (sepIdx === -1) {
+    return {
+      ok: false,
+      message:
+        'No separator found. Separate the two texts with a line containing only "---".',
+    };
+  }
+
+  const left = inputLines.slice(0, sepIdx);
+  const right = inputLines.slice(sepIdx + 1);
+
+  if (left.length > MAX_LINES_PER_SIDE || right.length > MAX_LINES_PER_SIDE) {
+    return {
+      ok: false,
+      message: `Too many lines to diff (limit ${MAX_LINES_PER_SIDE} per side; got ${left.length} / ${right.length}).`,
+    };
+  }
+
+  const { added, removed, lines } = buildDiff(left, right);
+  const summary = `@@ +${added} -${removed} @@`;
+  return { ok: true, output: [summary, ...lines].join('\n') };
+}
+
+export const TextDiffBoxSource = {
+  defaultDisabled: true,
+  name: 'Text Diff',
+  description:
+    'Line diff between two texts separated by a line containing only "---".',
+  defaultInput: 'foo\nbar\n---\nfoo\nbaz ::textdiff',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'textdiff', 'linediff')) return [];
+    if (!isString(input) || input.length > MAX_INPUT) return [];
+
+    const result = computeDiff(input);
+
+    if (!result.ok) {
+      // plain message box (no diff syntax highlighting)
+      return [
+        new BoxBuilder('Text Diff', result.message)
+          .setTemplate(CodeBoxTemplate)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    return [
+      new BoxBuilder('Text Diff', result.output)
+        .setOptions({ language: 'diff' })
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default TextDiffBoxSource;

--- a/src/modules/boxSources/__test__/TextDiffBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TextDiffBoxSource.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { TextDiffBoxSource } from '../TextDiffBoxSource';
+
+describe('TextDiffBoxSource', () => {
+  it('returns [] when no matching option is provided', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      null,
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for unrelated options', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      { json: true },
+    );
+    expect(boxes).toEqual([]);
+  });
+
+  it('triggers on ::textdiff option', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      { textdiff: true },
+    );
+    expect(boxes.length).toBe(1);
+  });
+
+  it('triggers on ::linediff option', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      { linediff: true },
+    );
+    expect(boxes.length).toBe(1);
+  });
+
+  it('produces correct diff lines for foo/bar vs foo/baz', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      { textdiff: true },
+    );
+    const output: string = boxes[0].props.plaintextOutput;
+    expect(output).toContain('  foo');
+    expect(output).toContain('- bar');
+    expect(output).toContain('+ baz');
+  });
+
+  it('summary shows +1 -1 for foo/bar vs foo/baz', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      'foo\nbar\n---\nfoo\nbaz',
+      { textdiff: true },
+    );
+    const output: string = boxes[0].props.plaintextOutput;
+    expect(output).toMatch(/@@ \+1 -1 @@/);
+  });
+
+  it('identical texts produce no + or - lines and summary +0 -0', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes('a\nb\n---\na\nb', {
+      textdiff: true,
+    });
+    const output: string = boxes[0].props.plaintextOutput;
+    const diffLines = output
+      .split('\n')
+      .filter((l) => l.startsWith('+ ') || l.startsWith('- '));
+    expect(diffLines).toHaveLength(0);
+    expect(output).toContain('@@ +0 -0 @@');
+  });
+
+  it('empty left side produces all added lines', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes('\n---\nx', {
+      textdiff: true,
+    });
+    const output: string = boxes[0].props.plaintextOutput;
+    expect(output).toContain('+ x');
+  });
+
+  it('no separator returns a box mentioning --- separator', async () => {
+    const boxes = await TextDiffBoxSource.generateBoxes('just one text', {
+      textdiff: true,
+    });
+    expect(boxes.length).toBe(1);
+    const output: string = boxes[0].props.plaintextOutput;
+    expect(output).toContain('---');
+  });
+
+  it('returns [] for non-string input', async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional type coercion for test
+    const boxes = await TextDiffBoxSource.generateBoxes(null as any, {
+      textdiff: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for input exceeding MAX_INPUT', async () => {
+    const huge = 'a'.repeat(20_001);
+    const boxes = await TextDiffBoxSource.generateBoxes(huge, {
+      textdiff: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('refuses to diff more lines than the per-side cap (no LCS freeze)', async () => {
+    // many short lines stays within MAX_INPUT but would be a huge LCS table
+    const side = Array.from({ length: 2500 }, () => 'a').join('\n');
+    const boxes = await TextDiffBoxSource.generateBoxes(
+      `${side}\n---\n${side}`,
+      {
+        textdiff: true,
+      },
+    );
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput.toLowerCase()).toContain(
+      'too many lines',
+    );
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -37,6 +37,7 @@ import SoundexBoxSource from './SoundexBoxSource';
 import SpeedConvertBoxSource from './SpeedConvertBoxSource';
 import SubnetBoxSource from './SubnetBoxSource';
 import TemperatureBoxSource from './TemperatureBoxSource';
+import TextDiffBoxSource from './TextDiffBoxSource';
 import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
@@ -98,6 +99,7 @@ export const boxSources: BoxSource[] = [
   SpeedConvertBoxSource,
   SubnetBoxSource,
   TemperatureBoxSource,
+  TextDiffBoxSource,
   TextReverseBoxSource,
   TwosComplementBoxSource,
   UlidBoxSource,


### PR DESCRIPTION
### Box Source: Text Diff (Analyze)

Adds the `Text Diff` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `foo
bar
---
foo
baz ::textdiff`

#### Options:
- `::linediff`, `::textdiff`

#### Description:
Line diff between two texts separated by a line containing only "---".

#### Usage Examples:
- **Input**:
```
foo
bar
---
foo
baz ::textdiff
```
- **Output Box (`Text Diff`)**:
```
@@ +1 -1 @@
  foo
- bar
+ baz
```
