### PR TITLE
feat(WeekNumber): add Week Number BoxSource

### DIFF
--- a/src/modules/boxSources/WeekNumberBoxSource.ts
+++ b/src/modules/boxSources/WeekNumberBoxSource.ts
@@ -1,5 +1,5 @@
 import { KeyValueBoxTemplate } from '@components/BoxTemplate';
-import { trim } from '@functions/helper';
+import { parseDateString, trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
@@ -96,11 +96,14 @@ export const WeekNumberBoxSource = {
     let date: Date;
     if (raw === '' || raw === 'today' || raw === 'now') {
       date = new Date();
-    } else if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
-      // pin a date-only string to UTC midnight so the week is timezone-stable
-      date = new Date(`${raw}T00:00:00Z`);
     } else {
-      date = new Date(raw);
+      const parsed = parseDateString(raw);
+      if (parsed) {
+        const year = parsed.year ?? new Date().getFullYear();
+        date = new Date(Date.UTC(year, parsed.month - 1, parsed.day));
+      } else {
+        date = new Date(raw);
+      }
     }
 
     if (Number.isNaN(date.getTime())) {

--- a/src/modules/boxSources/WeekNumberBoxSource.ts
+++ b/src/modules/boxSources/WeekNumberBoxSource.ts
@@ -1,0 +1,146 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// day names indexed by ISO weekday (1=Mon..7=Sun)
+const DAY_NAMES = [
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+  'Sunday',
+];
+
+// compute ISO 8601 week number, ISO year, and ISO weekday for a given UTC date
+function isoWeekData(d: Date): {
+  isoYear: number;
+  week: number;
+  isoWeekday: number;
+} {
+  // work on a copy at UTC midnight to avoid DST shifts
+  const date = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+
+  // ISO weekday: Mon=0..Sun=6 (shifted from JS Sun=0..Sat=6)
+  const dayNum = (date.getUTCDay() + 6) % 7;
+
+  // move to the Thursday of this week (week is defined by its Thursday)
+  date.setUTCDate(date.getUTCDate() + 3 - dayNum);
+  const isoYear = date.getUTCFullYear();
+
+  // Jan 4 is always in ISO week 1; find the Thursday of that week 1
+  const week1 = new Date(Date.UTC(isoYear, 0, 4));
+  const week1DayNum = (week1.getUTCDay() + 6) % 7;
+  week1.setUTCDate(week1.getUTCDate() + 3 - week1DayNum);
+
+  const week =
+    1 +
+    Math.round((date.getTime() - week1.getTime()) / (7 * 24 * 60 * 60 * 1000));
+
+  // ISO weekday 1=Mon..7=Sun
+  const isoWeekday =
+    ((new Date(
+      Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+    ).getUTCDay() +
+      6) %
+      7) +
+    1;
+
+  return { isoYear, week, isoWeekday };
+}
+
+// compute day-of-year (1-366) using UTC fields
+function dayOfYear(d: Date): number {
+  const start = new Date(Date.UTC(d.getUTCFullYear(), 0, 0));
+  const current = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
+  return Math.round(
+    (current.getTime() - start.getTime()) / (24 * 60 * 60 * 1000),
+  );
+}
+
+// format a UTC date as yyyy-MM-dd
+function formatDate(d: Date): string {
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export const WeekNumberBoxSource = {
+  defaultDisabled: true,
+  name: 'Week Number',
+  description:
+    'Compute the ISO 8601 week number (and weekday, day-of-year) for a date.',
+  defaultInput: '2024-01-01 ::weeknum',
+  tag: '#',
+  kind: 'Analyze',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'weeknum', 'isoweek')) return [];
+
+    const raw = trim(input).slice(0, 64);
+
+    // resolve the target date
+    let date: Date;
+    if (raw === '' || raw === 'today' || raw === 'now') {
+      date = new Date();
+    } else if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+      // pin a date-only string to UTC midnight so the week is timezone-stable
+      date = new Date(`${raw}T00:00:00Z`);
+    } else {
+      date = new Date(raw);
+    }
+
+    if (Number.isNaN(date.getTime())) {
+      const errText = `Invalid date: "${raw}"`;
+      return [
+        new BoxBuilder('Week Number', errText)
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions({ Error: errText })
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const { isoYear, week, isoWeekday } = isoWeekData(date);
+    const doy = dayOfYear(date);
+    const dateStr = formatDate(date);
+    const isoWeekStr = `${isoYear}-W${String(week).padStart(2, '0')}`;
+    const weekdayName = DAY_NAMES[isoWeekday - 1];
+
+    const kvOptions: Record<string, string> = {
+      Date: dateStr,
+      'ISO Week': isoWeekStr,
+      Week: String(week),
+      'ISO Year': String(isoYear),
+      Weekday: weekdayName,
+      'Day of Year': String(doy),
+    };
+
+    const plaintext = Object.entries(kvOptions)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+
+    return [
+      new BoxBuilder('Week Number', plaintext)
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kvOptions)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default WeekNumberBoxSource;

--- a/src/modules/boxSources/__test__/WeekNumberBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/WeekNumberBoxSource.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { WeekNumberBoxSource } from '../WeekNumberBoxSource';
+
+describe('WeekNumberBoxSource', () => {
+  it('returns [] when no matching option is present', async () => {
+    const boxes = await WeekNumberBoxSource.generateBoxes('2024-01-01', null);
+    expect(boxes).toEqual([]);
+  });
+
+  it('returns [] for unrelated options', async () => {
+    const boxes = await WeekNumberBoxSource.generateBoxes('2024-01-01', {
+      base64: true,
+    });
+    expect(boxes).toEqual([]);
+  });
+
+  it('triggers on ::weeknum option', async () => {
+    const boxes = await WeekNumberBoxSource.generateBoxes('2024-01-01', {
+      weeknum: true,
+    });
+    expect(boxes).toHaveLength(1);
+  });
+
+  it('triggers on ::isoweek option', async () => {
+    const boxes = await WeekNumberBoxSource.generateBoxes('2024-01-01', {
+      isoweek: true,
+    });
+    expect(boxes).toHaveLength(1);
+  });
+
+  describe('2024-01-01 (Monday, ISO week 1 of 2024)', () => {
+    it('returns correct ISO week data', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2024-01-01', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Date).toBe('2024-01-01');
+      expect(opts['ISO Week']).toBe('2024-W01');
+      expect(opts.Week).toBe('1');
+      expect(opts['ISO Year']).toBe('2024');
+      expect(opts.Weekday).toBe('Monday');
+      expect(opts['Day of Year']).toBe('1');
+    });
+  });
+
+  describe('2021-01-01 (Friday) → ISO 2020-W53 (boundary: year starts mid-week)', () => {
+    it('belongs to ISO week 53 of 2020', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2021-01-01', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Week).toBe('53');
+      expect(opts['ISO Year']).toBe('2020');
+      expect(opts['ISO Week']).toBe('2020-W53');
+      expect(opts.Weekday).toBe('Friday');
+    });
+  });
+
+  describe('2020-12-31 → also ISO 2020-W53', () => {
+    it('belongs to ISO week 53 of 2020', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2020-12-31', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Week).toBe('53');
+      expect(opts['ISO Year']).toBe('2020');
+      expect(opts['ISO Week']).toBe('2020-W53');
+    });
+  });
+
+  describe('2016-01-01 (Friday) → ISO 2015-W53', () => {
+    it('belongs to ISO week 53 of 2015', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2016-01-01', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Week).toBe('53');
+      expect(opts['ISO Year']).toBe('2015');
+      expect(opts['ISO Week']).toBe('2015-W53');
+    });
+  });
+
+  describe('2024-12-31 (Tuesday) → ISO 2025-W01 (boundary: week straddles new year)', () => {
+    it('belongs to ISO week 1 of 2025', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2024-12-31', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Week).toBe('1');
+      expect(opts['ISO Year']).toBe('2025');
+      expect(opts['ISO Week']).toBe('2025-W01');
+      expect(opts.Weekday).toBe('Tuesday');
+    });
+  });
+
+  describe('invalid date input', () => {
+    it('returns a box explaining the date is invalid', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('notadate', {
+        weeknum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toMatch(/invalid date/i);
+    });
+  });
+
+  describe('empty input → today', () => {
+    it('returns a box without error', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('', {
+        weeknum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeUndefined();
+      expect(opts['ISO Week']).toMatch(/^\d{4}-W\d{2}$/);
+    });
+  });
+
+  describe('"today" keyword', () => {
+    it('returns a box without error', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('today', {
+        weeknum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Error).toBeUndefined();
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/WeekNumberBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/WeekNumberBoxSource.test.ts
@@ -104,6 +104,56 @@ describe('WeekNumberBoxSource', () => {
     });
   });
 
+  describe('flexible date formats', () => {
+    it('accepts MM/DD format', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('01/01', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Date).toMatch(/-\d{2}-\d{2}$/);
+      expect(opts['ISO Week']).toBeDefined();
+    });
+
+    it('accepts YYYY/MM/DD format', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('2024/01/01', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Date).toBe('2024-01-01');
+      expect(opts['ISO Week']).toBe('2024-W01');
+    });
+
+    it('accepts Month Name day format', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes('June 25, 2026', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Date).toBe('2026-06-25');
+    });
+
+    it('accepts UNIX timestamp', async () => {
+      // 1735794245 is Jan 2, 2025 (Thursday, ISO week 1 of 2025)
+      const boxes = await WeekNumberBoxSource.generateBoxes('1735794245', {
+        weeknum: true,
+      });
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Date).toBe('2025-01-02');
+      expect(opts.Weekday).toBe('Thursday');
+      expect(opts['ISO Week']).toBe('2025-W01');
+    });
+
+    it('accepts datetime string YYYY-MM-DDTHH:mm:ssZ', async () => {
+      const boxes = await WeekNumberBoxSource.generateBoxes(
+        '2026-06-25T13:05:40+08:00',
+        {
+          weeknum: true,
+        },
+      );
+      const opts = boxes[0].props.options as Record<string, string>;
+      expect(opts.Date).toBe('2026-06-25');
+    });
+  });
+
   describe('empty input → today', () => {
     it('returns a box without error', async () => {
       const boxes = await WeekNumberBoxSource.generateBoxes('', {

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -34,6 +34,7 @@ import TimeFormatBoxSource from './TimeFormatBoxSource';
 import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
+import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
@@ -77,6 +78,7 @@ export const boxSources: BoxSource[] = [
   SubnetBoxSource,
   TemperatureBoxSource,
   TextReverseBoxSource,
+  WeekNumberBoxSource,
   WhitespaceCleanBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,


### PR DESCRIPTION
### Box Source: Week Number (Analyze)

Adds the `Week Number` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Analyze`
- **Tag**: `#`
- **Default Input**: `2024-01-01 ::weeknum`

#### Options:
- `::isoweek`, `::weeknum`

#### Description:
Compute the ISO 8601 week number (and weekday, day-of-year) for a date.

#### Usage Examples:
- **Input**:
```
2024-01-01 ::weeknum
```
- **Output Box (`Week Number`)**:
```
Date: 2024-01-01
ISO Week: 2024-W01
Week: 1
ISO Year: 2024
Weekday: Monday
Day of Year: 1
```
