### PR TITLE
feat(WordsToNumber): add Words to Number BoxSource

### DIFF
--- a/src/modules/boxSources/WordsToNumberBoxSource.ts
+++ b/src/modules/boxSources/WordsToNumberBoxSource.ts
@@ -1,0 +1,148 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { isString, trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+const MAX_INPUT = 1000;
+
+// maps unit words (zero–nineteen) to their numeric values
+const UNITS: Record<string, number> = {
+  zero: 0,
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+  thirteen: 13,
+  fourteen: 14,
+  fifteen: 15,
+  sixteen: 16,
+  seventeen: 17,
+  eighteen: 18,
+  nineteen: 19,
+};
+
+// maps tens words to their numeric values
+const TENS: Record<string, number> = {
+  twenty: 20,
+  thirty: 30,
+  forty: 40,
+  fifty: 50,
+  sixty: 60,
+  seventy: 70,
+  eighty: 80,
+  ninety: 90,
+};
+
+// scales that flush the accumulator into the result; 'hundred' is handled
+// separately (it multiplies the accumulator) so it's intentionally not here
+const SCALES: Record<string, number> = {
+  thousand: 1_000,
+  million: 1_000_000,
+  billion: 1_000_000_000,
+  trillion: 1_000_000_000_000,
+};
+
+type ParseResult =
+  | { ok: true; value: number }
+  | { ok: false; unrecognized: string };
+
+/** Converts a list of normalised word tokens into an integer using standard accumulation. */
+function parseWords(words: string[]): ParseResult {
+  let result = 0;
+  let current = 0;
+  let negative = false;
+
+  for (const word of words) {
+    if (word === 'negative' || word === 'minus') {
+      negative = true;
+      continue;
+    }
+    if (word === 'and') {
+      continue;
+    }
+
+    if (Object.hasOwn(UNITS, word)) {
+      current += UNITS[word];
+    } else if (Object.hasOwn(TENS, word)) {
+      current += TENS[word];
+    } else if (word === 'hundred') {
+      // hundred multiplies only the sub-hundred accumulator, not the full result
+      current = current === 0 ? 100 : current * 100;
+    } else if (Object.hasOwn(SCALES, word)) {
+      // thousand and above: flush current into result scaled up, then reset current
+      result += current * SCALES[word];
+      current = 0;
+    } else {
+      return { ok: false, unrecognized: word };
+    }
+  }
+
+  result += current;
+  return { ok: true, value: negative ? -result : result };
+}
+
+export const WordsToNumberBoxSource = {
+  defaultDisabled: true,
+  name: 'Words to Number',
+  description:
+    'Parse English number words into an integer (e.g. "one thousand two hundred" → 1200).',
+  defaultInput: 'one million two hundred thirty-four thousand ::wordstonum',
+  tag: '#',
+  kind: 'Convert',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'wordstonum', 'wordstonumber')) return [];
+    if (
+      !isString(input) ||
+      trim(input).length === 0 ||
+      input.length > MAX_INPUT
+    )
+      return [];
+
+    // normalise: lowercase, replace hyphens with spaces, split on whitespace
+    const words = input
+      .toLowerCase()
+      .replace(/-/g, ' ')
+      .trim()
+      .split(/\s+/)
+      .filter((w) => w.length > 0);
+
+    const result = parseWords(words);
+
+    if (!result.ok) {
+      return [
+        new BoxBuilder(
+          'Words to Number',
+          `couldn't parse '${result.unrecognized}'`,
+        )
+          .setTemplate(DefaultBoxTemplate)
+          .setShowExpandButton(false)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    return [
+      new BoxBuilder('Words to Number', String(result.value))
+        .setTemplate(DefaultBoxTemplate)
+        .setShowExpandButton(false)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default WordsToNumberBoxSource;

--- a/src/modules/boxSources/__test__/WordsToNumberBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/WordsToNumberBoxSource.test.ts
@@ -1,0 +1,140 @@
+import { DefaultBoxTemplate } from '@components/BoxTemplate';
+import { describe, expect, it } from 'vitest';
+
+import { WordsToNumberBoxSource } from '../WordsToNumberBoxSource';
+
+describe('WordsToNumberBoxSource', () => {
+  describe('option gating', () => {
+    it('returns [] when no option is provided', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'forty-two',
+        null,
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] when an unrelated option is provided', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('forty-two', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for empty input with option', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns [] for whitespace-only input', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('   ', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+  });
+
+  describe('basic parsing with ::wordstonum', () => {
+    it('parses "forty-two" → 42', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('forty-two', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('42');
+    });
+
+    it('parses "one hundred" → 100', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('one hundred', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('100');
+    });
+
+    it('parses "one hundred one" → 101', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'one hundred one',
+        {
+          wordstonum: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('101');
+    });
+
+    it('parses "one thousand two hundred thirty-four" → 1234', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'one thousand two hundred thirty-four',
+        { wordstonum: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1234');
+    });
+
+    it('parses "one million two hundred thirty-four thousand five hundred sixty-seven" → 1234567', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'one million two hundred thirty-four thousand five hundred sixty-seven',
+        { wordstonum: true },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('1234567');
+    });
+
+    it('parses "negative five" → -5', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'negative five',
+        {
+          wordstonum: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('-5');
+    });
+
+    it('parses "zero" → 0', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('zero', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('0');
+    });
+  });
+
+  describe('alias option ::wordstonumber', () => {
+    it('also triggers on ::wordstonumber', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('five', {
+        wordstonumber: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toBe('5');
+    });
+  });
+
+  describe('unrecognized word', () => {
+    it('returns a box mentioning the unrecognized word for "one bazillion"', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes(
+        'one bazillion',
+        {
+          wordstonum: true,
+        },
+      );
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain("couldn't parse");
+      expect(boxes[0].props.plaintextOutput).toContain('bazillion');
+    });
+  });
+
+  describe('box metadata', () => {
+    it('sets correct name, priority, template, and showExpandButton', async () => {
+      const boxes = await WordsToNumberBoxSource.generateBoxes('ten', {
+        wordstonum: true,
+      });
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Words to Number');
+      expect(boxes[0].props.priority).toBe(10);
+      expect(boxes[0].props.showExpandButton).toBe(false);
+      expect(boxes[0].boxTemplate).toBe(DefaultBoxTemplate);
+    });
+  });
+});

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -42,6 +42,7 @@ import UuidBoxSource from './UuidBoxSource';
 import WeekNumberBoxSource from './WeekNumberBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
+import WordsToNumberBoxSource from './WordsToNumberBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
 import ZodiacBoxSource from './ZodiacBoxSource';
 
@@ -90,6 +91,7 @@ export const boxSources: BoxSource[] = [
   UnicodeNormalizeBoxSource,
   WeekNumberBoxSource,
   WhitespaceCleanBoxSource,
+  WordsToNumberBoxSource,
   ZodiacBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Words to Number (Convert)

Adds the `Words to Number` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Convert`
- **Tag**: `#`
- **Default Input**: `one million two hundred thirty-four thousand ::wordstonum`

#### Options:
- `::wordstonum`, `::wordstonumber`

#### Description:
Parse English number words into an integer (e.g. "one thousand two hundred" → 1200).

#### Usage Examples:
- **Input**:
```
one million two hundred thirty-four thousand ::wordstonum
```
- **Output Box (`Words to Number`)**:
```
1234000
```
