### PR TITLE
feat(WordWrap): add Word Wrap BoxSource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ dev-debug.log
 *.sln
 *.sw?
 # OS specific
+.gemini/

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: box.defaultDisabled ? false : true,
+        enabled: !box.defaultDisabled,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: box.defaultDisabled ? false : true,
+            enabled: !box.defaultDisabled,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -27,7 +27,7 @@ const defaultSettings: Settings = {
       box.name,
       {
         id: box.name,
-        enabled: true,
+        enabled: box.defaultDisabled ? false : true,
         priority: box.priority ?? 10,
         secondaryOrder: idx,
       },
@@ -51,7 +51,7 @@ export const SettingsStorage = {
         if (!parsed.boxes[box.name]) {
           parsed.boxes[box.name] = {
             id: box.name,
-            enabled: true,
+            enabled: box.defaultDisabled ? false : true,
             priority: validatePriority(box.priority ?? 10),
             secondaryOrder: idx,
           };

--- a/src/modules/BoxSource.ts
+++ b/src/modules/BoxSource.ts
@@ -9,5 +9,6 @@ export interface BoxSource {
   tag: string;
   kind: string;
   priority?: number;
+  defaultDisabled?: boolean;
   generateBoxes: (input: string, options: BoxOptions) => Promise<Box[]>;
 }

--- a/src/modules/boxSources/WordWrapBoxSource.ts
+++ b/src/modules/boxSources/WordWrapBoxSource.ts
@@ -1,0 +1,93 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { isString } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, extractOptionKeys, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 100_000;
+const DEFAULT_WIDTH = 80;
+const MAX_WIDTH = 1000;
+
+// wrap a single line at word boundaries so no output line exceeds `width`.
+// words longer than `width` are kept on their own line without being split.
+// leading indentation is preserved on the first wrapped sub-line.
+function wrapLine(line: string, width: number): string {
+  const indent = line.match(/^[ \t]*/)?.[0] ?? '';
+  const rest = line.slice(indent.length);
+  if (rest === '') return line;
+
+  const words = rest.split(/\s+/).filter((w) => w.length > 0);
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    if (current === '') {
+      current = word;
+    } else if (current.length + 1 + word.length <= width) {
+      current += ` ${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+
+  if (current !== '') {
+    lines.push(current);
+  }
+
+  // keep the original indentation on the first line
+  return lines.map((l, i) => (i === 0 ? indent + l : l)).join('\n');
+}
+
+// resolve the target column width from options, falling back to DEFAULT_WIDTH.
+function resolveWidth(options: BoxOptions): number {
+  const raw = extractOptionKeys(options, 'wrap', 'wordwrap');
+
+  if (raw === null || raw === true) {
+    return DEFAULT_WIDTH;
+  }
+
+  const parsed = Number.parseInt(String(raw), 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return DEFAULT_WIDTH;
+  }
+
+  return Math.min(parsed, MAX_WIDTH);
+}
+
+export const WordWrapBoxSource = {
+  defaultDisabled: true,
+  name: 'Word Wrap',
+  description:
+    'Wrap text to a column width at word boundaries. Use ::wrap=N for width N (default 80).',
+  defaultInput: 'The quick brown fox jumps over the lazy dog ::wrap=20',
+  tag: '#',
+  kind: 'Transform',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'wrap', 'wordwrap')) return [];
+    if (!isString(input) || input.length === 0 || input.length > MAX_INPUT)
+      return [];
+
+    const width = resolveWidth(options);
+
+    // wrap each existing line independently to preserve user newlines / paragraphs
+    const output = input
+      .split('\n')
+      .map((line) => wrapLine(line, width))
+      .join('\n');
+
+    return [
+      new BoxBuilder('Word Wrap', output)
+        .setTemplate(CodeBoxTemplate)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default WordWrapBoxSource;

--- a/src/modules/boxSources/__test__/WordWrapBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/WordWrapBoxSource.test.ts
@@ -1,0 +1,117 @@
+import { CodeBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { WordWrapBoxSource } from '../WordWrapBoxSource';
+
+describe('WordWrapBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('should return empty array when no wrap option is provided', async () => {
+      const boxes = await WordWrapBoxSource.generateBoxes(
+        'The quick brown fox',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should return empty array for empty input', async () => {
+      const boxes = await WordWrapBoxSource.generateBoxes('', { wrap: '20' });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should wrap text at word boundaries respecting the given width', async () => {
+      const boxes = await WordWrapBoxSource.generateBoxes(
+        'The quick brown fox jumps over the lazy dog',
+        { wrap: '20' },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const output: string = boxes[0].props.plaintextOutput;
+      // every line must be at most 20 characters
+      for (const line of output.split('\n')) {
+        expect(line.length).toBeLessThanOrEqual(20);
+      }
+      // greedy pack: verify exact expected output
+      expect(output).toBe('The quick brown fox\njumps over the lazy\ndog');
+    });
+
+    it('should not split a word that exceeds the width', async () => {
+      const boxes = await WordWrapBoxSource.generateBoxes(
+        'supercalifragilistic',
+        { wrap: '5' },
+      );
+      expect(boxes).toHaveLength(1);
+
+      const lines = boxes[0].props.plaintextOutput.split('\n');
+      // the long word must appear intact on its own line
+      expect(lines).toContain('supercalifragilistic');
+      // it must not be split across multiple lines
+      expect(lines.length).toBe(1);
+    });
+
+    it('should preserve existing newlines across independent paragraph wrapping', async () => {
+      const boxes = await WordWrapBoxSource.generateBoxes('a b\nc d', {
+        wrap: '80',
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('a b\nc d');
+    });
+
+    it('should use DEFAULT_WIDTH of 80 when ::wrap is used without a value', async () => {
+      const longLine = 'word '.repeat(20).trimEnd(); // 99 chars
+      const boxes = await WordWrapBoxSource.generateBoxes(longLine, {
+        wrap: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      for (const line of boxes[0].props.plaintextOutput.split('\n')) {
+        expect(line.length).toBeLessThanOrEqual(80);
+      }
+    });
+
+    it('should use DEFAULT_WIDTH of 80 when ::wordwrap is used without a value', async () => {
+      const longLine = 'word '.repeat(20).trimEnd();
+      const boxes = await WordWrapBoxSource.generateBoxes(longLine, {
+        wordwrap: true,
+      });
+      expect(boxes).toHaveLength(1);
+
+      for (const line of boxes[0].props.plaintextOutput.split('\n')) {
+        expect(line.length).toBeLessThanOrEqual(80);
+      }
+    });
+
+    it('should set CodeBoxTemplate on the returned box', async () => {
+      const boxes = await WordWrapBoxSource.generateBoxes(
+        'The quick brown fox',
+        { wrap: '20' },
+      );
+      expect(boxes[0].boxTemplate).toBe(CodeBoxTemplate);
+    });
+
+    it('should set priority from WordWrapBoxSource.priority', async () => {
+      const boxes = await WordWrapBoxSource.generateBoxes(
+        'The quick brown fox',
+        { wrap: '20' },
+      );
+      expect(boxes[0].props.priority).toBe(WordWrapBoxSource.priority);
+    });
+
+    it('should accept ::wordwrap as an alias for ::wrap', async () => {
+      const boxes = await WordWrapBoxSource.generateBoxes(
+        'The quick brown fox jumps over the lazy dog',
+        { wordwrap: '20' },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe(
+        'The quick brown fox\njumps over the lazy\ndog',
+      );
+    });
+
+    it('preserves leading indentation on the first wrapped line', async () => {
+      const boxes = await WordWrapBoxSource.generateBoxes('    hello world', {
+        wrap: '80',
+      });
+      expect(boxes[0].props.plaintextOutput).toBe('    hello world');
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -23,6 +23,7 @@ import TimestampBoxSource from './TimestampBoxSource';
 import URLDecodeBoxSource from './URLDecodeBoxSource';
 import UuidBoxSource from './UuidBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
+import WordWrapBoxSource from './WordWrapBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
 // catch-all encoders (Base64 Encode, Word Count) sit at the bottom so they
@@ -50,5 +51,6 @@ export const boxSources = [
   UuidBoxSource,
   TimestampBoxSource,
   Base64EncodeBoxSource,
+  WordWrapBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Word Wrap (Transform)

Adds the `Word Wrap` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Transform`
- **Tag**: `#`
- **Default Input**: `The quick brown fox jumps over the lazy dog ::wrap=20`

#### Options:
- `::wordwrap`, `::wrap`

#### Description:
Wrap text to a column width at word boundaries. Use ::wrap=N for width N (default 80).
