### PR TITLE
feat(TextWrap): add Text Wrap BoxSource

### DIFF
--- a/src/modules/boxSources/TextWrapBoxSource.ts
+++ b/src/modules/boxSources/TextWrapBoxSource.ts
@@ -1,0 +1,81 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+const DEFAULT_WIDTH = 80;
+const MIN_WIDTH = 1;
+const MAX_WIDTH = 1000;
+
+// greedy word-wrap a single line of text to the given column width.
+// words longer than width are placed on their own line without breaking.
+function wrapLine(line: string, width: number): string {
+  const words = line.split(' ').filter((w) => w.length > 0);
+  if (words.length === 0) return '';
+
+  const result: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    if (current.length === 0) {
+      current = word;
+    } else if (current.length + 1 + word.length <= width) {
+      current = `${current} ${word}`;
+    } else {
+      result.push(current);
+      current = word;
+    }
+  }
+  if (current.length > 0) {
+    result.push(current);
+  }
+
+  return result.join('\n');
+}
+
+// wrap text paragraph-by-paragraph, preserving blank lines as paragraph boundaries.
+function wrapText(text: string, width: number): string {
+  const lines = text.split('\n');
+  return lines.map((line) => wrapLine(line, width)).join('\n');
+}
+
+function resolveWidth(raw: string | boolean | null): number {
+  if (raw === null || raw === true || raw === false) return DEFAULT_WIDTH;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed)) return DEFAULT_WIDTH;
+  return Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, parsed));
+}
+
+export const TextWrapBoxSource = {
+  defaultDisabled: true,
+  name: 'Text Wrap',
+  description: 'Word-wrap text to a column width. ::wrap=<width> (default 80).',
+  defaultInput: 'The quick brown fox jumps over the lazy dog ::wrap=20',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'wrap', 'wordwrap')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const rawWidth = extractOptionKeys(options, 'wrap', 'wordwrap');
+    const width = resolveWidth(rawWidth);
+    const wrapped = wrapText(input, width);
+
+    return [
+      new BoxBuilder('Text Wrap', wrapped)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default TextWrapBoxSource;

--- a/src/modules/boxSources/__test__/TextWrapBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TextWrapBoxSource.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { TextWrapBoxSource } from '../TextWrapBoxSource';
+
+describe('TextWrapBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no wrap option is present', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes('hello world');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with wrap option', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes('', { wrap: '20' });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('wraps "The quick brown fox..." at width 20 with greedy boundaries', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes(
+        'The quick brown fox jumps over the lazy dog',
+        { wrap: '20' },
+      );
+      expect(boxes).toHaveLength(1);
+      // greedy: 'The quick brown fox' = 19 chars (fits), 'jumps over the lazy' = 19 chars (fits), 'dog'
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'The quick brown fox\njumps over the lazy\ndog',
+      );
+    });
+
+    it('wraps "aaa bbb ccc" at width 10 correctly', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes('aaa bbb ccc', {
+        wrap: '10',
+      });
+      expect(boxes).toHaveLength(1);
+      // 'aaa bbb' = 7 chars, adding ' ccc' = 11 > 10, so new line
+      expect(boxes[0].props.plaintextOutput).toBe('aaa bbb\nccc');
+    });
+
+    it('places a long word exceeding width on its own line without breaking', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes(
+        'supercalifragilistic',
+        { wrap: '5' },
+      );
+      expect(boxes).toHaveLength(1);
+      // the word is longer than width=5 but is not broken mid-word
+      expect(boxes[0].props.plaintextOutput).toBe('supercalifragilistic');
+    });
+
+    it('preserves blank lines between paragraphs', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes(
+        'line one here\n\nline two here',
+        { wrap: '10' },
+      );
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      // blank line must be preserved as a paragraph boundary
+      expect(output).toContain('\n\n');
+      // each paragraph line should not exceed 10 chars where words permit
+      const lines = output.split('\n');
+      for (const line of lines) {
+        if (line.trim().length > 0) {
+          // single words may exceed width, but joined lines should not
+          // 'line one' = 8, 'here' = 4 — all fit within 10
+          expect(line.length).toBeLessThanOrEqual(10);
+        }
+      }
+    });
+
+    it('uses default width 80 when ::wrap has no numeric value', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes('a b c', {
+        wrap: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // 'a b c' is 5 chars, well within 80 — no line breaks added
+      expect(boxes[0].props.plaintextOutput).toBe('a b c');
+    });
+
+    it('triggers on ::wordwrap option as well', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes(
+        'The quick brown fox jumps over the lazy dog',
+        { wordwrap: '20' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'The quick brown fox\njumps over the lazy\ndog',
+      );
+    });
+
+    it('sets box name to "Text Wrap" and correct priority', async () => {
+      const boxes = await TextWrapBoxSource.generateBoxes('hello world', {
+        wrap: '80',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Text Wrap');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -38,6 +38,7 @@ import SpeedConvertBoxSource from './SpeedConvertBoxSource';
 import SubnetBoxSource from './SubnetBoxSource';
 import TemperatureBoxSource from './TemperatureBoxSource';
 import TextReverseBoxSource from './TextReverseBoxSource';
+import TextWrapBoxSource from './TextWrapBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
@@ -99,6 +100,7 @@ export const boxSources: BoxSource[] = [
   SubnetBoxSource,
   TemperatureBoxSource,
   TextReverseBoxSource,
+  TextWrapBoxSource,
   TwosComplementBoxSource,
   UlidBoxSource,
   UnicodeNormalizeBoxSource,


### PR DESCRIPTION
### Box Source: Text Wrap (Transform)

Adds the `Text Wrap` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `The quick brown fox jumps over the lazy dog ::wrap=20`

#### Options:
- `::wordwrap`, `::wrap`

#### Description:
Word-wrap text to a column width. ::wrap=<width> (default 80).

#### Usage Examples:
- **Input**:
```
The quick brown fox jumps over the lazy dog ::wrap=20
```
- **Output Box (`Text Wrap`)**:
```
The quick brown fox
jumps over the lazy
dog
```
