### PR TITLE
feat(UnicodeEscape): add Unicode Escape BoxSource

### DIFF
--- a/src/modules/boxSources/UnicodeEscapeBoxSource.ts
+++ b/src/modules/boxSources/UnicodeEscapeBoxSource.ts
@@ -1,0 +1,84 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// escape each UTF-16 code unit: keep printable ASCII (0x20–0x7e), \uXXXX everything else.
+// astral chars (e.g. emoji) are naturally emitted as surrogate pairs (\uD800–\uDFFF).
+function escapeUnicode(input: string): string {
+  let result = '';
+  for (let i = 0; i < input.length; i++) {
+    const cp = input.charCodeAt(i);
+    if (cp >= 0x20 && cp <= 0x7e) {
+      result += input[i];
+    } else {
+      result += `\\u${cp.toString(16).padStart(4, '0')}`;
+    }
+  }
+  return result;
+}
+
+// unescape \u{XXXXX} (1–6 hex, cp <= 0x10ffff) and \uXXXX (exactly 4 hex) sequences.
+// unrecognised text is passed through unchanged.
+function unescapeUnicode(input: string): string {
+  // replace braces form first so \u{...} does not conflict with the 4-hex pattern
+  let result = input.replace(/\\u\{([0-9a-fA-F]{1,6})\}/g, (match, hex) => {
+    const cp = Number.parseInt(hex, 16);
+    if (cp > 0x10ffff) return match; // guard against invalid code point
+    return String.fromCodePoint(cp);
+  });
+
+  result = result.replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => {
+    return String.fromCharCode(Number.parseInt(hex, 16));
+  });
+
+  return result;
+}
+
+export const UnicodeEscapeBoxSource = {
+  defaultDisabled: true,
+  name: 'Unicode Escape',
+  description:
+    'Escape text to \\uXXXX sequences, or unescape \\uXXXX / \\u{...} back to text.',
+  defaultInput: 'héllo 😀 ::unicodeescape',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const wantEscape = hasOptionKeys(options, 'unicodeescape', 'uescape');
+    const wantUnescape = hasOptionKeys(options, 'unicodeunescape', 'uunescape');
+    if (!wantEscape && !wantUnescape) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    if (wantEscape) {
+      const escaped = escapeUnicode(input);
+      return [
+        new BoxBuilder('Unicode Escape', escaped)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    // wantUnescape
+    const unescaped = unescapeUnicode(input);
+    return [
+      new BoxBuilder('Unicode Unescape', unescaped)
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UnicodeEscapeBoxSource;

--- a/src/modules/boxSources/__test__/UnicodeEscapeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UnicodeEscapeBoxSource.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import { UnicodeEscapeBoxSource } from '../UnicodeEscapeBoxSource';
+
+describe('UnicodeEscapeBoxSource', () => {
+  describe('generateBoxes - option gating', () => {
+    it('returns empty array when no option is provided', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('hello', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty options object', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('hello', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array for empty string even with option', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('', {
+        unicodeescape: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('generateBoxes - escape', () => {
+    it('escapes non-ASCII: A€ → A\\u20ac', async () => {
+      // '\\u20ac' here is the literal 6-character string backslash-u-2-0-a-c
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('A€', {
+        unicodeescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('A\\u20ac');
+    });
+
+    it('keeps printable ASCII unchanged: hi! stays hi!', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('hi!', {
+        unicodeescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hi!');
+    });
+
+    it('escapes astral char 😀 (U+1F600) as surrogate pair \\ud83d\\ude00', async () => {
+      // 😀 = U+1F600 splits into surrogates U+D83D U+DE00
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('😀', {
+        unicodeescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('\\ud83d\\ude00');
+    });
+
+    it('accepts ::uescape alias', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('€', {
+        uescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('\\u20ac');
+    });
+
+    it('sets box name to "Unicode Escape"', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('A', {
+        unicodeescape: true,
+      });
+      expect(boxes[0].props.name).toBe('Unicode Escape');
+    });
+
+    it('sets priority to 10', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('A', {
+        unicodeescape: true,
+      });
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+
+  describe('generateBoxes - unescape', () => {
+    it('unescapes \\u20ac back to €', async () => {
+      // the input string contains literal backslash-u-20ac
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u20ac', {
+        unicodeunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('€');
+    });
+
+    it('unescapes braces form \\u{1f600} back to 😀', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u{1f600}', {
+        unicodeunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('😀');
+    });
+
+    it('leaves text outside escape sequences unchanged', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes(
+        'hi \\u0021 there',
+        { unicodeunescape: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('hi ! there');
+    });
+
+    it('guards invalid braces code point > 0x10ffff and leaves it literal', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u{110000}', {
+        unicodeunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      // code point is out of range — the sequence must remain as-is
+      expect(boxes[0].props.plaintextOutput).toBe('\\u{110000}');
+    });
+
+    it('accepts ::uunescape alias', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u0041', {
+        uunescape: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('A');
+    });
+
+    it('sets box name to "Unicode Unescape"', async () => {
+      const boxes = await UnicodeEscapeBoxSource.generateBoxes('\\u0041', {
+        unicodeunescape: true,
+      });
+      expect(boxes[0].props.name).toBe('Unicode Unescape');
+    });
+  });
+
+  describe('round-trip', () => {
+    it('héllo escapes and unescapes back to the original', async () => {
+      const original = 'héllo';
+
+      const escapeBoxes = await UnicodeEscapeBoxSource.generateBoxes(original, {
+        unicodeescape: true,
+      });
+      expect(escapeBoxes).toHaveLength(1);
+      const escaped = escapeBoxes[0].props.plaintextOutput;
+
+      const unescapeBoxes = await UnicodeEscapeBoxSource.generateBoxes(
+        escaped,
+        { unicodeunescape: true },
+      );
+      expect(unescapeBoxes).toHaveLength(1);
+      expect(unescapeBoxes[0].props.plaintextOutput).toBe(original);
+    });
+  });
+
+  describe('metadata', () => {
+    it('has expected static properties', () => {
+      expect(UnicodeEscapeBoxSource.name).toBe('Unicode Escape');
+      expect(UnicodeEscapeBoxSource.tag).toBe('#');
+      expect(UnicodeEscapeBoxSource.kind).toBe('Encode');
+      expect(UnicodeEscapeBoxSource.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -42,6 +42,7 @@ import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
 import UlidBoxSource from './UlidBoxSource';
+import UnicodeEscapeBoxSource from './UnicodeEscapeBoxSource';
 import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UnitConverterBoxSource from './UnitConverterBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  UnicodeEscapeBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Unicode Escape (Encode)

Adds the `Unicode Escape` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `héllo 😀 ::unicodeescape`

#### Options:
- `::uescape`, `::unicodeescape`, `::unicodeunescape`, `::uunescape`

#### Description:
Escape text to \uXXXX sequences, or unescape \uXXXX / \u{...} back to text.

#### Usage Examples:
- **Input**:
```
héllo 😀 ::unicodeescape
```
- **Output Box (`Unicode Escape`)**:
```
h\u00e9llo \ud83d\ude00
```
