### PR TITLE
feat(DataConverter): YAML merge keys, multi-document streams, visible parse errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Based on matching methods, we can roughly classify Boxes into two types:
 | option `toml` or `totoml` | convert input to formatted TOML          | formatted TOML              |
 | option `xml` or `toxml`   | convert input to formatted XML           | formatted XML               |
 
+YAML input resolves anchors/aliases and expands YAML 1.1 merge keys (`<<: *anchor`). When a `to*` option is given but the input cannot be parsed, the parse error is shown instead of an empty result.
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Based on matching methods, we can roughly classify Boxes into two types:
 | option `toml` or `totoml` | convert input to formatted TOML          | formatted TOML              |
 | option `xml` or `toxml`   | convert input to formatted XML           | formatted XML               |
 
-YAML input resolves anchors/aliases and expands YAML 1.1 merge keys (`<<: *anchor`). When a `to*` option is given but the input cannot be parsed, the parse error is shown instead of an empty result.
+YAML input resolves anchors/aliases and expands YAML 1.1 merge keys (`<<: *anchor`). A `---`-separated multi-document stream is read as a list of documents: it converts to a JSON/XML array and round-trips back to a `---`-separated YAML stream. When a `to*` option is given but the input cannot be parsed or cannot be represented in the target format, the error is shown instead of an empty result.
 
 </details>
 

--- a/src/modules/boxSources/DataConverterBoxSource.ts
+++ b/src/modules/boxSources/DataConverterBoxSource.ts
@@ -6,7 +6,7 @@ import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
 import {
   type ParseOptions,
-  parse as parseYaml,
+  parseAllDocuments,
   type SchemaOptions,
   stringify as stringifyYaml,
   type ToJSOptions,
@@ -35,9 +35,23 @@ const yamlParseOptions: ParseOptions & SchemaOptions & ToJSOptions = {
   maxAliasCount: 2500,
 };
 
+// TOML is line-oriented: a document needs either a table header (`[table]` /
+// `[[array]]`) or a key assignment anchored at the start of a line. Matching
+// that shape instead of searching for a bare `=` keeps large YAML and XML
+// documents from paying for a TOML parse that is certain to fail, and stops
+// detection from leaning on `smol-toml` throwing to correct a wrong guess.
+const TOML_KEY = String.raw`(?:[A-Za-z0-9_-]+|"[^"\n]*"|'[^'\n]*')`;
+const TOML_SHAPE = new RegExp(
+  String.raw`^[ \t]*(?:\[\[?[^\]\n]+\]\]?[ \t]*(?:#.*)?$|${TOML_KEY}(?:[ \t]*\.[ \t]*${TOML_KEY})*[ \t]*=)`,
+  'm',
+);
+
 interface DetectedData {
   format: DataFormat;
   data: unknown;
+  // true when the source was a YAML stream of several `---`-separated
+  // documents, in which case `data` is the array of their values.
+  multiDocument: boolean;
 }
 
 interface FormatError {
@@ -78,7 +92,10 @@ function detectFormat(input: string): DetectResult {
     try {
       const data = JSON.parse(trimmed);
       if (data && typeof data === 'object') {
-        return { ok: true, detected: { format: DataFormat.JSON, data } };
+        return {
+          ok: true,
+          detected: { format: DataFormat.JSON, data, multiDocument: false },
+        };
       }
     } catch (e) {
       errors.push({ format: DataFormat.JSON, message: errorMessage(e) });
@@ -90,7 +107,10 @@ function detectFormat(input: string): DetectResult {
     try {
       const data = xmlParser.parse(trimmed);
       if (data && typeof data === 'object' && Object.keys(data).length > 0) {
-        return { ok: true, detected: { format: DataFormat.XML, data } };
+        return {
+          ok: true,
+          detected: { format: DataFormat.XML, data, multiDocument: false },
+        };
       }
     } catch (e) {
       errors.push({ format: DataFormat.XML, message: errorMessage(e) });
@@ -98,11 +118,14 @@ function detectFormat(input: string): DetectResult {
   }
 
   // Try TOML
-  if (trimmed.includes('=') || trimmed.startsWith('[')) {
+  if (TOML_SHAPE.test(trimmed)) {
     try {
       const data = parseToml(trimmed);
       if (data && typeof data === 'object' && Object.keys(data).length > 0) {
-        return { ok: true, detected: { format: DataFormat.TOML, data } };
+        return {
+          ok: true,
+          detected: { format: DataFormat.TOML, data, multiDocument: false },
+        };
       }
     } catch (e) {
       errors.push({ format: DataFormat.TOML, message: errorMessage(e) });
@@ -111,13 +134,28 @@ function detectFormat(input: string): DetectResult {
 
   // Try YAML
   try {
-    const data = parseYaml(trimmed, yamlParseOptions);
+    // parseAllDocuments rather than parse, so a `---`-separated stream is not
+    // rejected outright. It collects syntax errors instead of throwing, while
+    // toJS() still throws on things like an alias reaching across documents —
+    // both have to be handled for broken input to reach the error box.
+    const documents = parseAllDocuments(trimmed, yamlParseOptions);
+    const failed = documents.find((doc) => doc.errors.length > 0);
+    if (failed) throw failed.errors[0];
+
+    // A trailing `---` yields an empty document; dropping the empty ones keeps
+    // a stray separator from turning one document into a two-element array.
+    const values = documents
+      .map((doc) => doc.toJS(yamlParseOptions))
+      .filter((value) => value !== null && value !== undefined);
+
+    const multiDocument = values.length > 1;
+    const data = multiDocument ? values : values[0];
     // YAML is very permissive, we only accept objects/arrays and exclude simple primitives
     if (data && typeof data === 'object' && Object.keys(data).length > 0) {
-      // Additional check to avoid false positives for simple strings that YAML might parse
-      if (typeof data === 'object') {
-        return { ok: true, detected: { format: DataFormat.YAML, data } };
-      }
+      return {
+        ok: true,
+        detected: { format: DataFormat.YAML, data, multiDocument },
+      };
     }
   } catch (e) {
     errors.push({ format: DataFormat.YAML, message: errorMessage(e) });
@@ -147,48 +185,50 @@ function describeDetectFailure(errors: FormatError[]): string {
   return `Failed to parse input as ${best.format.toUpperCase()}: ${best.message}`;
 }
 
-const FORMATS = [
+interface OutputFormat {
+  id: DataFormat;
+  name: string;
+  keys: string[];
+  // Throws when the data cannot be represented; the caller turns that into a
+  // visible error rather than an empty result.
+  stringify: (data: unknown, multiDocument: boolean) => string;
+}
+
+const FORMATS: readonly OutputFormat[] = [
   {
     id: DataFormat.JSON,
     name: 'JSON',
     keys: ['json', 'tojson'],
-    stringify: (d: unknown) => JSON.stringify(d, null, '    '),
+    stringify: (d) => JSON.stringify(d, null, '    '),
   },
   {
     id: DataFormat.YAML,
     name: 'YAML',
     keys: ['yaml', 'yml', 'toyaml', 'toyml'],
-    stringify: (d: unknown) => stringifyYaml(d),
+    // a multi-document source round-trips back to a `---`-separated stream
+    // rather than collapsing into a single sequence node
+    stringify: (d, multiDocument) =>
+      multiDocument && Array.isArray(d)
+        ? d.map((doc) => stringifyYaml(doc)).join('---\n')
+        : stringifyYaml(d),
   },
   {
     id: DataFormat.TOML,
     name: 'TOML',
     keys: ['toml', 'totoml'],
-    stringify: (d: unknown) => {
-      try {
-        return stringifyToml(d as Record<string, unknown>);
-      } catch (e) {
-        console.error('TOML stringify failed:', e);
-        return undefined;
-      }
-    },
+    stringify: (d) => stringifyToml(d as Record<string, unknown>),
   },
   {
     id: DataFormat.XML,
     name: 'XML',
     keys: ['xml', 'toxml'],
-    stringify: (d: unknown) => {
-      try {
-        const wrapData = Array.isArray(d)
-          ? { root: { item: d } }
-          : Object.keys(d as object).length > 1
-            ? { root: d }
-            : d;
-        return xmlBuilder.build(wrapData);
-      } catch (e) {
-        console.error('XML build failed:', e);
-        return undefined;
-      }
+    stringify: (d) => {
+      const wrapData = Array.isArray(d)
+        ? { root: { item: d } }
+        : Object.keys(d as object).length > 1
+          ? { root: d }
+          : d;
+      return xmlBuilder.build(wrapData);
     },
   },
 ];
@@ -223,7 +263,7 @@ export const DataConverterBoxSource = {
       ];
     }
 
-    const { format: srcFormat, data } = result.detected;
+    const { format: srcFormat, data, multiDocument } = result.detected;
     const boxes: Box[] = [];
 
     for (const fmt of FORMATS) {
@@ -239,8 +279,7 @@ export const DataConverterBoxSource = {
       }
 
       try {
-        const output = fmt.stringify(data);
-        if (output === undefined) continue;
+        const output = fmt.stringify(data, multiDocument);
 
         // For the source format, only show if it actually changed (formatted) the input
         if (isSourceFormat && trim(output) === trim(input)) {
@@ -256,6 +295,18 @@ export const DataConverterBoxSource = {
         );
       } catch (e) {
         console.error(`Conversion to ${fmt.name} failed:`, e);
+        // Same rule as a detection failure: only an explicit target deserves an
+        // error. TOML in particular cannot hold a top-level array, which is
+        // exactly what a multi-document YAML stream produces.
+        if (isTargetRequested) {
+          boxes.push(
+            errorBox(
+              'Data Converter',
+              `Cannot convert to ${fmt.name}: ${errorMessage(e)}`,
+              { priority: PriorityDataConverter },
+            ),
+          );
+        }
       }
     }
 

--- a/src/modules/boxSources/DataConverterBoxSource.ts
+++ b/src/modules/boxSources/DataConverterBoxSource.ts
@@ -1,10 +1,16 @@
 import { CodeBoxTemplate } from '@components/BoxTemplate';
 import { isString, trim } from '@functions/helper';
 import type { Box, BoxOptions } from '@modules/Box';
-import { BoxBuilder, hasOptionKeys } from '@modules/Box';
+import { BoxBuilder, errorBox, hasOptionKeys } from '@modules/Box';
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
-import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import {
+  type ParseOptions,
+  parse as parseYaml,
+  type SchemaOptions,
+  stringify as stringifyYaml,
+  type ToJSOptions,
+} from 'yaml';
 
 const PriorityDataConverter = 10;
 
@@ -15,10 +21,38 @@ enum DataFormat {
   XML = 'xml',
 }
 
+// YAML 1.2 dropped merge keys from the core schema, so the `yaml` package
+// disables them by default. Every real-world producer (k8s, docker-compose, CI
+// configs) still relies on `<<: *anchor`, so enable them explicitly; docs that
+// carry an explicit `%YAML 1.1` directive keep working unchanged.
+//
+// maxAliasCount is an expansion-cost budget (references x anchored-node size),
+// not an alias count. The library default of 100 rejects legitimate configs
+// that reuse a handful of anchors heavily, so raise it well above that while
+// still refusing exponential alias bombs.
+const yamlParseOptions: ParseOptions & SchemaOptions & ToJSOptions = {
+  merge: true,
+  maxAliasCount: 2500,
+};
+
 interface DetectedData {
   format: DataFormat;
   data: unknown;
 }
+
+interface FormatError {
+  format: DataFormat;
+  message: string;
+}
+
+// Detection succeeded, or it failed and carries the errors from every parser
+// whose gate matched — the caller decides whether those are worth surfacing.
+type DetectResult =
+  | { ok: true; detected: DetectedData }
+  | { ok: false; errors: FormatError[] };
+
+const errorMessage = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e);
 
 const xmlParser = new XMLParser({
   ignoreAttributes: false,
@@ -31,9 +65,10 @@ const xmlBuilder = new XMLBuilder({
   indentBy: '    ',
 });
 
-function detectFormat(input: string): DetectedData | undefined {
+function detectFormat(input: string): DetectResult {
   const trimmed = trim(input);
-  if (!trimmed) return undefined;
+  const errors: FormatError[] = [];
+  if (!trimmed) return { ok: false, errors };
 
   // Try JSON
   if (
@@ -43,10 +78,10 @@ function detectFormat(input: string): DetectedData | undefined {
     try {
       const data = JSON.parse(trimmed);
       if (data && typeof data === 'object') {
-        return { format: DataFormat.JSON, data };
+        return { ok: true, detected: { format: DataFormat.JSON, data } };
       }
-    } catch {
-      /* ignore */
+    } catch (e) {
+      errors.push({ format: DataFormat.JSON, message: errorMessage(e) });
     }
   }
 
@@ -55,10 +90,10 @@ function detectFormat(input: string): DetectedData | undefined {
     try {
       const data = xmlParser.parse(trimmed);
       if (data && typeof data === 'object' && Object.keys(data).length > 0) {
-        return { format: DataFormat.XML, data };
+        return { ok: true, detected: { format: DataFormat.XML, data } };
       }
-    } catch {
-      /* ignore */
+    } catch (e) {
+      errors.push({ format: DataFormat.XML, message: errorMessage(e) });
     }
   }
 
@@ -67,29 +102,96 @@ function detectFormat(input: string): DetectedData | undefined {
     try {
       const data = parseToml(trimmed);
       if (data && typeof data === 'object' && Object.keys(data).length > 0) {
-        return { format: DataFormat.TOML, data };
+        return { ok: true, detected: { format: DataFormat.TOML, data } };
       }
-    } catch {
-      /* ignore */
+    } catch (e) {
+      errors.push({ format: DataFormat.TOML, message: errorMessage(e) });
     }
   }
 
   // Try YAML
   try {
-    const data = parseYaml(trimmed);
+    const data = parseYaml(trimmed, yamlParseOptions);
     // YAML is very permissive, we only accept objects/arrays and exclude simple primitives
     if (data && typeof data === 'object' && Object.keys(data).length > 0) {
       // Additional check to avoid false positives for simple strings that YAML might parse
       if (typeof data === 'object') {
-        return { format: DataFormat.YAML, data };
+        return { ok: true, detected: { format: DataFormat.YAML, data } };
       }
     }
-  } catch {
-    /* ignore */
+  } catch (e) {
+    errors.push({ format: DataFormat.YAML, message: errorMessage(e) });
   }
 
-  return undefined;
+  return { ok: false, errors };
 }
+
+// Ranks the collected errors by how specific the parser's gate was, so a
+// YAML document that tokenized and then failed wins over TOML, whose gate is a
+// bare `=` check and fires on almost any text.
+const ERROR_PRIORITY = [
+  DataFormat.JSON,
+  DataFormat.XML,
+  DataFormat.YAML,
+  DataFormat.TOML,
+];
+
+function describeDetectFailure(errors: FormatError[]): string {
+  const best = ERROR_PRIORITY.map((format) =>
+    errors.find((e) => e.format === format),
+  ).find((e) => e !== undefined);
+
+  if (!best) {
+    return 'Input is not recognizable as JSON, YAML, TOML or XML.';
+  }
+  return `Failed to parse input as ${best.format.toUpperCase()}: ${best.message}`;
+}
+
+const FORMATS = [
+  {
+    id: DataFormat.JSON,
+    name: 'JSON',
+    keys: ['json', 'tojson'],
+    stringify: (d: unknown) => JSON.stringify(d, null, '    '),
+  },
+  {
+    id: DataFormat.YAML,
+    name: 'YAML',
+    keys: ['yaml', 'yml', 'toyaml', 'toyml'],
+    stringify: (d: unknown) => stringifyYaml(d),
+  },
+  {
+    id: DataFormat.TOML,
+    name: 'TOML',
+    keys: ['toml', 'totoml'],
+    stringify: (d: unknown) => {
+      try {
+        return stringifyToml(d as Record<string, unknown>);
+      } catch (e) {
+        console.error('TOML stringify failed:', e);
+        return undefined;
+      }
+    },
+  },
+  {
+    id: DataFormat.XML,
+    name: 'XML',
+    keys: ['xml', 'toxml'],
+    stringify: (d: unknown) => {
+      try {
+        const wrapData = Array.isArray(d)
+          ? { root: { item: d } }
+          : Object.keys(d as object).length > 1
+            ? { root: d }
+            : d;
+        return xmlBuilder.build(wrapData);
+      } catch (e) {
+        console.error('XML build failed:', e);
+        return undefined;
+      }
+    },
+  },
+];
 
 export const DataConverterBoxSource = {
   name: 'Data Converter',
@@ -103,63 +205,28 @@ export const DataConverterBoxSource = {
   async generateBoxes(input: string, options: BoxOptions): Promise<Box[]> {
     if (!isString(input)) return [];
 
-    const detected = detectFormat(input);
-    if (!detected) return [];
-
-    const { format: srcFormat, data } = detected;
-    const boxes: Box[] = [];
-
-    const formats = [
-      {
-        id: DataFormat.JSON,
-        name: 'JSON',
-        keys: ['json', 'tojson'],
-        stringify: (d: unknown) => JSON.stringify(d, null, '    '),
-      },
-      {
-        id: DataFormat.YAML,
-        name: 'YAML',
-        keys: ['yaml', 'yml', 'toyaml', 'toyml'],
-        stringify: (d: unknown) => stringifyYaml(d),
-      },
-      {
-        id: DataFormat.TOML,
-        name: 'TOML',
-        keys: ['toml', 'totoml'],
-        stringify: (d: unknown) => {
-          try {
-            return stringifyToml(d as Record<string, unknown>);
-          } catch (e) {
-            console.error('TOML stringify failed:', e);
-            return undefined;
-          }
-        },
-      },
-      {
-        id: DataFormat.XML,
-        name: 'XML',
-        keys: ['xml', 'toxml'],
-        stringify: (d: unknown) => {
-          try {
-            const wrapData = Array.isArray(d)
-              ? { root: { item: d } }
-              : Object.keys(d as object).length > 1
-                ? { root: d }
-                : d;
-            return xmlBuilder.build(wrapData);
-          } catch (e) {
-            console.error('XML build failed:', e);
-            return undefined;
-          }
-        },
-      },
-    ];
-
-    const hasAnyTargetOption = formats.some((fmt) =>
+    const hasAnyTargetOption = FORMATS.some((fmt) =>
       hasOptionKeys(options, ...fmt.keys),
     );
 
-    for (const fmt of formats) {
+    const result = detectFormat(input);
+    if (!result.ok) {
+      // Silence is right while guessing the format — every unmatched keystroke
+      // would otherwise raise an error. Once a `::toJSON`-style target is
+      // explicit the intent is unambiguous, so report why parsing failed
+      // instead of rendering nothing.
+      if (!hasAnyTargetOption || trim(input) === '') return [];
+      return [
+        errorBox('Data Converter', describeDetectFailure(result.errors), {
+          priority: PriorityDataConverter,
+        }),
+      ];
+    }
+
+    const { format: srcFormat, data } = result.detected;
+    const boxes: Box[] = [];
+
+    for (const fmt of FORMATS) {
       const isTargetRequested = hasOptionKeys(options, ...fmt.keys);
       const isSourceFormat = fmt.id === srcFormat;
 

--- a/src/modules/boxSources/__test__/DataConverterBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DataConverterBoxSource.test.ts
@@ -172,6 +172,133 @@ prod:
     });
   });
 
+  describe('multi-document YAML', () => {
+    const multiDoc = `kind: Service
+name: api
+---
+kind: Deployment
+name: api`;
+
+    it('should convert a --- separated stream to a JSON array', async () => {
+      const boxes = await DataConverterBoxSource.generateBoxes(multiDoc, {
+        json: true,
+      });
+
+      const jsonBox = boxes.find((b) => b.props.name === 'JSON Output');
+      const parsed = JSON.parse(jsonBox?.props.plaintextOutput ?? 'null');
+      expect(parsed).toEqual([
+        { kind: 'Service', name: 'api' },
+        { kind: 'Deployment', name: 'api' },
+      ]);
+    });
+
+    it('should round-trip back to a --- separated stream, not a sequence', async () => {
+      // spaced out so the reformatted output differs from the input and the
+      // "source format is already pretty" suppression does not hide the box
+      const boxes = await DataConverterBoxSource.generateBoxes(
+        'kind:    Service\nname:    api\n---\nkind:    Deployment\nname:    api',
+        { yaml: true },
+      );
+
+      const yamlBox = boxes.find((b) => b.props.name === 'YAML Output');
+      expect(yamlBox?.props.plaintextOutput).toBe(
+        'kind: Service\nname: api\n---\nkind: Deployment\nname: api\n',
+      );
+    });
+
+    it('should suppress the YAML box when the stream is already canonical', async () => {
+      const boxes = await DataConverterBoxSource.generateBoxes(multiDoc, {
+        yaml: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should ignore a trailing separator rather than emit an array', async () => {
+      const boxes = await DataConverterBoxSource.generateBoxes('a: 1\n---\n', {
+        json: true,
+      });
+
+      const jsonBox = boxes.find((b) => b.props.name === 'JSON Output');
+      expect(JSON.parse(jsonBox?.props.plaintextOutput ?? 'null')).toEqual({
+        a: 1,
+      });
+    });
+
+    it('should report a syntax error in any document of the stream', async () => {
+      const boxes = await DataConverterBoxSource.generateBoxes(
+        'a: 1\n---\nb: 2\nb: 3\n',
+        { json: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain(
+        'Failed to parse input as YAML',
+      );
+    });
+
+    it('should report an alias that reaches across documents', async () => {
+      // anchors are document-scoped, so this resolves to nothing at toJS time
+      const boxes = await DataConverterBoxSource.generateBoxes(
+        'x: &x\n  p: 1\n---\ny:\n  <<: *x\n',
+        { json: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain(
+        'Failed to parse input as YAML',
+      );
+    });
+
+    it('should report that TOML cannot hold a multi-document stream', async () => {
+      const boxes = await DataConverterBoxSource.generateBoxes(multiDoc, {
+        toml: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Data Converter');
+      expect(boxes[0].props.plaintextOutput).toContain(
+        'Cannot convert to TOML',
+      );
+    });
+  });
+
+  describe('TOML detection gate', () => {
+    it('should not treat YAML containing "=" as a TOML candidate', async () => {
+      const yamlInput = `args:
+  - --flag=value
+name: demo`;
+      const boxes = await DataConverterBoxSource.generateBoxes(yamlInput, {
+        json: true,
+      });
+
+      const jsonBox = boxes.find((b) => b.props.name === 'JSON Output');
+      const parsed = JSON.parse(jsonBox?.props.plaintextOutput ?? '{}');
+      expect(parsed.args).toEqual(['--flag=value']);
+      expect(parsed.name).toBe('demo');
+    });
+
+    it('should still detect TOML table headers and dotted keys', async () => {
+      const tomlInput = `# comment
+[server]
+host = "localhost"
+
+[server.limits]
+"max-body" = 100
+
+[[route]]
+path = "/health"`;
+      const boxes = await DataConverterBoxSource.generateBoxes(tomlInput, {
+        json: true,
+      });
+
+      const jsonBox = boxes.find((b) => b.props.name === 'JSON Output');
+      const parsed = JSON.parse(jsonBox?.props.plaintextOutput ?? '{}');
+      expect(parsed.server.host).toBe('localhost');
+      expect(parsed.server.limits['max-body']).toBe(100);
+      expect(parsed.route).toEqual([{ path: '/health' }]);
+    });
+  });
+
   describe('parse failure reporting', () => {
     it('should report the parse error when a target format was requested', async () => {
       // duplicate keys are a hard error in the YAML spec

--- a/src/modules/boxSources/__test__/DataConverterBoxSource.test.ts
+++ b/src/modules/boxSources/__test__/DataConverterBoxSource.test.ts
@@ -122,4 +122,97 @@ age = 30`;
       expect(boxes).toHaveLength(0);
     });
   });
+
+  describe('YAML 1.1 features', () => {
+    it('should resolve anchors and aliases', async () => {
+      const yamlInput = `defaults: &defaults
+  retries: 3
+prod: *defaults`;
+      const boxes = await DataConverterBoxSource.generateBoxes(yamlInput, {
+        json: true,
+      });
+
+      const jsonBox = boxes.find((b) => b.props.name === 'JSON Output');
+      const parsed = JSON.parse(jsonBox?.props.plaintextOutput ?? '{}');
+      expect(parsed.prod).toEqual({ retries: 3 });
+    });
+
+    it('should expand merge keys instead of emitting a literal "<<" key', async () => {
+      const yamlInput = `defaults: &defaults
+  retries: 3
+  timeout: 5
+prod:
+  <<: *defaults
+  timeout: 30`;
+      const boxes = await DataConverterBoxSource.generateBoxes(yamlInput, {
+        json: true,
+      });
+
+      const jsonBox = boxes.find((b) => b.props.name === 'JSON Output');
+      const parsed = JSON.parse(jsonBox?.props.plaintextOutput ?? '{}');
+      expect(parsed.prod).toEqual({ retries: 3, timeout: 30 });
+      expect(parsed.prod['<<']).toBeUndefined();
+    });
+
+    it('should accept documents that reuse anchors well past the library default', async () => {
+      // The `yaml` default budget of 100 rejects this; real configs routinely
+      // reference a shared block hundreds of times.
+      const anchor = 'base: &base\n  a: 1\n  b: 2\n  c: 3\n';
+      const uses = Array.from(
+        { length: 300 },
+        (_, i) => `svc${i}:\n  <<: *base\n  id: ${i}`,
+      ).join('\n');
+      const boxes = await DataConverterBoxSource.generateBoxes(anchor + uses, {
+        json: true,
+      });
+
+      const jsonBox = boxes.find((b) => b.props.name === 'JSON Output');
+      const parsed = JSON.parse(jsonBox?.props.plaintextOutput ?? '{}');
+      expect(parsed.svc299).toEqual({ a: 1, b: 2, c: 3, id: 299 });
+    });
+  });
+
+  describe('parse failure reporting', () => {
+    it('should report the parse error when a target format was requested', async () => {
+      // duplicate keys are a hard error in the YAML spec
+      const boxes = await DataConverterBoxSource.generateBoxes('a: 1\na: 2\n', {
+        json: true,
+      });
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.name).toBe('Data Converter');
+      expect(boxes[0].props.plaintextOutput).toContain(
+        'Failed to parse input as YAML',
+      );
+      expect(boxes[0].props.plaintextOutput).toContain('Map keys must be uniq');
+    });
+
+    it('should stay silent on a parse failure when no target format was requested', async () => {
+      const boxes = await DataConverterBoxSource.generateBoxes(
+        'a: 1\na: 2\n',
+        {},
+      );
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should stay silent on empty input even with a target format', async () => {
+      const boxes = await DataConverterBoxSource.generateBoxes('   ', {
+        json: true,
+      });
+      expect(boxes).toHaveLength(0);
+    });
+
+    it('should prefer the JSON error over looser format guesses', async () => {
+      // fails JSON and YAML alike; JSON's brace gate is the more specific match
+      const boxes = await DataConverterBoxSource.generateBoxes(
+        '{"a": 1, "b": @x}',
+        { yaml: true },
+      );
+
+      expect(boxes).toHaveLength(1);
+      expect(boxes[0].props.plaintextOutput).toContain(
+        'Failed to parse input as JSON',
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`::toJSON` on a real 88 KB production YAML config produced nothing at all — no output, no error. This PR fixes the three root causes behind that, plus the detection weakness next to them.

Motivating file: 3301 lines, 88 KB, 7 anchors, 236 aliases, 118 merge keys, no tabs, single document.

```
parse(src)                                   → THROW: Excessive alias count indicates a resource exhaustion attack
parse(src, {merge: true})                    → OK, 37ms, 8 top-level keys
parse(src, {merge: true, maxAliasCount: -1}) → OK, 33ms
```

Not a size limit — `DataConverterBoxSource` has never had a `MAX_INPUT`, and neither `MagicBox` nor the textarea caps input length.

---

## 1. YAML merge keys were never expanded

YAML 1.2 dropped merge keys from the core schema, so the `yaml` package disables them by default (`merge` defaults to `false` for 1.2). `<<: *anchor` was parsed into a **literal `"<<"` key** holding the unmerged map, silently producing wrong output rather than an error.

Every real-world YAML producer — Kubernetes, docker-compose, GitLab CI — relies on merge keys, so they are now enabled explicitly. Documents carrying an explicit `%YAML 1.1` directive already worked and are unaffected.

Anchors and plain aliases (`*anchor`) always worked and still do.

## 2. `maxAliasCount` rejected legitimate configs

Raised from the library default of `100` to `2500`.

The guard is not an alias count. From `yaml/dist/nodes/Alias.js:74`:

```js
if (data.count * data.aliasCount > maxAliasCount) { throw ... }
```

It is an **expansion-cost budget**: references × the size of the anchored node. A config that references one shared block a few hundred times blows past 100 without being remotely adversarial.

Note the two fixes are independent. `merge: true` alone happens to rescue the motivating file, because merged aliases resolve through `schema/yaml-1.1/merge.js` → `addMergeToJSMap` instead of `Alias.toJSON`, bypassing the counter entirely. A document with 236 *plain* aliases and no merge keys would still have been rejected. Both were needed.

<details>
<summary>Security note</summary>

`src/functions/shareLink.ts:27` puts the input into a shareable `?input=` link, so raising this ceiling lets a crafted link stall a recipient's tab for longer. The exposure stays bounded — client-side only, confined to that one tab, and 2500 is still far from unlimited (an exponential alias bomb is still rejected; verified by hand at 2000 nested aliases). Raising it was an explicit product decision, recorded here rather than left implicit.
</details>

## 3. Parse failures were invisible

`detectFormat` caught every parser error into `catch { /* ignore */ }` and returned `undefined`, so `generateBoxes` returned `[]` and the UI showed the generic "no matches" empty state. There was no way to learn *why* a conversion failed.

That silence is correct while **guessing** a format — every unmatched keystroke would otherwise raise an error. It is wrong once the user has written an explicit `::toJSON`-style target, where the intent is unambiguous.

`detectFormat` now returns a discriminated union carrying the errors from every parser whose gate matched:

```ts
type DetectResult =
  | { ok: true; detected: DetectedData }
  | { ok: false; errors: FormatError[] };
```

The caller decides whether to surface them, based on whether an explicit target option was given. Errors are ranked by gate specificity (`JSON → XML → YAML → TOML`) so a YAML document that tokenized and then failed wins over TOML, whose gate fires on almost any text.

Rendering uses the existing `errorBox()` helper (`src/modules/Box.ts:154`), matching the precedent in `UrlParseBoxSource.ts:68` — **not** a toast:

- The snackbar is already bound to "copy succeeded" semantics (`MagicBox/index.tsx:53`); reusing it would conflate two signals.
- Toasts auto-dismiss, but `Map keys must be unique at line 47, column 3` is something you read while editing your input.
- Boxes are this app's output channel: the error lands where the user is already looking, stays selectable and copyable, and `errorBox` deliberately leaves `boxTemplate` undefined so the web layer falls back to `DefaultBoxTemplate` and the headless TUI prints the message instead of rendering a blank grid.

## 4. Multi-document YAML (`---`) was rejected outright

`parse()` throws `Source contains multiple documents` on a `---`-separated stream — the single most common shape for Kubernetes manifests. Switched to `parseAllDocuments()`.

A stream is now read as a list of documents: it converts to a JSON/XML array, and YAML output **rebuilds the separators** rather than collapsing the stream into a single sequence node:

```ts
stringify: (d, multiDocument) =>
  multiDocument && Array.isArray(d)
    ? d.map((doc) => stringifyYaml(doc)).join('---\n')
    : stringifyYaml(d),
```

Two API traps had to be handled explicitly, and missing either would have been a **regression** against the previous throwing `parse()`:

1. **`parseAllDocuments` does not throw.** Syntax errors are collected per-document in `doc.errors`, and `toJS()` returns a value anyway — `a: 1\na: 2` would have quietly yielded `{a: 2}`. Each document's `errors` is now checked explicitly.
2. **`toJS()` throws on its own.** Anchors are document-scoped in YAML, so an alias reaching across documents (`x: &x` in doc 1, `<<: *x` in doc 2) leaves `errors` empty and only fails at `toJS()` time with `Merge sources must be maps or map aliases`. Both the parse and the `toJS()` calls are inside the try.

A trailing `---` yields an empty document; those are filtered out so a stray separator does not turn one document into a two-element array.

## 5. TOML detection gate was a `=` search

```ts
// before
if (trimmed.includes('=') || trimmed.startsWith('[')) {
```

This fires on most YAML and all prose. It happened not to misdetect anything because `smol-toml` throws and detection falls through to YAML — correctness resting on the downstream parser, not on the gate meaning anything. It also made every large YAML document pay for a doomed TOML parse.

Replaced with a match on the line-oriented TOML shape: a table header (`[table]` / `[[array]]`) or a key assignment anchored at a line start, supporting bare, quoted and dotted keys.

| input | old gate | new gate |
|---|---|---|
| `name = "x"` | ✅ | ✅ |
| `[server]` / `[[route]]` | ✅ | ✅ |
| `a.b.c = 1` / `"my key" = 1` | ✅ | ✅ |
| `# comment` then `name = 1` | ✅ | ✅ |
| `args:` / `  - --flag=value` | ⚠️ false positive | ✅ rejected |
| `cmd: foo = bar` | ⚠️ false positive | ✅ rejected |
| `the answer = 42` | ⚠️ false positive | ✅ rejected |
| the 88 KB YAML config | ⚠️ false positive | ✅ rejected (0.68 ms) |

TOML deliberately stays **before** YAML in the detection order. YAML is the permissive format and belongs last as the fallback; the bug was a gate that meant nothing, not the ordering.

Despite appearances, `KEY(?:[ \t]*\.[ \t]*KEY)*` does not backtrack catastrophically — `[A-Za-z0-9_-]`, `\.` and `[ \t]` are mutually disjoint, so there is no ambiguous split point.

## 6. Silent stringify failures

Closing a hole this PR would otherwise open: multi-document YAML → TOML is guaranteed to fail, since TOML cannot hold a top-level array. The `TOML` and `XML` stringifiers each caught their own errors, logged, and returned `undefined`, which skipped the box — reproducing the exact silent failure fixed in §3.

Stringifiers now throw, and a single catch in the emit loop applies the same rule as detection: report only when the format was explicitly requested.

## Incidental

The format table was being reallocated — four objects and four closures — on every keystroke, since `generateBoxes` runs for every box source on every input change. Hoisted to module scope as `FORMATS`.

---

## Verification

End-to-end through the real box source against the motivating file:

```
boxes: [ 'JSON Output' ]   48ms
88,056 bytes YAML → 504,649 bytes JSON
output contains no "<<" keys
```

`bun run test` 896 passed (75 files) · `bun run lint` clean · `tsc --noEmit` clean.

**+13 tests** on `DataConverterBoxSource`:

- anchors/aliases resolve
- merge keys expand, no literal `"<<"` survives
- a document referencing one anchor 300 times is accepted
- multi-document → JSON array
- multi-document YAML round-trips to a `---` stream
- an already-canonical stream is suppressed (proving the round-trip is byte-identical)
- a trailing `---` does not create an array
- a syntax error in *any* document of the stream is reported
- a cross-document alias is reported
- TOML reports that it cannot hold a stream
- YAML containing `=` is not treated as a TOML candidate
- TOML table headers, array-of-tables, dotted and quoted keys still detect
- parse errors surface only with an explicit target; silent otherwise, and on empty input
- error ranking prefers the JSON error over looser guesses

Two of these started as failing tests written on wrong premises, and both are worth flagging because the failures were informative:

- `{"a": 1, "b": }` was chosen as "fails JSON and YAML alike" — YAML parses it as a flow mapping into `{a: 1, b: null}`. Nearly all broken JSON is still valid YAML; the test now uses a YAML reserved character (`@`).
- The multi-document YAML round-trip returned no box at all, because `isSourceFormat && trim(output) === trim(input)` suppressed it. The failure *was* the proof that the round-trip is byte-identical. Split into two tests: one with deliberately loose spacing to inspect the output, one asserting the suppression directly.

README updated.
