### PR TITLE
feat(WhitespaceNormalize): add Normalize Whitespace BoxSource

### DIFF
--- a/src/modules/boxSources/WhitespaceNormalizeBoxSource.ts
+++ b/src/modules/boxSources/WhitespaceNormalizeBoxSource.ts
@@ -1,0 +1,98 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+
+// normalize line endings to LF
+function normalizeCRLF(text: string): string {
+  return text.replace(/\r\n|\r/g, '\n');
+}
+
+// strip trailing whitespace from every line
+function stripTrailingWhitespace(lines: string[]): string[] {
+  return lines.map((line) => line.replace(/[ \t]+$/, ''));
+}
+
+// collapse 2+ consecutive blank lines to a single blank line
+function collapseBlankLines(lines: string[]): string[] {
+  const result: string[] = [];
+  let blanks = 0;
+  for (const line of lines) {
+    if (line === '') {
+      blanks++;
+      if (blanks <= 1) result.push(line);
+    } else {
+      blanks = 0;
+      result.push(line);
+    }
+  }
+  return result;
+}
+
+// trim leading and trailing blank lines from the line array
+function trimLeadingTrailingBlankLines(lines: string[]): string[] {
+  let start = 0;
+  while (start < lines.length && lines[start] === '') start++;
+  let end = lines.length - 1;
+  while (end >= start && lines[end] === '') end--;
+  return lines.slice(start, end + 1);
+}
+
+// collapse internal runs of spaces/tabs to a single space and trim leading whitespace per line
+function collapseInternalWhitespace(lines: string[]): string[] {
+  return lines.map((line) =>
+    line.replace(/^[ \t]+/, '').replace(/[ \t]{2,}/g, ' '),
+  );
+}
+
+function normalize(input: string, applyNormalizews: boolean): string {
+  const text = normalizeCRLF(input);
+  let lines = text.split('\n');
+
+  lines = stripTrailingWhitespace(lines);
+
+  if (applyNormalizews) {
+    lines = collapseInternalWhitespace(lines);
+  }
+
+  lines = collapseBlankLines(lines);
+  lines = trimLeadingTrailingBlankLines(lines);
+
+  return lines.join('\n');
+}
+
+export const WhitespaceNormalizeBoxSource = {
+  defaultDisabled: true,
+  name: 'Normalize Whitespace',
+  description:
+    'Trim trailing spaces per line, collapse multiple blank lines to one, and strip leading/trailing blank lines.',
+  defaultInput: 'foo   \n\n\n  bar  \n\n ::trimlines',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'trimlines', 'normalizews')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const applyNormalizews = hasOptionKeys(options, 'normalizews');
+    const output = normalize(input, applyNormalizews);
+
+    return [
+      new BoxBuilder('Normalize Whitespace', output)
+        .setTemplate(CodeBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default WhitespaceNormalizeBoxSource;

--- a/src/modules/boxSources/__test__/WhitespaceNormalizeBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/WhitespaceNormalizeBoxSource.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { WhitespaceNormalizeBoxSource } from '../WhitespaceNormalizeBoxSource';
+
+describe('WhitespaceNormalizeBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns [] when no option keys present', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes(
+        'foo   \n\n\n  bar  \n\n',
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input even with option key', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes('', {
+        trimlines: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('trimlines: strips trailing spaces, collapses blank lines, trims leading/trailing blank lines', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes(
+        'foo   \n\n\n  bar  \n\n',
+        { trimlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      // trailing spaces stripped, triple blank → single blank, trailing blank line gone; leading indent on bar kept
+      expect(boxes[0].props.plaintextOutput).toBe('foo\n\n  bar');
+    });
+
+    it('trimlines: strips trailing spaces only', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes(
+        'a   \nb\t',
+        { trimlines: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb');
+    });
+
+    it('normalizews: collapses internal runs of spaces/tabs to a single space', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes('a    b', {
+        normalizews: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a b');
+    });
+
+    it('normalizews: trims leading whitespace per line', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes('   x', {
+        normalizews: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('x');
+    });
+
+    it('trimlines: normalizes CRLF to LF', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes('a\r\nb', {
+        trimlines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a\nb');
+    });
+
+    it('box has correct name and priority', async () => {
+      const boxes = await WhitespaceNormalizeBoxSource.generateBoxes('hello', {
+        trimlines: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Normalize Whitespace');
+      expect(boxes[0].props.priority).toBe(10);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -48,6 +48,7 @@ import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
+import WhitespaceNormalizeBoxSource from './WhitespaceNormalizeBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
@@ -108,4 +109,5 @@ export const boxSources: BoxSource[] = [
   WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
+  WhitespaceNormalizeBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Normalize Whitespace (Transform)

Adds the `Normalize Whitespace` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `foo   


  bar  

 ::trimlines`

#### Options:
- `::normalizews`, `::trimlines`

#### Description:
Trim trailing spaces per line, collapse multiple blank lines to one, and strip leading/trailing blank lines.

#### Usage Examples:
- **Input**:
```
foo   


  bar  

 ::trimlines
```
- **Output Box (`Normalize Whitespace`)**:
```
foo

  bar
```
