### PR TITLE
feat(TwosComplement): add TwosComplement Box Source

### DIFF
--- a/src/modules/boxSources/TwosComplementBoxSource.ts
+++ b/src/modules/boxSources/TwosComplementBoxSource.ts
@@ -1,0 +1,106 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// build a plaintext representation of key-value pairs for copy/TUI consumers
+function kvToPlaintext(pairs: Record<string, string>): string {
+  return Object.entries(pairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+// parse bit width from option value, defaulting to 8; clamp to [1, 256]
+function parseBits(raw: string | boolean | null): bigint {
+  if (raw === null || raw === true || raw === false) {
+    return 8n;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (Number.isNaN(n) || n < 1) return 8n;
+  if (n > 256) return 256n;
+  return BigInt(n);
+}
+
+export const TwosComplementBoxSource = {
+  defaultDisabled: true,
+  name: "Two's Complement",
+  description:
+    "Show the two's-complement binary/hex of an integer at a bit width. ::twos=<bits> (default 8).",
+  defaultInput: '-42 ::twos=8',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'twos', 'twoscomplement')) return [];
+
+    const rawValue = trim(input);
+
+    // validate that input is an integer (optional leading minus, then digits only)
+    if (!/^-?\d+$/.test(rawValue)) {
+      const kv: Record<string, string> = {
+        Error: `"${rawValue}" is not a valid integer`,
+      };
+      return [
+        new BoxBuilder("Two's Complement", kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const value = BigInt(rawValue);
+    const bits = parseBits(
+      extractOptionKeys(options, 'twos', 'twoscomplement'),
+    );
+
+    // signed range for a two's-complement integer of `bits` bits
+    const minSigned = -(1n << (bits - 1n));
+    const maxSigned = (1n << (bits - 1n)) - 1n;
+
+    if (value < minSigned || value > maxSigned) {
+      const kv: Record<string, string> = {
+        Error: `${rawValue} does not fit in ${bits}-bit signed range [${minSigned}, ${maxSigned}]`,
+      };
+      return [
+        new BoxBuilder("Two's Complement", kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // two's-complement bit pattern: negative values wrap around 2^bits
+    const pattern = value < 0n ? value + (1n << bits) : value;
+
+    const binary = pattern.toString(2).padStart(Number(bits), '0');
+    const hexDigits = Math.ceil(Number(bits) / 4);
+    const hex = `0x${pattern.toString(16).padStart(hexDigits, '0')}`;
+    const unsigned = pattern.toString(10);
+
+    const kv: Record<string, string> = {
+      Value: rawValue,
+      Bits: bits.toString(),
+      Binary: binary,
+      Hex: hex,
+      Unsigned: unsigned,
+    };
+
+    return [
+      new BoxBuilder("Two's Complement", kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default TwosComplementBoxSource;

--- a/src/modules/boxSources/__test__/TwosComplementBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/TwosComplementBoxSource.test.ts
@@ -1,0 +1,175 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { TwosComplementBoxSource } from '../TwosComplementBoxSource';
+
+describe('TwosComplementBoxSource', () => {
+  describe('no option → empty array', () => {
+    it('returns [] when no twos option is present', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty options object', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for unrelated option', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {
+        base64: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe("-42 in 8-bit two's complement", () => {
+    it('produces correct Binary, Hex, and Unsigned for -42 at 8 bits', async () => {
+      // -42 + 256 = 214 = 0xD6 = 11010110
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Binary: '11010110',
+        Hex: '0xd6',
+        Unsigned: '214',
+      });
+      expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+    });
+  });
+
+  describe('positive 42 in 8-bit', () => {
+    it('produces correct Binary, Hex, and Unsigned for 42 at 8 bits', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('42', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Binary: '00101010',
+        Hex: '0x2a',
+        Unsigned: '42',
+      });
+    });
+  });
+
+  describe('-1 in 8-bit', () => {
+    it('produces all-ones pattern for -1 at 8 bits', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-1', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Binary: '11111111',
+        Hex: '0xff',
+        Unsigned: '255',
+      });
+    });
+  });
+
+  describe('-1 in 16-bit', () => {
+    it('produces all-ones 16-bit pattern for -1', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-1', {
+        twos: '16',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Binary: '1111111111111111',
+        Unsigned: '65535',
+      });
+    });
+  });
+
+  describe('boundary: -128 and 128 at 8 bits', () => {
+    it('-128 is the minimum signed 8-bit value and has Unsigned 128', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-128', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Unsigned: '128',
+        Binary: '10000000',
+        Hex: '0x80',
+      });
+    });
+
+    it('128 is out of range for 8-bit signed and returns an error box', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('128', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      // the error box should not have Binary/Hex/Unsigned fields
+      expect(boxes[0].props.options).toHaveProperty('Error');
+      expect(boxes[0].props.options).not.toHaveProperty('Binary');
+    });
+  });
+
+  describe('default bits when no value specified for ::twos', () => {
+    it('defaults to 8 bits when option value is boolean true', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {
+        twos: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // 8-bit two's complement of -42
+      expect(boxes[0].props.options).toMatchObject({
+        Bits: '8',
+        Unsigned: '214',
+      });
+    });
+  });
+
+  describe('::twoscomplement alias', () => {
+    it('triggers on ::twoscomplement option key', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-42', {
+        twoscomplement: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Binary: '11010110',
+        Hex: '0xd6',
+        Unsigned: '214',
+      });
+    });
+  });
+
+  describe('-1 in 64-bit (BigInt precision)', () => {
+    it('produces exact unsigned 2^64-1 for -1 at 64 bits', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('-1', {
+        twos: '64',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toMatchObject({
+        Unsigned: '18446744073709551615',
+        Binary: '1'.repeat(64),
+      });
+    });
+  });
+
+  describe('invalid non-integer input', () => {
+    it('returns a single error box for alphabetic input', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('abc', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toHaveProperty('Error');
+      expect(boxes[0].props.options).not.toHaveProperty('Binary');
+    });
+
+    it('returns a single error box for float input', async () => {
+      const boxes = await TwosComplementBoxSource.generateBoxes('3.14', {
+        twos: '8',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.options).toHaveProperty('Error');
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(TwosComplementBoxSource.name).toBe("Two's Complement");
+      expect(TwosComplementBoxSource.tag).toBe('#');
+      expect(TwosComplementBoxSource.kind).toBe('Convert');
+      expect(typeof TwosComplementBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -33,6 +33,7 @@ import TemperatureBoxSource from './TemperatureBoxSource';
 import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import TwosComplementBoxSource from './TwosComplementBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
@@ -80,6 +81,7 @@ export const boxSources: BoxSource[] = [
   SubnetBoxSource,
   TemperatureBoxSource,
   TextReverseBoxSource,
+  TwosComplementBoxSource,
   WeekNumberBoxSource,
   WhitespaceCleanBoxSource,
   ZodiacBoxSource,


### PR DESCRIPTION
### Box Source: Two's Complement (Convert)

Adds the `Two's Complement` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `-42 ::twos=8`

#### Options:
- `::twos`, `::twoscomplement`

#### Description:
Show the two's-complement binary/hex of an integer at a bit width. ::twos=<bits> (default 8).

#### Usage Examples:
- **Input**:
```
-42 ::twos=8
```
- **Output Box (`Two's Complement`)**:
```
Value: -42
Bits: 8
Binary: 11010110
Hex: 0xd6
Unsigned: 214
```
