### PR TITLE
ci: keep Dependabot lockfiles and WASM builds reliable

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -13,17 +13,19 @@ runs:
     - name: Install wasm-pack
       if: ${{ inputs.buildWasm == 'true' }}
       uses: jetli/wasm-pack-action@v0.4.0
+      with:
+        version: v0.15.0
 
     - name: Build WASM
       if: ${{ inputs.buildWasm == 'true' }}
       shell: bash
       run: |
-        find wasmModules -type d -maxdepth 1 -mindepth 1 -exec wasm-pack build --target web --release {} \;
+        for module in wasmModules/*/; do
+          wasm-pack build --target web --release "$module"
+        done
 
     - name: Setup bun
       uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: latest
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,8 +5,8 @@
 
 version: 2
 updates:
-  # Maintain dependencies for npm
-  - package-ecosystem: npm
+  # Maintain dependencies with Bun so package.json and bun.lock stay in sync
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly

--- a/.github/workflows/wasm-test.yaml
+++ b/.github/workflows/wasm-test.yaml
@@ -78,6 +78,8 @@ jobs:
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.15.0
 
       - name: Setup Firefox
         if: matrix.browser == 'firefox' && matrix.os != 'ubuntu-latest'


### PR DESCRIPTION
## What changed

- switch Dependabot from the npm ecosystem to the Bun ecosystem so `package.json` and `bun.lock` are updated together
- pin CI to the repository's `packageManager` Bun version instead of `latest`
- install wasm-pack 0.15.0 in both WASM workflows
- build WASM modules in a fail-fast loop so a failed module cannot surface later as a misleading Vite import error

## Why

The open dependency PRs changed `package.json` without updating `bun.lock`, causing every frozen install to fail. A separate Cypress retry showed that the existing `find -exec` WASM build could also swallow a failed `wasm-pack` invocation and continue until Vite reported a missing local package.

## Validation

- parsed all changed YAML files
- `git diff --check`
- built every WASM module
- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run build`
- `bun run test -- --run` (69 files, 797 tests)

## Dependency updates verified before this PR

- Vite 8.0.16 to 8.1.5
- Rollup 4.60.4 to 4.62.2
- `@types/node` 25.x to 26.x
- TypeScript 6.0.3 to 7.0.2

Each effective Dependabot PR passed GitHub CI before merge. The superseded `@types/node` 26.0.0 PR was closed after the 26.1.1 PR merged.
