### PR TITLE
feat(UnicodeInspector): add Unicode Inspector BoxSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev-debug.log
 *.sln
 *.sw?
 # OS specific
+.gemini/

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: box.defaultDisabled ? false : true,
+        enabled: !box.defaultDisabled,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: box.defaultDisabled ? false : true,
+            enabled: !box.defaultDisabled,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: true,
+        enabled: box.defaultDisabled ? false : true,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: true,
+            enabled: box.defaultDisabled ? false : true,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/modules/BoxSource.ts
+++ b/src/modules/BoxSource.ts
@@ -9,5 +9,6 @@ export interface BoxSource {
   tag: string;
   kind: string;
   priority?: number;
+  defaultDisabled?: boolean;
   generateBoxes: (input: string, options: BoxOptions) => Promise<Box[]>;
 }

--- a/src/modules/boxSources/UnicodeInspectorBoxSource.ts
+++ b/src/modules/boxSources/UnicodeInspectorBoxSource.ts
@@ -1,0 +1,83 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_CHARS = 256;
+
+// reused across the per-character utf-8 lookups
+const ENCODER = new TextEncoder();
+
+// format a code point as U+XXXX (uppercase, minimum 4 hex digits)
+function formatCodePoint(cp: number): string {
+  return `U+${cp.toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
+// encode a single code point's UTF-8 bytes as space-separated lowercase 2-digit hex
+function utf8Hex(ch: string): string {
+  return Array.from(ENCODER.encode(ch))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join(' ');
+}
+
+// encode a single code point's UTF-16 code units as space-separated lowercase 4-digit hex
+function utf16Hex(ch: string): string {
+  const units: string[] = [];
+  for (let i = 0; i < ch.length; i++) {
+    units.push(ch.charCodeAt(i).toString(16).padStart(4, '0'));
+  }
+  return units.join(' ');
+}
+
+// build one inspector line for a single code point character
+function inspectChar(ch: string): string {
+  const cp = ch.codePointAt(0) as number;
+  return `${ch}  ${formatCodePoint(cp)}  dec=${cp}  utf8=${utf8Hex(ch)}  utf16=${utf16Hex(ch)}`;
+}
+
+export const UnicodeInspectorBoxSource = {
+  defaultDisabled: true,
+  name: 'Unicode Inspector',
+  description:
+    'Show the code point, UTF-8 and UTF-16 encoding of each character.',
+  defaultInput: 'A€😀 ::unicode',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'unicode')) return [];
+    if (!isString(input) || trim(input).length === 0) return [];
+
+    const lines: string[] = [];
+    let count = 0;
+    let truncated = false;
+
+    for (const ch of input) {
+      if (count >= MAX_CHARS) {
+        truncated = true;
+        break;
+      }
+      lines.push(inspectChar(ch));
+      count++;
+    }
+
+    // note truncation at the end of the output when input exceeds the cap
+    if (truncated) {
+      lines.push(`... truncated at ${MAX_CHARS} code points`);
+    }
+
+    const box = new BoxBuilder('Unicode Inspector', lines.join('\n'))
+      .setTemplate(CodeBoxTemplate)
+      .setPriority(this.priority)
+      .build();
+
+    return [box];
+  },
+};
+
+export default UnicodeInspectorBoxSource;

--- a/src/modules/boxSources/__test__/UnicodeInspectorBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UnicodeInspectorBoxSource.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { UnicodeInspectorBoxSource } from '../UnicodeInspectorBoxSource';
+
+describe('UnicodeInspectorBoxSource', () => {
+  describe('guard conditions', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('A', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options object lacks ::unicode', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('A', {});
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with ::unicode', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input with ::unicode', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('   ', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('ASCII character — A (U+0041)', () => {
+    it('produces one box with a line containing U+0041, dec=65, utf8=41, utf16=0041', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('A', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Unicode Inspector');
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('U+0041');
+      expect(output).toContain('dec=65');
+      expect(output).toContain('utf8=41');
+      expect(output).toContain('utf16=0041');
+    });
+  });
+
+  describe('BMP non-ASCII character — € (U+20AC)', () => {
+    it('produces a line containing U+20AC and utf8=e2 82 ac', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('€', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('U+20AC');
+      expect(output).toContain('utf8=e2 82 ac');
+    });
+  });
+
+  describe('astral plane character — 😀 (U+1F600)', () => {
+    it('produces exactly ONE line (surrogate pair treated as single code point)', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('😀', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toHaveLength(1);
+    });
+
+    it('line contains U+1F600, dec=128512, utf16=d83d de00, utf8=f0 9f 98 80', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('😀', {
+        unicode: true,
+      });
+      const output = boxes[0].props.plaintextOutput;
+      expect(output).toContain('U+1F600');
+      expect(output).toContain('dec=128512');
+      expect(output).toContain('utf16=d83d de00');
+      expect(output).toContain('utf8=f0 9f 98 80');
+    });
+  });
+
+  describe('multi-character string', () => {
+    it('a 3-char string yields 3 lines in the output', async () => {
+      const boxes = await UnicodeInspectorBoxSource.generateBoxes('A€!', {
+        unicode: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      expect(lines).toHaveLength(3);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -20,6 +20,7 @@ import ReadableBytesBoxSource from './ReadableBytesBoxSource';
 import ShortenURLBoxSource from './ShortenURLBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
+import UnicodeInspectorBoxSource from './UnicodeInspectorBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
@@ -50,5 +51,6 @@ export const boxSources = [
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
+  UnicodeInspectorBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Unicode Inspector (Analyze)

Adds the `Unicode Inspector` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `A€😀 ::unicode`

#### Options:
- `::unicode`

#### Description:
Show the code point, UTF-8 and UTF-16 encoding of each character.

#### Usage Examples:
- **Input**:
```
A€😀 ::unicode
```
- **Output Box (`Unicode Inspector`)**:
```
A  U+0041  dec=65  utf8=41  utf16=0041
€  U+20AC  dec=8364  utf8=e2 82 ac  utf16=20ac
😀  U+1F600  dec=128512  utf8=f0 9f 98 80  utf16=d83d de00
```
