### PR TITLE
feat(TextIndent): add Indent BoxSource

### DIFF
--- a/src/modules/boxSources/TextIndentBoxSource.ts
+++ b/src/modules/boxSources/TextIndentBoxSource.ts
@@ -1,0 +1,110 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// compute the length of the common leading-space prefix across all non-empty lines
+function commonLeadingSpaces(lines: string[]): number {
+  const nonEmpty = lines.filter((l) => l.length > 0);
+  if (nonEmpty.length === 0) return 0;
+
+  let min = Number.POSITIVE_INFINITY;
+  for (const line of nonEmpty) {
+    let count = 0;
+    while (count < line.length && line[count] === ' ') {
+      count++;
+    }
+    if (count < min) min = count;
+  }
+  return min === Number.POSITIVE_INFINITY ? 0 : min;
+}
+
+// apply indentation: positive n prepends spaces, negative n removes leading spaces
+function applyIndent(lines: string[], n: number): string[] {
+  if (n === 0) return lines;
+
+  if (n > 0) {
+    const pad = ' '.repeat(n);
+    return lines.map((line) => (line.length === 0 ? line : pad + line));
+  }
+
+  // dedent: remove up to |n| leading spaces per line
+  const remove = -n;
+  return lines.map((line) => {
+    let i = 0;
+    while (i < remove && i < line.length && line[i] === ' ') {
+      i++;
+    }
+    return line.slice(i);
+  });
+}
+
+export const TextIndentBoxSource = {
+  defaultDisabled: true,
+  name: 'Indent',
+  description:
+    'Indent every line by N spaces (::indent=<n>) or dedent (::dedent / ::indent=-<n>).',
+  defaultInput: 'line one\nline two ::indent=2',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantIndent = hasOptionKeys(options, 'indent');
+    const wantDedent = hasOptionKeys(options, 'dedent');
+    if (!wantIndent && !wantDedent) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    // normalize line endings
+    const normalized = (input as string)
+      .replace(/\r\n/g, '\n')
+      .replace(/\r/g, '\n');
+    const lines = normalized.split('\n');
+
+    let amount: number;
+
+    if (wantIndent) {
+      const raw = extractOptionKeys(options, 'indent');
+      if (raw === true || raw === null) {
+        // ::indent with no value defaults to 2
+        amount = 2;
+      } else {
+        const parsed = Number.parseInt(raw as string, 10);
+        amount = Number.isNaN(parsed)
+          ? 2
+          : Math.max(-1000, Math.min(1000, parsed));
+      }
+    } else {
+      // ::dedent branch
+      const raw = extractOptionKeys(options, 'dedent');
+      if (raw === true || raw === null) {
+        // auto-dedent: remove the common leading whitespace prefix
+        amount = -commonLeadingSpaces(lines);
+      } else {
+        const parsed = Number.parseInt(raw as string, 10);
+        const fixed = Number.isNaN(parsed)
+          ? 0
+          : Math.max(0, Math.min(1000, parsed));
+        amount = -fixed;
+      }
+    }
+
+    const result = applyIndent(lines, amount).join('\n');
+
+    return [
+      new BoxBuilder('Indent', result)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default TextIndentBoxSource;

--- a/src/modules/boxSources/__test__/TextIndentBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TextIndentBoxSource.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import { TextIndentBoxSource } from '../TextIndentBoxSource';
+
+describe('TextIndentBoxSource', () => {
+  describe('guard conditions', () => {
+    it('returns [] when no option keys provided', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\nb', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated option keys provided', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\nb', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('', {
+        indent: '2',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for input exceeding MAX_INPUT', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes(
+        'a'.repeat(100_001),
+        {
+          indent: '2',
+        },
+      );
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('::indent=N (positive)', () => {
+    it('prepends N spaces to each non-empty line', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\nb', {
+        indent: '2',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('  a\n  b');
+    });
+
+    it('preserves blank lines — blank line stays blank, non-empty lines indented', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\n\nb', {
+        indent: '2',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('  a\n\n  b');
+    });
+
+    it('indents by 4 spaces on single-line input', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('x', {
+        indent: '4',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('    x');
+    });
+
+    it('defaults to 2 spaces when ::indent has no value (boolean true)', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('hello', {
+        indent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('  hello');
+    });
+  });
+
+  describe('::indent=-N (negative — dedent fixed amount)', () => {
+    it('removes up to N leading spaces from each line', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('    a\n    b', {
+        indent: '-2',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('  a\n  b');
+    });
+
+    it('does not remove more spaces than available', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('  a', {
+        indent: '-10',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a');
+    });
+  });
+
+  describe('::dedent=N (fixed dedent)', () => {
+    it('removes up to N leading spaces per line', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('    a\n      b', {
+        dedent: '4',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a\n  b');
+    });
+
+    it('does not remove non-space characters', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('  ab', {
+        dedent: '10',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('ab');
+    });
+  });
+
+  describe('::dedent (auto-dedent — no value)', () => {
+    it('removes the common leading-space prefix from all lines', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('    a\n      b', {
+        dedent: true,
+      });
+      // common prefix is 4 spaces: 'a' and '  b'
+      expect(boxes[0].props.plaintextOutput).toBe('a\n  b');
+    });
+
+    it('leaves blank lines empty after auto-dedent', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('  a\n\n  b', {
+        dedent: true,
+      });
+      // common prefix from non-empty lines is 2; blank stays blank
+      expect(boxes[0].props.plaintextOutput).toBe('a\n\nb');
+    });
+
+    it('produces no change when there is no common leading whitespace', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\n  b', {
+        dedent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('a\n  b');
+    });
+  });
+
+  describe('box properties', () => {
+    it('sets box name to "Indent"', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('x', {
+        indent: '2',
+      });
+      expect(boxes[0].props.name).toBe('Indent');
+    });
+
+    it('sets priority from source priority', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('x', {
+        indent: '2',
+      });
+      expect(boxes[0].props.priority).toBe(TextIndentBoxSource.priority);
+    });
+
+    it('uses CodeBoxTemplate', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('x', {
+        indent: '2',
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+  });
+
+  describe('CRLF normalization', () => {
+    it('normalizes CRLF to LF before indenting', async () => {
+      const boxes = await TextIndentBoxSource.generateBoxes('a\r\nb', {
+        indent: '2',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('  a\n  b');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -32,6 +32,7 @@ import SortLinesBoxSource from './SortLinesBoxSource';
 import SpeedConvertBoxSource from './SpeedConvertBoxSource';
 import SubnetBoxSource from './SubnetBoxSource';
 import TemperatureBoxSource from './TemperatureBoxSource';
+import TextIndentBoxSource from './TextIndentBoxSource';
 import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
@@ -85,6 +86,7 @@ export const boxSources: BoxSource[] = [
   SpeedConvertBoxSource,
   SubnetBoxSource,
   TemperatureBoxSource,
+  TextIndentBoxSource,
   TextReverseBoxSource,
   TwosComplementBoxSource,
   UnicodeNormalizeBoxSource,


### PR DESCRIPTION
### Box Source: Indent (Transform)

Adds the `Indent` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `line one
line two ::indent=2`

#### Options:
- `::dedent`, `::indent`

#### Description:
Indent every line by N spaces (::indent=<n>) or dedent (::dedent / ::indent=-<n>).

#### Usage Examples:
- **Input**:
```
line one
line two ::indent=2
```
- **Output Box (`Indent`)**:
```
  line one
  line two
```
