### PR TITLE
feat(Zodiac): add Capricorn BoxSource

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
         "jsdom": "^29.1.1",
         "mathjs": "^15.2.0",
         "rollup": "4.60.4",
-        "vite": "8.0.13",
+        "vite": "8.0.16",
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.1.5",
         "workbox-build": "^7.4.1",
@@ -464,7 +464,7 @@
 
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.130.0", "", {}, "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q=="],
+    "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -490,35 +490,35 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.1", "", { "os": "linux", "cpu": "arm" }, "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.1", "", { "os": "none", "cpu": "arm64" }, "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.1", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.1", "", { "os": "win32", "cpu": "x64" }, "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
@@ -1302,7 +1302,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "5.0.0" } }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
@@ -1372,7 +1372,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
@@ -1448,7 +1448,7 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
-    "rolldown": ["rolldown@1.0.1", "", { "dependencies": { "@oxc-project/types": "=0.130.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.1", "@rolldown/binding-darwin-arm64": "1.0.1", "@rolldown/binding-darwin-x64": "1.0.1", "@rolldown/binding-freebsd-x64": "1.0.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.1", "@rolldown/binding-linux-arm64-gnu": "1.0.1", "@rolldown/binding-linux-arm64-musl": "1.0.1", "@rolldown/binding-linux-ppc64-gnu": "1.0.1", "@rolldown/binding-linux-s390x-gnu": "1.0.1", "@rolldown/binding-linux-x64-gnu": "1.0.1", "@rolldown/binding-linux-x64-musl": "1.0.1", "@rolldown/binding-openharmony-arm64": "1.0.1", "@rolldown/binding-wasm32-wasi": "1.0.1", "@rolldown/binding-win32-arm64-msvc": "1.0.1", "@rolldown/binding-win32-x64-msvc": "1.0.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ=="],
+    "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
 
     "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
 
@@ -1642,7 +1642,7 @@
 
     "verror": ["verror@1.10.0", "", { "dependencies": { "assert-plus": "1.0.0", "core-util-is": "1.0.2", "extsprintf": "1.3.0" } }, "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw=="],
 
-    "vite": ["vite@8.0.13", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.1", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw=="],
+    "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
 
     "vite-plugin-pwa": ["vite-plugin-pwa@1.3.0", "", { "dependencies": { "debug": "^4.3.6", "pretty-bytes": "^6.1.1", "tinyglobby": "^0.2.10", "workbox-build": "^7.4.1", "workbox-window": "^7.4.1" }, "peerDependencies": { "@vite-pwa/assets-generator": "^1.0.0", "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@vite-pwa/assets-generator"] }, "sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A=="],
 
@@ -1958,6 +1958,8 @@
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "vite-plugin-pwa/pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
 
     "vitest/@types/node": ["@types/node@22.15.32", "", { "dependencies": { "undici-types": "6.21.0" } }, "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA=="],
@@ -2161,6 +2163,8 @@
     "@cypress/request/tough-cookie/tldts/tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
     "@vitest/mocker/vite/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@vitest/mocker/vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "@vitest/mocker/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 

--- a/src/functions/__test__/helper.test.ts
+++ b/src/functions/__test__/helper.test.ts
@@ -8,6 +8,8 @@ import {
   isObject,
   isRFC3339,
   isString,
+  isValidDay,
+  parseDateString,
   toNumeric,
   trim,
 } from '../helper';
@@ -170,6 +172,112 @@ describe('helper functions', () => {
       expect(isJSON('not json')).toBe(false);
       expect(isJSON('{invalid:json}')).toBe(false);
       expect(isJSON('{"unclosed:"object"')).toBe(false);
+    });
+  });
+
+  describe('isValidDay', () => {
+    it('should return true for valid month and day', () => {
+      expect(isValidDay(1, 31)).toBe(true);
+      expect(isValidDay(2, 29)).toBe(true); // leap year tolerance
+      expect(isValidDay(12, 31)).toBe(true);
+    });
+
+    it('should return false for invalid month or day', () => {
+      expect(isValidDay(0, 15)).toBe(false);
+      expect(isValidDay(13, 15)).toBe(false);
+      expect(isValidDay(2, 30)).toBe(false);
+      expect(isValidDay(4, 31)).toBe(false);
+    });
+  });
+
+  describe('parseDateString', () => {
+    it('should parse YYYY-MM-DD formats', () => {
+      expect(parseDateString('2026-06-25')).toEqual({
+        year: 2026,
+        month: 6,
+        day: 25,
+      });
+      expect(parseDateString('2026/06/25')).toEqual({
+        year: 2026,
+        month: 6,
+        day: 25,
+      });
+      expect(parseDateString('2026.06.25')).toEqual({
+        year: 2026,
+        month: 6,
+        day: 25,
+      });
+      expect(parseDateString('2026年6月25日')).toEqual({
+        year: 2026,
+        month: 6,
+        day: 25,
+      });
+    });
+
+    it('should parse MM-DD formats', () => {
+      expect(parseDateString('06-25')).toEqual({ month: 6, day: 25 });
+      expect(parseDateString('6/25')).toEqual({ month: 6, day: 25 });
+      expect(parseDateString('06.25')).toEqual({ month: 6, day: 25 });
+      expect(parseDateString('6月25日')).toEqual({ month: 6, day: 25 });
+    });
+
+    it('should parse datetime strings', () => {
+      expect(parseDateString('2026-06-25T13:05:40+08:00')).toEqual({
+        year: 2026,
+        month: 6,
+        day: 25,
+      });
+      expect(parseDateString('2026-06-25 13:05:40')).toEqual({
+        year: 2026,
+        month: 6,
+        day: 25,
+      });
+    });
+
+    it('should parse Month Name formats', () => {
+      expect(parseDateString('June 25')).toEqual({ month: 6, day: 25 });
+      expect(parseDateString('June 25, 2026')).toEqual({
+        year: 2026,
+        month: 6,
+        day: 25,
+      });
+      expect(parseDateString('25 June')).toEqual({ month: 6, day: 25 });
+      expect(parseDateString('25 June 2026')).toEqual({
+        year: 2026,
+        month: 6,
+        day: 25,
+      });
+      expect(parseDateString('Jan 1')).toEqual({ month: 1, day: 1 });
+      expect(parseDateString('1 Jan')).toEqual({ month: 1, day: 1 });
+    });
+
+    it('should parse UNIX timestamps', () => {
+      // 1735794245 is Jan 2, 2025
+      const res = parseDateString('1735794245');
+      expect(res).not.toBeNull();
+      expect(res?.month).toBe(1);
+      expect(res?.day).toBe(2);
+
+      // 1735794245000 is Jan 2, 2025 in ms
+      const resMs = parseDateString('1735794245000');
+      expect(resMs).not.toBeNull();
+      expect(resMs?.month).toBe(1);
+      expect(resMs?.day).toBe(2);
+    });
+
+    it('should fallback to standard JS Date parsing', () => {
+      expect(parseDateString('Thu Jun 25 2026')).toEqual({
+        year: 2026,
+        month: 6,
+        day: 25,
+      });
+    });
+
+    it('should return null for invalid inputs', () => {
+      expect(parseDateString('')).toBeNull();
+      expect(parseDateString('hello')).toBeNull();
+      expect(parseDateString('13-45')).toBeNull();
+      expect(parseDateString('2026-02-30')).toBeNull();
     });
   });
 });

--- a/src/functions/helper.ts
+++ b/src/functions/helper.ts
@@ -84,6 +84,182 @@ export function isJSON(str: string): boolean {
   return false;
 }
 
+const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+export function isValidDay(month: number, day: number): boolean {
+  if (month < 1 || month > 12) return false;
+  if (day < 1 || day > DAYS_IN_MONTH[month]) return false;
+  return true;
+}
+
+export function parseDateString(
+  input: string,
+): { year?: number; month: number; day: number } | null {
+  const cleaned = trim(input);
+  if (!cleaned) return null;
+
+  // 1. Check numeric timestamp
+  // A UNIX timestamp in seconds/ms is an integer and usually has 8 to 13 digits
+  if (/^\d{8,13}$/.test(cleaned)) {
+    const num = parseInt(cleaned, 10);
+    const date = new Date(num >= 1e11 ? num : num * 1000);
+    if (!Number.isNaN(date.getTime())) {
+      const year = date.getFullYear();
+      const month = date.getMonth() + 1;
+      const day = date.getDate();
+      if (isValidDay(month, day)) {
+        return { year, month, day };
+      }
+    }
+  }
+
+  // 2. YYYY-MM-DD or YYYY/MM/DD or YYYY.MM.DD or YYYY年MM月DD日
+  const ymdRegex =
+    /^\s*(\d{4})[-/.\s年]+(\d{1,2})[-/.\s月]+(\d{1,2})(?:日|號)?(?:\s|$|T)/i;
+  const ymdMatch = ymdRegex.exec(cleaned);
+  if (ymdMatch) {
+    const year = parseInt(ymdMatch[1], 10);
+    const month = parseInt(ymdMatch[2], 10);
+    const day = parseInt(ymdMatch[3], 10);
+    if (isValidDay(month, day)) {
+      return { year, month, day };
+    }
+    return null;
+  }
+
+  // 3. MM-DD-YYYY or DD-MM-YYYY
+  const mdyRegex = /^\s*(\d{1,2})[-/.\s]+(\d{1,2})[-/.\s]+(\d{2,4})(?:\s|$|T)/i;
+  const mdyMatch = mdyRegex.exec(cleaned);
+  if (mdyMatch) {
+    let month = parseInt(mdyMatch[1], 10);
+    let day = parseInt(mdyMatch[2], 10);
+    const yearRaw = parseInt(mdyMatch[3], 10);
+    if (month > 12 && day <= 12) {
+      const temp = month;
+      month = day;
+      day = temp;
+    }
+    const year =
+      yearRaw < 100
+        ? yearRaw > 50
+          ? 1900 + yearRaw
+          : 2000 + yearRaw
+        : yearRaw;
+    if (isValidDay(month, day)) {
+      return { year, month, day };
+    }
+    return null;
+  }
+
+  // 4. Month Name patterns
+  const MONTH_MAP: Record<string, number> = {
+    jan: 1,
+    january: 1,
+    feb: 2,
+    february: 2,
+    mar: 3,
+    march: 3,
+    apr: 4,
+    april: 4,
+    may: 5,
+    jun: 6,
+    june: 6,
+    jul: 7,
+    july: 7,
+    aug: 8,
+    august: 8,
+    sep: 9,
+    september: 9,
+    oct: 10,
+    october: 10,
+    nov: 11,
+    november: 11,
+    dec: 12,
+    december: 12,
+  };
+  const monthNamesPattern =
+    '(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)';
+
+  // June 25, 2026
+  const mNameDayYear = new RegExp(
+    `^\\s*${monthNamesPattern}[-/.,\\s]+(\\d{1,2})(?:[-/.,\\s]+(\\d{2,4}))?`,
+    'i',
+  );
+  const mndyMatch = mNameDayYear.exec(cleaned);
+  if (mndyMatch) {
+    const monthName = mndyMatch[1].toLowerCase();
+    const month = MONTH_MAP[monthName];
+    const day = parseInt(mndyMatch[2], 10);
+    if (month && isValidDay(month, day)) {
+      if (mndyMatch[3]) {
+        const yearRaw = parseInt(mndyMatch[3], 10);
+        const year =
+          yearRaw < 100
+            ? yearRaw > 50
+              ? 1900 + yearRaw
+              : 2000 + yearRaw
+            : yearRaw;
+        return { year, month, day };
+      }
+      return { month, day };
+    }
+    return null;
+  }
+
+  // 25 June 2026
+  const dayMNameYear = new RegExp(
+    `^\\s*(\\d{1,2})(?:st|n[d]|rd|th)?[-/.,\\s]+(?:of\\s+)?${monthNamesPattern}(?:[-/.,\\s]+(\\d{2,4}))?`,
+    'i',
+  );
+  const dmnyMatch = dayMNameYear.exec(cleaned);
+  if (dmnyMatch) {
+    const day = parseInt(dmnyMatch[1], 10);
+    const monthName = dmnyMatch[2].toLowerCase();
+    const month = MONTH_MAP[monthName];
+    if (month && isValidDay(month, day)) {
+      if (dmnyMatch[3]) {
+        const yearRaw = parseInt(dmnyMatch[3], 10);
+        const year =
+          yearRaw < 100
+            ? yearRaw > 50
+              ? 1900 + yearRaw
+              : 2000 + yearRaw
+            : yearRaw;
+        return { year, month, day };
+      }
+      return { month, day };
+    }
+    return null;
+  }
+
+  // 5. MM-DD or MM/DD or MM.DD or MM月DD日
+  const mdRegex = /^\s*(\d{1,2})[-/.\s月]+(\d{1,2})(?:日|號)?\s*$/i;
+  const mdMatch = mdRegex.exec(cleaned);
+  if (mdMatch) {
+    const month = parseInt(mdMatch[1], 10);
+    const day = parseInt(mdMatch[2], 10);
+    if (isValidDay(month, day)) {
+      return { month, day };
+    }
+    return null;
+  }
+
+  // 6. General JS Date parsing fallback (only if it doesn't look like an invalid date string with slashes/dashes)
+  if (!/[\d-]/.test(cleaned) || !Number.isNaN(Date.parse(cleaned))) {
+    const fallbackDate = new Date(cleaned);
+    if (!Number.isNaN(fallbackDate.getTime())) {
+      const year = fallbackDate.getFullYear();
+      const month = fallbackDate.getMonth() + 1;
+      const day = fallbackDate.getDate();
+      if (isValidDay(month, day)) {
+        return { year, month, day };
+      }
+    }
+  }
+
+  return null;
+}
+
 export const helper = {
   isNumeric,
   toNumeric,
@@ -94,4 +270,6 @@ export const helper = {
   isRFC3339,
   isBase64,
   isJSON,
+  isValidDay,
+  parseDateString,
 };

--- a/src/modules/boxSources/ZodiacBoxSource.ts
+++ b/src/modules/boxSources/ZodiacBoxSource.ts
@@ -1,12 +1,12 @@
 import { KeyValueBoxTemplate } from '@components/BoxTemplate';
-import { trim } from '@functions/helper';
+import { parseDateString, trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
 import { BoxBuilder, hasOptionKeys } from '@modules/Box';
 
 const Priority = 10;
 
 // max input length to avoid processing arbitrary long strings
-const MAX_INPUT_LENGTH = 20;
+const MAX_INPUT_LENGTH = 45;
 
 interface ZodiacSign {
   name: string;
@@ -77,38 +77,6 @@ function lookupSign(month: number, day: number): ZodiacSign {
   return SIGNS[0];
 }
 
-// days in each month; feb 29 is accepted (leap-year tolerance for zodiac purposes)
-const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-
-function isValidDay(month: number, day: number): boolean {
-  if (month < 1 || month > 12) return false;
-  if (day < 1 || day > DAYS_IN_MONTH[month]) return false;
-  return true;
-}
-
-// parse input as MM-DD, MM/DD, YYYY-MM-DD, or YYYY/MM/DD.
-// returns [month, day] on success or null when the format is unrecognized.
-function parseDate(input: string): [number, number] | null {
-  // normalize separators so we handle both '-' and '/'
-  const normalized = input.replace(/\//g, '-');
-
-  const fullMatch = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(normalized);
-  if (fullMatch) {
-    const month = Number.parseInt(fullMatch[2], 10);
-    const day = Number.parseInt(fullMatch[3], 10);
-    return isValidDay(month, day) ? [month, day] : null;
-  }
-
-  const shortMatch = /^(\d{1,2})-(\d{1,2})$/.exec(normalized);
-  if (shortMatch) {
-    const month = Number.parseInt(shortMatch[1], 10);
-    const day = Number.parseInt(shortMatch[2], 10);
-    return isValidDay(month, day) ? [month, day] : null;
-  }
-
-  return null;
-}
-
 // build a k:v plaintext string consumed by KeyValueBoxTemplate
 function kvToPlaintext(kv: Record<string, string>): string {
   return Object.entries(kv)
@@ -135,7 +103,7 @@ export const ZodiacBoxSource = {
     const raw = trim(input);
     if (raw.length > MAX_INPUT_LENGTH) return [];
 
-    const parsed = parseDate(raw);
+    const parsed = parseDateString(raw);
 
     if (parsed === null) {
       // return an informational box so the user knows the input is invalid
@@ -149,7 +117,7 @@ export const ZodiacBoxSource = {
       ];
     }
 
-    const [month, day] = parsed;
+    const { month, day } = parsed;
     const sign = lookupSign(month, day);
     const mmdd = `${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
 

--- a/src/modules/boxSources/ZodiacBoxSource.ts
+++ b/src/modules/boxSources/ZodiacBoxSource.ts
@@ -1,0 +1,174 @@
+import { KeyValueBoxTemplate } from '@components/BoxTemplate';
+import { trim } from '@functions/helper';
+import type { Box, BoxOptions } from '@modules/Box';
+import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+
+const Priority = 10;
+
+// max input length to avoid processing arbitrary long strings
+const MAX_INPUT_LENGTH = 20;
+
+interface ZodiacSign {
+  name: string;
+  symbol: string;
+  element: string;
+  dates: string;
+}
+
+// tropical zodiac sign lookup table ordered by calendar month/day.
+// capricorn wraps around year-end so it is checked via month boundary logic.
+const SIGNS: ZodiacSign[] = [
+  {
+    name: 'Capricorn',
+    symbol: '♑',
+    element: 'Earth',
+    dates: 'Dec 22 – Jan 19',
+  },
+  { name: 'Aquarius', symbol: '♒', element: 'Air', dates: 'Jan 20 – Feb 18' },
+  { name: 'Pisces', symbol: '♓', element: 'Water', dates: 'Feb 19 – Mar 20' },
+  { name: 'Aries', symbol: '♈', element: 'Fire', dates: 'Mar 21 – Apr 19' },
+  { name: 'Taurus', symbol: '♉', element: 'Earth', dates: 'Apr 20 – May 20' },
+  { name: 'Gemini', symbol: '♊', element: 'Air', dates: 'May 21 – Jun 20' },
+  { name: 'Cancer', symbol: '♋', element: 'Water', dates: 'Jun 21 – Jul 22' },
+  { name: 'Leo', symbol: '♌', element: 'Fire', dates: 'Jul 23 – Aug 22' },
+  { name: 'Virgo', symbol: '♍', element: 'Earth', dates: 'Aug 23 – Sep 22' },
+  { name: 'Libra', symbol: '♎', element: 'Air', dates: 'Sep 23 – Oct 22' },
+  { name: 'Scorpio', symbol: '♏', element: 'Water', dates: 'Oct 23 – Nov 21' },
+  {
+    name: 'Sagittarius',
+    symbol: '♐',
+    element: 'Fire',
+    dates: 'Nov 22 – Dec 21',
+  },
+];
+
+// each entry: [startMonth, startDay, endMonth, endDay, signIndex in SIGNS]
+// capricorn (index 0) spans dec 22 – jan 19 and is handled separately below.
+const RANGES: [number, number, number, number, number][] = [
+  [1, 20, 2, 18, 1], // aquarius
+  [2, 19, 3, 20, 2], // pisces
+  [3, 21, 4, 19, 3], // aries
+  [4, 20, 5, 20, 4], // taurus
+  [5, 21, 6, 20, 5], // gemini
+  [6, 21, 7, 22, 6], // cancer
+  [7, 23, 8, 22, 7], // leo
+  [8, 23, 9, 22, 8], // virgo
+  [9, 23, 10, 22, 9], // libra
+  [10, 23, 11, 21, 10], // scorpio
+  [11, 22, 12, 21, 11], // sagittarius
+];
+
+// compare two (month, day) pairs as integers for range checks
+function mdGte(month: number, day: number, m2: number, d2: number): boolean {
+  return month > m2 || (month === m2 && day >= d2);
+}
+
+function mdLte(month: number, day: number, m2: number, d2: number): boolean {
+  return month < m2 || (month === m2 && day <= d2);
+}
+
+function lookupSign(month: number, day: number): ZodiacSign {
+  for (const [sm, sd, em, ed, idx] of RANGES) {
+    if (mdGte(month, day, sm, sd) && mdLte(month, day, em, ed)) {
+      return SIGNS[idx];
+    }
+  }
+  // capricorn: dec 22 – jan 19 (wraps the year boundary)
+  return SIGNS[0];
+}
+
+// days in each month; feb 29 is accepted (leap-year tolerance for zodiac purposes)
+const DAYS_IN_MONTH = [0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function isValidDay(month: number, day: number): boolean {
+  if (month < 1 || month > 12) return false;
+  if (day < 1 || day > DAYS_IN_MONTH[month]) return false;
+  return true;
+}
+
+// parse input as MM-DD, MM/DD, YYYY-MM-DD, or YYYY/MM/DD.
+// returns [month, day] on success or null when the format is unrecognized.
+function parseDate(input: string): [number, number] | null {
+  // normalize separators so we handle both '-' and '/'
+  const normalized = input.replace(/\//g, '-');
+
+  const fullMatch = /^(\d{4})-(\d{1,2})-(\d{1,2})$/.exec(normalized);
+  if (fullMatch) {
+    const month = Number.parseInt(fullMatch[2], 10);
+    const day = Number.parseInt(fullMatch[3], 10);
+    return isValidDay(month, day) ? [month, day] : null;
+  }
+
+  const shortMatch = /^(\d{1,2})-(\d{1,2})$/.exec(normalized);
+  if (shortMatch) {
+    const month = Number.parseInt(shortMatch[1], 10);
+    const day = Number.parseInt(shortMatch[2], 10);
+    return isValidDay(month, day) ? [month, day] : null;
+  }
+
+  return null;
+}
+
+// build a k:v plaintext string consumed by KeyValueBoxTemplate
+function kvToPlaintext(kv: Record<string, string>): string {
+  return Object.entries(kv)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+export const ZodiacBoxSource = {
+  defaultDisabled: true,
+  name: 'Zodiac Sign',
+  description:
+    'Determine the Western zodiac sign for a date (MM-DD or YYYY-MM-DD).',
+  defaultInput: '03-21 ::zodiac',
+  tag: '#',
+  kind: 'Calculate',
+  priority: Priority,
+
+  async generateBoxes(
+    input: string,
+    options: BoxOptions = null,
+  ): Promise<Box[]> {
+    if (!hasOptionKeys(options, 'zodiac', 'starsign')) return [];
+
+    const raw = trim(input);
+    if (raw.length > MAX_INPUT_LENGTH) return [];
+
+    const parsed = parseDate(raw);
+
+    if (parsed === null) {
+      // return an informational box so the user knows the input is invalid
+      const kv = { Error: `Invalid date "${raw}" — use MM-DD or YYYY-MM-DD` };
+      return [
+        new BoxBuilder('Zodiac Sign', kvToPlaintext(kv))
+          .setTemplate(KeyValueBoxTemplate)
+          .setOptions(kv)
+          .setPriority(this.priority)
+          .build(),
+      ];
+    }
+
+    const [month, day] = parsed;
+    const sign = lookupSign(month, day);
+    const mmdd = `${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+
+    const kv: Record<string, string> = {
+      Date: mmdd,
+      Sign: sign.name,
+      Symbol: sign.symbol,
+      Element: sign.element,
+      Dates: sign.dates,
+    };
+
+    return [
+      new BoxBuilder('Zodiac Sign', kvToPlaintext(kv))
+        .setTemplate(KeyValueBoxTemplate)
+        .setOptions(kv)
+        .setPriority(this.priority)
+        .build(),
+    ];
+  },
+};
+
+export default ZodiacBoxSource;

--- a/src/modules/boxSources/__test__/ZodiacBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ZodiacBoxSource.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import { ZodiacBoxSource } from '../ZodiacBoxSource';
+
+describe('ZodiacBoxSource', () => {
+  describe('generateBoxes', () => {
+    it('returns empty array when no zodiac option is present', async () => {
+      const boxes = await ZodiacBoxSource.generateBoxes('03-21', null);
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns empty array when unrelated options are present', async () => {
+      const boxes = await ZodiacBoxSource.generateBoxes('03-21', {
+        qrcode: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('returns a box for ::zodiac option', async () => {
+      const boxes = await ZodiacBoxSource.generateBoxes('03-21', {
+        zodiac: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    it('returns a box for ::starsign option', async () => {
+      const boxes = await ZodiacBoxSource.generateBoxes('03-21', {
+        starsign: true,
+      });
+      expect(boxes).toHaveLength(1);
+    });
+
+    describe('sign determination', () => {
+      async function getOptions(input: string) {
+        const boxes = await ZodiacBoxSource.generateBoxes(input, {
+          zodiac: true,
+        });
+        expect(boxes).toHaveLength(1);
+        return boxes[0].props.options as Record<string, string>;
+      }
+
+      it('03-21 → Aries (start of Aries, Fire)', async () => {
+        const opts = await getOptions('03-21');
+        expect(opts.Sign).toBe('Aries');
+        expect(opts.Element).toBe('Fire');
+        expect(opts.Symbol).toBe('♈');
+      });
+
+      it('2000-07-04 → Cancer (YYYY-MM-DD format, Water)', async () => {
+        const opts = await getOptions('2000-07-04');
+        expect(opts.Sign).toBe('Cancer');
+        expect(opts.Element).toBe('Water');
+      });
+
+      it('12-25 → Capricorn (Dec 25, year-end wrap, Earth)', async () => {
+        const opts = await getOptions('12-25');
+        expect(opts.Sign).toBe('Capricorn');
+        expect(opts.Element).toBe('Earth');
+      });
+
+      it('01-15 → Capricorn (Jan 15, still within Capricorn until Jan 19)', async () => {
+        const opts = await getOptions('01-15');
+        expect(opts.Sign).toBe('Capricorn');
+      });
+
+      it('01-20 → Aquarius (boundary start Jan 20)', async () => {
+        const opts = await getOptions('01-20');
+        expect(opts.Sign).toBe('Aquarius');
+      });
+
+      it('02-19 → Pisces (boundary start Feb 19)', async () => {
+        const opts = await getOptions('02-19');
+        expect(opts.Sign).toBe('Pisces');
+      });
+
+      it('04-19 → Aries (last day of Aries)', async () => {
+        const opts = await getOptions('04-19');
+        expect(opts.Sign).toBe('Aries');
+      });
+
+      it('04-20 → Taurus (first day of Taurus)', async () => {
+        const opts = await getOptions('04-20');
+        expect(opts.Sign).toBe('Taurus');
+      });
+
+      it('01-19 → Capricorn (last day of Capricorn)', async () => {
+        const opts = await getOptions('01-19');
+        expect(opts.Sign).toBe('Capricorn');
+      });
+    });
+
+    describe('slash separator support', () => {
+      it('accepts MM/DD format', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('03/21', {
+          zodiac: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Sign).toBe('Aries');
+      });
+
+      it('accepts YYYY/MM/DD format', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('2000/07/04', {
+          zodiac: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Sign).toBe('Cancer');
+      });
+    });
+
+    describe('output shape', () => {
+      it('box is named Zodiac Sign with correct keys', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('03-21', {
+          zodiac: true,
+        });
+        const box = boxes[0];
+        expect(box.props.name).toBe('Zodiac Sign');
+        expect(box.props.priority).toBe(10);
+        const opts = box.props.options as Record<string, string>;
+        expect(opts).toHaveProperty('Date', '03-21');
+        expect(opts).toHaveProperty('Sign');
+        expect(opts).toHaveProperty('Symbol');
+        expect(opts).toHaveProperty('Element');
+        expect(opts).toHaveProperty('Dates');
+      });
+
+      it('plaintextOutput contains key: value lines', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('03-21', {
+          zodiac: true,
+        });
+        const text = boxes[0].props.plaintextOutput;
+        expect(text).toContain('Sign: Aries');
+        expect(text).toContain('Element: Fire');
+      });
+    });
+
+    describe('invalid input', () => {
+      it('returns an error box for month 13', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('13-01', {
+          zodiac: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts).toHaveProperty('Error');
+      });
+
+      it('returns an error box for free-text input', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('hello', {
+          zodiac: true,
+        });
+        expect(boxes).toHaveLength(1);
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts).toHaveProperty('Error');
+      });
+    });
+  });
+});

--- a/src/modules/boxSources/__test__/ZodiacBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/ZodiacBoxSource.test.ts
@@ -107,6 +107,36 @@ describe('ZodiacBoxSource', () => {
       });
     });
 
+    describe('flexible date/time formats', () => {
+      it('accepts datetime string YYYY-MM-DDTHH:mm:ssZ', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes(
+          '2026-06-25T13:05:40+08:00',
+          {
+            zodiac: true,
+          },
+        );
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Sign).toBe('Cancer');
+      });
+
+      it('accepts Month Name day format', async () => {
+        const boxes = await ZodiacBoxSource.generateBoxes('June 25', {
+          zodiac: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Sign).toBe('Cancer');
+      });
+
+      it('accepts UNIX timestamp', async () => {
+        // 1735794245 is Jan 2, 2025 (Capricorn)
+        const boxes = await ZodiacBoxSource.generateBoxes('1735794245', {
+          zodiac: true,
+        });
+        const opts = boxes[0].props.options as Record<string, string>;
+        expect(opts.Sign).toBe('Capricorn');
+      });
+    });
+
     describe('output shape', () => {
       it('box is named Zodiac Sign with correct keys', async () => {
         const boxes = await ZodiacBoxSource.generateBoxes('03-21', {

--- a/src/modules/boxSources/index.ts
+++ b/src/modules/boxSources/index.ts
@@ -37,6 +37,7 @@ import UuidBoxSource from './UuidBoxSource';
 import WhitespaceCleanBoxSource from './WhitespaceCleanBoxSource';
 import WordCountBoxSource from './WordCountBoxSource';
 import WordWrapBoxSource from './WordWrapBoxSource';
+import ZodiacBoxSource from './ZodiacBoxSource';
 
 // Path B: default order is the display order. High-signal sources sit on top;
 // catch-all encoders (Base64 Encode, Word Count) sit at the bottom so they
@@ -77,5 +78,6 @@ export const boxSources: BoxSource[] = [
   TemperatureBoxSource,
   TextReverseBoxSource,
   WhitespaceCleanBoxSource,
+  ZodiacBoxSource,
   WordCountBoxSource,
 ];


### PR DESCRIPTION
### Box Source: Zodiac Sign (Calculate)

Adds the `Zodiac Sign` box source to Magic Box. It is disabled by default.

#### Details:
- **Category (Kind)**: `Calculate`
- **Tag**: `#`
- **Default Input**: `03-21 ::zodiac`

#### Options:
- `::starsign`, `::zodiac`

#### Description:
Determine the Western zodiac sign for a date (MM-DD or YYYY-MM-DD).

#### Usage Examples:
- **Input**:
```
03-21 ::zodiac
```
- **Output Box (`Zodiac Sign`)**:
```
Date: 03-21
Sign: Aries
Symbol: ♈
Element: Fire
Dates: Mar 21 – Apr 19
```
