### PR TITLE
feat(TextReverse): add Text Reverse BoxSource

### DIFF
--- a/src/modules/boxSources/TextReverseBoxSource.ts
+++ b/src/modules/boxSources/TextReverseBoxSource.ts
@@ -1,0 +1,40 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+export const TextReverseBoxSource = {
+  defaultDisabled: true,
+  name: 'Text Reverse',
+  description:
+    'Reverse the characters of the input string (Unicode code-point aware).',
+  defaultInput: 'hello 😀 ::reverse',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'reverse', 'reversetext')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    // iterate by code point so surrogate pairs (emoji, astral chars) stay intact
+    const reversed = [...input].reverse().join('');
+
+    return [
+      new BoxBuilder('Text Reverse', reversed)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default TextReverseBoxSource;

--- a/src/modules/boxSources/__test__/TextReverseBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TextReverseBoxSource.test.ts
@@ -1,0 +1,76 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { TextReverseBoxSource } from '../TextReverseBoxSource';
+
+describe('TextReverseBoxSource', () => {
+  describe('generateBoxes - option guard', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await TextReverseBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await TextReverseBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input string', async () => {
+      const boxes = await TextReverseBoxSource.generateBoxes('', {
+        reverse: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - basic reversal', () => {
+    it('reverses "hello" to "olleh"', async () => {
+      const boxes = await TextReverseBoxSource.generateBoxes('hello', {
+        reverse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Text Reverse');
+      expect(boxes[0].props.plaintextOutput).toBe('olleh');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+
+    it('reverses "abc123" to "321cba"', async () => {
+      const boxes = await TextReverseBoxSource.generateBoxes('abc123', {
+        reverse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('321cba');
+    });
+
+    it('also triggers on "reversetext" option key', async () => {
+      const boxes = await TextReverseBoxSource.generateBoxes('hello', {
+        reversetext: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('olleh');
+    });
+  });
+
+  describe('generateBoxes - Unicode / astral safety', () => {
+    it('keeps emoji intact: "a😀b" → "b😀a"', async () => {
+      const boxes = await TextReverseBoxSource.generateBoxes('a😀b', {
+        reverse: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('b😀a');
+    });
+
+    it('double-reverse returns the original string', async () => {
+      const original = 'hello 😀 world';
+      const [first] = await TextReverseBoxSource.generateBoxes(original, {
+        reverse: true,
+      });
+      const reversed = first.props.plaintextOutput as string;
+      const [second] = await TextReverseBoxSource.generateBoxes(reversed, {
+        reverse: true,
+      });
+      expect(second.props.plaintextOutput).toBe(original);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -25,6 +25,7 @@ import SortLinesBoxSource from './SortLinesBoxSource';
 import SpeedConvertBoxSource from './SpeedConvertBoxSource';
 import SubnetBoxSource from './SubnetBoxSource';
 import TemperatureBoxSource from './TemperatureBoxSource';
+import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
@@ -67,6 +68,7 @@ export const boxSources = [
   SpeedConvertBoxSource,
   SubnetBoxSource,
   TemperatureBoxSource,
+  TextReverseBoxSource,
   WhitespaceCleanBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Text Reverse (Transform)

Adds the `Text Reverse` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `hello 😀 ::reverse`

#### Options:
- `::reverse`, `::reversetext`

#### Description:
Reverse the characters of the input string (Unicode code-point aware).

#### Usage Examples:
- **Input**:
```
hello 😀 ::reverse
```
- **Output Box (`Text Reverse`)**:
```
😀 olleh
```
