### PR TITLE
feat(UnicodeNormalize): add Unicode Normalize BoxSource

### DIFF
--- a/src/modules/boxSources/UnicodeNormalizeBoxSource.ts
+++ b/src/modules/boxSources/UnicodeNormalizeBoxSource.ts
@@ -1,0 +1,68 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// supported Unicode normalization forms
+const FORMS = ['NFC', 'NFD', 'NFKC', 'NFKD'] as const;
+type NormalizationForm = (typeof FORMS)[number];
+
+function resolveForm(raw: string | boolean | null): NormalizationForm {
+  if (
+    typeof raw === 'string' &&
+    (FORMS as readonly string[]).includes(raw.toUpperCase())
+  ) {
+    return raw.toUpperCase() as NormalizationForm;
+  }
+  return 'NFC';
+}
+
+export const UnicodeNormalizeBoxSource = {
+  defaultDisabled: true,
+  name: 'Unicode Normalize',
+  description:
+    'Normalize text to a Unicode form (NFC/NFD/NFKC/NFKD). ::normalize=nfc (default NFC).',
+  defaultInput: 'café ::normalize=nfd',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'normalize', 'unicodenormalize')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const raw = extractOptionKeys(options, 'normalize', 'unicodenormalize');
+    const form = resolveForm(raw);
+    const normalized = input.normalize(form);
+
+    const kvOptions: Record<string, string> = {
+      Form: form,
+      Normalized: normalized,
+      'Input Length': String(input.length),
+      'Output Length': String(normalized.length),
+      Changed: String(normalized !== input),
+    };
+
+    // plaintext k:v lines for headless/TUI consumers
+    const plaintextOutput = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Unicode Normalize', plaintextOutput)
+        .setOptions(kvOptions)
+        .setTemplate(KeyValueBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default UnicodeNormalizeBoxSource;

--- a/src/modules/boxSources/__test__/UnicodeNormalizeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/UnicodeNormalizeBoxSource.test.ts
@@ -1,0 +1,117 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { UnicodeNormalizeBoxSource } from '../UnicodeNormalizeBoxSource';
+
+describe('UnicodeNormalizeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no trigger option is present', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('café', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when options exist but no normalize key', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('café', {
+        hash: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input', async () => {
+      const boxes = await UnicodeNormalizeBoxSource.generateBoxes('', {
+        normalize: 'nfc',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    describe('NFD decomposition', () => {
+      // 'café' with precomposed é (U+00E9) has length 4.
+      // NFD decomposes é → e + U+0301 (combining acute accent), giving length 5.
+      it('decomposes precomposed é under NFD', async () => {
+        const input = 'café'; // café, length 4 (NFC form)
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes(input, {
+          normalize: 'nfd',
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options;
+        expect(opts?.Form).toBe('NFD');
+        expect(opts?.['Input Length']).toBe('4');
+        expect(opts?.['Output Length']).toBe('5');
+        expect(opts?.Changed).toBe('true');
+        expect(boxes[0].boxTemplate).toBe(KeyValueBoxTemplate);
+      });
+    });
+
+    describe('NFC recomposition', () => {
+      // 'café' with decomposed é (e + U+0301) has length 5.
+      // NFC recomposes back to é (U+00E9), giving length 4.
+      it('recomposes decomposed é under NFC', async () => {
+        const input = 'café'; // e + combining acute, length 5 (NFD form)
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes(input, {
+          normalize: 'nfc',
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options;
+        expect(opts?.Form).toBe('NFC');
+        expect(opts?.Normalized).toBe('café');
+        expect(opts?.['Input Length']).toBe('5');
+        expect(opts?.['Output Length']).toBe('4');
+        expect(opts?.Changed).toBe('true');
+      });
+    });
+
+    describe('already-normalized input', () => {
+      it('ASCII hello under NFC is unchanged', async () => {
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes('hello', {
+          normalize: 'nfc',
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options;
+        expect(opts?.Changed).toBe('false');
+        expect(opts?.['Input Length']).toBe(opts?.['Output Length']);
+      });
+    });
+
+    describe('NFKC compatibility normalization', () => {
+      // fullwidth Latin capital A (U+FF21) normalizes to ASCII A (U+0041) under NFKC
+      it('converts fullwidth A to ASCII A', async () => {
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes('Ａ', {
+          normalize: 'nfkc',
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options;
+        expect(opts?.Form).toBe('NFKC');
+        expect(opts?.Normalized).toBe('A');
+        expect(opts?.Changed).toBe('true');
+      });
+    });
+
+    describe('default form fallback', () => {
+      it('uses NFC when option value is a bare flag (true)', async () => {
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes('x', {
+          normalize: true,
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Form).toBe('NFC');
+      });
+
+      it('uses NFC for unrecognized form string', async () => {
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes('x', {
+          normalize: 'xyz',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Form).toBe('NFC');
+      });
+    });
+
+    describe('unicodenormalize alias', () => {
+      it('triggers on ::unicodenormalize option key', async () => {
+        const boxes = await UnicodeNormalizeBoxSource.generateBoxes('hello', {
+          unicodenormalize: 'nfd',
+        });
+        expect(boxes).toHaveLength(1);
+        expect(boxes[0].props.options?.Form).toBe('NFD');
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -34,6 +34,7 @@ import TextReverseBoxSource from './TextReverseBoxSource';
 import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import TwosComplementBoxSource from './TwosComplementBoxSource';
+import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
@@ -82,6 +83,7 @@ export const boxSources: BoxSource[] = [
   TemperatureBoxSource,
   TextReverseBoxSource,
   TwosComplementBoxSource,
+  UnicodeNormalizeBoxSource,
   WeekNumberBoxSource,
   WhitespaceCleanBoxSource,
   ZodiacBoxSource,


### PR DESCRIPTION
### Box Source: Unicode Normalize (Transform)

Adds the `Unicode Normalize` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `café ::normalize=nfd`

#### Options:
- `::normalize`, `::unicodenormalize`

#### Description:
Normalize text to a Unicode form (NFC/NFD/NFKC/NFKD). ::normalize=nfc (default NFC).

#### Usage Examples:
- **Input**:
```
café ::normalize=nfd
```
- **Output Box (`Unicode Normalize`)**:
```
Form: NFD
Normalized: café
Input Length: 4
Output Length: 5
Changed: true
```
