### PR TITLE
feat(Unaccent): add Remove Accents BoxSource

### DIFF
--- a/src/modules/boxSources/UnaccentBoxSource.ts
+++ b/src/modules/boxSources/UnaccentBoxSource.ts
@@ -1,0 +1,77 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// characters that NFD decomposition does not handle — mapped to their ASCII equivalents
+const SPECIAL_CHAR_MAP: Record<string, string> = {
+  ø: 'o',
+  Ø: 'O',
+  ß: 'ss',
+  æ: 'ae',
+  Æ: 'AE',
+  œ: 'oe',
+  Œ: 'OE',
+  đ: 'd',
+  Đ: 'D',
+  ł: 'l',
+  Ł: 'L',
+  ð: 'd',
+  þ: 'th',
+};
+
+const SPECIAL_CHAR_REGEX = new RegExp(
+  `[${Object.keys(SPECIAL_CHAR_MAP).join('')}]`,
+  'g',
+);
+
+// strips combining diacritical marks (U+0300–U+036F) after NFD normalization,
+// then substitutes characters NFD cannot decompose
+function removeAccents(input: string): string {
+  const nfdStripped = input.normalize('NFD').replace(/[̀-ͯ]/g, '');
+  return nfdStripped.replace(
+    SPECIAL_CHAR_REGEX,
+    (ch) => SPECIAL_CHAR_MAP[ch] ?? ch,
+  );
+}
+
+export const UnaccentBoxSource = {
+  defaultDisabled: true,
+  name: 'Remove Accents',
+  description:
+    'Strip diacritics/accents from text (café → cafe). ::unaccent or ::deburr.',
+  defaultInput: 'Crème brûlée ::unaccent',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'unaccent', 'deburr', 'removeaccents')) {
+      return [];
+    }
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    ) {
+      return [];
+    }
+
+    const result = removeAccents(input);
+    return [
+      new BoxBuilder('Remove Accents', result)
+        .setTemplate(CodeBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UnaccentBoxSource;

--- a/src/modules/boxSources/__test__/UnaccentBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UnaccentBoxSource.test.ts
@@ -1,0 +1,176 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { UnaccentBoxSource } from '../UnaccentBoxSource';
+
+describe('UnaccentBoxSource', () => {
+  describe('generateBoxes - gate checks', () => {
+    it('returns empty array when no trigger option is provided', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for unrelated option', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {
+        foo: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input string', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('', {
+        unaccent: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for whitespace-only input', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('   ', {
+        unaccent: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - NFD diacritics', () => {
+    it('strips acute accent: café → cafe', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {
+        unaccent: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('cafe');
+    });
+
+    it('strips multiple accents: Crème brûlée → Creme brulee', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Crème brûlée', {
+        unaccent: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('Creme brulee');
+    });
+
+    it('strips diaeresis: naïve résumé → naive resume', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('naïve résumé', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('naive resume');
+    });
+
+    it('strips tilde: piñata → pinata', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('piñata', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('pinata');
+    });
+
+    it('strips umlaut: Zürich → Zurich', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Zürich', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Zurich');
+    });
+  });
+
+  describe('generateBoxes - special character map', () => {
+    it('converts Łódź → Lodz (ł, ó, dź)', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Łódź', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Lodz');
+    });
+
+    it('converts ß → ss: Straße → Strasse', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Straße', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Strasse');
+    });
+
+    it('converts Æ → AE: Æon → AEon', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Æon', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('AEon');
+    });
+
+    it('converts œ → oe: œuvre → oeuvre', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('œuvre', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('oeuvre');
+    });
+
+    it('converts ø → o and Ø → O', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('søster Øst', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('soster Ost');
+    });
+
+    it('converts đ → d and Đ → D', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('Đà Nẵng', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('Da Nang');
+    });
+
+    it('converts ð → d and þ → th', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('þing ðat', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('thing dat');
+    });
+  });
+
+  describe('generateBoxes - non-latin pass-through', () => {
+    it('leaves CJK characters unchanged: 日本語 → 日本語', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('日本語', {
+        unaccent: true,
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('日本語');
+    });
+  });
+
+  describe('generateBoxes - alias options', () => {
+    it('::deburr alias works', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {
+        deburr: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('cafe');
+    });
+
+    it('::removeaccents alias works', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {
+        removeaccents: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('cafe');
+    });
+  });
+
+  describe('generateBoxes - box metadata', () => {
+    it('sets correct box name, priority, and template', async () => {
+      const boxes = await UnaccentBoxSource.generateBoxes('café', {
+        unaccent: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Remove Accents');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(UnaccentBoxSource.name).toBe('Remove Accents');
+      expect(UnaccentBoxSource.kind).toBe('Transform');
+      expect(typeof UnaccentBoxSource.priority).toBe('number');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -36,6 +36,7 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
+import UnaccentBoxSource from './UnaccentBoxSource';
 import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
@@ -87,6 +88,7 @@ export const boxSources: BoxSource[] = [
   TemperatureBoxSource,
   TextReverseBoxSource,
   TwosComplementBoxSource,
+  UnaccentBoxSource,
   UnicodeNormalizeBoxSource,
   WeekNumberBoxSource,
   WhitespaceCleanBoxSource,


### PR DESCRIPTION
### Box Source: Remove Accents (Transform)

Adds the `Remove Accents` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `Crème brûlée ::unaccent`

#### Options:
- `::deburr`, `::removeaccents`, `::unaccent`

#### Description:
Strip diacritics/accents from text (café → cafe). ::unaccent or ::deburr.

#### Usage Examples:
- **Input**:
```
Crème brûlée ::unaccent
```
- **Output Box (`Remove Accents`)**:
```
Creme brulee
```
