### PR TITLE
feat(TimezoneConvert): add Timezone Convert BoxSource

### DIFF
--- a/src/modules/boxSources/TimezoneConvertBoxSource.ts
+++ b/src/modules/boxSources/TimezoneConvertBoxSource.ts
@@ -1,0 +1,135 @@
+import {
+  DefaultBoxTemplate,
+  KeyValueBoxTemplate,
+} from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// extract the zone string from options — tzconvert takes priority over intz
+function getZone(options: BoxOptions): string | null {
+  if (!options) return null;
+  const raw = options.tzconvert ?? options.intz;
+  if (typeof raw === 'string') return raw || null;
+  // bare flag (boolean true) means no value was supplied
+  return null;
+}
+
+// format a date in the given IANA timezone as 'yyyy-MM-dd HH:mm:ss'
+function formatInZone(date: Date, zone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: zone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+
+  const get = (type: string) =>
+    parts.find((p) => p.type === type)?.value ?? '??';
+  return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}:${get('second')}`;
+}
+
+// derive the UTC offset label (e.g. 'GMT+9') for a zone at a given instant
+function getOffset(date: Date, zone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: zone,
+    timeZoneName: 'shortOffset',
+  }).formatToParts(date);
+  return parts.find((p) => p.type === 'timeZoneName')?.value ?? zone;
+}
+
+// validate that the zone string is a recognised IANA timezone
+function validateZone(zone: string, date: Date): void {
+  // Intl throws RangeError on an unknown timeZone
+  new Intl.DateTimeFormat('en-US', { timeZone: zone, year: 'numeric' }).format(
+    date,
+  );
+}
+
+function errorBox(name: string, message: string): Box {
+  // a plain message box, not a key/value box
+  return new BoxBuilder(name, message)
+    .setTemplate(DefaultBoxTemplate)
+    .setShowExpandButton(false)
+    .setPriority(Priority)
+    .build();
+}
+
+export const TimezoneConvertBoxSource = {
+  defaultDisabled: true,
+  name: 'Timezone Convert',
+  description:
+    'Show a date/time in a target IANA timezone. Input is an ISO date or "now"; zone via ::tzconvert=Asia/Tokyo.',
+  defaultInput: '2024-01-01T12:00:00Z ::tzconvert=Asia/Tokyo',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'tzconvert', 'intz')) return [];
+
+    const zone = getZone(options);
+
+    // bare flag or empty value — no zone supplied
+    if (!zone) {
+      return [
+        errorBox(
+          'Timezone Convert',
+          'A target timezone is required. Example: ::tzconvert=Asia/Tokyo',
+        ),
+      ];
+    }
+
+    // resolve the source time
+    const s = trim(input);
+    let date: Date;
+    if (s === '' || s.toLowerCase() === 'now') {
+      date = new Date();
+    } else {
+      date = new Date(s);
+      if (Number.isNaN(date.getTime())) {
+        return [
+          errorBox(
+            'Timezone Convert',
+            `"${s}" is not a valid date. Use ISO 8601 or "now".`,
+          ),
+        ];
+      }
+    }
+
+    // validate the timezone before formatting
+    try {
+      validateZone(zone, date);
+    } catch {
+      return [
+        errorBox('Timezone Convert', `"${zone}" is not a valid IANA timezone.`),
+      ];
+    }
+
+    const kvOptions: Record<string, string> = {
+      Zone: zone,
+      'Local Time': formatInZone(date, zone),
+      UTC: date.toISOString(),
+      Offset: getOffset(date, zone),
+    };
+
+    const box = new BoxBuilder('Timezone Convert', '')
+      .setOptions(kvOptions)
+      .setTemplate(KeyValueBoxTemplate)
+      .setPriority(Priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default TimezoneConvertBoxSource;

--- a/src/modules/boxSources/__test__/TimezoneConvertBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TimezoneConvertBoxSource.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { TimezoneConvertBoxSource } from '../TimezoneConvertBoxSource';
+
+const { generateBoxes } = TimezoneConvertBoxSource;
+
+describe('TimezoneConvertBoxSource', () => {
+  it('returns [] when no trigger option is present', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', null);
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] when unrelated options are present', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', { foo: 'bar' });
+    expect(boxes).toEqual([]);
+  });
+
+  it('converts UTC input to Asia/Tokyo correctly', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', {
+      tzconvert: 'Asia/Tokyo',
+    });
+    expect(boxes).toHaveLength(1);
+
+    const opts = boxes[0].props.options as Record<string, string>;
+    // UTC should round-trip unchanged
+    expect(opts.UTC).toBe('2024-01-01T12:00:00.000Z');
+    // Tokyo is UTC+9, so 12:00 UTC → 21:00 JST on the same calendar date
+    expect(opts['Local Time']).toContain('21:00:00');
+    expect(opts['Local Time']).toContain('2024-01-01');
+    expect(opts.Zone).toBe('Asia/Tokyo');
+  });
+
+  it('handles ::intz alias the same way', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', {
+      intz: 'Asia/Tokyo',
+    });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Local Time']).toContain('21:00:00');
+  });
+
+  it('converts to UTC zone correctly', async () => {
+    const boxes = await generateBoxes('2024-06-15T00:00:00Z', {
+      tzconvert: 'UTC',
+    });
+    expect(boxes).toHaveLength(1);
+
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Local Time']).toContain('2024-06-15');
+    expect(opts['Local Time']).toContain('00:00:00');
+  });
+
+  it('returns an error box for an invalid IANA zone', async () => {
+    const boxes = await generateBoxes('2024-01-01T00:00:00Z', {
+      tzconvert: 'Not/AZone',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toMatch(/not a valid.*timezone/i);
+  });
+
+  it('returns an error box for an unparseable date string', async () => {
+    const boxes = await generateBoxes('notadate', { tzconvert: 'UTC' });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toMatch(/not a valid date/i);
+  });
+
+  it('returns an error box when zone value is missing (bare flag)', async () => {
+    // hasOptionKeys returns true for boolean true values, but getZone returns null
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', {
+      tzconvert: true,
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toMatch(/required/i);
+  });
+
+  it('returns an error box when zone is an empty string', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', {
+      tzconvert: '',
+    });
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].props.plaintextOutput).toMatch(/required/i);
+  });
+
+  it('treats empty input string as "now" and returns a result', async () => {
+    const boxes = await generateBoxes('', { tzconvert: 'UTC' });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts.Zone).toBe('UTC');
+    // just verify it produced a date-like string
+    expect(opts['Local Time']).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('treats "now" (case-insensitive) as current time', async () => {
+    const boxes = await generateBoxes('NOW', { tzconvert: 'UTC' });
+    expect(boxes).toHaveLength(1);
+    const opts = boxes[0].props.options as Record<string, string>;
+    expect(opts['Local Time']).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('includes Offset in the output options', async () => {
+    const boxes = await generateBoxes('2024-01-01T12:00:00Z', {
+      tzconvert: 'Asia/Tokyo',
+    });
+    const opts = boxes[0].props.options as Record<string, string>;
+    // Tokyo offset is GMT+9
+    expect(opts.Offset).toContain('+9');
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -35,6 +35,7 @@ import TemperatureBoxSource from './TemperatureBoxSource';
 import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import TimezoneConvertBoxSource from './TimezoneConvertBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
 import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
@@ -86,6 +87,7 @@ export const boxSources: BoxSource[] = [
   SubnetBoxSource,
   TemperatureBoxSource,
   TextReverseBoxSource,
+  TimezoneConvertBoxSource,
   TwosComplementBoxSource,
   UnicodeNormalizeBoxSource,
   WeekNumberBoxSource,


### PR DESCRIPTION
### Box Source: Timezone Convert (Convert)

Adds the `Timezone Convert` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `2024-01-01T12:00:00Z ::tzconvert=Asia/Tokyo`

#### Options:
- `::intz`, `::tzconvert`

#### Description:
Show a date/time in a target IANA timezone. Input is an ISO date or "now"; zone via ::tzconvert=Asia/Tokyo.

#### Usage Examples:
- **Input**:
```
2024-01-01T12:00:00Z ::tzconvert=Asia/Tokyo
```
- **Output Box (`Timezone Convert`)**:
```
Zone: Asia/Tokyo
Local Time: 2024-01-01 21:00:00
UTC: 2024-01-01T12:00:00.000Z
Offset: GMT+9
```
