### PR TITLE
feat(Vigenere): add Vigenere BoxSource

### DIFF
--- a/src/modules/boxSources/VigenereBoxSource.ts
+++ b/src/modules/boxSources/VigenereBoxSource.ts
@@ -1,0 +1,109 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions, BoxOptionValues } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// extracts only alphabetic characters, uppercased, as the cipher key
+function sanitizeKey(raw: BoxOptionValues): string {
+  if (typeof raw !== 'string') return '';
+  return raw.replace(/[^a-zA-Z]/g, '').toUpperCase();
+}
+
+// applies the Vigenère cipher; direction +1 for encrypt, -1 for decrypt
+function vigenere(text: string, key: string, direction: 1 | -1): string {
+  let keyIndex = 0;
+  return text
+    .split('')
+    .map((ch) => {
+      const isUpper = ch >= 'A' && ch <= 'Z';
+      const isLower = ch >= 'a' && ch <= 'z';
+      if (!isUpper && !isLower) return ch; // non-letters pass through unchanged
+
+      const base = isUpper ? 65 : 97;
+      const charIdx = ch.charCodeAt(0) - base;
+      const keyShift = key.charCodeAt(keyIndex % key.length) - 65;
+      const shifted = ((charIdx + direction * keyShift + 26) % 26) + base;
+      keyIndex++;
+      return String.fromCharCode(shifted);
+    })
+    .join('');
+}
+
+export const VigenereBoxSource = {
+  defaultDisabled: true,
+  name: 'Vigenere',
+  description:
+    'Vigenere cipher. Encrypt with ::vigenere=key, decrypt with ::vigeneredecode=key.',
+  defaultInput: 'attackatdawn ::vigenere=lemon',
+  tag: '#',
+  kind: 'Encode',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    const encKey = extractOptionKeys(options, 'vigenere', 'vigenereencode');
+    const decKey = extractOptionKeys(options, 'vigeneredecode');
+
+    if (encKey === null && decKey === null) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const boxes: Box[] = [];
+
+    if (encKey !== null) {
+      const key = sanitizeKey(encKey);
+      if (key.length === 0) {
+        // key contained no letters — return an informational box
+        const box = new BoxBuilder(
+          'Vigenere (Encrypt)',
+          'Key must contain at least one alphabetic character.',
+        )
+          .setPriority(Priority)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .build();
+        boxes.push(box);
+      } else {
+        const encrypted = vigenere(input, key, 1);
+        const box = new BoxBuilder('Vigenere (Encrypt)', encrypted)
+          .setPriority(Priority)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .build();
+        boxes.push(box);
+      }
+    }
+
+    if (decKey !== null) {
+      const key = sanitizeKey(decKey);
+      if (key.length === 0) {
+        const box = new BoxBuilder(
+          'Vigenere (Decrypt)',
+          'Key must contain at least one alphabetic character.',
+        )
+          .setPriority(Priority)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .build();
+        boxes.push(box);
+      } else {
+        const decrypted = vigenere(input, key, -1);
+        const box = new BoxBuilder('Vigenere (Decrypt)', decrypted)
+          .setPriority(Priority)
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .build();
+        boxes.push(box);
+      }
+    }
+
+    return boxes;
+  },
+};
+
+export default VigenereBoxSource;

--- a/src/modules/boxSources/__test__/VigenereBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/VigenereBoxSource.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { VigenereBoxSource } from '../VigenereBoxSource';
+
+describe('VigenereBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option is given', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('attackatdawn');
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with a valid option', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('', {
+        vigenere: 'lemon',
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('encrypts attackatdawn with key lemon → lxfopvefrnhr (canonical vector)', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('attackatdawn', {
+        vigenere: 'lemon',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Vigenere (Encrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('lxfopvefrnhr');
+    });
+
+    it('decrypts lxfopvefrnhr with key lemon → attackatdawn', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('lxfopvefrnhr', {
+        vigeneredecode: 'lemon',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Vigenere (Decrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('attackatdawn');
+    });
+
+    it('preserves case and non-letter characters unchanged', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('Hello, World!', {
+        vigenere: 'key',
+      });
+      expect(boxes).toHaveLength(1);
+      const output = boxes[0].props.plaintextOutput;
+      // comma, space, and exclamation mark must survive intact
+      expect(output[5]).toBe(',');
+      expect(output[6]).toBe(' ');
+      expect(output[12]).toBe('!');
+      // first letter 'H' is uppercase, so output letter must also be uppercase
+      expect(output[0]).toMatch(/[A-Z]/);
+    });
+
+    it('round-trips Hello, World! through encrypt then decrypt', async () => {
+      const plain = 'Hello, World!';
+      const [encBox] = await VigenereBoxSource.generateBoxes(plain, {
+        vigenere: 'key',
+      });
+      const [decBox] = await VigenereBoxSource.generateBoxes(
+        encBox.props.plaintextOutput,
+        { vigeneredecode: 'key' },
+      );
+      expect(decBox.props.plaintextOutput).toBe(plain);
+    });
+
+    it('returns an error box when the key contains no alphabetic characters', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('hello', {
+        vigenere: '123',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toMatch(/alphabetic/i);
+    });
+
+    it('round-trips a mixed-case sentence', async () => {
+      const plain = 'The Quick Brown Fox Jumps Over The Lazy Dog!';
+      const [encBox] = await VigenereBoxSource.generateBoxes(plain, {
+        vigenere: 'Secret',
+      });
+      const [decBox] = await VigenereBoxSource.generateBoxes(
+        encBox.props.plaintextOutput,
+        { vigeneredecode: 'Secret' },
+      );
+      expect(decBox.props.plaintextOutput).toBe(plain);
+    });
+
+    it('aliases vigenereencode as an encrypt trigger', async () => {
+      const boxes = await VigenereBoxSource.generateBoxes('attackatdawn', {
+        vigenereencode: 'lemon',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Vigenere (Encrypt)');
+      expect(boxes[0].props.plaintextOutput).toBe('lxfopvefrnhr');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -46,6 +46,7 @@ import UnicodeNormalizeBoxSource from './UnicodeNormalizeBoxSource';
 import UnitConverterBoxSource from './UnitConverterBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
+import VigenereBoxSource from './VigenereBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  VigenereBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Vigenere (Encode)

Adds the `Vigenere` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Encode`
- **Tag**: `#`
- **Default Input**: `attackatdawn ::vigenere=lemon`

#### Options:
- None

#### Description:
Vigenere cipher. Encrypt with ::vigenere=key, decrypt with ::vigeneredecode=key.

#### Usage Examples:
- **Input**:
```
attackatdawn ::vigenere=lemon
```
- **Output Box (`Vigenere (Encrypt)`)**:
```
lxfopvefrnhr
```
