### PR TITLE
feat(Ulid): add ULID BoxSource

### DIFF
--- a/src/modules/boxSources/UlidBoxSource.ts
+++ b/src/modules/boxSources/UlidBoxSource.ts
@@ -1,0 +1,137 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// Crockford base32 alphabet — excludes I, L, O, U to avoid visual ambiguity
+const ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+// maps a Crockford base32 character to its 5-bit value
+function crockfordCharValue(ch: string): number {
+  const idx = ENCODING.indexOf(ch.toUpperCase());
+  if (idx === -1) {
+    throw new RangeError(`invalid Crockford base32 character: ${ch}`);
+  }
+  return idx;
+}
+
+// encodes a BigInt value into n Crockford base32 characters (most-significant first)
+function encodeBase32(value: bigint, n: number): string {
+  let result = '';
+  let v = value;
+  for (let i = 0; i < n; i++) {
+    result = ENCODING[Number(v & 0x1fn)] + result;
+    v >>= 5n;
+  }
+  return result;
+}
+
+// decodes the first n characters of a Crockford base32 string to a BigInt
+function decodeBase32(chars: string, n: number): bigint {
+  let result = 0n;
+  for (let i = 0; i < n; i++) {
+    result = (result << 5n) | BigInt(crockfordCharValue(chars[i]));
+  }
+  return result;
+}
+
+// generates a new ULID using Date.now() for the timestamp and
+// crypto.getRandomValues for the 80-bit random component
+function generateUlid(): string {
+  const tsMs = BigInt(Date.now());
+
+  // 10 Crockford base32 chars encode 50 bits; the 48-bit ms timestamp
+  // fits with room to spare (max 48-bit value = 281474976710655 ms ≈ year 10889)
+  const tsPart = encodeBase32(tsMs, 10);
+
+  // 80 bits of randomness → 16 base32 chars (each char = 5 bits)
+  const randBytes = new Uint8Array(10);
+  crypto.getRandomValues(randBytes);
+
+  // pack 10 bytes into a bigint for base32 encoding
+  let randBits = 0n;
+  for (const byte of randBytes) {
+    randBits = (randBits << 8n) | BigInt(byte);
+  }
+
+  const randPart = encodeBase32(randBits, 16);
+  return tsPart + randPart;
+}
+
+// 26-character Crockford base32 ULID pattern (case-insensitive)
+const ULID_REGEX = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
+
+export const UlidBoxSource = {
+  defaultDisabled: true,
+  name: 'ULID',
+  description:
+    'Generate a ULID (::ulid) or decode the timestamp of an existing ULID (::ulid=<ulid> or ::ulidparse).',
+  defaultInput: ' ::ulid',
+  tag: '#',
+  kind: 'Generate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'ulid', 'ulidparse')) return [];
+
+    const trimmed = trim(input).toUpperCase();
+
+    if (ULID_REGEX.test(trimmed)) {
+      // decode path: extract the 48-bit millisecond timestamp from the first 10 chars
+      const tsMs = Number(decodeBase32(trimmed, 10));
+      const isoTimestamp = new Date(tsMs).toISOString();
+
+      const content = `ULID: ${trimmed}\nTimestamp: ${isoTimestamp}\nUnix (ms): ${tsMs}`;
+      const kvOptions: Record<string, string> = {
+        ULID: trimmed,
+        Timestamp: isoTimestamp,
+        'Unix (ms)': tsMs.toString(),
+      };
+
+      return [
+        new BoxBuilder('ULID', content)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kvOptions)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // generate path: produce a fresh ULID
+    if (
+      typeof crypto === 'undefined' ||
+      typeof crypto.getRandomValues !== 'function'
+    ) {
+      const errorContent = 'ULID generation requires a secure context (HTTPS).';
+      return [
+        new BoxBuilder('ULID', errorContent).setPriority(this.priority).build(),
+      ];
+    }
+
+    const ulid = generateUlid();
+    const tsMs = Number(decodeBase32(ulid, 10));
+    const isoTimestamp = new Date(tsMs).toISOString();
+
+    const content = `ULID: ${ulid}\nTimestamp: ${isoTimestamp}\nUnix (ms): ${tsMs}`;
+    const kvOptions: Record<string, string> = {
+      ULID: ulid,
+      Timestamp: isoTimestamp,
+      'Unix (ms)': tsMs.toString(),
+    };
+
+    return [
+      new BoxBuilder('ULID', content)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UlidBoxSource;

--- a/src/modules/boxSources/__test__/UlidBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UlidBoxSource.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { UlidBoxSource } from '../UlidBoxSource';
+
+// canonical ULID from the ULID spec — timestamp encodes 1469922850259 ms
+const CANONICAL_ULID = '01ARZ3NDEKTSV4RRFFQ69G5FAV';
+const CANONICAL_TS_MS = 1469922850259;
+const CANONICAL_ISO = '2016-07-30T23:54:10.259Z';
+
+// valid Crockford base32 alphabet (26 chars, uppercase)
+const ULID_REGEX = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+describe('UlidBoxSource', () => {
+  describe('no matching option', () => {
+    it('returns [] when no relevant option is present', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when unrelated options are present', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', { foo: true });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generate path', () => {
+    it('generates a 26-char Crockford base32 ULID', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', { ulid: true });
+      expect(boxes).toHaveLength(1);
+
+      const ulid = (boxes[0].props.options as Record<string, string>).ULID;
+      expect(ulid).toMatch(ULID_REGEX);
+    });
+
+    it('Unix (ms) is within a few seconds of Date.now()', async () => {
+      const before = Date.now();
+      const boxes = await UlidBoxSource.generateBoxes('', { ulid: true });
+      const after = Date.now();
+
+      const ms = Number.parseInt(
+        (boxes[0].props.options as Record<string, string>)['Unix (ms)'],
+        10,
+      );
+      expect(ms).toBeGreaterThanOrEqual(before);
+      expect(ms).toBeLessThanOrEqual(after + 1000);
+    });
+
+    it('two consecutive calls produce different ULIDs', async () => {
+      const [b1, b2] = await Promise.all([
+        UlidBoxSource.generateBoxes('', { ulid: true }),
+        UlidBoxSource.generateBoxes('', { ulid: true }),
+      ]);
+
+      const u1 = (b1[0].props.options as Record<string, string>).ULID;
+      const u2 = (b2[0].props.options as Record<string, string>).ULID;
+      expect(u1).not.toBe(u2);
+    });
+
+    it('Timestamp is a valid ISO string', async () => {
+      const boxes = await UlidBoxSource.generateBoxes('', { ulidparse: true });
+      const ts = (boxes[0].props.options as Record<string, string>).Timestamp;
+      expect(() => new Date(ts).toISOString()).not.toThrow();
+    });
+  });
+
+  describe('decode path', () => {
+    it('decodes the canonical ULID timestamp to 1469922850259 ms', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(CANONICAL_ULID, {
+        ulid: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Unix (ms)']).toBe(CANONICAL_TS_MS.toString());
+    });
+
+    it('decodes the canonical ULID to the correct ISO timestamp', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(CANONICAL_ULID, {
+        ulid: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Timestamp).toBe(CANONICAL_ISO);
+    });
+
+    it('normalises the decoded ULID to uppercase', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(CANONICAL_ULID, {
+        ulid: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.ULID).toBe(CANONICAL_ULID.toUpperCase());
+    });
+
+    it('decode is case-insensitive', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(
+        CANONICAL_ULID.toLowerCase(),
+        { ulid: true },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts['Unix (ms)']).toBe(CANONICAL_TS_MS.toString());
+    });
+
+    it('uses KeyValueBoxTemplate for decoded output', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(CANONICAL_ULID, {
+        ulid: true,
+      });
+      expect(boxes[0].boxTemplate).toBeDefined();
+    });
+
+    it('box name is ULID', async () => {
+      const boxes = await UlidBoxSource.generateBoxes(CANONICAL_ULID, {
+        ulid: true,
+      });
+      expect(boxes[0].props.name).toBe('ULID');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -36,6 +36,7 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
+import UlidBoxSource from './UlidBoxSource';
 import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
@@ -87,6 +88,7 @@ export const boxSources: BoxSource[] = [
   TemperatureBoxSource,
   TextReverseBoxSource,
   TwosComplementBoxSource,
+  UlidBoxSource,
   UnicodeNormalizeBoxSource,
   WeekNumberBoxSource,
   WhitespaceCleanBoxSource,


### PR DESCRIPTION
### Box Source: ULID (Generate)

Adds the `ULID` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Generate`
- **Tag**: `#`
- **Default Input**: ` ::ulid`

#### Options:
- `::ulid`, `::ulidparse`

#### Description:
Generate a ULID (::ulid) or decode the timestamp of an existing ULID (::ulid=<ulid> or ::ulidparse).

#### Usage Examples:
- **Input**:
```
 ::ulid
```
- **Output Box (`ULID`)**:
```
ULID: 01KVW6K595415YKR8PZB93DGAP
Timestamp: 2026-06-24T06:55:29.573Z
Unix (ms): 1782284129573
```
